### PR TITLE
cspl-348: K8 SmartStore: Create a Config map for the indexes configuration in INI format

### DIFF
--- a/deploy/crds/enterprise.splunk.com_indexerclusters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_indexerclusters_crd.yaml
@@ -1011,11 +1011,15 @@ spec:
                   items:
                     description: IndexSpec defines Splunk index name and storage path
                     properties:
-                      location:
-                        description: Index location on the remote storage path
-                        type: string
                       name:
                         description: Splunk index name
+                        type: string
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
+                        type: string
+                      volumeName:
+                        description: Remote Volume name
                         type: string
                     type: object
                   type: array
@@ -1030,6 +1034,9 @@ spec:
                         type: string
                       name:
                         description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
                         type: string
                     type: object
                   type: array
@@ -2350,11 +2357,15 @@ spec:
                   items:
                     description: IndexSpec defines Splunk index name and storage path
                     properties:
-                      location:
-                        description: Index location on the remote storage path
-                        type: string
                       name:
                         description: Splunk index name
+                        type: string
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
+                        type: string
+                      volumeName:
+                        description: Remote Volume name
                         type: string
                     type: object
                   type: array
@@ -2369,6 +2380,9 @@ spec:
                         type: string
                       name:
                         description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
                         type: string
                     type: object
                   type: array

--- a/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
@@ -1003,11 +1003,15 @@ spec:
                   items:
                     description: IndexSpec defines Splunk index name and storage path
                     properties:
-                      location:
-                        description: Index location on the remote storage path
-                        type: string
                       name:
                         description: Splunk index name
+                        type: string
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
+                        type: string
+                      volumeName:
+                        description: Remote Volume name
                         type: string
                     type: object
                   type: array
@@ -1022,6 +1026,9 @@ spec:
                         type: string
                       name:
                         description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
                         type: string
                     type: object
                   type: array
@@ -2330,11 +2337,15 @@ spec:
                   items:
                     description: IndexSpec defines Splunk index name and storage path
                     properties:
-                      location:
-                        description: Index location on the remote storage path
-                        type: string
                       name:
                         description: Splunk index name
+                        type: string
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
+                        type: string
+                      volumeName:
+                        description: Remote Volume name
                         type: string
                     type: object
                   type: array
@@ -2349,6 +2360,9 @@ spec:
                         type: string
                       name:
                         description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
                         type: string
                     type: object
                   type: array

--- a/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_indexerclusters_crd.yaml
+++ b/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_indexerclusters_crd.yaml
@@ -1011,11 +1011,15 @@ spec:
                   items:
                     description: IndexSpec defines Splunk index name and storage path
                     properties:
-                      location:
-                        description: Index location on the remote storage path
-                        type: string
                       name:
                         description: Splunk index name
+                        type: string
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
+                        type: string
+                      volumeName:
+                        description: Remote Volume name
                         type: string
                     type: object
                   type: array
@@ -1030,6 +1034,9 @@ spec:
                         type: string
                       name:
                         description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
                         type: string
                     type: object
                   type: array
@@ -2350,11 +2357,15 @@ spec:
                   items:
                     description: IndexSpec defines Splunk index name and storage path
                     properties:
-                      location:
-                        description: Index location on the remote storage path
-                        type: string
                       name:
                         description: Splunk index name
+                        type: string
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
+                        type: string
+                      volumeName:
+                        description: Remote Volume name
                         type: string
                     type: object
                   type: array
@@ -2369,6 +2380,9 @@ spec:
                         type: string
                       name:
                         description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
                         type: string
                     type: object
                   type: array

--- a/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_standalones_crd.yaml
@@ -1003,11 +1003,15 @@ spec:
                   items:
                     description: IndexSpec defines Splunk index name and storage path
                     properties:
-                      location:
-                        description: Index location on the remote storage path
-                        type: string
                       name:
                         description: Splunk index name
+                        type: string
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
+                        type: string
+                      volumeName:
+                        description: Remote Volume name
                         type: string
                     type: object
                   type: array
@@ -1022,6 +1026,9 @@ spec:
                         type: string
                       name:
                         description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
                         type: string
                     type: object
                   type: array
@@ -2330,11 +2337,15 @@ spec:
                   items:
                     description: IndexSpec defines Splunk index name and storage path
                     properties:
-                      location:
-                        description: Index location on the remote storage path
-                        type: string
                       name:
                         description: Splunk index name
+                        type: string
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
+                        type: string
+                      volumeName:
+                        description: Remote Volume name
                         type: string
                     type: object
                   type: array
@@ -2349,6 +2360,9 @@ spec:
                         type: string
                       name:
                         description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
                         type: string
                     type: object
                   type: array

--- a/pkg/apis/enterprise/v1alpha3/common_types.go
+++ b/pkg/apis/enterprise/v1alpha3/common_types.go
@@ -84,6 +84,9 @@ type VolumeSpec struct {
 
 	// Remote volume URI
 	Endpoint string `json:"endpoint"`
+
+	// Remote volume path
+	Path string `json:"path"`
 }
 
 // IndexSpec defines Splunk index name and storage path
@@ -91,6 +94,9 @@ type IndexSpec struct {
 	// Splunk index name
 	Name string `json:"name"`
 
-	// Index location on the remote storage path
-	RemoteLocation string `json:"location"`
+	// Index location relative to the remote volume path
+	RemotePath string `json:"remotePath"`
+
+	// Remote Volume name
+	VolName string `json:"volumeName"`
 }

--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -223,6 +223,19 @@ func getSplunkDefaults(identifier, namespace string, instanceType InstanceType, 
 	}
 }
 
+// getSplunkSmartstoreConfigMap returns a Kubernetes ConfigMap containing Splunk smartstore cofig in INI format
+func getSplunkSmartstoreConfigMap(identifier, namespace string, crKind string, smartstoreConf string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      GetSplunkSmartstoreConfigMapName(identifier, crKind),
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"indexes.conf": smartstoreConf,
+		},
+	}
+}
+
 // getSplunkSecrets returns a Kubernetes Secret containing randomly generated default secrets to use for a Splunk Enterprise resource.
 func getSplunkSecrets(cr splcommon.MetaObject, instanceType InstanceType, idxcSecret []byte, pass4SymmKey []byte) *corev1.Secret {
 	// idxc_secret is option, and may be used to override random generation
@@ -648,7 +661,7 @@ func LogSmartStoreVolumes(volumeList []enterprisev1.VolumeSpec) {
 	scopedLog := logC.WithName("LogSmartStoreVolumes")
 	//var temp string
 	for _, volume := range volumeList {
-		scopedLog.Info("Volume: ", "name: ", volume.Name, "endpoint: ", volume.Endpoint)
+		scopedLog.Info("Volume: ", "name: ", volume.Name, "endpoint: ", volume.Endpoint, "path: ", volume.Path)
 	}
 }
 
@@ -656,7 +669,7 @@ func LogSmartStoreVolumes(volumeList []enterprisev1.VolumeSpec) {
 func LogSmartStoreIndexes(indexList []enterprisev1.IndexSpec) {
 	scopedLog := logC.WithName("LogSmartStoreIndexes")
 	for _, index := range indexList {
-		scopedLog.Info("Index: ", "name: ", index.Name, "location: ", index.RemoteLocation)
+		scopedLog.Info("Index: ", "name: ", index.Name, "remotePath: ", index.RemotePath, "volumeName", index.VolName)
 	}
 }
 
@@ -687,19 +700,32 @@ func ValidateSplunkSmartstoreSpec(smartstore *enterprisev1.SmartStoreSpec) error
 	volume := smartstore.VolList[0]
 	// Make sure that the smartstore volume info is correct
 	if volume.Name == "" {
+		// To Do: cspl-348 sgontla: Once multiple volumes are supported, we can relax this by introducing default volume concept
 		return fmt.Errorf("Volume name is missing")
-	} else if volume.Endpoint == "" {
+	}
+
+	if volume.Endpoint == "" {
 		return fmt.Errorf("Volume Endpoint URI is missing")
+	}
+
+	if volume.Path == "" {
+		return fmt.Errorf("Volume Path is missing")
 	}
 
 	indexList := smartstore.IndexList
 	// Make sure that all the indexes are provided with the mandatory config values.
-	// Placeholder to fill any default values. All
+	// Placeholder to support any default volume.
 	for i, index := range indexList {
 		if index.Name == "" {
 			return fmt.Errorf("Index name is missing for index at: %d", i)
-		} else if index.RemoteLocation == "" {
-			return fmt.Errorf("Index RemoteLocation is missing for index at: %d", i)
+		}
+
+		if index.VolName == "" {
+			return fmt.Errorf("volumeName is missing for index: %s", index.Name)
+		}
+
+		if index.VolName != volume.Name {
+			return fmt.Errorf("Unknown volume %s configured for index: %s", index.VolName, index.Name)
 		}
 	}
 
@@ -707,4 +733,57 @@ func ValidateSplunkSmartstoreSpec(smartstore *enterprisev1.SmartStoreSpec) error
 	LogSmartStoreVolumes(smartstore.VolList)
 	LogSmartStoreIndexes(indexList)
 	return nil
+}
+
+// GetSmartstoreVolumesConfig returns the list of Volumes configuration in INI format
+func GetSmartstoreVolumesConfig(client splcommon.ControllerClient, cr splcommon.MetaObject, smartstore *enterprisev1.SmartStoreSpec) (string, error) {
+	var (
+		volumesConf                   = ""
+		s3AccessKey, s3SecretKey, err = GetSmartstoreSecrets(client, cr, smartstore)
+	)
+
+	if err != nil {
+		return "", err
+	}
+
+	volumes := smartstore.VolList
+	for i := len(volumes) - 1; i >= 0; i-- {
+		volumesConf = fmt.Sprintf(`
+[volume:%s]
+storageType = remote
+path = s3://%s
+remote.s3.access_key = %s
+remote.s3.secret_key = %s
+remote.s3.endpoint = %s
+%s`, volumes[i].Name, volumes[i].Path, s3AccessKey, s3SecretKey, volumes[i].Endpoint, volumesConf)
+	}
+
+	return volumesConf, nil
+}
+
+// GetSmartstoreIndexesConfig returns the list of indexes configuration in INI format
+func GetSmartstoreIndexesConfig(indexes []enterprisev1.IndexSpec) string {
+
+	var (
+		indexesConf = ""
+		remotePath  string
+
+		//To Do: sgontla: Do we need to enforce $_index_name?
+		defaultRemotePath = "$_index_name"
+	)
+
+	for i := len(indexes) - 1; i >= 0; i-- {
+		if indexes[i].RemotePath != "" {
+			remotePath = indexes[i].RemotePath
+		} else {
+			remotePath = defaultRemotePath
+		}
+
+		indexesConf = fmt.Sprintf(`
+[%s]
+remotePath = volume:%s
+%s`, indexes[i].Name, remotePath, indexesConf)
+	}
+
+	return indexesConf
 }

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -56,8 +56,23 @@ func ApplyIndexerCluster(client splcommon.ControllerClient, cr *enterprisev1.Ind
 	cr.Status.ClusterMasterPhase = splcommon.PhaseError
 	cr.Status.Replicas = cr.Spec.Replicas
 	if !reflect.DeepEqual(cr.Status.SmartStore, cr.Spec.SmartStore) {
+		_, err := CreateSmartStoreConfigMap(client, cr, &cr.Spec.SmartStore)
+		if err != nil {
+			return result, err
+		}
+
+		// To do: sgontla: Do we need to update the status in K8 etcd immediately?
+		// Consider the case, where the Cluster master validates the config, and
+		// generates config map, but fails later in the flow to complete its
+		// stateful set. Meanwhile, all the indexer cluster sites notices new
+		// config map, and keeps resetting the indexers. This is not problem,
+		// as long as:
+		// 1. ApplyConfigMap avoids a CRUD update if there is no change to data,
+		// which is already happening today, so, this scenario shouldn't happen.
+		// 2. To Do: Is there anything additional to be done on indexer site?
 		cr.Status.SmartStore = cr.Spec.SmartStore
 	}
+
 	cr.Status.Selector = fmt.Sprintf("app.kubernetes.io/instance=splunk-%s-indexer", cr.GetName())
 	if cr.Status.Peers == nil {
 		cr.Status.Peers = []enterprisev1.IndexerClusterMemberStatus{}

--- a/pkg/splunk/enterprise/names.go
+++ b/pkg/splunk/enterprise/names.go
@@ -41,6 +41,9 @@ const (
 	// identifier
 	defaultsTemplateStr = "splunk-%s-%s-defaults"
 
+	// identifier
+	smartstoreTemplateStr = "splunk-%s-%s-smartstore"
+
 	// default docker image used for Splunk instances
 	defaultSplunkImage = "splunk/splunk"
 
@@ -52,6 +55,12 @@ const (
 
 	// namespace scoped secret name
 	commonSecretName = "splunk-secrets"
+
+	// identified used for S3 access key
+	s3AccessKey = "s3_access_key"
+
+	// identified used for S3 access key
+	s3SecretKey = "s3_secret_key"
 )
 
 // GetSplunkDeploymentName uses a template to name a Kubernetes Deployment for Splunk instances.
@@ -90,6 +99,11 @@ func GetSplunkSecretsName(identifier string, instanceType InstanceType) string {
 // GetSplunkDefaultsName uses a template to name a Kubernetes ConfigMap for a SplunkEnterprise resource.
 func GetSplunkDefaultsName(identifier string, instanceType InstanceType) string {
 	return fmt.Sprintf(defaultsTemplateStr, identifier, instanceType.ToKind())
+}
+
+// GetSplunkSmartstoreConfigMapName uses a template to name a Kubernetes ConfigMap for a SplunkEnterprise resource.
+func GetSplunkSmartstoreConfigMapName(identifier string, crKind string) string {
+	return fmt.Sprintf(smartstoreTemplateStr, identifier, strings.ToLower(crKind))
 }
 
 // GetSplunkStatefulsetUrls returns a list of fully qualified domain names for all pods within a Splunk StatefulSet.

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -52,8 +52,14 @@ func ApplyStandalone(client splcommon.ControllerClient, cr *enterprisev1.Standal
 	cr.Status.Phase = splcommon.PhaseError
 	cr.Status.Replicas = cr.Spec.Replicas
 	if !reflect.DeepEqual(cr.Status.SmartStore, cr.Spec.SmartStore) {
+		_, err := CreateSmartStoreConfigMap(client, cr, &cr.Spec.SmartStore)
+		if err != nil {
+			return result, err
+		}
+
 		cr.Status.SmartStore = cr.Spec.SmartStore
 	}
+
 	cr.Status.Selector = fmt.Sprintf("app.kubernetes.io/instance=splunk-%s-standalone", cr.GetName())
 	defer func() {
 		client.Status().Update(context.TODO(), cr)


### PR DESCRIPTION
- When the CR is configured for  Smartstore indexes in yaml format, convert that config
into INI stanza format, and write a configMap, which can be later mounted to the indexer
as indexes.conf.