### PR TITLE
Various fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@
 
 all: image
 
-image: deploy/all-in-one.yaml
+image: deploy/all-in-one-scoped.yaml deploy/all-in-one-cluster.yaml
 	@echo Building splunk-operator image
 	@operator-sdk build splunk/splunk-operator
 
-package: deploy/all-in-one.yaml
+package: deploy/all-in-one-scoped.yaml deploy/all-in-one-cluster.yaml
 	@build/package.sh
 
 local:
@@ -28,6 +28,10 @@ fmt:
 lint:
 	@golint ./...
 
-deploy/all-in-one.yaml: deploy/crds/enterprise_v1alpha1_splunkenterprise_crd.yaml deploy/service_account.yaml deploy/role.yaml deploy/role_binding.yaml deploy/operator.yaml
-	@echo Rebuilding deploy/all-in-one.yaml
-	@cat deploy/crds/enterprise_v1alpha1_splunkenterprise_crd.yaml deploy/service_account.yaml deploy/role.yaml deploy/role_binding.yaml deploy/operator.yaml > deploy/all-in-one.yaml
+deploy/all-in-one-scoped.yaml: deploy/crds/enterprise_v1alpha1_splunkenterprise_crd.yaml deploy/rbac.yaml deploy/operator.yaml
+	@echo Rebuilding deploy/all-in-one-scoped.yaml
+	@cat deploy/crds/enterprise_v1alpha1_splunkenterprise_crd.yaml deploy/rbac.yaml deploy/operator.yaml > deploy/all-in-one-scoped.yaml
+
+deploy/all-in-one-cluster.yaml: deploy/crds/enterprise_v1alpha1_splunkenterprise_crd.yaml deploy/rbac.yaml deploy/cluster_operator.yaml
+	@echo Rebuilding deploy/all-in-one-cluster.yaml
+	@cat deploy/crds/enterprise_v1alpha1_splunkenterprise_crd.yaml deploy/rbac.yaml deploy/cluster_operator.yaml > deploy/all-in-one-cluster.yaml

--- a/README.md
+++ b/README.md
@@ -68,44 +68,24 @@ Other make targets include (more info below):
 * `make lint`: runs the `golint` utility on all `*.go` source files in this project
 
 
-## Pushing Your Splunk Operator Image
-
-If you are using a local, single-node Kubernetes cluster like
-[minikube](https://minikube.sigs.k8s.io/) or [Docker Desktop](https://www.docker.com/products/docker-desktop),
-you only need to build the `splunk/splunk-operator` image.
-You can skip the rest of this section.
-
-If possible, we recommend re-tagging your custom-built images and pushing
-them to a remote registry that your Kubernetes workers are able to pull from.
-Please see the [Required Images Documentation](Images.md) for more information.
-
-
 ## Running the Splunk Operator
 
-### Running as a foreground process
+Ensure that you have the `SplunkEnterprise` Custom Resource Definition installed
+in your cluster:
+
+```
+kubectl apply -f deploy/crds/enterprise_v1alpha1_splunkenterprise_crd.yaml
+```
 
 Use this to run the operator as a local foreground process on your machine:
+
 ```
 make run
 ```
-This will use your current Kubernetes context from `~/.kube/config`.
 
-
-### Running in Local and Remote Clusters
-
-You can install and start the operator by running
-```
-kubectl apply -f deploy/all-in-one.yaml
-```
-
-Note that `deploy/all-in-one.yaml` uses the image name `splunk/splunk-operator`.
-If you pushed this image to a remote registry, you need to change the `image`
-parameter in this file to refer to the correct location.
-
-You can stop and remove the operator by running
-```
-kubectl delete -f deploy/all-in-one.yaml
-```
+This will use your current Kubernetes context from `~/.kube/config` to manage
+resources in your current namespace.
 
 Please see the [Getting Started Documentation](docs/README.md) for more
-information.
+information, including instructions on how to install the operator in your
+cluster.

--- a/deploy/all-in-one-cluster.yaml
+++ b/deploy/all-in-one-cluster.yaml
@@ -134,8 +134,6 @@ spec:
       containers:
         - name: splunk-operator
           image: splunk/splunk-operator
-          command:
-          - splunk-operator
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/all-in-one-cluster.yaml
+++ b/deploy/all-in-one-cluster.yaml
@@ -134,9 +134,6 @@ spec:
       containers:
         - name: splunk-operator
           image: splunk/splunk-operator
-          ports:
-          - containerPort: 60000
-            name: metrics
           command:
           - splunk-operator
           imagePullPolicy: IfNotPresent

--- a/deploy/all-in-one-cluster.yaml
+++ b/deploy/all-in-one-cluster.yaml
@@ -1,0 +1,155 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    k8s-app: splunk-kubecontroller
+  name: splunkenterprises.enterprise.splunk.com
+spec:
+  group: enterprise.splunk.com
+  names:
+    kind: SplunkEnterprise
+    listKind: SplunkEnterpriseList
+    plural: splunkenterprises
+    shortNames:
+      - enterprise
+    singular: splunkenterprise
+  scope: Namespaced
+  version: v1alpha1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: splunk:operator:namespace-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - configmaps
+  - secrets
+  - events
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - enterprise.splunk.com
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: splunk:operator:resource-manager
+rules:
+  - apiGroups:
+      - enterprise.splunk.com
+    resources:
+      - '*'
+    verbs:
+      - '*'
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: splunk-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: splunk-operator
+  namespace: splunk-operator
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: splunk:operator:resource-manager
+subjects:
+- kind: ServiceAccount
+  name: splunk-operator
+  namespace: splunk-operator
+roleRef:
+  kind: ClusterRole
+  name: splunk:operator:resource-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: splunk:operator:namespace-manager
+  namespace: splunk-operator
+subjects:
+- kind: ServiceAccount
+  name: splunk-operator
+  namespace: splunk-operator
+roleRef:
+  kind: ClusterRole
+  name: splunk:operator:namespace-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: splunk-operator
+  namespace: splunk-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: splunk-operator
+  template:
+    metadata:
+      labels:
+        name: splunk-operator
+    spec:
+      serviceAccountName: splunk-operator
+      containers:
+        - name: splunk-operator
+          image: splunk/splunk-operator
+          ports:
+          - containerPort: 60000
+            name: metrics
+          command:
+          - splunk-operator
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "splunk-operator"
+            - name: SPLUNK_IMAGE
+              value: "splunk/splunk:8.0"
+            - name: SPARK_IMAGE
+              value: "splunk/spark"

--- a/deploy/all-in-one-scoped.yaml
+++ b/deploy/all-in-one-scoped.yaml
@@ -1,4 +1,82 @@
 ---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    k8s-app: splunk-kubecontroller
+  name: splunkenterprises.enterprise.splunk.com
+spec:
+  group: enterprise.splunk.com
+  names:
+    kind: SplunkEnterprise
+    listKind: SplunkEnterpriseList
+    plural: splunkenterprises
+    shortNames:
+      - enterprise
+    singular: splunkenterprise
+  scope: Namespaced
+  version: v1alpha1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: splunk:operator:namespace-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - configmaps
+  - secrets
+  - events
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - enterprise.splunk.com
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: splunk:operator:resource-manager
+rules:
+  - apiGroups:
+      - enterprise.splunk.com
+    resources:
+      - '*'
+    verbs:
+      - '*'
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/all-in-one-scoped.yaml
+++ b/deploy/all-in-one-scoped.yaml
@@ -112,8 +112,6 @@ spec:
       containers:
         - name: splunk-operator
           image: splunk/splunk-operator
-          command:
-          - splunk-operator
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/all-in-one-scoped.yaml
+++ b/deploy/all-in-one-scoped.yaml
@@ -112,9 +112,6 @@ spec:
       containers:
         - name: splunk-operator
           image: splunk/splunk-operator
-          ports:
-          - containerPort: 60000
-            name: metrics
           command:
           - splunk-operator
           imagePullPolicy: IfNotPresent

--- a/deploy/cluster_operator.yaml
+++ b/deploy/cluster_operator.yaml
@@ -1,16 +1,37 @@
 ---
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: splunk-operator
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: splunk-operator
+  namespace: splunk-operator
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: splunk:operator:resource-manager
+subjects:
+- kind: ServiceAccount
+  name: splunk-operator
+  namespace: splunk-operator
+roleRef:
+  kind: ClusterRole
+  name: splunk:operator:resource-manager
+  apiGroup: rbac.authorization.k8s.io
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: splunk:operator:namespace-manager
+  namespace: splunk-operator
 subjects:
 - kind: ServiceAccount
   name: splunk-operator
+  namespace: splunk-operator
 roleRef:
   kind: ClusterRole
   name: splunk:operator:namespace-manager
@@ -20,6 +41,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: splunk-operator
+  namespace: splunk-operator
 spec:
   replicas: 1
   selector:
@@ -42,9 +64,7 @@ spec:
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/cluster_operator.yaml
+++ b/deploy/cluster_operator.yaml
@@ -56,11 +56,6 @@ spec:
       containers:
         - name: splunk-operator
           image: splunk/splunk-operator
-          ports:
-          - containerPort: 60000
-            name: metrics
-          command:
-          - splunk-operator
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/crds/enterprise_v1alpha1_splunkenterprise_crd.yaml
+++ b/deploy/crds/enterprise_v1alpha1_splunkenterprise_crd.yaml
@@ -16,17 +16,3 @@ spec:
     singular: splunkenterprise
   scope: Namespaced
   version: v1alpha1
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  labels:
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
-  name: splunk:splunk-enterprise-operator
-rules:
-  - apiGroups:
-      - enterprise.splunk.com
-    resources:
-      - '*'
-    verbs:
-      - '*'

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -34,11 +34,6 @@ spec:
       containers:
         - name: splunk-operator
           image: splunk/splunk-operator
-          ports:
-          - containerPort: 60000
-            name: metrics
-          command:
-          - splunk-operator
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -1,9 +1,8 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
-  creationTimestamp: null
-  name: splunk-operator
+  name: splunk:operator:namespace-manager
 rules:
 - apiGroups:
   - ""
@@ -13,6 +12,7 @@ rules:
   - persistentvolumeclaims
   - configmaps
   - secrets
+  - events
   verbs:
   - create
   - delete
@@ -21,14 +21,6 @@ rules:
   - list
   - patch
   - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - apps
@@ -52,3 +44,17 @@ rules:
   - '*'
   verbs:
   - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: splunk:operator:resource-manager
+rules:
+  - apiGroups:
+      - enterprise.splunk.com
+    resources:
+      - '*'
+    verbs:
+      - '*'

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -2,11 +2,12 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: splunk-operator
+  name: splunk:operator:namespace-manager
 subjects:
 - kind: ServiceAccount
   name: splunk-operator
+  namespace: splunk-operator
 roleRef:
-  kind: Role
-  name: splunk-operator
+  kind: ClusterRole
+  name: splunk:operator:namespace-manager
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: splunk-operator

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -1,5 +1,35 @@
 # Splunk Operator for Kubernetes Change Log
 
+## 0.0.6 Alpha (2019-12-12)
+
+* The operator now injects a podAntiAffinity rule to try to ensure
+  that no two pods of the same type are scheduled on the same host
+
+* Ingest updates: HEC is now always enabled by default; added S2S port
+  9997 to indexer pod specs, added splunk-indexer-service, doc updates
+
+* Fixed bugs and updated docs, YAML deployment files, roles and bindings
+  to better accomodate using a single instance of the Splunk operator to
+  manage SplunkEnterprise stacks across an entire cluster (cluster scope).
+
+* Fixed deadlock condition between deployer and search heads when
+  apps_location is specified (note this this also requires a patch
+  in splunk-ansible https://github.com/splunk/splunk-ansible/pull/312
+
+* Fixed issues with randomly generated secrets sometimes containing
+  characters that broken ansible's YAML parsing, causing failures
+  to provision new stacks. All randomly-generated secrets now use
+  only alpha-numeric characters. Exception is hec_token which now
+  uses a UUID like format.
+
+* DFS spark worker pool now uses a Deployment instead of StatefulSet
+
+* Added annotations to get istio to not intercept certain ports
+
+* Removed unused port 60000 from splunk-operator deployment spec
+
+* Pod template change now log the name of the thing that was updated
+
 ## 0.0.5 Alpha (2019-10-31)
 
 * Added port 8088 to expose on indexers, and only exposting DFC ports on search heads

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -1,5 +1,16 @@
 # Configuring Splunk Enterprise Deployments
 
+This document includes various examples for configuring Splunk Enterprise
+deployments.
+
+* [Creating a ConfigMap for Your License](#creating-a-configmap-for-your-license)
+* [Creating a Clustered Deployment](#creating-a-clustered-deployment)
+* [Creating a Cluster with Data Fabric Search (DFS)](#creating-a-cluster-with-data-fabric-search-(dfs))
+* [Using Default Settings](#using-default-settings)
+* [Installing Splunk Apps](#installing-splunk-apps)
+* [Using Apps for Splunk Configuration](#using-apps-for-splunk-configuration)
+
+
 ## Creating a ConfigMap for Your License
 
 Many of the examples in this document require that you have a valid Splunk
@@ -170,7 +181,7 @@ kubectl delete splunkenterprise/dfscluster
 ```
 
 
-## Default Settings
+## Using Default Settings
 
 The Splunk Enterprise container supports many
 [default configuration settings](https://github.com/splunk/splunk-ansible/blob/develop/docs/advanced/default.yml.spec.md)
@@ -234,3 +245,113 @@ spec:
 *Setting passwords in your CRDs may be OK for testing, but it is discouraged.*
 
 Inline `defaults` are always processed last, after any `defaultsUrl` files.
+
+
+## Installing Splunk Apps
+
+*Note that this requires using the Splunk Enterprise container version 8.0.1 or later*
+
+The Splunk Operator can be used to automatically install apps for you by
+including the `apps_location` parameter in your default settings. The value
+may either be a comma-separated list of apps or a YAML list, with each app
+referenced using a filesystem path or URL.
+
+When using filesystem paths, the apps should be mounted using the
+`splunkVolumes` parameter. This may be used to reference either Kubernetes
+ConfigMaps or multi-read Volumes.
+
+For example, let's say you want to store two of your apps (`app1.tgz` and
+`app2.tgz`) in a ConfigMap named `splunk-apps`:
+
+```
+kubectl create configmap splunk-apps --from-file=app1.tgz --from-file=app2.tgz
+```
+
+You can have the Splunk Operator install these automatically using something
+like the following:
+
+```yaml
+apiVersion: "enterprise.splunk.com/v1alpha1"
+kind: "SplunkEnterprise"
+metadata:
+  name: "example"
+spec:
+  splunkVolumes:
+    - name: apps
+      configMap:
+        name: splunk-apps
+  defaults: |-
+    splunk:
+      apps_location:
+        - "/mnt/apps/app1.tgz"
+        - "/mnt/apps/app2.tgz"
+```
+
+If you are using a search head cluster, the deployer will be used to push
+these apps out to your search heads.
+
+Instead of using a YAML list, you could also have used a comma-separated list:
+
+```yaml
+  defaults: |-
+    splunk:
+      apps_location: "/mnt/apps/app1.tgz,/mnt/apps/app2.tgz"
+```
+
+You can also install apps hosted remotely using URLs:
+
+```yaml
+    splunk:
+      apps_location:
+        - "/mnt/apps/app1.tgz"
+        - "/mnt/apps/app2.tgz"
+        - "https://example.com/splunk-apps/app3.tgz"
+```
+
+
+## Using Apps for Splunk Configuration
+
+Splunk Enterprise apps are often used to package custom configuration files.
+An app in its simplest form needs only to provide a `default/app.conf` file.
+To create a new app, first create a directory containing a `default`
+subdirectory. For example, let's create a simple app in a directory named
+`myapp`:
+
+```
+mkdir -p myapp/default && cat <<EOF > myapp/default/app.conf
+[install]
+is_configured = 0
+
+[ui]
+is_visible = 1
+label = My Splunk App
+
+[launcher]
+author = Me
+description = My Splunk App for Custom Configuration
+version = 1.0
+EOF
+```
+
+Next, we'll add a few event type knowledge objects (from
+[docs](https://docs.splunk.com/Documentation/Splunk/latest/Knowledge/Configureeventtypes)):
+
+```
+cat <<EOF > myapp/default/eventtypes.conf
+[web]
+search = html OR http OR https OR css OR htm OR html OR shtml OR xls OR cgi
+
+[fatal]
+search = FATAL
+EOF
+```
+
+Splunk apps are typically packaged into gzip'd tarballs:
+
+```
+tar cvzf myapp.tgz myapp
+```
+
+You now have your custom knowledge objects configuration packaged into an app
+that can be automatically deployed to your Splunk Enterprise clusters by
+following instructions from the [previous example](#installing-splunk-apps).

--- a/docs/Ingress.md
+++ b/docs/Ingress.md
@@ -335,6 +335,6 @@ spec:
     loadBalancer:
       consistentHash:
         httpCookie:
-        name: SPLUNK_ISTIO_SESSION
-        ttl: 3600s
+          name: SPLUNK_ISTIO_SESSION
+          ttl: 3600s
 ```

--- a/docs/Ingress.md
+++ b/docs/Ingress.md
@@ -17,6 +17,7 @@ $ kubectl get services -o name
 service/splunk-cluster-cluster-master-service
 service/splunk-cluster-deployer-service
 service/splunk-cluster-indexer-headless
+service/splunk-cluster-indexer-service
 service/splunk-cluster-license-master-service
 service/splunk-cluster-search-head-headless
 service/splunk-cluster-search-head-service
@@ -70,7 +71,7 @@ spec:
           servicePort: 8000
       - path: /services/collector
         backend:
-          serviceName: splunk-example-indexer-headless
+          serviceName: splunk-example-indexer-service
           servicePort: 8088
   - host: deployer.splunk.example.com
     http:
@@ -256,7 +257,7 @@ spec:
     - destination:
         port:
           number: 8088
-        host: splunk-example-indexer-headless
+        host: splunk-example-indexer-service
   - route:
     - destination:
         port:
@@ -269,7 +270,7 @@ spec:
     - destination:
         port:
           number: 9997
-        host: splunk-example-indexer-headless
+        host: splunk-example-indexer-service
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService

--- a/docs/Ingress.md
+++ b/docs/Ingress.md
@@ -58,16 +58,20 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/affinity: cookie
-    nginx.ingress.kubernetes.io/rewrite-target: /
     certmanager.k8s.io/cluster-issuer: "letsencrypt-prod"
 spec:
   rules:
   - host: splunk.example.com
     http:
       paths:
-      - backend:
-          serviceName: splunk-dfscluster-search-head-service
+      - path: /
+        backend:
+          serviceName: splunk-example-search-head-service
           servicePort: 8000
+      - path: /services/collector
+        backend:
+          serviceName: splunk-example-indexer-headless
+          servicePort: 8088
   - host: deployer.splunk.example.com
     http:
       paths:
@@ -92,12 +96,6 @@ spec:
       - backend:
           serviceName: splunk-example-spark-master-service
           servicePort: 8009
-  - host: hec.splunk.example.com
-    http:
-      paths:
-      - backend:
-          serviceName: splunk-example-indexer-headless
-          servicePort: 8088
   tls:
   - hosts:
     - splunk.example.com
@@ -105,7 +103,6 @@ spec:
     - cluster-master.splunk.example.com
     - license-master.splunk.example.com
     - spark-master.splunk.example.com
-    - hec.splunk.example.com
     secretName: splunk.example.com-tls
 ```
 
@@ -164,7 +161,6 @@ spec:
     - deployer.splunk.example.com
     - cluster-master.splunk.example.com
     - license-master.splunk.example.com
-    - hec.splunk.example.com
   issuerRef:
     name: letsencrypt-prod
     kind: ClusterIssuer
@@ -191,7 +187,6 @@ spec:
     - "deployer.splunk.example.com"
     - "cluster-master.splunk.example.com"
     - "license-master.splunk.example.com"
-    - "hec.splunk.example.com"
     tls:
       httpsRedirect: true
   - port:
@@ -206,7 +201,12 @@ spec:
     - "deployer.splunk.example.com"
     - "cluster-master.splunk.example.com"
     - "license-master.splunk.example.com"
-    - "hec.splunk.example.com"
+  - port:
+      number: 9997
+      name: tcp
+      protocol: TCP
+    hosts:
+    - "*"
 ```
 
 Note that `credentialName` references the same `secretName` created and
@@ -242,18 +242,34 @@ Next, you will need to create VirtualServices for each of the components that yo
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: splunk-search-head
+  name: splunk
 spec:
   hosts:
   - "splunk.example.com"
   gateways:
   - "splunk-gw"
   http:
+  - match:
+    - uri:
+        prefix: "/services/collector"
+    route:
+    - destination:
+        port:
+          number: 8088
+        host: splunk-example-indexer-headless
   - route:
     - destination:
         port:
           number: 8000
         host: splunk-example-search-head-service
+  tcp:
+  - match:
+    - port: 9997
+    route:
+    - destination:
+        port:
+          number: 9997
+        host: splunk-example-indexer-headless
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -302,22 +318,6 @@ spec:
         port:
           number: 8000
         host: splunk-example-license-master-service
----
-apiVersion: networking.istio.io/v1alpha3
-kind: VirtualService
-metadata:
-  name: splunk-hec
-spec:
-  hosts:
-  - "hec.splunk.example.com"
-  gateways:
-  - "splunk-gw"
-  http:
-  - route:
-    - destination:
-        port:
-          number: 8088
-        host: splunk-example-indexer-headless
 ```
 
 Finally, you will need to create a DestinationRule to ensure user sessions are

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -15,7 +15,29 @@ wget -O splunk-operator.yaml https://tiny.cc/splunk-operator-install
 ```
 
 
-## Installation for Multiple Namespaces
+## Installation By a Regular User
+
+Kubernetes only allows administrators to install new
+`CustomResourceDefinition`, `ClusterRole` and `ClusterRoleBinding` objects.
+All other objects included in the `splunk-operator.yaml` file can be installed
+by regular users within their own namespaces. If you are not an administrator,
+you can have someone else create these objects for you by running
+
+```
+kubectl apply -f https://tiny.cc/splunk-operator-cluster-admin
+```
+
+You should then be able download and use the following YAML to install the
+operator within your own namespace:
+
+```
+wget -O splunk-operator.yaml 
+kubectl config set-context --current --namespace=<NAMESPACE>
+kubectl apply -f splunk-operator.yaml
+```
+
+
+## Admin Installation for All Namespaces
 
 If you wish to have a single instance of the operator managing Splunk
 objects for all the namespaces of your cluster, you can use the alternative
@@ -84,120 +106,15 @@ to the appropriate locations.
 ```
 
 
-## For Kubernetes Administrators
+## Installing Splunk Operator
 
-If you are an administrator of your Kubernetes cluster, you can install and
-start the operator by running
+You can install and start the operator by running
 
 ```
 kubectl apply -f splunk-operator.yaml
 ```
 
-
-## For Other Kubernetes Users (Not Administrators)
-
-Please note that Kubernetes only allows administrators to install new
-`CustomResourceDefinition` and `ClusterRole` objects. All other objects
-included in the `splunk-operator.yaml` file can be installed by regular users
-within their own namespaces. If you are not an administrator, you can have
-someone else create these objects for you by running
-
-```yaml
-cat <<EOF | kubectl apply -f -
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  labels:
-    k8s-app: splunk-kubecontroller
-  name: splunkenterprises.enterprise.splunk.com
-spec:
-  group: enterprise.splunk.com
-  names:
-    kind: SplunkEnterprise
-    listKind: SplunkEnterpriseList
-    plural: splunkenterprises
-    shortNames:
-    - enterprise
-    singular: splunkenterprise
-  scope: Namespaced
-  version: v1alpha1
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: splunk:operator:namespace-manager
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - configmaps
-  - secrets
-  - events
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - enterprise.splunk.com
-  resources:
-  - '*'
-  verbs:
-  - '*'
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  labels:
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
-  name: splunk:operator:resource-manager
-rules:
-  - apiGroups:
-      - enterprise.splunk.com
-    resources:
-      - '*'
-    verbs:
-      - '*'
-EOF
-```
-
-After removing the above content from the beginning of your 
-`splunk-operator.yaml` file, you should be able to install the Splunk 
-Operator within your own namespace by running
-
-```
-kubectl config set-context --current --namespace=<NAMESPACE>
-kubectl apply -f splunk-operator.yaml
-```
-
-
-## After Installation
-
-After starting the Splunk Operator, you should see a single pod running
+After starting the operator, you should see a single pod running
 within your namespace:
 
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,8 +105,9 @@ Users of Red Hat OpenShift should read the additional
 [Red Hat OpenShift](OpenShift.md) documentation.
 
 Please see the [Advanced Installation Instructions](Install.md) for
-special considerations, including the use of private image registries and
-installing as a regular user (who is not a Kubernetes cluster administrator).
+special considerations, including the use of private image registries,
+installation at cluster scope, and installing as a regular user (who is
+not a Kubernetes cluster administrator).
 
 *Note: The `splunk/splunk:8.0` image is rather large, so we strongly
 recommend copying this to a private registry or directly onto your

--- a/pkg/splunk/deploy/deployment.go
+++ b/pkg/splunk/deploy/deployment.go
@@ -52,7 +52,7 @@ func ApplyDeployment(client client.Client, deployment *appsv1.Deployment) error 
 		// found existing Deployment
 		if MergeDeploymentUpdates(&current, deployment) {
 			// only update if there are material differences, as determined by comparison function
-			err = UpdateResource(client, deployment)
+			err = UpdateResource(client, &current)
 		} else {
 			log.Printf("No changes for Deployment %s in namespace %s\n", deployment.GetObjectMeta().GetName(), deployment.GetObjectMeta().GetNamespace())
 		}
@@ -79,7 +79,7 @@ func MergeDeploymentUpdates(current *appsv1.Deployment, revised *appsv1.Deployme
 	}
 
 	// check for changes in Pod template
-	if MergePodUpdates(&current.Spec.Template, &revised.Spec.Template) {
+	if MergePodUpdates(&current.Spec.Template, &revised.Spec.Template, current.GetObjectMeta().GetName()) {
 		result = true
 	}
 

--- a/pkg/splunk/deploy/launch.go
+++ b/pkg/splunk/deploy/launch.go
@@ -287,12 +287,17 @@ func LaunchSparkCluster(cr *v1alpha1.SplunkEnterprise, client client.Client) err
 		return err
 	}
 
-	err = ApplySparkDeployment(cr, client, spark.SparkMaster, 1, spark.GetSparkMasterConfiguration(), spark.GetSparkMasterContainerPorts())
+	err = ApplySparkDeployment(cr,
+		client,
+		spark.SparkMaster,
+		1,
+		spark.GetSparkMasterConfiguration(),
+		spark.GetSparkMasterContainerPorts())
 	if err != nil {
 		return err
 	}
 
-	err = ApplySparkStatefulSet(cr,
+	err = ApplySparkDeployment(cr,
 		client,
 		spark.SparkWorker,
 		cr.Spec.Topology.SparkWorkers,

--- a/pkg/splunk/deploy/launch.go
+++ b/pkg/splunk/deploy/launch.go
@@ -236,6 +236,11 @@ func LaunchIndexers(cr *v1alpha1.SplunkEnterprise, client client.Client) error {
 		return err
 	}
 
+	err = ApplyService(client, enterprise.GetSplunkService(cr, enterprise.SplunkIndexer, false))
+	if err != nil {
+		return err
+	}
+
 	return err
 }
 

--- a/pkg/splunk/deploy/statefulset.go
+++ b/pkg/splunk/deploy/statefulset.go
@@ -25,24 +25,12 @@ import (
 
 	"github.com/splunk/splunk-operator/pkg/apis/enterprise/v1alpha1"
 	"github.com/splunk/splunk-operator/pkg/splunk/enterprise"
-	"github.com/splunk/splunk-operator/pkg/splunk/spark"
 )
 
 // ApplySplunkStatefulSet creates or updates a Kubernetes StatefulSet for a given type of Splunk Enterprise instance (indexers or search heads).
 func ApplySplunkStatefulSet(cr *v1alpha1.SplunkEnterprise, client client.Client, instanceType enterprise.InstanceType, replicas int, envVariables []corev1.EnvVar) error {
 
 	statefulSet, err := enterprise.GetSplunkStatefulSet(cr, instanceType, replicas, envVariables)
-	if err != nil {
-		return err
-	}
-
-	return ApplyStatefulSet(client, statefulSet)
-}
-
-// ApplySparkStatefulSet creates or updates a Kubernetes StatefulSet for a given type of Spark instance (master or workers).
-func ApplySparkStatefulSet(cr *v1alpha1.SplunkEnterprise, client client.Client, instanceType spark.InstanceType, replicas int, envVariables []corev1.EnvVar, containerPorts []corev1.ContainerPort) error {
-
-	statefulSet, err := spark.GetSparkStatefulSet(cr, instanceType, replicas, envVariables, containerPorts)
 	if err != nil {
 		return err
 	}
@@ -91,7 +79,7 @@ func MergeStatefulSetUpdates(current *appsv1.StatefulSet, revised *appsv1.Statef
 	}
 
 	// check for changes in Pod template
-	if MergePodUpdates(&current.Spec.Template, &revised.Spec.Template) {
+	if MergePodUpdates(&current.Spec.Template, &revised.Spec.Template, current.GetObjectMeta().GetName()) {
 		result = true
 	}
 

--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -271,6 +271,10 @@ func GetSplunkStatefulSet(cr *v1alpha1.SplunkEnterprise, instanceType InstanceTy
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
+					Annotations: map[string]string{
+						"traffic.sidecar.istio.io/excludeOutboundPorts": "8089",
+						"traffic.sidecar.istio.io/includeInboundPorts":  "19000,9000,8000,17000",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Affinity:      cr.Spec.Affinity,

--- a/pkg/splunk/enterprise/names.go
+++ b/pkg/splunk/enterprise/names.go
@@ -24,14 +24,32 @@ import (
 )
 
 const (
-	deploymentTemplateStr     = "splunk-%s-%s"       // identifier, instanceType (ex: standalone, indexers, etc...)
-	statefulSetTemplateStr    = "splunk-%s-%s"       // identifier, instanceType (ex: standalone, indexers, etc...)
-	statefulSetPodTemplateStr = "splunk-%s-%s-%d"    // identifier, instanceType, index (ex: 0, 1, 2, ...)
-	serviceTemplateStr        = "splunk-%s-%s-%s"    // identifier, instanceType, "headless" or "service"
-	secretsTemplateStr        = "splunk-%s-secrets"  // identifier
-	defaultsTemplateStr       = "splunk-%s-defaults" // identifier
-	defaultSplunkImage        = "splunk/splunk"      // default docker image used for Splunk instances
-	splunkSecretLen           = 24
+	// identifier, instanceType (ex: standalone, indexers, etc...)
+	deploymentTemplateStr = "splunk-%s-%s"
+
+	// identifier, instanceType (ex: standalone, indexers, etc...)
+	statefulSetTemplateStr = "splunk-%s-%s"
+
+	// identifier, instanceType, index (ex: 0, 1, 2, ...)
+	statefulSetPodTemplateStr = "splunk-%s-%s-%d"
+
+	// identifier, instanceType, "headless" or "service"
+	serviceTemplateStr = "splunk-%s-%s-%s"
+
+	// identifier
+	secretsTemplateStr = "splunk-%s-secrets"
+
+	// identifier
+	defaultsTemplateStr = "splunk-%s-defaults"
+
+	// default docker image used for Splunk instances
+	defaultSplunkImage = "splunk/splunk"
+
+	// bytes used to generate random hexidecimal strings (e.g. HEC tokens)
+	hexBytes = "ABCDEF01234567890"
+
+	// bytes used to generate Splunk secrets
+	secretBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 )
 
 // GetSplunkDeploymentName uses a template to name a Kubernetes Deployment for Splunk instances.

--- a/pkg/splunk/resources/util.go
+++ b/pkg/splunk/resources/util.go
@@ -30,10 +30,6 @@ import (
 	"github.com/splunk/splunk-operator/pkg/apis/enterprise/v1alpha1"
 )
 
-const (
-	secretBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890%()*+,-./<=>?@^_|~"
-)
-
 func init() {
 	// seed random number generator for splunk secret generation
 	rand.Seed(time.Now().UnixNano())
@@ -84,7 +80,7 @@ func GetServiceFQDN(namespace string, name string) string {
 }
 
 // GenerateSecret returns a randomly generated sequence of text that is n bytes in length.
-func GenerateSecret(n int) []byte {
+func GenerateSecret(secretBytes string, n int) []byte {
 	b := make([]byte, n)
 	for i := range b {
 		b[i] = secretBytes[rand.Int63()%int64(len(secretBytes))]

--- a/pkg/splunk/resources/util.go
+++ b/pkg/splunk/resources/util.go
@@ -88,6 +88,14 @@ func GenerateSecret(secretBytes string, n int) []byte {
 	return b
 }
 
+// SortPorts returns a sorted list of Kubernetes ContainerPorts.
+func SortPorts(ports []corev1.ContainerPort) []corev1.ContainerPort {
+	sorted := make([]corev1.ContainerPort, len(ports))
+	copy(sorted, ports)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].ContainerPort < sorted[j].ContainerPort })
+	return sorted
+}
+
 // ComparePorts is a generic comparer of two Kubernetes ContainerPorts.
 // It returns true if there are material differences between them, or false otherwise.
 // TODO: could use refactoring; lots of boilerplate copy-pasta here
@@ -97,15 +105,9 @@ func ComparePorts(a []corev1.ContainerPort, b []corev1.ContainerPort) bool {
 		return true
 	}
 
-	// make sorted copy of a
-	aSorted := make([]corev1.ContainerPort, len(a))
-	copy(aSorted, a)
-	sort.Slice(aSorted, func(i, j int) bool { return aSorted[i].ContainerPort < aSorted[j].ContainerPort })
-
-	// make sorted copy of b
-	bSorted := make([]corev1.ContainerPort, len(b))
-	copy(bSorted, b)
-	sort.Slice(bSorted, func(i, j int) bool { return bSorted[i].ContainerPort < bSorted[j].ContainerPort })
+	// make sorted copies of a and b
+	aSorted := SortPorts(a)
+	bSorted := SortPorts(b)
 
 	// iterate elements, checking for differences
 	for n := range aSorted {
@@ -115,6 +117,14 @@ func ComparePorts(a []corev1.ContainerPort, b []corev1.ContainerPort) bool {
 	}
 
 	return false
+}
+
+// SortEnvs returns a sorted list of Kubernetes EnvVar.
+func SortEnvs(envvars []corev1.EnvVar) []corev1.EnvVar {
+	sorted := make([]corev1.EnvVar, len(envvars))
+	copy(sorted, envvars)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+	return sorted
 }
 
 // CompareEnvs is a generic comparer of two Kubernetes Env variables.
@@ -125,15 +135,9 @@ func CompareEnvs(a []corev1.EnvVar, b []corev1.EnvVar) bool {
 		return true
 	}
 
-	// make sorted copy of a
-	aSorted := make([]corev1.EnvVar, len(a))
-	copy(aSorted, a)
-	sort.Slice(aSorted, func(i, j int) bool { return aSorted[i].Name < aSorted[j].Name })
-
-	// make sorted copy of b
-	bSorted := make([]corev1.EnvVar, len(b))
-	copy(bSorted, b)
-	sort.Slice(bSorted, func(i, j int) bool { return bSorted[i].Name < bSorted[j].Name })
+	// make sorted copies of a and b
+	aSorted := SortEnvs(a)
+	bSorted := SortEnvs(b)
 
 	// iterate elements, checking for differences
 	for n := range aSorted {
@@ -145,6 +149,14 @@ func CompareEnvs(a []corev1.EnvVar, b []corev1.EnvVar) bool {
 	return false
 }
 
+// SortVolumeMounts returns a sorted list of Kubernetes VolumeMounts.
+func SortVolumeMounts(mounts []corev1.VolumeMount) []corev1.VolumeMount {
+	sorted := make([]corev1.VolumeMount, len(mounts))
+	copy(sorted, mounts)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+	return sorted
+}
+
 // CompareVolumeMounts is a generic comparer of two Kubernetes VolumeMounts.
 // It returns true if there are material differences between them, or false otherwise.
 func CompareVolumeMounts(a []corev1.VolumeMount, b []corev1.VolumeMount) bool {
@@ -153,15 +165,9 @@ func CompareVolumeMounts(a []corev1.VolumeMount, b []corev1.VolumeMount) bool {
 		return true
 	}
 
-	// make sorted copy of a
-	aSorted := make([]corev1.VolumeMount, len(a))
-	copy(aSorted, a)
-	sort.Slice(aSorted, func(i, j int) bool { return aSorted[i].Name < aSorted[j].Name })
-
-	// make sorted copy of b
-	bSorted := make([]corev1.VolumeMount, len(b))
-	copy(bSorted, b)
-	sort.Slice(bSorted, func(i, j int) bool { return bSorted[i].Name < bSorted[j].Name })
+	// make sorted copies of a and b
+	aSorted := SortVolumeMounts(a)
+	bSorted := SortVolumeMounts(b)
 
 	// iterate elements, checking for differences
 	for n := range aSorted {
@@ -194,7 +200,10 @@ func CompareByMarshall(a interface{}, b interface{}) bool {
 }
 
 // GetIstioAnnotations returns a map of istio annotations for a pod template
-func GetIstioAnnotations(ports []corev1.ContainerPort, excludeOutboundPorts []int32) map[string]string {
+func GetIstioAnnotations(ports []corev1.ContainerPort) map[string]string {
+	// list of ports within the deployments that we want istio to leave alone
+	excludeOutboundPorts := []int32{8089, 8191, 9997, 7777, 9000, 17000, 17500, 19000}
+
 	// calculate outbound port exclusions
 	excludeOutboundPortsLookup := make(map[int32]bool)
 	excludeOutboundPortsBuf := bytes.NewBufferString("")
@@ -208,13 +217,14 @@ func GetIstioAnnotations(ports []corev1.ContainerPort, excludeOutboundPorts []in
 
 	// calculate inbound port inclusions
 	includeInboundPortsBuf := bytes.NewBufferString("")
-	for idx := range ports {
-		_, skip := excludeOutboundPortsLookup[ports[idx].ContainerPort]
+	sortedPorts := SortPorts(ports)
+	for idx := range sortedPorts {
+		_, skip := excludeOutboundPortsLookup[sortedPorts[idx].ContainerPort]
 		if !skip {
 			if includeInboundPortsBuf.Len() > 0 {
 				fmt.Fprint(includeInboundPortsBuf, ",")
 			}
-			fmt.Fprintf(includeInboundPortsBuf, "%d", ports[idx].ContainerPort)
+			fmt.Fprintf(includeInboundPortsBuf, "%d", sortedPorts[idx].ContainerPort)
 		}
 	}
 
@@ -222,4 +232,60 @@ func GetIstioAnnotations(ports []corev1.ContainerPort, excludeOutboundPorts []in
 		"traffic.sidecar.istio.io/excludeOutboundPorts": excludeOutboundPortsBuf.String(),
 		"traffic.sidecar.istio.io/includeInboundPorts":  includeInboundPortsBuf.String(),
 	}
+}
+
+// GetLabels returns a map of labels to use for managed components.
+func GetLabels(identifier string, typeLabel string, isSelector bool) map[string]string {
+	// see https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels
+
+	result := make(map[string]string)
+
+	if !isSelector {
+		result = map[string]string{
+			"app":                          "splunk",
+			"for":                          identifier,
+			"type":                         typeLabel,
+			"app.kubernetes.io/name":       fmt.Sprintf("splunk-%s", identifier),
+			"app.kubernetes.io/part-of":    "splunk",
+			"app.kubernetes.io/managed-by": "splunk-operator",
+		}
+	}
+
+	result["app.kubernetes.io/instance"] = fmt.Sprintf("splunk-%s-%s", identifier, typeLabel)
+
+	return result
+}
+
+// AppendPodAntiAffinity appends a Kubernetes Affinity object to include anti-affinity for pods of the same type, and returns the result.
+func AppendPodAntiAffinity(affinity *corev1.Affinity, identifier string, typeLabel string) *corev1.Affinity {
+	if affinity == nil {
+		affinity = &corev1.Affinity{}
+	} else {
+		affinity = affinity.DeepCopy()
+	}
+
+	if affinity.PodAntiAffinity == nil {
+		affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
+	}
+
+	affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+		affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+		corev1.WeightedPodAffinityTerm{
+			Weight: 100,
+			PodAffinityTerm: corev1.PodAffinityTerm{
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "app.kubernetes.io/instance",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{fmt.Sprintf("splunk-%s-%s", identifier, typeLabel)},
+						},
+					},
+				},
+				TopologyKey: "kubernetes.io/hostname",
+			},
+		},
+	)
+
+	return affinity
 }

--- a/pkg/splunk/spark/configuration.go
+++ b/pkg/splunk/spark/configuration.go
@@ -165,6 +165,7 @@ func GetSparkDeployment(cr *v1alpha1.SplunkEnterprise, instanceType InstanceType
 	// prepare labels and other values
 	labels := GetSparkAppLabels(cr.GetIdentifier(), instanceType.ToString())
 	replicas32 := int32(replicas)
+	annotations := resources.GetIstioAnnotations(ports, []int32{7777, 17500})
 
 	// create deployment configuration
 	deployment := &appsv1.Deployment{
@@ -183,11 +184,8 @@ func GetSparkDeployment(cr *v1alpha1.SplunkEnterprise, instanceType InstanceType
 			Replicas: &replicas32,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
-					Annotations: map[string]string{
-						"traffic.sidecar.istio.io/excludeOutboundPorts": "7777,17500",
-						"traffic.sidecar.istio.io/includeInboundPorts":  "7000,8009",
-					},
+					Labels:      labels,
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					Affinity:      cr.Spec.Affinity,
@@ -225,6 +223,7 @@ func GetSparkStatefulSet(cr *v1alpha1.SplunkEnterprise, instanceType InstanceTyp
 	// prepare labels and other values
 	labels := GetSparkAppLabels(cr.GetIdentifier(), instanceType.ToString())
 	replicas32 := int32(replicas)
+	annotations := resources.GetIstioAnnotations(containerPorts, []int32{7777, 17500})
 
 	// create StatefulSet configuration
 	statefulSet := &appsv1.StatefulSet{
@@ -245,11 +244,8 @@ func GetSparkStatefulSet(cr *v1alpha1.SplunkEnterprise, instanceType InstanceTyp
 			PodManagementPolicy: "Parallel",
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
-					Annotations: map[string]string{
-						"traffic.sidecar.istio.io/excludeOutboundPorts": "7777,17500",
-						"traffic.sidecar.istio.io/includeInboundPorts":  "7000,8009",
-					},
+					Labels:      labels,
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					Affinity:      cr.Spec.Affinity,

--- a/pkg/splunk/spark/configuration.go
+++ b/pkg/splunk/spark/configuration.go
@@ -184,6 +184,10 @@ func GetSparkDeployment(cr *v1alpha1.SplunkEnterprise, instanceType InstanceType
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
+					Annotations: map[string]string{
+						"traffic.sidecar.istio.io/excludeOutboundPorts": "7777,17500",
+						"traffic.sidecar.istio.io/includeInboundPorts":  "7000,8009",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Affinity:      cr.Spec.Affinity,
@@ -242,6 +246,10 @@ func GetSparkStatefulSet(cr *v1alpha1.SplunkEnterprise, instanceType InstanceTyp
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
+					Annotations: map[string]string{
+						"traffic.sidecar.istio.io/excludeOutboundPorts": "7777,17500",
+						"traffic.sidecar.istio.io/includeInboundPorts":  "7000,8009",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Affinity:      cr.Spec.Affinity,

--- a/pkg/splunk/spark/configuration.go
+++ b/pkg/splunk/spark/configuration.go
@@ -26,14 +26,10 @@ import (
 	"github.com/splunk/splunk-operator/pkg/splunk/resources"
 )
 
-// GetSparkAppLabels returns a map of labels to use for Spark instances.
-func GetSparkAppLabels(identifier string, typeLabel string) map[string]string {
-	labels := map[string]string{
-		"app":  "spark",
-		"for":  identifier,
-		"type": typeLabel,
-	}
-
+// GetSparkAppLabels returns a map of labels to use for Spark components.
+func GetSparkAppLabels(identifier string, typeLabel string, isSelector bool) map[string]string {
+	labels := resources.GetLabels(identifier, typeLabel, isSelector)
+	labels["app"] = "spark"
 	return labels
 }
 
@@ -122,6 +118,9 @@ func GetSparkWorkerConfiguration(identifier string) []corev1.EnvVar {
 		}, {
 			Name:  "SPARK_MASTER_HOSTNAME",
 			Value: GetSparkServiceName(SparkMaster, identifier, false),
+		}, {
+			Name:  "SPARK_WORKER_PORT", // this is set in new versions of splunk/spark container, but defined here for backwards-compatability
+			Value: "7777",
 		},
 	}
 }
@@ -162,10 +161,10 @@ func GetSparkRequirements(cr *v1alpha1.SplunkEnterprise) (corev1.ResourceRequire
 // GetSparkDeployment returns a Kubernetes Deployment object for the Spark master configured for a SplunkEnterprise resource.
 func GetSparkDeployment(cr *v1alpha1.SplunkEnterprise, instanceType InstanceType, replicas int, envVariables []corev1.EnvVar, ports []corev1.ContainerPort) (*appsv1.Deployment, error) {
 
-	// prepare labels and other values
-	labels := GetSparkAppLabels(cr.GetIdentifier(), instanceType.ToString())
+	// prepare values
 	replicas32 := int32(replicas)
-	annotations := resources.GetIstioAnnotations(ports, []int32{7777, 17500})
+	annotations := resources.GetIstioAnnotations(ports)
+	affinity := resources.AppendPodAntiAffinity(cr.Spec.Affinity, cr.GetIdentifier(), instanceType.ToString())
 
 	// create deployment configuration
 	deployment := &appsv1.Deployment{
@@ -179,16 +178,16 @@ func GetSparkDeployment(cr *v1alpha1.SplunkEnterprise, instanceType InstanceType
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: GetSparkAppLabels(cr.GetIdentifier(), instanceType.ToString(), true),
 			},
 			Replicas: &replicas32,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labels,
+					Labels:      GetSparkAppLabels(cr.GetIdentifier(), instanceType.ToString(), false),
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
-					Affinity:      cr.Spec.Affinity,
+					Affinity:      affinity,
 					SchedulerName: cr.Spec.SchedulerName,
 					Hostname:      GetSparkServiceName(instanceType, cr.GetIdentifier(), false),
 					Containers: []corev1.Container{
@@ -217,70 +216,12 @@ func GetSparkDeployment(cr *v1alpha1.SplunkEnterprise, instanceType InstanceType
 	return deployment, nil
 }
 
-// GetSparkStatefulSet returns a Kubernetes StatefulSet object for Spark workers configured for a SplunkEnterprise resource.
-func GetSparkStatefulSet(cr *v1alpha1.SplunkEnterprise, instanceType InstanceType, replicas int, envVariables []corev1.EnvVar, containerPorts []corev1.ContainerPort) (*appsv1.StatefulSet, error) {
-
-	// prepare labels and other values
-	labels := GetSparkAppLabels(cr.GetIdentifier(), instanceType.ToString())
-	replicas32 := int32(replicas)
-	annotations := resources.GetIstioAnnotations(containerPorts, []int32{7777, 17500})
-
-	// create StatefulSet configuration
-	statefulSet := &appsv1.StatefulSet{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "StatefulSet",
-			APIVersion: "apps/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      GetSparkStatefulsetName(instanceType, cr.GetIdentifier()),
-			Namespace: cr.Namespace,
-		},
-		Spec: appsv1.StatefulSetSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
-			},
-			ServiceName:         GetSparkServiceName(instanceType, cr.GetIdentifier(), true),
-			Replicas:            &replicas32,
-			PodManagementPolicy: "Parallel",
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labels,
-					Annotations: annotations,
-				},
-				Spec: corev1.PodSpec{
-					Affinity:      cr.Spec.Affinity,
-					SchedulerName: cr.Spec.SchedulerName,
-					Containers: []corev1.Container{
-						{
-							Image:           GetSparkImage(cr),
-							ImagePullPolicy: corev1.PullPolicy(cr.Spec.ImagePullPolicy),
-							Name:            "spark",
-							Ports:           containerPorts,
-							Env:             envVariables,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	statefulSet.SetOwnerReferences(append(statefulSet.GetOwnerReferences(), resources.AsOwner(cr)))
-
-	// update with common spark pod config
-	err := updateSparkPodTemplateWithConfig(&statefulSet.Spec.Template, cr, instanceType)
-	if err != nil {
-		return nil, err
-	}
-
-	return statefulSet, nil
-}
-
 // GetSparkService returns a Kubernetes Service object for Spark instances configured for a SplunkEnterprise resource.
 func GetSparkService(cr *v1alpha1.SplunkEnterprise, instanceType InstanceType, isHeadless bool, ports []corev1.ServicePort) *corev1.Service {
 
 	serviceName := GetSparkServiceName(instanceType, cr.GetIdentifier(), isHeadless)
-	serviceTypeLabels := GetSparkAppLabels(cr.GetIdentifier(), fmt.Sprintf("%s-%s", instanceType, "service"))
-	selectLabels := GetSparkAppLabels(cr.GetIdentifier(), instanceType.ToString())
+	serviceTypeLabels := GetSparkAppLabels(cr.GetIdentifier(), fmt.Sprintf("%s-%s", instanceType, "service"), false)
+	selectLabels := GetSparkAppLabels(cr.GetIdentifier(), instanceType.ToString(), true)
 
 	service := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{

--- a/version/version.go
+++ b/version/version.go
@@ -16,5 +16,5 @@ package version
 
 var (
 	// Version of splunk-operator
-	Version = "0.0.5"
+	Version = "0.0.6"
 )


### PR DESCRIPTION
 Fixed deadlock condition between deployer and search heads when apps_location is specified (note this this also requires a patch in splunk-ansible splunk/splunk-ansible#312

Updated auto-generated secrets to use alpha-numeric characters only to prevent escaping errors. This was after running into yet more circumstances where ansible plays would fail due to random bytes selected.

Updated auto-generated hec_token secret to use UUID like format

Updates to ensure HEC is always enabled by default

Updates to Ingress examples to include S2S and consolidate HEC

Added examples for app installation and custom config 