### PR TITLE
Do not require licenseURL for clusters

### DIFF
--- a/docs/SplunkEnterprise.md
+++ b/docs/SplunkEnterprise.md
@@ -42,7 +42,7 @@ The following configuration parameters can be used within a `spec` section:
 | splunkVolumes         | [Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) | List of one or more [Kubernetes volumes](https://kubernetes.io/docs/concepts/storage/volumes/). These will be mounted in all Splunk containers as as `/mnt/&lt;name&gt;` |
 | defaults              | string  | Inline map of [default.yml](https://github.com/splunk/splunk-ansible/blob/develop/docs/advanced/default.yml.spec.md) overrides used to initialize the environment     |
 | defaultsUrl           | string  | Full path or URL for one or more [default.yml](https://github.com/splunk/splunk-ansible/blob/develop/docs/advanced/default.yml.spec.md) files, separated by commas    |
-| licenseUrl            | string  | Full path or URL for a Splunk Enterprise license file                                                                                                                 |
+| licenseUrl            | string  | Full path or URL for a Splunk Enterprise license file. If defined, a license master will be created and used to manage licensing for your deployment.                 |
 | imagePullPolicy       | string  | Sets pull policy for all images (either "Always" or the default: "IfNotPresent")                                                                                      |
 | storageClassName      | string  | Name of StorageClass to use for persistent volume claims                                                                                                              |
 | schedulerName         | string  | Name of Scheduler to use for pod placement (defaults to "default-scheduler")                                                                                          |

--- a/pkg/splunk/deploy/launch.go
+++ b/pkg/splunk/deploy/launch.go
@@ -94,12 +94,13 @@ func LaunchStandalones(cr *v1alpha2.SplunkEnterprise, client ControllerClient) e
 // LaunchCluster creates all Kubernetes resources necessary to represent a complete Splunk Enterprise cluster.
 func LaunchCluster(cr *v1alpha2.SplunkEnterprise, client ControllerClient) error {
 
-	err := LaunchLicenseMaster(cr, client)
-	if err != nil {
-		return err
+	if cr.Spec.LicenseURL != "" {
+		if err := LaunchLicenseMaster(cr, client); err != nil {
+			return err
+		}
 	}
 
-	err = LaunchClusterMaster(cr, client)
+	err := LaunchClusterMaster(cr, client)
 	if err != nil {
 		return err
 	}

--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -100,10 +100,13 @@ func GetSplunkClusterConfiguration(cr *v1alpha2.SplunkEnterprise, searchHeadClus
 		}, {
 			Name:  "SPLUNK_INDEXER_URL",
 			Value: GetSplunkStatefulsetUrls(cr.GetNamespace(), SplunkIndexer, cr.GetIdentifier(), cr.Spec.Topology.Indexers, false),
-		}, {
+		},
+	}
+	if cr.Spec.LicenseURL != "" {
+		urls = append(urls, corev1.EnvVar{
 			Name:  "SPLUNK_LICENSE_MASTER_URL",
 			Value: GetSplunkServiceName(SplunkLicenseMaster, cr.GetIdentifier(), false),
-		},
+		})
 	}
 
 	searchHeadConf := []corev1.EnvVar{
@@ -341,9 +344,6 @@ func ValidateSplunkCustomResource(cr *v1alpha2.SplunkEnterprise) error {
 	}
 	if cr.Spec.Topology.SearchHeads <= 0 && cr.Spec.Topology.Indexers > 0 {
 		return errors.New("You must specify how many search heads the cluster should have")
-	}
-	if cr.Spec.Topology.Indexers > 0 && cr.Spec.Topology.SearchHeads > 0 && cr.Spec.LicenseURL == "" {
-		return errors.New("You must provide a license to create a cluster")
 	}
 
 	// default to using a single standalone instance

--- a/pkg/splunk/enterprise/configuration_test.go
+++ b/pkg/splunk/enterprise/configuration_test.go
@@ -107,6 +107,7 @@ func TestGetSplunkClusterConfiguration(t *testing.T) {
 				Indexers:    3,
 				SearchHeads: 3,
 			},
+			LicenseURL: "/path/to/splunk.lic",
 		},
 	}
 	searchHeadCluster := true
@@ -158,6 +159,15 @@ func TestGetSplunkClusterConfiguration(t *testing.T) {
 		},
 	}
 
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetSplunkClusterConfiguration(,%t,%v) = %v; want %v",
+			searchHeadCluster, overrides, got, want)
+	}
+
+	// don't set SPLUNK_LICENSE_MASTER_URL if LicenseURL is empty
+	cr.Spec.LicenseURL = ""
+	got = GetSplunkClusterConfiguration(&cr, searchHeadCluster, overrides)
+	want = append(want[:2], want[3:]...)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("GetSplunkClusterConfiguration(,%t,%v) = %v; want %v",
 			searchHeadCluster, overrides, got, want)
@@ -270,7 +280,7 @@ func TestValidateSplunkCustomResource(t *testing.T) {
 			SearchHeads: 3,
 		},
 	}
-	test(errors.New("You must provide a license to create a cluster"))
+	test(nil)
 }
 
 func TestGetSplunkDefaults(t *testing.T) {


### PR DESCRIPTION
Previously, the operator only allowed creation of clusters if a licenseURL was provided.

A license is not actually required to create clusters. Without providing a license, a time-limited trial will be created. This is especially desirable for testing.

This changes the behavior so that clusters may be created without a license. When a licenseURL is not provided, the license master will not be created and the pods in the deployment will not be configured to use a license master.