### PR TITLE
[CSPL-236] Implementation of Splunk Secrets override

### DIFF
--- a/deploy/crds/enterprise.splunk.com_indexerclusters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_indexerclusters_crd.yaml
@@ -760,6 +760,43 @@ spec:
               description: Name of Scheduler to use for pod placement (defaults to
                 “default-scheduler”)
               type: string
+            secretsRef:
+              description: SecretsRef refers to kubernetes secret that holds Splunk
+                secrets that are overriden by
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
             serviceTemplate:
               description: ServiceTemplate is a template used to create Kubernetes
                 services

--- a/deploy/crds/enterprise.splunk.com_licensemasters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_licensemasters_crd.yaml
@@ -738,6 +738,43 @@ spec:
               description: Name of Scheduler to use for pod placement (defaults to
                 “default-scheduler”)
               type: string
+            secretsRef:
+              description: SecretsRef refers to kubernetes secret that holds Splunk
+                secrets that are overriden by
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
             serviceTemplate:
               description: ServiceTemplate is a template used to create Kubernetes
                 services

--- a/deploy/crds/enterprise.splunk.com_searchheadclusters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_searchheadclusters_crd.yaml
@@ -760,6 +760,43 @@ spec:
               description: Name of Scheduler to use for pod placement (defaults to
                 “default-scheduler”)
               type: string
+            secretsRef:
+              description: SecretsRef refers to kubernetes secret that holds Splunk
+                secrets that are overriden by
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
             serviceTemplate:
               description: ServiceTemplate is a template used to create Kubernetes
                 services

--- a/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
@@ -752,6 +752,43 @@ spec:
               description: Name of Scheduler to use for pod placement (defaults to
                 “default-scheduler”)
               type: string
+            secretsRef:
+              description: SecretsRef refers to kubernetes secret that holds Splunk
+                secrets that are overriden by
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
             serviceTemplate:
               description: ServiceTemplate is a template used to create Kubernetes
                 services

--- a/pkg/apis/enterprise/v1alpha2/common_types.go
+++ b/pkg/apis/enterprise/v1alpha2/common_types.go
@@ -108,6 +108,9 @@ type CommonSplunkSpec struct {
 
 	// IndexerClusterRef refers to a Splunk Enterprise indexer cluster managed by the operator within Kubernetes
 	IndexerClusterRef corev1.ObjectReference `json:"indexerClusterRef"`
+
+	// SecretsRef refers to kubernetes secret that holds Splunk secrets that are overriden by
+	SecretsRef corev1.ObjectReference `json:"secretsRef"`
 }
 
 // MetaObject is used to represent common interfaces of custom resources

--- a/pkg/apis/enterprise/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/enterprise/v1alpha2/zz_generated.deepcopy.go
@@ -41,6 +41,7 @@ func (in *CommonSplunkSpec) DeepCopyInto(out *CommonSplunkSpec) {
 	}
 	out.LicenseMasterRef = in.LicenseMasterRef
 	out.IndexerClusterRef = in.IndexerClusterRef
+	out.SecretsRef = in.SecretsRef
 	return
 }
 

--- a/pkg/splunk/enterprise/types.go
+++ b/pkg/splunk/enterprise/types.go
@@ -35,6 +35,13 @@ const (
 
 	// SplunkLicenseMaster controls one or more license slaves
 	SplunkLicenseMaster InstanceType = "license-master"
+
+	// Splunk secrets
+	HecToken     string = "hec_token"
+	Password     string = "password"
+	Pass4SymmKey string = "pass4SymmKey"
+	IdxcSecret   string = "idxc_secret"
+	ShcSecret    string = "shc_secret"
 )
 
 // ToString returns a string for a given InstanceType

--- a/pkg/splunk/enterprise/types.go
+++ b/pkg/splunk/enterprise/types.go
@@ -36,12 +36,20 @@ const (
 	// SplunkLicenseMaster controls one or more license slaves
 	SplunkLicenseMaster InstanceType = "license-master"
 
-	// Splunk secrets
-	HecToken     string = "hec_token"
-	Password     string = "password"
+	// HecToken key
+	HecToken string = "hec_token"
+
+	// Password key
+	Password string = "password"
+
+	// Pass4SymmKey key
 	Pass4SymmKey string = "pass4SymmKey"
-	IdxcSecret   string = "idxc_secret"
-	ShcSecret    string = "shc_secret"
+
+	// IdxcSecret key
+	IdxcSecret string = "idxc_secret"
+
+	// ShcSecret key
+	ShcSecret string = "shc_secret"
 )
 
 // ToString returns a string for a given InstanceType

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2018-2020 Splunk Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enterprise
+
+import (
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// kubernetes logger used by splunk.enterprise package
+var enterpriselog = logf.Log.WithName("splunk.enterprise")

--- a/pkg/splunk/reconcile/deployment.go
+++ b/pkg/splunk/reconcile/deployment.go
@@ -25,7 +25,7 @@ import (
 
 // ApplyDeployment creates or updates a Kubernetes Deployment
 func ApplyDeployment(c ControllerClient, revised *appsv1.Deployment) (enterprisev1.ResourcePhase, error) {
-	scopedLog := log.WithName("ApplyDeployment").WithValues(
+	scopedLog := rconcilelog.WithName("ApplyDeployment").WithValues(
 		"name", revised.GetObjectMeta().GetName(),
 		"namespace", revised.GetObjectMeta().GetNamespace())
 

--- a/pkg/splunk/reconcile/finalizers.go
+++ b/pkg/splunk/reconcile/finalizers.go
@@ -32,7 +32,7 @@ const (
 // CheckSplunkDeletion checks to see if deletion was requested for the custom resource.
 // If so, it will process and remove any remaining finalizers.
 func CheckSplunkDeletion(cr enterprisev1.MetaObject, c ControllerClient) (bool, error) {
-	scopedLog := log.WithName("CheckSplunkDeletion").WithValues("kind", cr.GetTypeMeta().Kind, "name", cr.GetIdentifier(), "namespace", cr.GetNamespace())
+	scopedLog := rconcilelog.WithName("CheckSplunkDeletion").WithValues("kind", cr.GetTypeMeta().Kind, "name", cr.GetIdentifier(), "namespace", cr.GetNamespace())
 	currentTime := metav1.Now()
 
 	// sanity check: return early if missing GetDeletionTimestamp
@@ -73,7 +73,7 @@ func CheckSplunkDeletion(cr enterprisev1.MetaObject, c ControllerClient) (bool, 
 
 // DeleteSplunkPvc removes all corresponding PersistentVolumeClaims that are associated with a custom resource.
 func DeleteSplunkPvc(cr enterprisev1.MetaObject, c ControllerClient) error {
-	scopedLog := log.WithName("DeleteSplunkPvc").WithValues("kind", cr.GetTypeMeta().Kind, "name", cr.GetIdentifier(), "namespace", cr.GetNamespace())
+	scopedLog := rconcilelog.WithName("DeleteSplunkPvc").WithValues("kind", cr.GetTypeMeta().Kind, "name", cr.GetIdentifier(), "namespace", cr.GetNamespace())
 
 	var component string
 	switch cr.GetTypeMeta().Kind {
@@ -121,7 +121,7 @@ func DeleteSplunkPvc(cr enterprisev1.MetaObject, c ControllerClient) error {
 
 // RemoveSplunkFinalizer removes a finalizer from a custom resource.
 func RemoveSplunkFinalizer(cr enterprisev1.MetaObject, c ControllerClient, finalizer string) error {
-	scopedLog := log.WithName("RemoveSplunkFinalizer").WithValues("kind", cr.GetTypeMeta().Kind, "name", cr.GetIdentifier(), "namespace", cr.GetNamespace())
+	scopedLog := rconcilelog.WithName("RemoveSplunkFinalizer").WithValues("kind", cr.GetTypeMeta().Kind, "name", cr.GetIdentifier(), "namespace", cr.GetNamespace())
 	scopedLog.Info("Removing finalizer", "name", finalizer)
 
 	// create new list of finalizers that doesn't include the one being removed

--- a/pkg/splunk/reconcile/indexercluster.go
+++ b/pkg/splunk/reconcile/indexercluster.go
@@ -38,7 +38,7 @@ func ApplyIndexerCluster(client ControllerClient, cr *enterprisev1.IndexerCluste
 		Requeue:      true,
 		RequeueAfter: time.Second * 5,
 	}
-	scopedLog := log.WithName("ApplyIndexerCluster").WithValues("name", cr.GetIdentifier(), "namespace", cr.GetNamespace())
+	scopedLog := rconcilelog.WithName("ApplyIndexerCluster").WithValues("name", cr.GetIdentifier(), "namespace", cr.GetNamespace())
 
 	// validate and updates defaults for CR
 	err := enterprise.ValidateIndexerClusterSpec(&cr.Spec)

--- a/pkg/splunk/reconcile/indexercluster_test.go
+++ b/pkg/splunk/reconcile/indexercluster_test.go
@@ -74,7 +74,7 @@ func indexerClusterPodManagerTester(t *testing.T, method string, mockHandlers []
 	wantCalls map[string][]mockFuncCall, wantError error, initObjects ...runtime.Object) {
 
 	// test for updating
-	scopedLog := log.WithName(method)
+	scopedLog := rconcilelog.WithName(method)
 	cr := enterprisev1.IndexerCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "IndexerCluster",

--- a/pkg/splunk/reconcile/searchheadcluster.go
+++ b/pkg/splunk/reconcile/searchheadcluster.go
@@ -37,7 +37,7 @@ func ApplySearchHeadCluster(client ControllerClient, cr *enterprisev1.SearchHead
 		Requeue:      true,
 		RequeueAfter: time.Second * 5,
 	}
-	scopedLog := log.WithName("ApplySearchHeadCluster").WithValues("name", cr.GetIdentifier(), "namespace", cr.GetNamespace())
+	scopedLog := rconcilelog.WithName("ApplySearchHeadCluster").WithValues("name", cr.GetIdentifier(), "namespace", cr.GetNamespace())
 
 	// validate and updates defaults for CR
 	err := enterprise.ValidateSearchHeadClusterSpec(&cr.Spec)

--- a/pkg/splunk/reconcile/searchheadcluster_test.go
+++ b/pkg/splunk/reconcile/searchheadcluster_test.go
@@ -73,7 +73,7 @@ func searchHeadClusterPodManagerTester(t *testing.T, method string, mockHandlers
 	wantCalls map[string][]mockFuncCall, wantError error, initObjects ...runtime.Object) {
 
 	// test for updating
-	scopedLog := log.WithName(method)
+	scopedLog := rconcilelog.WithName(method)
 	cr := enterprisev1.SearchHeadCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "SearchHeadCluster",

--- a/pkg/splunk/reconcile/service.go
+++ b/pkg/splunk/reconcile/service.go
@@ -23,7 +23,7 @@ import (
 
 // ApplyService creates or updates a Kubernetes Service
 func ApplyService(client ControllerClient, revised *corev1.Service) error {
-	scopedLog := log.WithName("ApplyService").WithValues(
+	scopedLog := rconcilelog.WithName("ApplyService").WithValues(
 		"name", revised.GetObjectMeta().GetName(),
 		"namespace", revised.GetObjectMeta().GetNamespace())
 

--- a/pkg/splunk/reconcile/statefulset.go
+++ b/pkg/splunk/reconcile/statefulset.go
@@ -101,7 +101,7 @@ func ApplyStatefulSet(c ControllerClient, revised *appsv1.StatefulSet) (enterpri
 // UpdateStatefulSetPods manages scaling and config updates for StatefulSets
 func UpdateStatefulSetPods(c ControllerClient, statefulSet *appsv1.StatefulSet, mgr StatefulSetPodManager, desiredReplicas int32) (enterprisev1.ResourcePhase, error) {
 
-	scopedLog := log.WithName("UpdateStatefulSetPods").WithValues(
+	scopedLog := rconcilelog.WithName("UpdateStatefulSetPods").WithValues(
 		"name", statefulSet.GetObjectMeta().GetName(),
 		"namespace", statefulSet.GetObjectMeta().GetNamespace())
 
@@ -165,7 +165,7 @@ func UpdateStatefulSetPods(c ControllerClient, statefulSet *appsv1.StatefulSet, 
 				scopedLog.Error(err, "Unable to find PVC for deletion", "pvcName", pvc.ObjectMeta.Name)
 				return enterprisev1.PhaseError, err
 			}
-			log.Info("Deleting PVC", "pvcName", pvc.ObjectMeta.Name)
+			rconcilelog.Info("Deleting PVC", "pvcName", pvc.ObjectMeta.Name)
 			err = c.Delete(context.Background(), &pvc)
 			if err != nil {
 				scopedLog.Error(err, "Unable to delete PVC", "pvcName", pvc.ObjectMeta.Name)

--- a/pkg/splunk/reconcile/util.go
+++ b/pkg/splunk/reconcile/util.go
@@ -32,7 +32,7 @@ import (
 )
 
 // kubernetes logger used by splunk.reconcile package
-var log = logf.Log.WithName("splunk.reconcile")
+var rconcilelog = logf.Log.WithName("splunk.reconcile")
 
 // simple stdout logger, used for debugging
 //var log = stdr.New(stdlog.New(os.Stderr, "", stdlog.LstdFlags|stdlog.Lshortfile)).WithName("splunk.reconcile")
@@ -50,7 +50,7 @@ type ControllerClient interface {
 
 // CreateResource creates a new Kubernetes resource using the REST API.
 func CreateResource(client ControllerClient, obj ResourceObject) error {
-	scopedLog := log.WithName("CreateResource").WithValues(
+	scopedLog := rconcilelog.WithName("CreateResource").WithValues(
 		"name", obj.GetObjectMeta().GetName(),
 		"namespace", obj.GetObjectMeta().GetNamespace())
 
@@ -68,7 +68,7 @@ func CreateResource(client ControllerClient, obj ResourceObject) error {
 
 // UpdateResource updates an existing Kubernetes resource using the REST API.
 func UpdateResource(client ControllerClient, obj ResourceObject) error {
-	scopedLog := log.WithName("UpdateResource").WithValues(
+	scopedLog := rconcilelog.WithName("UpdateResource").WithValues(
 		"name", obj.GetObjectMeta().GetName(),
 		"namespace", obj.GetObjectMeta().GetNamespace())
 	err := client.Update(context.TODO(), obj)
@@ -100,7 +100,7 @@ func MergePodUpdates(current *corev1.PodTemplateSpec, revised *corev1.PodTemplat
 // current. This enables us to minimize updates. It returns true if there
 // are material differences between them, or false otherwise.
 func MergePodMetaUpdates(current *metav1.ObjectMeta, revised *metav1.ObjectMeta, name string) bool {
-	scopedLog := log.WithName("MergePodMetaUpdates").WithValues("name", name)
+	scopedLog := rconcilelog.WithName("MergePodMetaUpdates").WithValues("name", name)
 	result := false
 
 	// check Annotations
@@ -125,7 +125,7 @@ func MergePodMetaUpdates(current *metav1.ObjectMeta, revised *metav1.ObjectMeta,
 // current. This enables us to minimize updates. It returns true if there
 // are material differences between them, or false otherwise.
 func MergePodSpecUpdates(current *corev1.PodSpec, revised *corev1.PodSpec, name string) bool {
-	scopedLog := log.WithName("MergePodUpdates").WithValues("name", name)
+	scopedLog := rconcilelog.WithName("MergePodUpdates").WithValues("name", name)
 	result := false
 
 	// check for changes in Affinity
@@ -207,7 +207,7 @@ func MergePodSpecUpdates(current *corev1.PodSpec, revised *corev1.PodSpec, name 
 
 // MergeServiceSpecUpdates merges the current and revised spec of the service object
 func MergeServiceSpecUpdates(current *corev1.ServiceSpec, revised *corev1.ServiceSpec, name string) bool {
-	scopedLog := log.WithName("MergeServiceSpecUpdates").WithValues("name", name)
+	scopedLog := rconcilelog.WithName("MergeServiceSpecUpdates").WithValues("name", name)
 	result := false
 
 	// check service Type


### PR DESCRIPTION
Addresses issue https://github.com/splunk/splunk-operator/issues/53

- Implementation of Splunk secrets override through k8s secret
- An improvement to the current security model where secrets to be overridden are provided through defaultsUrl. Moving the override to k8s secrets is more secure
- The Splunk operator and Splunk Enterprise system all use the same secrets.

