### PR TITLE
Bug fixes and updated ingress examples for HEC

### DIFF
--- a/build/package.sh
+++ b/build/package.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 # Script to export splunk-operator image to tarball and generated combined YAML
 
+# exit when any command fails
+set -e
+
 VERSION=$1
 if [[ "x$VERSION" == "x" ]]; then
     # Use latest commit id if no version is provided
     VERSION=`git rev-parse HEAD | cut -c1-12`
 fi
-IMAGE_ID=`docker images splunk-operator:latest -q`
+IMAGE_ID=`docker images splunk/splunk-operator:latest -q`
 
 echo Tagging image ${IMAGE_ID} as splunk/splunk-operator:${VERSION}
 docker tag ${IMAGE_ID} splunk/splunk-operator:${VERSION}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -46,6 +46,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to get watch namespace: %v", err)
 	}
+	log.Printf("Watching namespace: %s", namespace)
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()

--- a/docs/Ingress.md
+++ b/docs/Ingress.md
@@ -92,6 +92,12 @@ spec:
       - backend:
           serviceName: splunk-example-spark-master-service
           servicePort: 8009
+  - host: hec.splunk.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: splunk-example-indexer-headless
+          servicePort: 8088
   tls:
   - hosts:
     - splunk.example.com
@@ -99,6 +105,7 @@ spec:
     - cluster-master.splunk.example.com
     - license-master.splunk.example.com
     - spark-master.splunk.example.com
+    - hec.splunk.example.com
     secretName: splunk.example.com-tls
 ```
 
@@ -157,6 +164,7 @@ spec:
     - deployer.splunk.example.com
     - cluster-master.splunk.example.com
     - license-master.splunk.example.com
+    - hec.splunk.example.com
   issuerRef:
     name: letsencrypt-prod
     kind: ClusterIssuer
@@ -183,6 +191,7 @@ spec:
     - "deployer.splunk.example.com"
     - "cluster-master.splunk.example.com"
     - "license-master.splunk.example.com"
+    - "hec.splunk.example.com"
     tls:
       httpsRedirect: true
   - port:
@@ -197,6 +206,7 @@ spec:
     - "deployer.splunk.example.com"
     - "cluster-master.splunk.example.com"
     - "license-master.splunk.example.com"
+    - "hec.splunk.example.com"
 ```
 
 Note that `credentialName` references the same `secretName` created and
@@ -241,9 +251,9 @@ spec:
   http:
   - route:
     - destination:
-      port:
-        number: 8000
-      host: splunk-example-search-head-service
+        port:
+          number: 8000
+        host: splunk-example-search-head-service
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -257,9 +267,9 @@ spec:
   http:
   - route:
     - destination:
-      port:
-        number: 8000
-      host: splunk-example-deployer-service
+        port:
+          number: 8000
+        host: splunk-example-deployer-service
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -273,9 +283,9 @@ spec:
   http:
   - route:
     - destination:
-      port:
-        number: 8000
-      host: splunk-example-cluster-master-service
+        port:
+          number: 8000
+        host: splunk-example-cluster-master-service
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -289,9 +299,25 @@ spec:
   http:
   - route:
     - destination:
-         port:
-        number: 8000
-         host: splunk-example-license-master-service
+        port:
+          number: 8000
+        host: splunk-example-license-master-service
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: splunk-hec
+spec:
+  hosts:
+  - "hec.splunk.example.com"
+  gateways:
+  - "splunk-gw"
+  http:
+  - route:
+    - destination:
+        port:
+          number: 8088
+        host: splunk-example-indexer-headless
 ```
 
 Finally, you will need to create a DestinationRule to ensure user sessions are

--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -451,6 +451,7 @@ func getSplunkPorts(instanceType InstanceType) map[string]int {
 		result["dfsmaster"] = 9000
 	case SplunkIndexer:
 		result["hec"] = 8088
+		result["s2s"] = 9997
 	}
 
 	return result

--- a/pkg/splunk/resources/util.go
+++ b/pkg/splunk/resources/util.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	secretBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890%()*+,-./<=>?@[]^_{|}~"
+	secretBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890%()*+,-./<=>?@^_|~"
 )
 
 func init() {


### PR DESCRIPTION
Fixed bug where random secret generation sometimes contained braces that broke ansible's YAML parser, causing pods to fail to start up

Fixed bad image name in build/package.sh, and added check for errors

Added s2s port to indexers

Added HEC endpoint to ingress doc examples