### PR TITLE
cspl-348: K8 SmartStore: Create a Config map for the indexes configuration in INI format

### DIFF
--- a/deploy/crds/enterprise.splunk.com_indexerclusters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_indexerclusters_crd.yaml
@@ -1011,11 +1011,15 @@ spec:
                   items:
                     description: IndexSpec defines Splunk index name and storage path
                     properties:
-                      location:
-                        description: Index location on the remote storage path
-                        type: string
                       name:
                         description: Splunk index name
+                        type: string
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
+                        type: string
+                      volumeName:
+                        description: Remote Volume name
                         type: string
                     type: object
                   type: array
@@ -1030,6 +1034,9 @@ spec:
                         type: string
                       name:
                         description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
                         type: string
                     type: object
                   type: array
@@ -2350,11 +2357,15 @@ spec:
                   items:
                     description: IndexSpec defines Splunk index name and storage path
                     properties:
-                      location:
-                        description: Index location on the remote storage path
-                        type: string
                       name:
                         description: Splunk index name
+                        type: string
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
+                        type: string
+                      volumeName:
+                        description: Remote Volume name
                         type: string
                     type: object
                   type: array
@@ -2369,6 +2380,9 @@ spec:
                         type: string
                       name:
                         description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
                         type: string
                     type: object
                   type: array

--- a/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
@@ -1003,11 +1003,15 @@ spec:
                   items:
                     description: IndexSpec defines Splunk index name and storage path
                     properties:
-                      location:
-                        description: Index location on the remote storage path
-                        type: string
                       name:
                         description: Splunk index name
+                        type: string
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
+                        type: string
+                      volumeName:
+                        description: Remote Volume name
                         type: string
                     type: object
                   type: array
@@ -1022,6 +1026,9 @@ spec:
                         type: string
                       name:
                         description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
                         type: string
                     type: object
                   type: array
@@ -2330,11 +2337,15 @@ spec:
                   items:
                     description: IndexSpec defines Splunk index name and storage path
                     properties:
-                      location:
-                        description: Index location on the remote storage path
-                        type: string
                       name:
                         description: Splunk index name
+                        type: string
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
+                        type: string
+                      volumeName:
+                        description: Remote Volume name
                         type: string
                     type: object
                   type: array
@@ -2349,6 +2360,9 @@ spec:
                         type: string
                       name:
                         description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
                         type: string
                     type: object
                   type: array

--- a/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_indexerclusters_crd.yaml
+++ b/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_indexerclusters_crd.yaml
@@ -1011,11 +1011,15 @@ spec:
                   items:
                     description: IndexSpec defines Splunk index name and storage path
                     properties:
-                      location:
-                        description: Index location on the remote storage path
-                        type: string
                       name:
                         description: Splunk index name
+                        type: string
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
+                        type: string
+                      volumeName:
+                        description: Remote Volume name
                         type: string
                     type: object
                   type: array
@@ -1030,6 +1034,9 @@ spec:
                         type: string
                       name:
                         description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
                         type: string
                     type: object
                   type: array
@@ -2350,11 +2357,15 @@ spec:
                   items:
                     description: IndexSpec defines Splunk index name and storage path
                     properties:
-                      location:
-                        description: Index location on the remote storage path
-                        type: string
                       name:
                         description: Splunk index name
+                        type: string
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
+                        type: string
+                      volumeName:
+                        description: Remote Volume name
                         type: string
                     type: object
                   type: array
@@ -2369,6 +2380,9 @@ spec:
                         type: string
                       name:
                         description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
                         type: string
                     type: object
                   type: array

--- a/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_standalones_crd.yaml
@@ -1003,11 +1003,15 @@ spec:
                   items:
                     description: IndexSpec defines Splunk index name and storage path
                     properties:
-                      location:
-                        description: Index location on the remote storage path
-                        type: string
                       name:
                         description: Splunk index name
+                        type: string
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
+                        type: string
+                      volumeName:
+                        description: Remote Volume name
                         type: string
                     type: object
                   type: array
@@ -1022,6 +1026,9 @@ spec:
                         type: string
                       name:
                         description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
                         type: string
                     type: object
                   type: array
@@ -2330,11 +2337,15 @@ spec:
                   items:
                     description: IndexSpec defines Splunk index name and storage path
                     properties:
-                      location:
-                        description: Index location on the remote storage path
-                        type: string
                       name:
                         description: Splunk index name
+                        type: string
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
+                        type: string
+                      volumeName:
+                        description: Remote Volume name
                         type: string
                     type: object
                   type: array
@@ -2349,6 +2360,9 @@ spec:
                         type: string
                       name:
                         description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
                         type: string
                     type: object
                   type: array

--- a/pkg/apis/enterprise/v1alpha3/common_types.go
+++ b/pkg/apis/enterprise/v1alpha3/common_types.go
@@ -84,6 +84,9 @@ type VolumeSpec struct {
 
 	// Remote volume URI
 	Endpoint string `json:"endpoint"`
+
+	// Remote volume path
+	Path string `json:"path"`
 }
 
 // IndexSpec defines Splunk index name and storage path
@@ -91,6 +94,9 @@ type IndexSpec struct {
 	// Splunk index name
 	Name string `json:"name"`
 
-	// Index location on the remote storage path
-	RemoteLocation string `json:"location"`
+	// Index location relative to the remote volume path
+	RemotePath string `json:"remotePath"`
+
+	// Remote Volume name
+	VolName string `json:"volumeName"`
 }

--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -223,6 +223,19 @@ func getSplunkDefaults(identifier, namespace string, instanceType InstanceType, 
 	}
 }
 
+// getSplunkSmartstoreConfigMap returns a Kubernetes ConfigMap containing Splunk smartstore cofig in INI format
+func getSplunkSmartstoreConfigMap(identifier, namespace string, crKind string, smartstoreConf string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      GetSplunkSmartstoreConfigMapName(identifier, crKind),
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"indexes.conf": smartstoreConf,
+		},
+	}
+}
+
 // generateSplunkSecret returns a randomly generated Splunk secret.
 func generateSplunkSecret() []byte {
 	return splcommon.GenerateSecret(secretBytes, 24)
@@ -600,7 +613,7 @@ func LogSmartStoreVolumes(volumeList []enterprisev1.VolumeSpec) {
 	scopedLog := logC.WithName("LogSmartStoreVolumes")
 	//var temp string
 	for _, volume := range volumeList {
-		scopedLog.Info("Volume: ", "name: ", volume.Name, "endpoint: ", volume.Endpoint)
+		scopedLog.Info("Volume: ", "name: ", volume.Name, "endpoint: ", volume.Endpoint, "path: ", volume.Path)
 	}
 }
 
@@ -608,7 +621,7 @@ func LogSmartStoreVolumes(volumeList []enterprisev1.VolumeSpec) {
 func LogSmartStoreIndexes(indexList []enterprisev1.IndexSpec) {
 	scopedLog := logC.WithName("LogSmartStoreIndexes")
 	for _, index := range indexList {
-		scopedLog.Info("Index: ", "name: ", index.Name, "location: ", index.RemoteLocation)
+		scopedLog.Info("Index: ", "name: ", index.Name, "remotePath: ", index.RemotePath, "volumeName", index.VolName)
 	}
 }
 
@@ -639,19 +652,32 @@ func ValidateSplunkSmartstoreSpec(smartstore *enterprisev1.SmartStoreSpec) error
 	volume := smartstore.VolList[0]
 	// Make sure that the smartstore volume info is correct
 	if volume.Name == "" {
+		// To Do: cspl-348 sgontla: Once multiple volumes are supported, we can relax this by introducing default volume concept
 		return fmt.Errorf("Volume name is missing")
-	} else if volume.Endpoint == "" {
+	}
+
+	if volume.Endpoint == "" {
 		return fmt.Errorf("Volume Endpoint URI is missing")
+	}
+
+	if volume.Path == "" {
+		return fmt.Errorf("Volume Path is missing")
 	}
 
 	indexList := smartstore.IndexList
 	// Make sure that all the indexes are provided with the mandatory config values.
-	// Placeholder to fill any default values. All
+	// Placeholder to support any default volume.
 	for i, index := range indexList {
 		if index.Name == "" {
 			return fmt.Errorf("Index name is missing for index at: %d", i)
-		} else if index.RemoteLocation == "" {
-			return fmt.Errorf("Index RemoteLocation is missing for index at: %d", i)
+		}
+
+		if index.VolName == "" {
+			return fmt.Errorf("volumeName is missing for index: %s", index.Name)
+		}
+
+		if index.VolName != volume.Name {
+			return fmt.Errorf("Unknown volume %s configured for index: %s", index.VolName, index.Name)
 		}
 	}
 
@@ -659,4 +685,57 @@ func ValidateSplunkSmartstoreSpec(smartstore *enterprisev1.SmartStoreSpec) error
 	LogSmartStoreVolumes(smartstore.VolList)
 	LogSmartStoreIndexes(indexList)
 	return nil
+}
+
+// GetSmartstoreVolumesConfig returns the list of Volumes configuration in INI format
+func GetSmartstoreVolumesConfig(client splcommon.ControllerClient, cr splcommon.MetaObject, smartstore *enterprisev1.SmartStoreSpec) (string, error) {
+	var (
+		volumesConf                   = ""
+		s3AccessKey, s3SecretKey, err = GetSmartstoreSecrets(client, cr, smartstore)
+	)
+
+	if err != nil {
+		return "", err
+	}
+
+	volumes := smartstore.VolList
+	for i := len(volumes) - 1; i >= 0; i-- {
+		volumesConf = fmt.Sprintf(`
+[volume:%s]
+storageType = remote
+path = s3://%s
+remote.s3.access_key = %s
+remote.s3.secret_key = %s
+remote.s3.endpoint = %s
+%s`, volumes[i].Name, volumes[i].Path, s3AccessKey, s3SecretKey, volumes[i].Endpoint, volumesConf)
+	}
+
+	return volumesConf, nil
+}
+
+// GetSmartstoreIndexesConfig returns the list of indexes configuration in INI format
+func GetSmartstoreIndexesConfig(indexes []enterprisev1.IndexSpec) string {
+
+	var (
+		indexesConf = ""
+		remotePath  string
+
+		//To Do: sgontla: Do we need to enforce $_index_name?
+		defaultRemotePath = "$_index_name"
+	)
+
+	for i := len(indexes) - 1; i >= 0; i-- {
+		if indexes[i].RemotePath != "" {
+			remotePath = indexes[i].RemotePath
+		} else {
+			remotePath = defaultRemotePath
+		}
+
+		indexesConf = fmt.Sprintf(`
+[%s]
+remotePath = volume:%s
+%s`, indexes[i].Name, remotePath, indexesConf)
+	}
+
+	return indexesConf
 }

--- a/pkg/splunk/enterprise/configuration_test.go
+++ b/pkg/splunk/enterprise/configuration_test.go
@@ -199,13 +199,13 @@ func TestSmartstoreApplyIndexerClusterFailsOnInvalidSmartStoreConfig(t *testing.
 			Replicas: 1,
 			SmartStore: enterprisev1.SmartStoreSpec{
 				VolList: []enterprisev1.VolumeSpec{
-					{Name: "msos_s2s3_vol", Endpoint: ""},
+					{Name: "msos_s2s3_vol", Endpoint: "", Path: "testbucket-rs-london"},
 				},
 
 				IndexList: []enterprisev1.IndexSpec{
-					{Name: "salesdata1", RemoteLocation: "testbucket-rs-london/$_index_name"},
-					{Name: "salesdata2", RemoteLocation: "testbucket-rs-london/$_index_name"},
-					{Name: "salesdata3", RemoteLocation: "testbucket-rs-london/$_index_name"},
+					{Name: "salesdata1"},
+					{Name: "salesdata2", RemotePath: "salesdata2"},
+					{Name: "salesdata3", RemotePath: ""},
 				},
 			},
 		},
@@ -229,13 +229,13 @@ func TestSmartstoreApplyStandaloneFailsOnInvalidSmartStoreConfig(t *testing.T) {
 			Replicas: 1,
 			SmartStore: enterprisev1.SmartStoreSpec{
 				VolList: []enterprisev1.VolumeSpec{
-					{Name: "msos_s2s3_vol", Endpoint: ""},
+					{Name: "msos_s2s3_vol", Endpoint: "", Path: "testbucket-rs-london"},
 				},
 
 				IndexList: []enterprisev1.IndexSpec{
-					{Name: "salesdata1", RemoteLocation: "testbucket-rs-london/$_index_name"},
-					{Name: "salesdata2", RemoteLocation: "testbucket-rs-london/$_index_name"},
-					{Name: "salesdata3", RemoteLocation: "testbucket-rs-london/$_index_name"},
+					{Name: "salesdata1"},
+					{Name: "salesdata2", RemotePath: "salesdata2"},
+					{Name: "salesdata3", RemotePath: ""},
 				},
 			},
 		},
@@ -259,13 +259,13 @@ func TestSmartStoreConfigDoesNotFailOnIndexerClusterCRForCM(t *testing.T) {
 			Replicas: 3,
 			SmartStore: enterprisev1.SmartStoreSpec{
 				VolList: []enterprisev1.VolumeSpec{
-					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com"},
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london"},
 				},
 
 				IndexList: []enterprisev1.IndexSpec{
-					{Name: "salesdata1", RemoteLocation: "testbucket-rs-london/$_index_name"},
-					{Name: "salesdata2", RemoteLocation: "testbucket-rs-london/$_index_name"},
-					{Name: "salesdata3", RemoteLocation: "testbucket-rs-london/$_index_name"},
+					{Name: "salesdata1", VolName: "msos_s2s3_vol"},
+					{Name: "salesdata2", RemotePath: "salesdata2", VolName: "msos_s2s3_vol"},
+					{Name: "salesdata3", RemotePath: "", VolName: "msos_s2s3_vol"},
 				},
 			},
 		},
@@ -288,13 +288,13 @@ func TestSmartStoreConfigFailsOnIndexerClusterCRForIndexers(t *testing.T) {
 			Replicas: 3,
 			SmartStore: enterprisev1.SmartStoreSpec{
 				VolList: []enterprisev1.VolumeSpec{
-					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com"},
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london"},
 				},
 
 				IndexList: []enterprisev1.IndexSpec{
-					{Name: "salesdata1", RemoteLocation: "testbucket-rs-london/$_index_name"},
-					{Name: "salesdata2", RemoteLocation: "testbucket-rs-london/$_index_name"},
-					{Name: "salesdata3", RemoteLocation: "testbucket-rs-london/$_index_name"},
+					{Name: "salesdata1"},
+					{Name: "salesdata2", RemotePath: "salesdata2"},
+					{Name: "salesdata3", RemotePath: ""},
 				},
 			},
 		},
@@ -315,13 +315,13 @@ func TestValidateSplunkSmartstoreSpec(t *testing.T) {
 	// Valid smartstore config
 	SmartStore := enterprisev1.SmartStoreSpec{
 		VolList: []enterprisev1.VolumeSpec{
-			{Name: "msos_s2s3_vol_2", Endpoint: "https://s3-us-west-2.amazonaws.com"},
+			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london"},
 		},
 
 		IndexList: []enterprisev1.IndexSpec{
-			{Name: "salesdata1", RemoteLocation: "testbucket-rs-london/$_index_name"},
-			{Name: "salesdata2", RemoteLocation: "testbucket-rs-london/$_index_name"},
-			{Name: "salesdata3", RemoteLocation: "testbucket-rs-london/$_index_name"},
+			{Name: "salesdata1", VolName: "msos_s2s3_vol"},
+			{Name: "salesdata2", RemotePath: "salesdata2", VolName: "msos_s2s3_vol"},
+			{Name: "salesdata3", VolName: "msos_s2s3_vol"},
 		},
 	}
 
@@ -333,14 +333,14 @@ func TestValidateSplunkSmartstoreSpec(t *testing.T) {
 	// Only one remote volume is allowed
 	SmartStoreMultipleVolumes := enterprisev1.SmartStoreSpec{
 		VolList: []enterprisev1.VolumeSpec{
-			{Name: "msos_s2s3_vol_1", Endpoint: "https://s3-eu-west-2.amazonaws.com"},
-			{Name: "msos_s2s3_vol_2", Endpoint: "https://s3-us-west-2.amazonaws.com"},
+			{Name: "msos_s2s3_vol_1", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london"},
+			{Name: "msos_s2s3_vol_2", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london"},
 		},
 
 		IndexList: []enterprisev1.IndexSpec{
-			{Name: "salesdata1", RemoteLocation: "testbucket-rs-london/$_index_name"},
-			{Name: "salesdata2", RemoteLocation: "testbucket-rs-london/$_index_name"},
-			{Name: "salesdata3", RemoteLocation: "testbucket-rs-london/$_index_name"},
+			{Name: "salesdata1", VolName: "msos_s2s3_vol"},
+			{Name: "salesdata2", RemotePath: "salesdata2", VolName: "msos_s2s3_vol"},
+			{Name: "salesdata3", VolName: "msos_s2s3_vol"},
 		},
 	}
 
@@ -352,13 +352,13 @@ func TestValidateSplunkSmartstoreSpec(t *testing.T) {
 	// Smartstore config with missing endpoint for the volume
 	SmartStoreVolumeWithNoRemoteEndPoint := enterprisev1.SmartStoreSpec{
 		VolList: []enterprisev1.VolumeSpec{
-			{Name: "msos_s2s3_vol_1", Endpoint: ""},
+			{Name: "msos_s2s3_vol", Endpoint: "", Path: "testbucket-rs-london"},
 		},
 
 		IndexList: []enterprisev1.IndexSpec{
-			{Name: "salesdata1", RemoteLocation: "testbucket-rs-london/$_index_name"},
-			{Name: "salesdata2", RemoteLocation: "testbucket-rs-london/$_index_name"},
-			{Name: "salesdata3", RemoteLocation: "testbucket-rs-london/$_index_name"},
+			{Name: "salesdata1", VolName: "msos_s2s3_vol"},
+			{Name: "salesdata2", RemotePath: "salesdata2", VolName: "msos_s2s3_vol"},
+			{Name: "salesdata3", VolName: "msos_s2s3_vol"},
 		},
 	}
 
@@ -370,13 +370,13 @@ func TestValidateSplunkSmartstoreSpec(t *testing.T) {
 	// Smartstore config with missing remote name for the volume
 	SmartStoreWithVolumeNameMissing := enterprisev1.SmartStoreSpec{
 		VolList: []enterprisev1.VolumeSpec{
-			{Name: "", Endpoint: "https://s3-eu-west-2.amazonaws.com"},
+			{Name: "", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london"},
 		},
 
 		IndexList: []enterprisev1.IndexSpec{
-			{Name: "salesdata1", RemoteLocation: "testbucket-rs-london/$_index_name"},
-			{Name: "salesdata2", RemoteLocation: "testbucket-rs-london/$_index_name"},
-			{Name: "salesdata3", RemoteLocation: "testbucket-rs-london/$_index_name"},
+			{Name: "salesdata1", VolName: "msos_s2s3_vol"},
+			{Name: "salesdata2", RemotePath: "salesdata2", VolName: "msos_s2s3_vol"},
+			{Name: "salesdata3", VolName: "msos_s2s3_vol"},
 		},
 	}
 
@@ -385,40 +385,58 @@ func TestValidateSplunkSmartstoreSpec(t *testing.T) {
 		t.Errorf("Should not accept a volume with missing Remotename")
 	}
 
-	// Smartstore config with missing index name
-	SmartStoreWithMissingIndexName := enterprisev1.SmartStoreSpec{
+	// Smartstore config with missing path for the volume
+	SmartStoreWithVolumePathMissing := enterprisev1.SmartStoreSpec{
 		VolList: []enterprisev1.VolumeSpec{
-			{Name: "msos_s2s3_vol_1", Endpoint: "https://s3-eu-west-2.amazonaws.com"},
+			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: ""},
 		},
 
 		IndexList: []enterprisev1.IndexSpec{
-			{Name: "", RemoteLocation: "testbucket-rs-london/$_index_name"},
-			{Name: "salesdata2", RemoteLocation: "testbucket-rs-london/$_index_name"},
-			{Name: "salesdata3", RemoteLocation: "testbucket-rs-london/$_index_name"},
+			{Name: "salesdata1", VolName: "msos_s2s3_vol"},
+			{Name: "salesdata2", RemotePath: "salesdata2", VolName: "msos_s2s3_vol"},
+			{Name: "salesdata3", VolName: "msos_s2s3_vol"},
 		},
 	}
 
-	//Smartstore config with missing remote index location
+	err = ValidateSplunkSmartstoreSpec(&SmartStoreWithVolumePathMissing)
+	if err == nil {
+		t.Errorf("Should not accept a volume with missing Remote Path")
+	}
+
+	// Smartstore config with missing index name
+	SmartStoreWithMissingIndexName := enterprisev1.SmartStoreSpec{
+		VolList: []enterprisev1.VolumeSpec{
+			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london"},
+		},
+
+		IndexList: []enterprisev1.IndexSpec{
+			{Name: "", VolName: "msos_s2s3_vol"},
+			{Name: "salesdata2", RemotePath: "salesdata2", VolName: "msos_s2s3_vol"},
+			{Name: "salesdata3", VolName: "msos_s2s3_vol"},
+		},
+	}
+
 	err = ValidateSplunkSmartstoreSpec(&SmartStoreWithMissingIndexName)
 	if err == nil {
 		t.Errorf("Should not accept an Index with missing indexname ")
 	}
 
+	//Smartstore config with missing remotePath
 	SmartStoreWithMissingIndexLocation := enterprisev1.SmartStoreSpec{
 		VolList: []enterprisev1.VolumeSpec{
-			{Name: "msos_s2s3_vol_1", Endpoint: "https://s3-eu-west-2.amazonaws.com"},
+			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london"},
 		},
 
 		IndexList: []enterprisev1.IndexSpec{
-			{Name: "salesdata1", RemoteLocation: "testbucket-rs-london/$_index_name"},
-			{Name: "salesdata2", RemoteLocation: ""},
-			{Name: "salesdata3", RemoteLocation: "testbucket-rs-london/$_index_name"},
+			{Name: "salesdata1", VolName: "msos_s2s3_vol"},
+			{Name: "salesdata2", RemotePath: "salesdata2", VolName: "msos_s2s3_vol"},
+			{Name: "salesdata3", VolName: "msos_s2s3_vol"},
 		},
 	}
 
 	err = ValidateSplunkSmartstoreSpec(&SmartStoreWithMissingIndexLocation)
-	if err == nil {
-		t.Errorf("Should not accept an Index with missing index location")
+	if err != nil {
+		t.Errorf("Should accept an Index with missing remotePath location")
 	}
 
 	// Empty smartstore config

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -56,8 +56,23 @@ func ApplyIndexerCluster(client splcommon.ControllerClient, cr *enterprisev1.Ind
 	cr.Status.ClusterMasterPhase = splcommon.PhaseError
 	cr.Status.Replicas = cr.Spec.Replicas
 	if !reflect.DeepEqual(cr.Status.SmartStore, cr.Spec.SmartStore) {
+		_, err := CreateSmartStoreConfigMap(client, cr, &cr.Spec.SmartStore)
+		if err != nil {
+			return result, err
+		}
+
+		// To do: sgontla: Do we need to update the status in K8 etcd immediately?
+		// Consider the case, where the Cluster master validates the config, and
+		// generates config map, but fails later in the flow to complete its
+		// stateful set. Meanwhile, all the indexer cluster sites notices new
+		// config map, and keeps resetting the indexers. This is not problem,
+		// as long as:
+		// 1. ApplyConfigMap avoids a CRUD update if there is no change to data,
+		// which is already happening today, so, this scenario shouldn't happen.
+		// 2. To Do: Is there anything additional to be done on indexer site?
 		cr.Status.SmartStore = cr.Spec.SmartStore
 	}
+
 	cr.Status.Selector = fmt.Sprintf("app.kubernetes.io/instance=splunk-%s-indexer", cr.GetName())
 	if cr.Status.Peers == nil {
 		cr.Status.Peers = []enterprisev1.IndexerClusterMemberStatus{}

--- a/pkg/splunk/enterprise/names.go
+++ b/pkg/splunk/enterprise/names.go
@@ -38,6 +38,9 @@ const (
 	// identifier
 	defaultsTemplateStr = "splunk-%s-%s-defaults"
 
+	// identifier
+	smartstoreTemplateStr = "splunk-%s-%s-smartstore"
+
 	// default docker image used for Splunk instances
 	defaultSplunkImage = "splunk/splunk"
 
@@ -55,6 +58,12 @@ const (
 
 	// firstVersion secret
 	firstVersion = "1"
+
+	// identifier used for S3 access key
+	s3AccessKey = "s3_access_key"
+
+	// identifier used for S3 secret key
+	s3SecretKey = "s3_secret_key"
 )
 
 // GetSplunkDeploymentName uses a template to name a Kubernetes Deployment for Splunk instances.
@@ -88,6 +97,11 @@ func GetSplunkServiceName(instanceType InstanceType, identifier string, isHeadle
 // GetSplunkDefaultsName uses a template to name a Kubernetes ConfigMap for a SplunkEnterprise resource.
 func GetSplunkDefaultsName(identifier string, instanceType InstanceType) string {
 	return fmt.Sprintf(defaultsTemplateStr, identifier, instanceType.ToKind())
+}
+
+// GetSplunkSmartstoreConfigMapName uses a template to name a Kubernetes ConfigMap for a SplunkEnterprise resource.
+func GetSplunkSmartstoreConfigMapName(identifier string, crKind string) string {
+	return fmt.Sprintf(smartstoreTemplateStr, identifier, strings.ToLower(crKind))
 }
 
 // GetSplunkStatefulsetUrls returns a list of fully qualified domain names for all pods within a Splunk StatefulSet.

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -52,8 +52,14 @@ func ApplyStandalone(client splcommon.ControllerClient, cr *enterprisev1.Standal
 	cr.Status.Phase = splcommon.PhaseError
 	cr.Status.Replicas = cr.Spec.Replicas
 	if !reflect.DeepEqual(cr.Status.SmartStore, cr.Spec.SmartStore) {
+		_, err := CreateSmartStoreConfigMap(client, cr, &cr.Spec.SmartStore)
+		if err != nil {
+			return result, err
+		}
+
 		cr.Status.SmartStore = cr.Spec.SmartStore
 	}
+
 	cr.Status.Selector = fmt.Sprintf("app.kubernetes.io/instance=splunk-%s-standalone", cr.GetName())
 	defer func() {
 		client.Status().Update(context.TODO(), cr)

--- a/pkg/splunk/enterprise/standalone_test.go
+++ b/pkg/splunk/enterprise/standalone_test.go
@@ -24,6 +24,7 @@ import (
 
 	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1alpha3"
 	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
+	splctrl "github.com/splunk/splunk-operator/pkg/splunk/controller"
 	spltest "github.com/splunk/splunk-operator/pkg/splunk/test"
 )
 
@@ -61,6 +62,90 @@ func TestApplyStandalone(t *testing.T) {
 		return err
 	}
 	spltest.ReconcileTester(t, "TestApplyStandalone", &current, revised, createCalls, updateCalls, reconcile, true)
+
+	// test deletion
+	currentTime := metav1.NewTime(time.Now())
+	revised.ObjectMeta.DeletionTimestamp = &currentTime
+	revised.ObjectMeta.Finalizers = []string{"enterprise.splunk.com/delete-pvc"}
+	deleteFunc := func(cr splcommon.MetaObject, c splcommon.ControllerClient) (bool, error) {
+		_, err := ApplyStandalone(c, cr.(*enterprisev1.Standalone))
+		return true, err
+	}
+	splunkDeletionTester(t, revised, deleteFunc)
+}
+
+func TestApplyStandaloneWithSmartstore(t *testing.T) {
+	funcCalls := []spltest.MockFuncCall{
+		{MetaName: "*v1.Secret-test-splunk-test-secret"},
+		{MetaName: "*v1.ConfigMap-test-splunk-stack1-standalone-smartstore"},
+		{MetaName: "*v1.Secret-test-splunk-test-secret"},
+		{MetaName: "*v1.Service-test-splunk-stack1-standalone-headless"},
+		{MetaName: "*v1.Service-test-splunk-stack1-standalone-service"},
+		{MetaName: "*v1.Secret-test-splunk-test-secret"},
+		{MetaName: "*v1.Secret-test-splunk-stack1-standalone-secret-v1"},
+		{MetaName: "*v1.StatefulSet-test-splunk-stack1-standalone"},
+	}
+	listOpts := []client.ListOption{
+		client.InNamespace("test"),
+	}
+	listmockCall := []spltest.MockFuncCall{
+		{ListOpts: listOpts}}
+
+	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[1], funcCalls[3], funcCalls[4], funcCalls[6], funcCalls[7]}, "List": {listmockCall[0]}}
+	updateCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Update": {funcCalls[7]}, "List": {listmockCall[0]}}
+
+	current := enterprisev1.Standalone{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Standalone",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stack1",
+			Namespace: "test",
+		},
+		Spec: enterprisev1.StandaloneSpec{
+			Replicas: 1,
+			SmartStore: enterprisev1.SmartStoreSpec{
+				VolList: []enterprisev1.VolumeSpec{
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london"},
+				},
+
+				IndexList: []enterprisev1.IndexSpec{
+					{Name: "salesdata1", VolName: "msos_s2s3_vol"},
+					{Name: "salesdata2", RemotePath: "salesdata2", VolName: "msos_s2s3_vol"},
+					{Name: "salesdata3", RemotePath: "", VolName: "msos_s2s3_vol"},
+				},
+			},
+		},
+	}
+
+	client := spltest.NewMockClient()
+
+	// Without S3 keys, ApplyStandalone should fail
+	_, err := ApplyStandalone(client, &current)
+	if err == nil {
+		t.Errorf("ApplyStandalone should fail without S3 secrets configured")
+	}
+
+	// Create namespace scoped secret
+	secret, err := ApplyNamespaceScopedSecretObject(client, "test")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	secret.Data[s3AccessKey] = []byte("abcdJDckRkxhMEdmSk5FekFRRzBFOXV6bGNldzJSWE9IenhVUy80aa")
+	secret.Data[s3SecretKey] = []byte("g4NVp0a29PTzlPdGczWk1vekVUcVBSa0o4NkhBWWMvR1NadDV4YVEy")
+	_, err = splctrl.ApplySecret(client, secret)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	revised := current.DeepCopy()
+	revised.Spec.Image = "splunk/test"
+	reconcile := func(c *spltest.MockClient, cr interface{}) error {
+		_, err := ApplyStandalone(c, cr.(*enterprisev1.Standalone))
+		return err
+	}
+	spltest.ReconcileTesterWithoutRedundantCheck(t, "TestApplyStandalone", &current, revised, createCalls, updateCalls, reconcile, true, secret)
 
 	// test deletion
 	currentTime := metav1.NewTime(time.Now())

--- a/pkg/splunk/enterprise/util_test.go
+++ b/pkg/splunk/enterprise/util_test.go
@@ -21,6 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1alpha3"
+	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
+	splctrl "github.com/splunk/splunk-operator/pkg/splunk/controller"
 	spltest "github.com/splunk/splunk-operator/pkg/splunk/test"
 )
 
@@ -101,4 +103,51 @@ func TestApplySplunkConfig(t *testing.T) {
 	createCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": funcCalls}
 	updateCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls}
 	spltest.ReconcileTester(t, "TestApplySplunkConfig", &indexerCR, indexerRevised, createCalls, updateCalls, reconcile, false)
+}
+
+func TestCreateSmartStoreConfigMap(t *testing.T) {
+	cr := enterprisev1.IndexerCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "idxCluster",
+			Namespace: "test",
+		},
+		Spec: enterprisev1.IndexerClusterSpec{
+			Replicas: 1,
+			SmartStore: enterprisev1.SmartStoreSpec{
+				VolList: []enterprisev1.VolumeSpec{
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london"},
+				},
+
+				IndexList: []enterprisev1.IndexSpec{
+					{Name: "salesdata1", VolName: "msos_s2s3_vol"},
+					{Name: "salesdata2", RemotePath: "salesdata2", VolName: "msos_s2s3_vol"},
+					{Name: "salesdata3", RemotePath: "", VolName: "msos_s2s3_vol"},
+				},
+			},
+		},
+	}
+
+	client := spltest.NewMockClient()
+
+	// Create namespace scoped secret
+	secret, err := ApplyNamespaceScopedSecretObject(client, "test")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	secret.Data[s3AccessKey] = []byte("abcdJDckRkxhMEdmSk5FekFRRzBFOXV6bGNldzJSWE9IenhVUy80aa")
+	secret.Data[s3SecretKey] = []byte("g4NVp0a29PTzlPdGczWk1vekVUcVBSa0o4NkhBWWMvR1NadDV4YVEy")
+	_, err = splctrl.ApplySecret(client, secret)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	test := func(client *spltest.MockClient, cr splcommon.MetaObject, smartstore *enterprisev1.SmartStoreSpec, want string) {
+		f := func() (interface{}, error) {
+			return CreateSmartStoreConfigMap(client, cr, smartstore)
+		}
+		configTester(t, "CreateSmartStoreConfigMap()", f, want)
+	}
+
+	test(client, &cr, &cr.Spec.SmartStore, `{"metadata":{"name":"splunk-idxCluster--smartstore","namespace":"test","creationTimestamp":null,"ownerReferences":[{"apiVersion":"","kind":"","name":"idxCluster","uid":"","controller":true}]},"data":{"indexes.conf":"\n[volume:msos_s2s3_vol]\nstorageType = remote\npath = s3://testbucket-rs-london\nremote.s3.access_key = abcdJDckRkxhMEdmSk5FekFRRzBFOXV6bGNldzJSWE9IenhVUy80aa\nremote.s3.secret_key = g4NVp0a29PTzlPdGczWk1vekVUcVBSa0o4NkhBWWMvR1NadDV4YVEy\nremote.s3.endpoint = https://s3-eu-west-2.amazonaws.com\n \n[salesdata1]\nremotePath = volume:$_index_name\n\n[salesdata2]\nremotePath = volume:salesdata2\n\n[salesdata3]\nremotePath = volume:$_index_name\n"}}`)
 }

--- a/pkg/splunk/test/controller.go
+++ b/pkg/splunk/test/controller.go
@@ -265,8 +265,10 @@ func (c *MockClient) CheckCalls(t *testing.T, testname string, wantCalls map[str
 			notEmptyWantCalls++
 		}
 
+		//t.Fatalf("%s: MockClient %s() calls = %d; want %d, got: %s \n want: %s", testname, methodName, len(gotFuncCalls), len(wantFuncCalls), gotFuncCalls, wantFuncCalls)
 		if len(gotFuncCalls) != len(wantFuncCalls) {
-			t.Fatalf("%s: MockClient %s() calls = %d; want %d", testname, methodName, len(gotFuncCalls), len(wantFuncCalls))
+			//t.Fatalf("%s: MockClient %s() calls = %d; want %d", testname, methodName, len(gotFuncCalls), len(wantFuncCalls))
+			t.Fatalf("%s: MockClient %s() calls = %d; want %d, got: %s \n want: %s", testname, methodName, len(gotFuncCalls), len(wantFuncCalls), gotFuncCalls, wantFuncCalls)
 		}
 
 		for n := range wantFuncCalls {
@@ -324,6 +326,19 @@ func getStateKeyWithKey(key client.ObjectKey, obj runtime.Object) string {
 	return fmt.Sprintf("%s-%s-%s", kind, key.Namespace, key.Name)
 }
 
+// testReconcileForResource is used to test create and update reconcile operations
+func testReconcileForResource(t *testing.T, c *MockClient, methodPlus string, resource interface{},
+	calls map[string][]MockFuncCall,
+	reconcile func(*MockClient, interface{}) error) {
+
+	c.ResetCalls()
+	err := reconcile(c, resource)
+	if err != nil {
+		t.Errorf("%s returned %v; want nil", methodPlus, err)
+	}
+	c.CheckCalls(t, methodPlus, calls)
+}
+
 // ReconcileTester is used to test create and update reconcile operations
 func ReconcileTester(t *testing.T, method string,
 	current, revised interface{},
@@ -338,33 +353,42 @@ func ReconcileTester(t *testing.T, method string,
 
 	// test create new
 	methodPlus := fmt.Sprintf("%s(create)", method)
-	err := reconcile(c, current)
-	if err != nil {
-		t.Errorf("%s returned %v; want nil", methodPlus, err)
-	}
-	c.CheckCalls(t, methodPlus, createCalls)
+	testReconcileForResource(t, c, methodPlus, current, createCalls, reconcile)
 
 	// test no updates required for current
 	methodPlus = fmt.Sprintf("%s(update-no-change)", method)
-	c.ResetCalls()
-	err = reconcile(c, current)
-	if err != nil {
-		t.Errorf("%s returned %v; want nil", methodPlus, err)
-	}
+	var updateNoChangecalls map[string][]MockFuncCall
 	if listInvolved {
-		c.CheckCalls(t, methodPlus, map[string][]MockFuncCall{"Get": createCalls["Get"], "List": createCalls["List"]})
+		updateNoChangecalls = map[string][]MockFuncCall{"Get": createCalls["Get"], "List": createCalls["List"]}
 	} else {
-		c.CheckCalls(t, methodPlus, map[string][]MockFuncCall{"Get": createCalls["Get"]})
+		updateNoChangecalls = map[string][]MockFuncCall{"Get": createCalls["Get"]}
 	}
+	testReconcileForResource(t, c, methodPlus, current, updateNoChangecalls, reconcile)
 
 	// test updates required
 	methodPlus = fmt.Sprintf("%s(update-with-change)", method)
-	c.ResetCalls()
-	err = reconcile(c, revised)
-	if err != nil {
-		t.Errorf("%s returned %v; want nil", methodPlus, err)
-	}
-	c.CheckCalls(t, methodPlus, updateCalls)
+	testReconcileForResource(t, c, methodPlus, revised, updateCalls, reconcile)
+}
+
+// ReconcileTesterWithoutRedundantCheck is used to test create and update reconcile operations
+func ReconcileTesterWithoutRedundantCheck(t *testing.T, method string,
+	current, revised interface{},
+	createCalls, updateCalls map[string][]MockFuncCall,
+	reconcile func(*MockClient, interface{}) error,
+	listInvolved bool,
+	initObjects ...runtime.Object) {
+
+	// initialize client
+	c := NewMockClient()
+	c.AddObjects(initObjects)
+
+	// test create new
+	methodPlus := fmt.Sprintf("%s(create)", method)
+	testReconcileForResource(t, c, methodPlus, current, createCalls, reconcile)
+
+	// test updates required
+	methodPlus = fmt.Sprintf("%s(update-with-change)", method)
+	testReconcileForResource(t, c, methodPlus, revised, updateCalls, reconcile)
 }
 
 // PodManagerUpdateTester is used to a single reconcile update using a StatefulSetPodManager


### PR DESCRIPTION
- When the CR is configured for  Smartstore indexes in yaml format, convert that config
into INI stanza format, and write a configMap, which can be later mounted to the indexer
as indexes.conf.