### PR TITLE
Integration test framework and basic tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,21 @@
 # See https://circleci.com/blog/using-circleci-workflows-to-replicate-docker-hub-automated-builds/
 version: 2.1
+
+orbs:
+  kubernetes: circleci/kubernetes@0.4.0
+  aws-cli: circleci/aws-cli@0.1.22
+  aws-eks: sandbox/aws-eks@0.1.2
+
 workflows:
   version: 2
   build-and-push:
     jobs:
       - build-image
       - unit-tests
+      - integration-tests:
+          requires:
+            - build-image
+            - unit-tests
       - vulnerability-scan:
           requires:
             - build-image
@@ -13,6 +23,7 @@ workflows:
           requires:
             - build-image
             - unit-tests
+            - integration-tests
             - vulnerability-scan
           filters:
             branches:
@@ -22,6 +33,7 @@ workflows:
           requires:
             - build-image
             - unit-tests
+            - integration-tests
             - vulnerability-scan
           filters:
             branches:
@@ -31,6 +43,7 @@ workflows:
           requires:
             - build-image
             - unit-tests
+            - integration-tests
             - vulnerability-scan
           filters:
             tags:
@@ -38,6 +51,18 @@ workflows:
             branches:
               ignore: /.*/
 executors:
+  ubuntu-machine:
+    environment:
+      # Test nodes for parallel runs
+      NUM_NODES: 2
+      # Size of k8s cluster.
+      NUM_WORKERS: 3
+      ENTERPRISE_IMAGE_NAME: splunk/splunk:8.0.3-20200415
+      IMAGE_NAME: splunk/splunk-operator
+      IMAGE_FILENAME: splunk-operator
+    machine:
+      image: ubuntu-1604:202004-01
+    resource_class: xlarge
   golang-builder:
     environment:
       IMAGE_NAME: splunk/splunk-operator
@@ -129,6 +154,62 @@ jobs:
       - store_artifacts:
           name: Save coverage.out as artifact
           path: coverage.out
+  # Runs integration tests against a k8s cluster
+  integration-tests:
+    executor: ubuntu-machine
+    steps:
+      - run: 
+          name: Setup Splunk operator and enterprise image env vars
+          command: |
+            echo 'export SPLUNK_OPERATOR_IMAGE=${IMAGE_NAME}:${CIRCLE_SHA1}' >> $BASH_ENV
+            echo 'export SPLUNK_ENTERPRISE_IMAGE=${ENTERPRISE_IMAGE_NAME}' >> $BASH_ENV
+            echo 'export COMMIT_HASH=$(echo ${CIRCLE_SHA1:0:7})' >> $BASH_ENV
+      - kubernetes/install
+      - aws-cli/install
+      - aws-eks/install-eksctl
+      - run:
+          name: Install kind tool
+          command: |
+            curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.7.0/kind-$(uname)-amd64
+            chmod +x ./kind
+            sudo mv ./kind /usr/local/bin
+      - checkout
+      - attach_workspace:
+          name: Restore workspace
+          at: /tmp
+      # load the operator image to local registry in the VM
+      - load_image
+      - run:
+          name: Print out version and environment
+          command: |
+            ls -al
+            echo "GO VERSION=`go version`"
+            echo "CIRCLE_SHA1=$CIRCLE_SHA1"
+            echo "SPLUNK_OPERATOR_IMAGE=$SPLUNK_OPERATOR_IMAGE"
+            echo "SPLUNK_ENTEPRISE_IMAGE=$SPLUNK_ENTERPRISE_IMAGE"
+            echo "PRIVATE_REGISTRY=$PRIVATE_REGISTRY"
+            echo "CLUSTER_PROVIDER=$CLUSTER_PROVIDER"
+      - run:
+          # Deploys a eks or kind cluster depending of CLUSTER_PROVIDER flag. If cluster already exists,
+          # it will skip. Uses NUM_WORKERS for size of cluster
+          name: Deploy k8s cluster
+          command: |
+            make cluster-up 
+            kubectl version # log the k8s version
+          no_output_timeout: 30m
+      - run:
+          # Run the integration tests againsts the cluster deployed above.
+          # Test againsts the SPLUNK_OPERATOR_IMAGE and SPLUNK_ENTERPRISE_IMAGE 
+          name: Run integration tests 
+          command: |
+            make int-test
+            mkdir -p /tmp/test-results
+            find ./test -name "*junit.xml" -exec cp {} /tmp/test-results \;
+      - store_test_results:
+          name: Save test results
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
   vulnerability-scan:
     executor: classic-machine
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ clair-scanner
 clair-scanner-logs
 release-*
 deploy/olm-certified
+*junit.xml

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for Splunk Operator
 
-.PHONY: all builder builder-image image package local clean run fmt lint test
+.PHONY: all builder builder-image image package local clean run fmt lint test cluster-up cluster-down int-test
 
 # Security Scanner Variables
 SCANNER_DATE := `date +%Y-%m-%d`
@@ -93,3 +93,13 @@ fmt:
 
 lint:
 	@golint ./...
+
+cluster-up:
+	@test/deploy-cluster.sh up
+
+cluster-down:
+	@test/deploy-cluster.sh down
+
+int-test:
+	@echo Run integration test
+	@test/run-tests.sh

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.13
 
 require (
 	github.com/go-logr/logr v0.1.0
+	github.com/onsi/ginkgo v1.10.1
+	github.com/onsi/gomega v1.7.0
 	github.com/operator-framework/operator-sdk v0.15.1
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect

--- a/go.sum
+++ b/go.sum
@@ -197,6 +197,7 @@ github.com/garyburd/redigo v1.6.0/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 h1:Mn26/9ZMNWSw9C9ERFA1PUxfmGpolnw2v0bKOREu5ew=
 github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
@@ -259,6 +260,7 @@ github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobuffalo/envy v1.6.5/go.mod h1:N+GkhhZ/93bGZc6ZKhJLP6+m+tCNPKwgSpH9kaifseQ=
+github.com/gobuffalo/envy v1.7.0 h1:GlXgaiBkmrYMHco6t4j7SacKO4XUjvh5pwXh0f4uxXU=
 github.com/gobuffalo/envy v1.7.0/go.mod h1:n7DRkBerg/aorDM8kbduw5dN3oXGswK5liaSCx4T5NI=
 github.com/gobuffalo/flect v0.1.5/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
 github.com/gobuffalo/logger v1.0.0/go.mod h1:2zbswyIUa45I+c+FLXuWl9zSWEiVuthsk8ze5s8JvPs=
@@ -382,6 +384,7 @@ github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mo
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -431,6 +434,7 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/maorfr/helm-plugin-utils v0.0.0-20181205064038-588190cb5e3b/go.mod h1:p3gwmRSFqbWw6plBpR0sKl3n3vpu8kX70gvCJKMvvCA=
+github.com/markbates/inflect v1.0.4 h1:5fh1gzTFhfae06u3hzHYO9xe3l3v3nW5Pwt3naLTP5g=
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
 github.com/martinlindhe/base36 v1.0.0/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
@@ -456,6 +460,7 @@ github.com/miekg/dns v1.1.4/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nr
 github.com/mindprince/gonvml v0.0.0-20171110221305-fee913ce8fb2/go.mod h1:2eu9pRWp8mo84xCg6KswZ+USQHjwgRhNp06sozOdsTY=
 github.com/mistifyio/go-zfs v2.1.1+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/hashstructure v0.0.0-20170609045927-2bca23e0e452/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
@@ -520,6 +525,7 @@ github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJ
 github.com/otiai10/curr v0.0.0-20190513014714-f5a3d24e5776/go.mod h1:3HNVkVOU7vZeFXocWuvtcS0XSFLcf2XUSDHkq9t1jU4=
 github.com/otiai10/mint v1.2.3/go.mod h1:YnfyPNhBvnY8bW4SGQHCs/aAFhkgySlMZbrF5U0bOVw=
 github.com/otiai10/mint v1.2.4/go.mod h1:d+b7n/0R3tdyUYYylALXpWQ/kTN+QobSq/4SRGBkR3M=
+github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.0.1/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -575,6 +581,7 @@ github.com/robfig/cron v1.1.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfm
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.5.0 h1:Usqs0/lDK/NqTkvrmKSwA/3XkZAs7ZAW/eLeQ2MVBTw=
 github.com/rogpeppe/go-internal v1.5.0/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rubenv/sql-migrate v0.0.0-20191025130928-9355dd04f4b3/go.mod h1:WS0rl9eEliYI8DPnr3TOwz4439pay+qNgzJoVya/DmY=
 github.com/rubiojr/go-vhd v0.0.0-20160810183302-0bfd3b39853c/go.mod h1:DM5xW0nvfNNm2uytzsvhI3OnX8uzaRAg8UX/CnDqbto=
@@ -588,6 +595,7 @@ github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9Nz
 github.com/sirupsen/logrus v1.0.5/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
@@ -595,9 +603,11 @@ github.com/soheilhy/cmux v0.1.3/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
@@ -730,6 +740,7 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180117170059-2c42eef0765b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,96 @@
+# Integration testing for Splunk Operator
+
+## Overview
+
+This README describes the test framework, how to run the various tests and how to write additional tests.
+
+## Test framework
+
+The test framework is based on Ginkgo/Gomega test framework. It is located in the test folder in the splunk-operator repository.
+The test framework has 2 main objects: TestEnv and Deployment.
+
+### TestEnv
+
+The TestEnv object represents the test environment that tests are run against. The test environment is a Kubernetes
+namespace. When a TestEnv is created, it will create a namespace in the current Kubernetes cluster. The following
+resources are then created in that new namespace:
+
+1. Service Account
+1. Role
+1. RoleBinding
+1. Operator/Deployment
+
+The tests are then run within the scope/context of the TestEnv object. Resources used by the tests are scoped to the
+TestEnv object (ie Kubernetes namespace). When the tests are completed, the TestEnv object is destroyed and the
+resources within are deleted.
+
+### Deployment
+
+The Deployment object is simply to encapsulate what we are deploying within the TestEnv object and help with cleanup.
+We can deploy standalone, indexers, search heads, ...etc within a single Deployment object. A TestEnv can have 1 or more
+Deployments.
+
+## Running the tests
+
+To run the tests, you will need to create or use an existing Kubernetes cluster. If you have a powerful machine and
+Docker engine installed, you can create a local Kubernetes cluster on top of Docker (Kubernetes-IN-Docker aka KIND
+cluster) for testing purpose.
+
+To create a KIND cluster, run
+> make cluster-up (make cluster-down to tear down the cluster)
+
+If you are using an existing cluster, you will need to install the enterprise CRDs
+> kubectl apply -f deploy/crds
+
+To run the test,
+> make int-test
+
+This calls the test/run-test.sh script. This test script will recursively runs all the tests in the test folder againsts
+the current Kubernetes cluster.
+
+The test will output the results into a junit xml output file.
+
+Note: Both make cluster-up and make int-test invokes the test/deploy-cluster.sh and test/run-test.sh scripts respectively.
+Both these scripts take in the env.sh script that defines various environment variables used to build the cluster and run
+the test.
+
+- SPLUNK_OPERATOR_IMAGE (Default: splunk/splunk-operator:latest): The splunk operator image to use for testing  
+- SPLUNK_ENTERPRISE_IMAGE (Default: splunk/splunk:latest)       : The splunk enterprise image to use for testing
+- CLUSTER_PROVIDER (Default: kind)                              : Supports creating eks or kind cluster
+- PRIVATE_REGISTRY (Default: localhost:5000)                    : Private registry to use push and pull the images used during testing
+
+Note: To run a specific test, you can
+
+1. cd ./test/{specific-test} folder
+2. ginkgo -v -progress --operator-image=localhost:5000/splunk/splunk-operator:latest --splunk-image=localhost:5000/splunk/splunk:latest
+
+### Circleci pipeline
+
+The circleci config.xml file will also run the integration tests when merging to master branch. By default, the pipeline workflow will
+deploy a KIND cluster and run the tests against it. To run the test againsts the EKS cluster, you will
+need to define the following project environment variables in the circleci console
+AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY
+CLUSTER_PROVIDER=[eks|kind]
+ECR_REGISTRY
+
+## Writing tests
+
+Ginkgo test framework has test suite and test spec ("It") files. A test suite file is the main test entry point and represents the test package.
+Each test folder is a test package and should have 1 test suite file and 1 or more test spec files.
+The test suite file to use to create and delete the TestEnv object. The test spec files are used to create and delete the Deployment object.
+
+### Adding a new test spec
+
+1. To add a new test spec, you can either add a new "It" spec in an existing test spec file or add a new test spec file. If you are adding a new test spec file,
+it is best to copy an existing test spec file in that suite and modified it.
+
+### Add a new test suite
+
+1. If you are adding a new test suite (ie you want to run the test in a separate TestEnv or k8s namespace), it is best to copy the test/example folder entirely and modify it
+
+## Notes
+
+1. As mentioned above, by default, we create a TestEnv (aka k8s namespace) for every test suite AND a Deployment for every test spec. It may be time consuming to tear down
+the deployment for each test spec especially if we are deploying a large cluster to test. It is possible then to actually create the TestEnv and Deployment at the test suite
+level.

--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+scriptdir=$(dirname "$0")
+topdir=${scriptdir}/..
+source ${scriptdir}/env.sh
+
+action=${1:-up}    
+
+# source the script file containing the create/delete cluster implementation
+srcfile="${scriptdir}/deploy-${CLUSTER_PROVIDER}-cluster.sh"
+
+if [ ! -f "$srcfile" ]; then
+    echo "Unknown cluster provider '${CLUSTER_PROVIDER}'"
+    exit 1
+fi
+source $srcfile
+
+case ${action} in
+    up)
+        createCluster
+        ;;
+    down)
+        deleteCluster
+        ;;
+esac

--- a/test/deploy-eks-cluster.sh
+++ b/test/deploy-eks-cluster.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+function deleteCluster() {
+  eksctl delete cluster --name=${CLUSTER_NAME}
+  if [ $? -ne 0 ]; then
+    echo "Unable to delete cluster - ${CLUSTER_NAME}"
+    return 1
+  fi
+
+  return 0
+}
+
+function createCluster() {
+  # Deploy eksctl cluster if not deploy
+  rc=$(which eksctl)
+  if [ -z "$rc" ]; then
+    echo "eksctl is not installed or in the PATH. Please install eksctl from https://github.com/weaveworks/eksctl."
+    return 1
+  fi
+
+  found=$(eksctl get cluster --name "${CLUSTER_NAME}")
+  if [ -z "${found}" ]; then
+    eksctl create cluster --name=${CLUSTER_NAME} --nodes=${NUM_WORKERS}
+    if [ $? -ne 0 ]; then
+      echo "Unable to create cluster - ${CLUSTER_NAME}"
+      return 1
+    fi
+  else
+    echo "Retrieving kubeconfig for ${CLUSTER_NAME}"
+    # Cluster exists but kubeconfig may not
+    eksctl utils write-kubeconfig --cluster=${CLUSTER_NAME}
+  fi
+
+  echo "Logging in to ECR"
+  rc=$(aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin "${PRIVATE_REGISTRY}"/splunk/splunk-operator)
+  if [ "$rc" != "Login Succeeded" ]; then
+      echo "Unable to login to ECR - $rc"
+      return 1
+  fi
+
+
+  # Login to ECR registry so images can be push and pull from later whe
+  # Output
+  echo "EKS cluster nodes:"
+  eksctl get cluster --name=${CLUSTER_NAME}
+}

--- a/test/deploy-kind-cluster.sh
+++ b/test/deploy-kind-cluster.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+reg_name='kind-registry'
+reg_port=$(echo $PRIVATE_REGISTRY | cut -d':' -f2)
+
+function deleteCluster() {
+  kind delete cluster --name=${CLUSTER_NAME}
+  if [ $? -ne 0 ]; then
+    echo "Unable to delete cluster - ${CLUSTER_NAME}"
+    return 1
+  fi
+
+  docker rm -f ${reg_name}  
+  if [ $? -ne 0 ]; then
+    echo "Unable to delete private registry - ${reg_name}"
+    return 1
+  fi
+  return 0
+}
+
+function createCluster() {
+  echo "Using private registry at ${PRIVATE_REGISTRY}"
+  # Deploy KIND cluster if not deploy
+  rc=$(which kind)
+  if [ -z "$rc" ]; then
+    echo "Kind is not installed or in the PATH. Please install kind from https://kind.sigs.k8s.io/docs/user/quick-start/"
+    return 1
+  fi
+
+  found=$(kind get clusters | grep "^${CLUSTER_NAME}$")
+  if [ -z "$found" ]; then
+    # create registry container unless it already exists
+    running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+    if [ "${running}" != 'true' ]; then
+      docker run \
+       -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
+       registry:2
+    fi
+    reg_ip="$(docker inspect -f '{{.NetworkSettings.IPAddress}}' "${reg_name}")"
+
+    workerNodes="- role: worker"
+    for i in $(seq 2 $NUM_WORKERS);do
+      workerNodes="${workerNodes}"$'\n'"- role: worker"
+    done    
+
+# create a cluster with the local registry enabled in containerd
+cat <<EOF | kind create cluster --name "${CLUSTER_NAME}" --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+${workerNodes}
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_ip}:5000"]
+EOF
+fi
+
+    # Output
+    echo "KIND cluster nodes:"
+    kind get nodes --name=${CLUSTER_NAME}
+}

--- a/test/env.sh
+++ b/test/env.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+: "${SPLUNK_OPERATOR_IMAGE:=splunk/splunk-operator:latest}"
+: "${SPLUNK_ENTERPRISE_IMAGE:=splunk/splunk:latest}"
+: "${CLUSTER_PROVIDER:=kind}"
+: "${CLUSTER_NAME:=integration-test-cluster}"
+: "${NUM_WORKERS:=3}"
+: "${NUM_NODES:=2}"
+: "${COMMIT_HASH:=}"
+: "${ECR_REGISTRY:=}"
+
+# Docker registry to use to push the test images to and pull from in the cluster
+if [ -z "${PRIVATE_REGISTRY}" ]; then
+    case ${CLUSTER_PROVIDER} in
+      kind)
+        PRIVATE_REGISTRY=localhost:5000
+        ;;
+      eks)
+        if [ -z "${ECR_REGISTRY}" ]; then
+          echo "Please define ECR_REGISTRY that specified where images are pushed and pulled from."
+          exit 1
+        fi
+        PRIVATE_REGISTRY="${ECR_REGISTRY}"
+        ;;
+    esac
+fi

--- a/test/example/example1_test.go
+++ b/test/example/example1_test.go
@@ -1,0 +1,47 @@
+package example
+
+import (
+	"math/rand"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+
+	"github.com/splunk/splunk-operator/test/testenv"
+)
+
+var _ = XDescribe("Example1", func() {
+
+	var deployment *testenv.Deployment
+
+	// This is invoke for each "It" spec below
+	BeforeEach(func() {
+		// Create a deployment for this test
+		deployment, _ = testenvInstance.NewDeployment(testenv.RandomDNSName(5))
+	})
+
+	AfterEach(func() {
+		deployment.Teardown()
+	})
+
+	// "It" spec
+	It("deploys successfully", func() {
+		// Add your test spec!!
+		// eg deployment.DeployStandalone()
+		time.Sleep(time.Duration(rand.Intn(100)) * time.Microsecond)
+		testenvInstance.Log.Info("Running test spec", "name", deployment.GetName())
+	})
+
+	// "It" spec
+	It("can update volumes", func() {
+		// Add your test spec!!
+		time.Sleep(time.Duration(rand.Intn(100)) * time.Microsecond)
+		testenvInstance.Log.Info("Running test spec", "name", deployment.GetName())
+	})
+
+	// "It" spec
+	It("can update service ports", func() {
+		// Add your test spec!!
+		time.Sleep(time.Duration(rand.Intn(100)) * time.Microsecond)
+		testenvInstance.Log.Info("Running test spec", "name", deployment.GetName())
+	})
+})

--- a/test/example/example2_test.go
+++ b/test/example/example2_test.go
@@ -1,0 +1,40 @@
+package example
+
+import (
+	"math/rand"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+
+	"github.com/splunk/splunk-operator/test/testenv"
+)
+
+var _ = XDescribe("Example2", func() {
+
+	var deployment *testenv.Deployment
+
+	// This is invoke for each "It" spec below
+	BeforeEach(func() {
+		// Create a deployment for this test
+		deployment, _ = testenvInstance.NewDeployment(testenv.RandomDNSName(5))
+	})
+
+	AfterEach(func() {
+		deployment.Teardown()
+	})
+
+	// "It" spec
+	It("deploys successfully", func() {
+		// Add your test spec!!
+		// eg deployment.DeployStandalone()
+		time.Sleep(time.Duration(rand.Intn(100)) * time.Microsecond)
+		testenvInstance.Log.Info("Running test spec", "name", deployment.GetName())
+	})
+
+	// "It" spec
+	It("can update volumes", func() {
+		// Add your test spec!!
+		time.Sleep(time.Duration(rand.Intn(100)) * time.Microsecond)
+		testenvInstance.Log.Info("Running test spec", "name", deployment.GetName())
+	})
+})

--- a/test/example/example_suite_test.go
+++ b/test/example/example_suite_test.go
@@ -1,0 +1,40 @@
+package example
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+
+	"github.com/splunk/splunk-operator/test/testenv"
+)
+
+var (
+	testenvInstance *testenv.TestEnv
+	testSuiteName   = "example-suite-" + testenv.RandomDNSName(6)
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func TestExampleSuite(t *testing.T) {
+
+	RegisterFailHandler(Fail)
+
+	junitReporter := reporters.NewJUnitReporter(testSuiteName + "_junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Running "+testSuiteName, []Reporter{junitReporter})
+}
+
+var _ = BeforeSuite(func() {
+	var err error
+	testenvInstance, err = testenv.NewDefaultTestEnv(testSuiteName)
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	Expect(testenvInstance.Teardown()).ToNot(HaveOccurred())
+})

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+scriptdir=$(dirname "$0")
+topdir=${scriptdir}/..
+
+source ${scriptdir}/env.sh
+
+PRIVATE_SPLUNK_OPERATOR_IMAGE=${SPLUNK_OPERATOR_IMAGE}
+PRIVATE_SPLUNK_ENTERPRISE_IMAGE=${SPLUNK_ENTERPRISE_IMAGE}
+
+rc=$(which go)
+if [ -z "$rc" ]; then
+  echo "go is not installed or in the PATH. Exiting..."
+  exit 1
+fi
+
+# if we are using private registry, we need to pull, tag and push images to it
+if [ -n "${PRIVATE_REGISTRY}" ]; then
+  echo "Using private registry at ${PRIVATE_REGISTRY}"
+
+  PRIVATE_SPLUNK_OPERATOR_IMAGE=${PRIVATE_REGISTRY}/${SPLUNK_OPERATOR_IMAGE}
+  PRIVATE_SPLUNK_ENTERPRISE_IMAGE=${PRIVATE_REGISTRY}/${SPLUNK_ENTERPRISE_IMAGE}
+
+  # Don't pull splunk operator if exists locally since we maybe building it locally
+  if [ -z $(docker images -q ${SPLUNK_OPERATOR_IMAGE}) ]; then 
+    docker pull ${SPLUNK_OPERATOR_IMAGE}
+    if [ $? -ne 0 ]; then
+     echo "Unable to pull ${SPLUNK_OPERATOR_IMAGE}. Exiting..."
+     exit 1
+    fi
+  fi
+
+  docker tag ${SPLUNK_OPERATOR_IMAGE} ${PRIVATE_SPLUNK_OPERATOR_IMAGE}
+  docker push ${PRIVATE_SPLUNK_OPERATOR_IMAGE}
+  if [ $? -ne 0 ]; then
+    echo "Unable to push ${PRIVATE_SPLUNK_OPERATOR_IMAGE}. Exiting..."
+    exit 1
+  fi
+
+  # Always attempt to pull splunk enterprise image
+  docker pull ${SPLUNK_ENTERPRISE_IMAGE}
+  if [ $? -ne 0 ]; then
+    echo "Unable to pull ${SPLUNK_ENTERPRISE_IMAGE}. Exiting..."
+    exit 1
+  fi
+  docker tag ${SPLUNK_ENTERPRISE_IMAGE} ${PRIVATE_SPLUNK_ENTERPRISE_IMAGE}
+  docker push ${PRIVATE_SPLUNK_ENTERPRISE_IMAGE}
+  if [ $? -ne 0 ]; then
+    echo "Unable to push ${PRIVATE_SPLUNK_ENTERPRISE_IMAGE}. Exiting..."
+    exit 1
+  fi
+
+  # Output
+  echo "Docker images"
+  docker images
+fi
+
+
+# Install the CRDs
+echo "Installing enterprise CRDs..."
+kubectl apply -f ${topdir}/deploy/crds
+if [ $? -ne 0 ]; then
+  echo "Unable to install the CRDs. Exiting..."
+  exit 1
+fi
+
+rc=$(which ginkgo)
+if [ -z "$rc" ]; then
+  echo "ginkgo is not installed or in the PATH. Installing..."
+  go get github.com/onsi/ginkgo/ginkgo
+  go get github.com/onsi/gomega/...
+
+  go install github.com/onsi/ginkgo/ginkgo
+fi 
+
+
+echo "Running test using number of nodes: ${NUM_NODES}"
+echo "Running test using these images: ${PRIVATE_SPLUNK_OPERATOR_IMAGE} and ${PRIVATE_SPLUNK_ENTERPRISE_IMAGE}..."
+# run Ginkgo
+ginkgo -v -progress -r -stream -nodes=${NUM_NODES} -skipPackage=example ${topdir}/test -- -commit-hash=${COMMIT_HASH} -operator-image=${PRIVATE_SPLUNK_OPERATOR_IMAGE}  -splunk-image=${PRIVATE_SPLUNK_ENTERPRISE_IMAGE}

--- a/test/smoke/smoke_suite_test.go
+++ b/test/smoke/smoke_suite_test.go
@@ -1,0 +1,47 @@
+package basic
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+
+	"github.com/splunk/splunk-operator/test/testenv"
+)
+
+const (
+	// PollInterval specifies the polling interval
+	PollInterval = 5 * time.Second
+
+	// ConsistentPollInterval is the interval to use to consistently check a state is stable
+	ConsistentPollInterval = 200 * time.Millisecond
+	ConsistentDuration     = 2000 * time.Millisecond
+)
+
+var (
+	testenvInstance *testenv.TestEnv
+	testSuiteName   = "smoke-" + testenv.RandomDNSName(2)
+)
+
+// TestBasic is the main entry point
+func TestBasic(t *testing.T) {
+
+	RegisterFailHandler(Fail)
+
+	junitReporter := reporters.NewJUnitReporter(testSuiteName + "_junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Running "+testSuiteName, []Reporter{junitReporter})
+}
+
+var _ = BeforeSuite(func() {
+	var err error
+	testenvInstance, err = testenv.NewDefaultTestEnv(testSuiteName)
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	if testenvInstance != nil {
+		Expect(testenvInstance.Teardown()).ToNot(HaveOccurred())
+	}
+})

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -1,0 +1,110 @@
+package basic
+
+import (
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1alpha2"
+	"github.com/splunk/splunk-operator/test/testenv"
+)
+
+func dumpGetPods(ns string) {
+	output, _ := exec.Command("kubectl", "get", "pod", "-n", ns).Output()
+	for _, line := range strings.Split(string(output), "\n") {
+		testenvInstance.Log.Info(line)
+	}
+}
+
+var _ = Describe("Smoke test", func() {
+
+	var deployment *testenv.Deployment
+
+	BeforeEach(func() {
+		var err error
+		deployment, err = testenvInstance.NewDeployment(testenv.RandomDNSName(3))
+		Expect(err).To(Succeed(), "Unable to create deployment")
+	})
+
+	AfterEach(func() {
+		// When a test spec failed, skip the teardown so we can troubleshoot.
+		if CurrentGinkgoTestDescription().Failed {
+			testenvInstance.SkipTeardown = true
+		}
+		if deployment != nil {
+			deployment.Teardown()
+		}
+	})
+
+	Context("Standalone deployment (S1)", func() {
+		It("can deploy a standalone instance", func() {
+
+			standalone, err := deployment.DeployStandalone(deployment.GetName())
+			Expect(err).To(Succeed(), "Unable to deploy standalone instance ")
+
+			Eventually(func() enterprisev1.ResourcePhase {
+				err = deployment.GetInstance(deployment.GetName(), standalone)
+				if err != nil {
+					return enterprisev1.PhaseError
+				}
+				testenvInstance.Log.Info("Waiting for standalone instance status to be ready", "instance", standalone.ObjectMeta.Name, "Phase", standalone.Status.Phase)
+				dumpGetPods(testenvInstance.GetName())
+
+				return standalone.Status.Phase
+			}, deployment.GetTimeout(), PollInterval).Should(Equal(enterprisev1.PhaseReady))
+
+			// In a steady state, we should stay in Ready and not flip-flop around
+			Consistently(func() enterprisev1.ResourcePhase {
+				_ = deployment.GetInstance(deployment.GetName(), standalone)
+				return standalone.Status.Phase
+			}, ConsistentDuration, ConsistentPollInterval).Should(Equal(enterprisev1.PhaseReady))
+		})
+	})
+
+	Context("Clustered deployment (C3 - clustered indexer, search head cluster)", func() {
+		It("can deploy indexers and search head cluster", func() {
+
+			err := deployment.DeployCluster(deployment.GetName(), 3)
+			Expect(err).To(Succeed(), "Unable to deploy cluster")
+
+			// Ensure indexers go to Ready phase
+			idc := &enterprisev1.IndexerCluster{}
+			Eventually(func() enterprisev1.ResourcePhase {
+				err := deployment.GetInstance(deployment.GetName(), idc)
+				if err != nil {
+					return enterprisev1.PhaseError
+				}
+				testenvInstance.Log.Info("Waiting for indexer cluster instance status to be ready", "instance", idc.ObjectMeta.Name, "Phase", idc.Status.Phase)
+
+				dumpGetPods(testenvInstance.GetName())
+
+				return idc.Status.Phase
+			}, deployment.GetTimeout(), PollInterval).Should(Equal(enterprisev1.PhaseReady))
+
+			// In a steady state, we should stay in Ready and not flip-flop around
+			Consistently(func() enterprisev1.ResourcePhase {
+				_ = deployment.GetInstance(deployment.GetName(), idc)
+				return idc.Status.Phase
+			}, ConsistentDuration, ConsistentPollInterval).Should(Equal(enterprisev1.PhaseReady))
+
+			shc := &enterprisev1.SearchHeadCluster{}
+			// Ensure search head cluster go to Ready phase
+			Eventually(func() enterprisev1.ResourcePhase {
+				err := deployment.GetInstance(deployment.GetName(), shc)
+				if err != nil {
+					return enterprisev1.PhaseError
+				}
+				testenvInstance.Log.Info("Waiting for search head cluster instance status to be ready", "instance", shc.ObjectMeta.Name, "Phase", shc.Status.Phase)
+				return shc.Status.Phase
+			}, deployment.GetTimeout(), PollInterval).Should(Equal(enterprisev1.PhaseReady))
+
+			// In a steady state, we should stay in Ready and not flip-flop around
+			Consistently(func() enterprisev1.ResourcePhase {
+				_ = deployment.GetInstance(deployment.GetName(), shc)
+				return shc.Status.Phase
+			}, ConsistentDuration, ConsistentPollInterval).Should(Equal(enterprisev1.PhaseReady))
+		})
+	})
+})

--- a/test/testenv/deployment.go
+++ b/test/testenv/deployment.go
@@ -1,0 +1,200 @@
+package testenv
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	wait "k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1alpha2"
+)
+
+// Deployment simply represents the deployment (standalone, clustered,...etc) we create on the testenv
+type Deployment struct {
+	name              string
+	testenv           *TestEnv
+	cleanupFuncs      []cleanupFunc
+	testTimeoutInSecs time.Duration
+}
+
+// GetName returns this deployment name
+func (d *Deployment) GetName() string {
+	return d.name
+}
+
+// GetTimeout returns deployment name
+func (d *Deployment) GetTimeout() time.Duration {
+	return d.testTimeoutInSecs
+}
+
+func (d *Deployment) pushCleanupFunc(fn cleanupFunc) {
+	d.cleanupFuncs = append(d.cleanupFuncs, fn)
+}
+
+func (d *Deployment) popCleanupFunc() (cleanupFunc, error) {
+	if len(d.cleanupFuncs) == 0 {
+		return nil, fmt.Errorf("cleanupFuncs is empty")
+	}
+
+	fn := d.cleanupFuncs[len(d.cleanupFuncs)-1]
+	d.cleanupFuncs = d.cleanupFuncs[:len(d.cleanupFuncs)-1]
+
+	return fn, nil
+}
+
+// Teardown teardowns the deployment resources
+func (d *Deployment) Teardown() error {
+	if d.testenv.SkipTeardown {
+		d.testenv.Log.Info("deployment teardown is skipped!\n")
+		return nil
+	}
+
+	var cleanupErr error
+
+	for fn, err := d.popCleanupFunc(); err == nil; fn, err = d.popCleanupFunc() {
+		cleanupErr = fn()
+		if cleanupErr != nil {
+			d.testenv.Log.Error(cleanupErr, "Deployment cleanupFunc returns an error. Attempt to continue.\n")
+		}
+	}
+
+	d.testenv.Log.Info("deployment deleted.\n", "name", d.name)
+	return cleanupErr
+}
+
+// DeployStandalone deploys a standalone splunk enterprise instance on the specified testenv
+func (d *Deployment) DeployStandalone(name string) (*enterprisev1.Standalone, error) {
+	standalone := newStandalone(name, d.testenv.namespace)
+	deployed, err := d.deployCR(name, standalone)
+	if err != nil {
+		return nil, err
+	}
+	return deployed.(*enterprisev1.Standalone), err
+}
+
+// GetInstance retrieves the standalone, indexer, searchhead, licensemaster instance
+func (d *Deployment) GetInstance(name string, instance runtime.Object) error {
+	key := client.ObjectKey{Name: name, Namespace: d.testenv.namespace}
+
+	err := d.testenv.GetKubeClient().Get(context.TODO(), key, instance)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+//DeployLicenseMaster deploys the license master instance
+func (d *Deployment) DeployLicenseMaster(name string) (*enterprisev1.LicenseMaster, error) {
+
+	if d.testenv.licenseFilePath == "" {
+		return nil, fmt.Errorf("No license file path specified")
+	}
+
+	lm := newLicenseMaster(name, d.testenv.namespace, d.testenv.licenseCMName)
+	deployed, err := d.deployCR(name, lm)
+	if err != nil {
+		return nil, err
+	}
+	return deployed.(*enterprisev1.LicenseMaster), err
+}
+
+//DeployIndexerCluster deploys the indexer cluster
+func (d *Deployment) DeployIndexerCluster(name, licenseMasterName string, count int) (*enterprisev1.IndexerCluster, error) {
+	indexer := newIndexerCluster(name, d.testenv.namespace, licenseMasterName, count)
+	deployed, err := d.deployCR(name, indexer)
+	if err != nil {
+		return nil, err
+	}
+	return deployed.(*enterprisev1.IndexerCluster), err
+}
+
+// DeploySearchHeadCluster deploys a search head cluster
+func (d *Deployment) DeploySearchHeadCluster(name, indexerClusterName, licenseMasterName string) (*enterprisev1.SearchHeadCluster, error) {
+	indexer := newSearchHeadCluster(name, d.testenv.namespace, indexerClusterName, licenseMasterName)
+	deployed, err := d.deployCR(name, indexer)
+	return deployed.(*enterprisev1.SearchHeadCluster), err
+}
+
+func (d *Deployment) deployCR(name string, cr runtime.Object) (runtime.Object, error) {
+
+	err := d.testenv.GetKubeClient().Create(context.TODO(), cr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Push the clean up func to delete the cr when done
+	d.pushCleanupFunc(func() error {
+		d.testenv.Log.Info("Deleting cr", "name", name)
+		err := d.testenv.GetKubeClient().Delete(context.TODO(), cr)
+		if err != nil {
+			return err
+		}
+		if err = wait.PollImmediate(PollInterval, DefaultTimeout, func() (bool, error) {
+			key := client.ObjectKey{Name: name, Namespace: d.testenv.namespace}
+			err := d.testenv.GetKubeClient().Get(context.TODO(), key, cr)
+
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}); err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	// Returns once we can retrieve the lm instance
+	if err := wait.PollImmediate(PollInterval, DefaultTimeout, func() (bool, error) {
+		key := client.ObjectKey{Name: name, Namespace: d.testenv.namespace}
+		err := d.testenv.GetKubeClient().Get(context.TODO(), key, cr)
+		if err != nil {
+
+			// Try again
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+
+		return true, nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return cr, nil
+}
+
+// DeployCluster deploys a lm, indexer and sh clusters
+func (d *Deployment) DeployCluster(name string, indexerReplicas int) error {
+
+	var licenseMaster string
+
+	// If license file specified, deploy License Master
+	if d.testenv.licenseFilePath != "" {
+		// Deploy the license master
+		_, err := d.DeployLicenseMaster(name)
+		if err != nil {
+			return err
+		}
+
+		licenseMaster = name
+	}
+
+	// Deploy the indexer cluster
+	_, err := d.DeployIndexerCluster(name, licenseMaster, indexerReplicas)
+	if err != nil {
+		return err
+	}
+
+	_, err = d.DeploySearchHeadCluster(name, name, licenseMaster)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/test/testenv/testenv.go
+++ b/test/testenv/testenv.go
@@ -1,0 +1,464 @@
+package testenv
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/onsi/ginkgo"
+	ginkgoconfig "github.com/onsi/ginkgo/config"
+	"github.com/operator-framework/operator-sdk/pkg/log/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	wait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+
+	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1alpha2"
+)
+
+const (
+	defaultOperatorImage = "splunk/splunk-operator"
+	defaultSplunkImage   = "splunk/splunk:latest"
+	defaultSparkImage    = "splunk/spark"
+
+	// defaultTestTimeout is the max timeout in seconds before async test failed.
+	defaultTestTimeout = 900
+
+	// PollInterval specifies the polling interval
+	PollInterval = 1 * time.Second
+	// DefaultTimeout is the max timeout before we failed.
+	DefaultTimeout = 5 * time.Minute
+)
+
+var (
+	metricsHost              = "0.0.0.0"
+	metricsPort              = 8383
+	specifiedOperatorImage   = defaultOperatorImage
+	specifiedSplunkImage     = defaultSplunkImage
+	specifiedSparkImage      = defaultSparkImage
+	specifiedSkipTeardown    = false
+	specifiedLicenseFilePath = ""
+	specifiedTestTimeout     = defaultTestTimeout
+	specifiedCommitHash      = ""
+)
+
+type cleanupFunc func() error
+
+// TestEnv represents a namespaced-isolated k8s cluster environment (aka virtual k8s cluster) to run tests against
+type TestEnv struct {
+	kubeAPIServer      string
+	name               string
+	namespace          string
+	serviceAccountName string
+	roleName           string
+	roleBindingName    string
+	operatorName       string
+	operatorImage      string
+	splunkImage        string
+	sparkImage         string
+	initialized        bool
+	SkipTeardown       bool
+	licenseFilePath    string
+	licenseCMName      string
+	kubeClient         client.Client
+	Log                logr.Logger
+	cleanupFuncs       []cleanupFunc
+}
+
+func init() {
+	l := zap.LoggerTo(ginkgo.GinkgoWriter)
+	l.WithName("testenv")
+	logf.SetLogger(l)
+
+	flag.StringVar(&specifiedLicenseFilePath, "license-file", "", "Enterprise license file to use")
+	flag.StringVar(&specifiedOperatorImage, "operator-image", defaultOperatorImage, "Splunk Operator image to use")
+	flag.StringVar(&specifiedSplunkImage, "splunk-image", defaultSplunkImage, "Splunk Enterprise (splunkd) image to use")
+	flag.StringVar(&specifiedSparkImage, "spark-image", defaultSparkImage, "Spark image to use")
+	flag.BoolVar(&specifiedSkipTeardown, "skip-teardown", false, "True to skip tearing down the test env after use")
+	flag.IntVar(&specifiedTestTimeout, "test-timeout", defaultTestTimeout, "Max test timeout in seconds to use")
+	flag.StringVar(&specifiedCommitHash, "commit-hash", "", "commit hash string to use as part of the name")
+}
+
+// GetKubeClient returns the kube client to talk to kube-apiserver
+func (testenv *TestEnv) GetKubeClient() client.Client {
+	return testenv.kubeClient
+}
+
+// NewDefaultTestEnv creates a default test environment
+func NewDefaultTestEnv(name string) (*TestEnv, error) {
+	return NewTestEnv(name, specifiedCommitHash, specifiedOperatorImage, specifiedSplunkImage, specifiedSparkImage, specifiedLicenseFilePath)
+}
+
+// NewTestEnv creates a new test environment to run tests againsts
+func NewTestEnv(name, commitHash, operatorImage, splunkImage, sparkImage, licenseFilePath string) (*TestEnv, error) {
+
+	var envName string
+	if commitHash == "" {
+		envName = name
+	} else {
+		envName = commitHash + "-" + name
+	}
+
+	// The name are used in various resource label and there is a 63 char limit. Do our part to make sure we do not exceed that limit
+	if len(envName) > 24 {
+		return nil, fmt.Errorf("both %s and %s combined have exceeded 24 chars", name, commitHash)
+	}
+
+	testenv := &TestEnv{
+		name:               envName,
+		namespace:          envName,
+		serviceAccountName: envName,
+		roleName:           envName,
+		roleBindingName:    envName,
+		operatorName:       "splunk-op-" + envName,
+		operatorImage:      operatorImage,
+		splunkImage:        splunkImage,
+		sparkImage:         sparkImage,
+		SkipTeardown:       specifiedSkipTeardown,
+		licenseCMName:      envName,
+		licenseFilePath:    licenseFilePath,
+	}
+
+	testenv.Log = logf.Log.WithValues("testenv", testenv.name)
+
+	// Scheme
+	enterprisev1.SchemeBuilder.AddToScheme(scheme.Scheme)
+
+	// Get a config to talk to the apiserver
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	testenv.kubeAPIServer = cfg.Host
+	testenv.Log.Info("Using kube-apiserver\n", "kube-apiserver", cfg.Host)
+
+	//
+	metricsAddr := fmt.Sprintf("%s:%d", metricsHost, metricsPort+ginkgoconfig.GinkgoConfig.ParallelNode)
+
+	kubeManager, err := manager.New(cfg, manager.Options{
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: metricsAddr,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	testenv.kubeClient = kubeManager.GetClient()
+	if testenv.kubeClient == nil {
+		return nil, fmt.Errorf("kubeClient is nil")
+	}
+
+	// We need to start the manager to setup the cache. Otherwise, we have to
+	// use apireader instead of kubeclient when retrieving resources
+	go func() {
+		err := kubeManager.Start(signals.SetupSignalHandler())
+		if err != nil {
+			panic("Unable to start kube manager. Error: " + err.Error())
+		}
+	}()
+
+	if err := testenv.setup(); err != nil {
+		// teardown() should still be invoked
+		return nil, err
+	}
+
+	return testenv, nil
+}
+
+//GetName returns the name of the testenv
+func (testenv *TestEnv) GetName() string {
+	return testenv.name
+}
+
+func (testenv *TestEnv) setup() error {
+	testenv.Log.Info("testenv initializing.\n")
+
+	var err error
+	err = testenv.createNamespace()
+	if err != nil {
+		return err
+	}
+
+	err = testenv.createSA()
+	if err != nil {
+		return err
+	}
+
+	err = testenv.createRole()
+	if err != nil {
+		return err
+	}
+
+	err = testenv.createRoleBinding()
+	if err != nil {
+		return err
+	}
+
+	err = testenv.createOperator()
+	if err != nil {
+		return err
+	}
+
+	if testenv.licenseFilePath != "" {
+		err = testenv.createLicenseConfigMap()
+		if err != nil {
+			return err
+		}
+	}
+	testenv.initialized = true
+	testenv.Log.Info("testenv initialized.\n", "namespace", testenv.namespace, "operatorImage", testenv.operatorImage, "splunkImage", testenv.splunkImage, "sparkImage", testenv.sparkImage)
+	return nil
+}
+
+// Teardown cleanup the resources use in this testenv
+func (testenv *TestEnv) Teardown() error {
+
+	if testenv.SkipTeardown {
+		testenv.Log.Info("testenv teardown is skipped!\n")
+		return nil
+	}
+
+	testenv.initialized = false
+
+	for fn, err := testenv.popCleanupFunc(); err == nil; fn, err = testenv.popCleanupFunc() {
+		cleanupErr := fn()
+		if cleanupErr != nil {
+			testenv.Log.Error(cleanupErr, "CleanupFunc returns an error. Attempt to continue.\n")
+		}
+	}
+
+	testenv.Log.Info("testenv deleted.\n")
+	return nil
+}
+
+func (testenv *TestEnv) pushCleanupFunc(fn cleanupFunc) {
+	testenv.cleanupFuncs = append(testenv.cleanupFuncs, fn)
+}
+
+func (testenv *TestEnv) popCleanupFunc() (cleanupFunc, error) {
+	if len(testenv.cleanupFuncs) == 0 {
+		return nil, fmt.Errorf("cleanupFuncs is empty")
+	}
+
+	fn := testenv.cleanupFuncs[len(testenv.cleanupFuncs)-1]
+	testenv.cleanupFuncs = testenv.cleanupFuncs[:len(testenv.cleanupFuncs)-1]
+
+	return fn, nil
+}
+
+func (testenv *TestEnv) createNamespace() error {
+
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testenv.namespace,
+		},
+	}
+
+	err := testenv.GetKubeClient().Create(context.TODO(), namespace)
+	if err != nil {
+		return err
+	}
+
+	// Cleanup the namespace when we teardown this testenv
+	testenv.pushCleanupFunc(func() error {
+		err := testenv.GetKubeClient().Delete(context.TODO(), namespace)
+		if err != nil {
+			testenv.Log.Error(err, "Unable to delete namespace")
+			return err
+		}
+		if err = wait.PollImmediate(PollInterval, DefaultTimeout, func() (bool, error) {
+			key := client.ObjectKey{Name: testenv.namespace, Namespace: testenv.namespace}
+			ns := &corev1.Namespace{}
+			err := testenv.GetKubeClient().Get(context.TODO(), key, ns)
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			if ns.Status.Phase == corev1.NamespaceTerminating {
+				return false, nil
+			}
+
+			return true, nil
+		}); err != nil {
+			testenv.Log.Error(err, "Unable to delete namespace")
+			return err
+		}
+
+		return nil
+	})
+
+	if err := wait.PollImmediate(PollInterval, DefaultTimeout, func() (bool, error) {
+		key := client.ObjectKey{Name: testenv.namespace}
+		ns := &corev1.Namespace{}
+		err := testenv.GetKubeClient().Get(context.TODO(), key, ns)
+		if err != nil {
+			// Try again
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		if ns.Status.Phase == corev1.NamespaceActive {
+			return true, nil
+		}
+
+		return false, nil
+	}); err != nil {
+		testenv.Log.Error(err, "Unable to get namespace")
+		return err
+	}
+
+	return nil
+}
+
+func (testenv *TestEnv) createSA() error {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testenv.serviceAccountName,
+			Namespace: testenv.namespace,
+		},
+	}
+
+	err := testenv.GetKubeClient().Create(context.TODO(), sa)
+	if err != nil {
+		testenv.Log.Error(err, "Unable to create service account")
+		return err
+	}
+
+	testenv.pushCleanupFunc(func() error {
+		err := testenv.GetKubeClient().Delete(context.TODO(), sa)
+		if err != nil {
+			testenv.Log.Error(err, "Unable to delete service account")
+			return err
+		}
+		return nil
+	})
+
+	return nil
+}
+
+func (testenv *TestEnv) createRole() error {
+	role := newRole(testenv.roleName, testenv.namespace)
+
+	err := testenv.GetKubeClient().Create(context.TODO(), role)
+	if err != nil {
+		testenv.Log.Error(err, "Unable to create role")
+		return err
+	}
+
+	testenv.pushCleanupFunc(func() error {
+		err := testenv.GetKubeClient().Delete(context.TODO(), role)
+		if err != nil {
+			testenv.Log.Error(err, "Unable to delete role")
+			return err
+		}
+		return nil
+	})
+
+	return nil
+}
+
+func (testenv *TestEnv) createRoleBinding() error {
+	binding := newRoleBinding(testenv.roleBindingName, testenv.serviceAccountName, testenv.namespace, testenv.roleName)
+
+	err := testenv.GetKubeClient().Create(context.TODO(), binding)
+	if err != nil {
+		testenv.Log.Error(err, "Unable to create rolebinding")
+		return err
+	}
+
+	testenv.pushCleanupFunc(func() error {
+		err := testenv.GetKubeClient().Delete(context.TODO(), binding)
+		if err != nil {
+			testenv.Log.Error(err, "Unable to delete rolebinding")
+			return err
+		}
+		return nil
+	})
+
+	return nil
+}
+
+func (testenv *TestEnv) createOperator() error {
+	op := newOperator(testenv.operatorName, testenv.namespace, testenv.serviceAccountName, testenv.operatorImage, testenv.splunkImage, testenv.sparkImage)
+	err := testenv.GetKubeClient().Create(context.TODO(), op)
+	if err != nil {
+		testenv.Log.Error(err, "Unable to create operator")
+		return err
+	}
+
+	testenv.pushCleanupFunc(func() error {
+		err := testenv.GetKubeClient().Delete(context.TODO(), op)
+		if err != nil {
+			testenv.Log.Error(err, "Unable to delete operator")
+			return err
+		}
+		return nil
+	})
+
+	if err := wait.PollImmediate(PollInterval, DefaultTimeout, func() (bool, error) {
+		key := client.ObjectKey{Name: testenv.operatorName, Namespace: testenv.namespace}
+		deployment := &appsv1.Deployment{}
+		err := testenv.GetKubeClient().Get(context.TODO(), key, deployment)
+		if err != nil {
+			return false, err
+		}
+
+		dumpGetPods(testenv.namespace)
+		if deployment.Status.UpdatedReplicas < deployment.Status.Replicas {
+			return false, nil
+		}
+
+		if deployment.Status.ReadyReplicas < *op.Spec.Replicas {
+			return false, nil
+		}
+
+		return true, nil
+	}); err != nil {
+		testenv.Log.Error(err, "Unable to create operator")
+		return err
+	}
+	return nil
+}
+
+func (testenv *TestEnv) createLicenseConfigMap() error {
+	lic, err := newLicenseConfigMap(testenv.licenseCMName, testenv.namespace, testenv.licenseFilePath)
+	if err != nil {
+		return err
+	}
+	if err := testenv.GetKubeClient().Create(context.TODO(), lic); err != nil {
+		testenv.Log.Error(err, "Unable to create license configmap")
+		return err
+	}
+
+	testenv.pushCleanupFunc(func() error {
+		err := testenv.GetKubeClient().Delete(context.TODO(), lic)
+		if err != nil {
+			testenv.Log.Error(err, "Unable to delete license configmap ")
+			return err
+		}
+		return nil
+	})
+
+	return nil
+}
+
+// NewDeployment creates a new deployment
+func (testenv *TestEnv) NewDeployment(name string) (*Deployment, error) {
+	d := Deployment{
+		name:              testenv.GetName() + "-" + name,
+		testenv:           testenv,
+		testTimeoutInSecs: time.Duration(specifiedTestTimeout) * time.Second,
+	}
+
+	return &d, nil
+}

--- a/test/testenv/util.go
+++ b/test/testenv/util.go
@@ -1,0 +1,316 @@
+package testenv
+
+import (
+	"io/ioutil"
+	"math/rand"
+	"os/exec"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/operator-framework/operator-sdk/pkg/log/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1alpha2"
+)
+
+const (
+	letterBytes = "abcdefghijklmnopqrstuvwxyz0123456789"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+	l := zap.LoggerTo(ginkgo.GinkgoWriter)
+	l.WithName("util")
+	logf.SetLogger(l)
+}
+
+// RandomDNSName returns a random string that is a valid DNS name
+func RandomDNSName(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		// Must start with letter
+		if i == 0 {
+			b[i] = letterBytes[rand.Intn(25)]
+		} else {
+			b[i] = letterBytes[rand.Intn(len(letterBytes))]
+		}
+	}
+	return string(b)
+}
+
+// newStandalone creates and initializes CR for Standalone Kind
+func newStandalone(name, ns string) *enterprisev1.Standalone {
+
+	new := enterprisev1.Standalone{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Standalone",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  ns,
+			Finalizers: []string{"enterprise.splunk.com/delete-pvc"},
+		},
+
+		Spec: enterprisev1.StandaloneSpec{
+			CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
+				Volumes: []corev1.Volume{},
+				CommonSpec: enterprisev1.CommonSpec{
+					ImagePullPolicy: "IfNotPresent",
+				},
+			},
+		},
+	}
+
+	return &new
+}
+
+func newLicenseMaster(name, ns, licenseConfigMapName string) *enterprisev1.LicenseMaster {
+	new := enterprisev1.LicenseMaster{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "LicenseMaster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  ns,
+			Finalizers: []string{"enterprise.splunk.com/delete-pvc"},
+		},
+
+		Spec: enterprisev1.LicenseMasterSpec{
+			CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
+				Volumes: []corev1.Volume{
+					{
+						Name: "licenses",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: licenseConfigMapName,
+								},
+							},
+						},
+					},
+				},
+				// TODO: Ensure the license file is actually called "enterprise.lic" when creating the config map
+				LicenseURL: "/mnt/licenses/enterprise.lic",
+				CommonSpec: enterprisev1.CommonSpec{
+					ImagePullPolicy: "IfNotPresent",
+				},
+			},
+		},
+	}
+
+	return &new
+}
+
+// newIndexerCluster creates and initialize the CR for IndexerCluster Kind
+func newIndexerCluster(name, ns, licenseMasterName string, replicas int) *enterprisev1.IndexerCluster {
+	new := enterprisev1.IndexerCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "IndexerCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  ns,
+			Finalizers: []string{"enterprise.splunk.com/delete-pvc"},
+		},
+
+		Spec: enterprisev1.IndexerClusterSpec{
+			CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
+				Volumes: []corev1.Volume{},
+				CommonSpec: enterprisev1.CommonSpec{
+					ImagePullPolicy: "IfNotPresent",
+				},
+				LicenseMasterRef: corev1.ObjectReference{
+					Name: licenseMasterName,
+				},
+			},
+			Replicas: int32(replicas),
+		},
+	}
+
+	return &new
+}
+
+func newSearchHeadCluster(name, ns, indexerClusterName, licenseMasterName string) *enterprisev1.SearchHeadCluster {
+	new := enterprisev1.SearchHeadCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "SearchHeadCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  ns,
+			Finalizers: []string{"enterprise.splunk.com/delete-pvc"},
+		},
+
+		Spec: enterprisev1.SearchHeadClusterSpec{
+			CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
+				Volumes: []corev1.Volume{},
+				CommonSpec: enterprisev1.CommonSpec{
+					ImagePullPolicy: "IfNotPresent",
+				},
+				IndexerClusterRef: corev1.ObjectReference{
+					Name: indexerClusterName,
+				},
+				LicenseMasterRef: corev1.ObjectReference{
+					Name: licenseMasterName,
+				},
+			},
+		},
+	}
+
+	return &new
+}
+
+func newRole(name, ns string) *rbacv1.Role {
+	new := rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"services", "endpoints", "persistentvolumeclaims", "configmaps", "secrets", "pods"},
+				Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"events"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments", "damonsets", "replicasets", "statefulsets"},
+				Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+			},
+			{
+				APIGroups: []string{"enterprise.splunk.com"},
+				Resources: []string{"*"},
+				Verbs:     []string{"*"},
+			},
+		},
+	}
+
+	return &new
+}
+
+func newRoleBinding(name, subject, ns, role string) *rbacv1.RoleBinding {
+	binding := rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      subject,
+				Namespace: ns,
+			},
+		},
+
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "Role",
+			Name:     role,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+
+	return &binding
+}
+
+func newLicenseConfigMap(name, ns, localLicenseFilePath string) (*corev1.ConfigMap, error) {
+
+	data, err := ioutil.ReadFile(localLicenseFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	cm := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Data: map[string]string{
+			path.Base(localLicenseFilePath): string(data),
+		},
+	}
+
+	return &cm, nil
+}
+
+func newOperator(name, ns, account, operatorImageAndTag, splunkEnterpriseImageAndTag, sparkImageAndTag string) *appsv1.Deployment {
+	var replicas int32 = 1
+
+	operator := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": "splunk-operator",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"name": "splunk-operator",
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: account,
+					Containers: []corev1.Container{
+						{
+							Name:            name,
+							Image:           operatorImageAndTag,
+							ImagePullPolicy: "IfNotPresent",
+							Env: []corev1.EnvVar{
+								{
+									Name: "WATCH_NAMESPACE",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								}, {
+									Name: "POD_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.name",
+										},
+									},
+								}, {
+									Name:  "OPERATOR_NAME",
+									Value: "splunk-operator",
+								}, {
+									Name:  "RELATED_IMAGE_SPLUNK_ENTERPRISE",
+									Value: splunkEnterpriseImageAndTag,
+								}, {
+									Name:  "RELATED_IMAGE_SPLUNK_SPARK",
+									Value: sparkImageAndTag,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return &operator
+}
+
+func dumpGetPods(ns string) {
+	output, _ := exec.Command("kubectl", "get", "pod", "-n", ns).Output()
+	for _, line := range strings.Split(string(output), "\n") {
+		logf.Log.Info(line)
+	}
+}


### PR DESCRIPTION
This PR
- adds the test framework using Ginkgo. It is under /test/testenv (Please see /test/README doc for more details).
- adds 2 basic tests using the test framework. The tests deploy a standalone (s2) and clustered (c3 - 3 indexers, 3 shs) and verified they are deployed and "ready".
- adds test scripts under /test to deploy kind or eks cluster and run the tests (Please see README doc under /test for details).
- updates Makefile and circleci's config.yaml to deploy the cluster and run the tests in the pipeline.