### PR TITLE
Adding monitoring console. On implementation of Standalone/LicenseMas…

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,7 @@ github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/libnetwork v0.0.0-20180830151422-a9cd636e3789/go.mod h1:93m0aTqz6z+g32wla4l4WxTrdtvBRmVzYRkYvasA5Z8=
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
+github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c h1:ZfSZ3P3BedhKGUhzj7BQlPSU4OvT6tfOKe3DVHzOA7s=
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/pkg/splunk/controller/util.go
+++ b/pkg/splunk/controller/util.go
@@ -177,6 +177,15 @@ func MergePodSpecUpdates(current *corev1.PodSpec, revised *corev1.PodSpec, name 
 				result = true
 			}
 
+			// check Env
+			if splcommon.CompareEnvs(current.Containers[idx].Env, revised.Containers[idx].Env) {
+				scopedLog.Info("Pod Container Env differ",
+					"current", current.Containers[idx].Env,
+					"revised", revised.Containers[idx].Env)
+				current.Containers[idx].Env = revised.Containers[idx].Env
+				result = true
+			}
+
 			// check VolumeMounts
 			if splcommon.CompareVolumeMounts(current.Containers[idx].VolumeMounts, revised.Containers[idx].VolumeMounts) {
 				scopedLog.Info("Pod Container VolumeMounts differ",

--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -121,6 +121,10 @@ func getSplunkService(cr splcommon.MetaObject, spec *enterprisev1.CommonSplunkSp
 	service.ObjectMeta.Namespace = cr.GetNamespace()
 	instanceIdentifier := cr.GetName()
 	var partOfIdentifier string
+	if instanceType == SplunkMonitoringConsole {
+		service.ObjectMeta.Name = GetSplunkServiceName(instanceType, cr.GetNamespace(), isHeadless)
+		instanceIdentifier = cr.GetNamespace()
+	}
 	if instanceType == SplunkIndexer {
 		if len(spec.IndexerClusterRef.Name) == 0 {
 			// Do not specify the instance label in the selector of IndexerCluster services, so that the services of the main part
@@ -247,6 +251,9 @@ func getSplunkPorts(instanceType InstanceType) map[string]int {
 	}
 
 	switch instanceType {
+	case SplunkMonitoringConsole:
+		result["hec"] = 8088
+		result["s2s"] = 9997
 	case SplunkStandalone:
 		result["dfccontrol"] = 17000
 		result["datareceive"] = 19000

--- a/pkg/splunk/enterprise/finalizers.go
+++ b/pkg/splunk/enterprise/finalizers.go
@@ -40,6 +40,8 @@ func DeleteSplunkPvc(cr splcommon.MetaObject, c splcommon.ControllerClient) erro
 		component = "standalone"
 	case "LicenseMaster":
 		component = "license-master"
+	case "MonitoringConsole":
+		component = "monitoring-console"
 	case "SearchHeadCluster":
 		component = "search-head"
 	case "IndexerCluster":

--- a/pkg/splunk/enterprise/finalizers_test.go
+++ b/pkg/splunk/enterprise/finalizers_test.go
@@ -37,6 +37,8 @@ func splunkDeletionTester(t *testing.T, cr splcommon.MetaObject, delete func(spl
 		component = "standalone"
 	case "LicenseMaster":
 		component = "license-master"
+	case "MonitoringConsole":
+		component = "monitoring-console"
 	case "SearchHeadCluster":
 		component = "search-head"
 	case "IndexerCluster":
@@ -46,7 +48,10 @@ func splunkDeletionTester(t *testing.T, cr splcommon.MetaObject, delete func(spl
 	labels := map[string]string{
 		"app.kubernetes.io/part-of": fmt.Sprintf("splunk-%s-%s", cr.GetName(), component),
 	}
-	listOpts := []client.ListOption{
+	listOptsA := []client.ListOption{
+		client.InNamespace("test"),
+	}
+	listOptsB := []client.ListOption{
 		client.InNamespace(cr.GetNamespace()),
 		client.MatchingLabels(labels),
 	}
@@ -69,12 +74,38 @@ func splunkDeletionTester(t *testing.T, cr splcommon.MetaObject, delete func(spl
 		mockCalls["Update"] = []spltest.MockFuncCall{
 			{MetaName: fmt.Sprintf("*%s.%s-%s-%s", apiVersion.Version, cr.GetObjectKind().GroupVersionKind().Kind, cr.GetNamespace(), cr.GetName())},
 		}
-		if component != "" {
+		if component != "indexer" {
 			mockCalls["Delete"] = []spltest.MockFuncCall{
 				{MetaName: "*v1.PersistentVolumeClaim-test-splunk-pvc-stack1-var"},
 			}
 			mockCalls["List"] = []spltest.MockFuncCall{
-				{ListOpts: listOpts},
+				{ListOpts: listOptsA},
+				{ListOpts: listOptsB},
+			}
+			mockCalls["Get"] = []spltest.MockFuncCall{
+				{MetaName: "*v1.Secret-test-splunk-test-secret"},
+				{MetaName: "*v1.Secret-test-splunk-test-secret"},
+				{MetaName: "*v1.Secret-test-splunk-test-monitoring-console-secret-v1"},
+				{MetaName: "*v1.Service-test-splunk-test-monitoring-console-service"},
+				{MetaName: "*v1.Service-test-splunk-test-monitoring-console-headless"},
+				{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console-defaults"},
+				{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console-defaults"},
+				{MetaName: "*v1.Deployment-test-splunk-test-monitoring-console"},
+			}
+			mockCalls["Create"] = []spltest.MockFuncCall{
+				{MetaName: "*v1.Secret-test-splunk-test-secret"},
+				{MetaName: "*v1.Secret-test-splunk-test-monitoring-console-secret-v1"},
+				{MetaName: "*v1.Service-test-splunk-test-monitoring-console-service"},
+				{MetaName: "*v1.Service-test-splunk-test-monitoring-console-headless"},
+				{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console-defaults"},
+				{MetaName: "*v1.Deployment-test-splunk-test-monitoring-console"},
+			}
+		} else if component == "indexer" {
+			mockCalls["Delete"] = []spltest.MockFuncCall{
+				{MetaName: "*v1.PersistentVolumeClaim-test-splunk-pvc-stack1-var"},
+			}
+			mockCalls["List"] = []spltest.MockFuncCall{
+				{ListOpts: listOptsB},
 			}
 		}
 	}

--- a/pkg/splunk/enterprise/licensemaster_test.go
+++ b/pkg/splunk/enterprise/licensemaster_test.go
@@ -29,6 +29,13 @@ import (
 func TestApplyLicenseMaster(t *testing.T) {
 	funcCalls := []spltest.MockFuncCall{
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
+		{MetaName: "*v1.Secret-test-splunk-test-secret"},
+		{MetaName: "*v1.Secret-test-splunk-test-monitoring-console-secret-v1"},
+		{MetaName: "*v1.Service-test-splunk-test-monitoring-console-service"},
+		{MetaName: "*v1.Service-test-splunk-test-monitoring-console-headless"},
+		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console-defaults"},
+		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console-defaults"},
+		{MetaName: "*v1.Deployment-test-splunk-test-monitoring-console"},
 		{MetaName: "*v1.Service-test-splunk-stack1-license-master-service"},
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
 		{MetaName: "*v1.Secret-test-splunk-stack1-license-master-secret-v1"},
@@ -40,8 +47,8 @@ func TestApplyLicenseMaster(t *testing.T) {
 	}
 	listmockCall := []spltest.MockFuncCall{
 		{ListOpts: listOpts}}
-	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[0], funcCalls[1], funcCalls[3], funcCalls[4]}, "List": {listmockCall[0]}}
-	updateCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Update": {funcCalls[4]}, "List": {listmockCall[0]}}
+	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[0], funcCalls[2], funcCalls[3], funcCalls[4], funcCalls[5], funcCalls[7], funcCalls[8], funcCalls[10], funcCalls[11]}, "List": {listmockCall[0], listmockCall[0]}}
+	updateCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Update": {funcCalls[7], funcCalls[11]}, "List": {listmockCall[0], listmockCall[0]}}
 	current := enterprisev1.LicenseMaster{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "LicenseMaster",

--- a/pkg/splunk/enterprise/monitoringconsole.go
+++ b/pkg/splunk/enterprise/monitoringconsole.go
@@ -1,0 +1,347 @@
+// Copyright (c) 2018-2020 Splunk Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enterprise
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strings"
+
+	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1alpha3"
+	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
+	splctrl "github.com/splunk/splunk-operator/pkg/splunk/controller"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ApplyMonitoringConsole reconciles the deployment for N standalone instances of Splunk Enterprise.
+func ApplyMonitoringConsole(client splcommon.ControllerClient, cr splcommon.MetaObject, spec enterprisev1.CommonSplunkSpec, extraEnv []corev1.EnvVar) error {
+	var secrets *corev1.Secret
+	var err error
+
+	secrets, err = GetLatestVersionedSecret(client, cr, cr.GetNamespace(), GetSplunkMonitoringConsoleDeploymentName(SplunkMonitoringConsole, cr.GetNamespace()))
+	if err != nil {
+		return err
+	}
+
+	secretName := ""
+	if secrets != nil {
+		secretName = secrets.GetName()
+	}
+
+	// create or update a regular monitoring console service
+	err = splctrl.ApplyService(client, getSplunkService(cr, &spec, SplunkMonitoringConsole, false))
+	if err != nil {
+		return err
+	}
+
+	// create or update a headless monitoring console service
+	err = splctrl.ApplyService(client, getSplunkService(cr, &spec, SplunkMonitoringConsole, true))
+	if err != nil {
+		return err
+	}
+
+	addNewURLs := true
+
+	if cr.GetObjectMeta().GetDeletionTimestamp() != nil {
+		addNewURLs = false
+	}
+
+	_, err = ApplyMonitoringConsoleEnvConfigMap(client, cr.GetNamespace(), extraEnv, addNewURLs)
+	if err != nil {
+		return err
+	}
+
+	//configMapHash to trigger the configMap change in monitoring console deployment
+	configMapHash, err := getConfigMapHash(client, cr.GetNamespace())
+	if err != nil {
+		return err
+	}
+
+	deploymentMC, err := getMonitoringConsoleDeployment(cr, &spec, SplunkMonitoringConsole, 1, configMapHash, secretName)
+	if err != nil {
+		return err
+	}
+
+	_, err = splctrl.ApplyDeployment(client, deploymentMC)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+// GetMonitoringConsoleDeployment returns a Kubernetes Deployment object for Splunk Enterprise monitoring console instance.
+func getMonitoringConsoleDeployment(cr splcommon.MetaObject, spec *enterprisev1.CommonSplunkSpec, instanceType InstanceType, replicas int32, configMapHash string, secretName string) (*appsv1.Deployment, error) {
+	ports := splcommon.SortContainerPorts(getSplunkContainerPorts(SplunkMonitoringConsole))
+	annotations := splcommon.GetIstioAnnotations(ports)
+	var partOfIdentifier string
+	selectLabels := getSplunkLabels(cr.GetNamespace(), instanceType, partOfIdentifier) //using Namespace here so that with every CR the name should remain same Ex- splunk-<namespace>-monitoring-console
+	affinity := splcommon.AppendPodAntiAffinity(&spec.Affinity, cr.GetNamespace(), instanceType.ToString())
+	configMap := GetSplunkDefaultsName(cr.GetNamespace(), SplunkMonitoringConsole)
+
+	// start with same labels as selector; note that this object gets modified by splcommon.AppendParentMeta()
+	labels := make(map[string]string)
+	for k, v := range selectLabels {
+		labels[k] = v
+	}
+
+	//create deployment configuration
+	deploymentMC := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      GetSplunkMonitoringConsoleDeploymentName(instanceType, cr.GetNamespace()),
+			Namespace: cr.GetNamespace(),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: selectLabels,
+			},
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      labels,
+					Annotations: annotations,
+				},
+				Spec: corev1.PodSpec{
+					Affinity:      affinity,
+					Tolerations:   spec.Tolerations,
+					SchedulerName: spec.SchedulerName,
+					Containers: []corev1.Container{
+						{
+							Image:           spec.Image,
+							ImagePullPolicy: corev1.PullPolicy(spec.ImagePullPolicy),
+							Name:            "splunk",
+							Ports:           ports,
+							EnvFrom: []corev1.EnvFromSource{
+								{
+									ConfigMapRef: &corev1.ConfigMapEnvSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: configMap, //monitoring console env variables configMap
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if configMapHash == "" {
+		return nil, nil
+	}
+
+	env := []corev1.EnvVar{
+		{Name: "SPLUNK_CONFIGMAP_HASH",
+			Value: configMapHash,
+		},
+	}
+	// append labels and annotations from parent
+	splcommon.AppendParentMeta(deploymentMC.Spec.Template.GetObjectMeta(), cr.GetObjectMeta())
+
+	// update statefulset's pod template with common splunk pod config
+	updateSplunkPodTemplateWithConfig(&deploymentMC.Spec.Template, cr, spec, instanceType, env, secretName)
+
+	return deploymentMC, nil
+}
+
+//ApplyMonitoringConsoleEnvConfigMap creates or updates a Kubernetes ConfigMap for extra env for monitoring console pod
+func ApplyMonitoringConsoleEnvConfigMap(client splcommon.ControllerClient, namespace string, newURLs []corev1.EnvVar, addNewURLs bool) (*corev1.ConfigMap, error) {
+
+	//1. Retrieve the existing McExtraEnvMap contents
+	namespacedName := types.NamespacedName{Namespace: namespace, Name: GetSplunkDefaultsName(namespace, SplunkMonitoringConsole)}
+
+	var current corev1.ConfigMap
+
+	err := client.Get(context.TODO(), namespacedName, &current) //save existing in current
+	revised := current.DeepCopy()
+
+	//If no configMap and deletion of CR is requested then retrun nil
+	if err != nil && addNewURLs == false {
+		//create a configMap with no values
+		current = corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      GetSplunkDefaultsName(namespace, SplunkMonitoringConsole),
+				Namespace: namespace,
+			},
+			Data: make(map[string]string),
+		}
+
+		err = splctrl.CreateResource(client, &current)
+		if err != nil {
+			return nil, err
+		}
+		return &current, nil
+	}
+
+	if err == nil {
+		for _, url := range newURLs {
+			_, ok := revised.Data[url.Name]
+			if addNewURLs { //if new instances are coming up
+				if !ok { //key doesn't exist in the configMap, then add it
+					revised.Data[url.Name] = url.Value //if new url doesn't exist add it in configmap
+				} else {
+					//TODO: For "SEARCH_HEAD_URL" need to find a better approach to update configMap, any other data structure?
+					if url.Name == "SPLUNK_SEARCH_HEAD_URL" {
+						if revised.Data[url.Name] == url.Value {
+							break
+						}
+						crNameTmp := strings.Split(url.Value, "-")
+						crName := crNameTmp[1] //find the cr.Name()
+						//delete all URLs for the crName custom resource
+						currentURLs := strings.Split(revised.Data[url.Name], ",") //split the existing values
+						for _, curr := range currentURLs {
+							if strings.Contains(curr, crName) { //delete that entry
+								revised.Data[url.Name] = strings.ReplaceAll(revised.Data[url.Name], curr, "")
+								if strings.HasPrefix(revised.Data[url.Name], ",") {
+									res := revised.Data[url.Name]
+									revised.Data[url.Name] = strings.TrimPrefix(res, ",")
+								}
+								if strings.HasSuffix(revised.Data[url.Name], ",") {
+									res := revised.Data[url.Name]
+									revised.Data[url.Name] = strings.TrimSuffix(res, ",")
+								}
+								if strings.Contains(revised.Data[url.Name], ",,") {
+									res := revised.Data[url.Name]
+									revised.Data[url.Name] = strings.ReplaceAll(res, ",,", ",")
+								}
+							}
+						}
+						newInsURLs := strings.Split(url.Value, ",")
+						for _, newEntry := range newInsURLs {
+							if !(strings.Contains(revised.Data[url.Name], newEntry)) {
+								if revised.Data[url.Name] == "" {
+									revised.Data[url.Name] = newEntry
+								} else {
+									str := []string{revised.Data[url.Name], newEntry}
+									revised.Data[url.Name] = strings.Join(str, ",")
+								}
+							}
+						}
+					} else {
+						//now add the incoming URLs as fresh entry
+						newInsURL := strings.Split(url.Value, ",")
+						for _, newEntry := range newInsURL {
+							if !(strings.Contains(revised.Data[url.Name], newEntry)) {
+								str := []string{revised.Data[url.Name], newEntry}
+								revised.Data[url.Name] = strings.Join(str, ",")
+							}
+						}
+					}
+				}
+			} else { //removing custom resource. Update configMap
+				//check if only dummy entery exist then no deletion can happen
+				if strings.Contains(revised.Data[url.Name], url.Value) {
+					revised.Data[url.Name] = strings.ReplaceAll(revised.Data[url.Name], url.Value, "")
+					if strings.HasPrefix(revised.Data[url.Name], ",") {
+						str := revised.Data[url.Name]
+						revised.Data[url.Name] = strings.TrimPrefix(str, ",")
+					}
+					if strings.HasSuffix(revised.Data[url.Name], ",") {
+						str := revised.Data[url.Name]
+						revised.Data[url.Name] = strings.TrimSuffix(str, ",")
+					}
+					if strings.Contains(revised.Data[url.Name], ",,") {
+						str := revised.Data[url.Name]
+						revised.Data[url.Name] = strings.ReplaceAll(str, ",,", ",")
+					}
+					if revised.Data[url.Name] == "" {
+						delete(revised.Data, url.Name)
+					}
+				}
+			}
+		}
+		if !reflect.DeepEqual(revised.Data, current.Data) {
+			current.Data = revised.Data
+			err = splctrl.UpdateResource(client, &current)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return &current, nil
+	}
+
+	McExtraEnv := make(map[string]string)
+	for _, url := range newURLs {
+		McExtraEnv[url.Name] = url.Value
+	}
+
+	current = corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      GetSplunkDefaultsName(namespace, SplunkMonitoringConsole),
+			Namespace: namespace,
+		},
+		Data: McExtraEnv,
+	}
+
+	err = splctrl.CreateResource(client, &current)
+	if err != nil {
+		return nil, err
+	}
+
+	return &current, nil
+}
+
+func getConfigMapHash(client splcommon.ControllerClient, namespace string) (string, error) {
+
+	namespacedName := types.NamespacedName{Namespace: namespace, Name: GetSplunkDefaultsName(namespace, SplunkMonitoringConsole)}
+	var current corev1.ConfigMap
+
+	err := client.Get(context.TODO(), namespacedName, &current)
+	// if configMap doens't exist and we try to get configMap hash just return with empty string
+	if err != nil {
+		return "", err
+	}
+
+	contents := current.Data //map[string]string
+
+	hash := md5.New()
+	b := new(bytes.Buffer)
+
+	//check key sorting. Collect keys in array and sort. Then use that sorted keys to append
+	var keys []string
+
+	for k := range contents {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys) //sort keys here
+
+	//now iterate through the map in sorted order
+	for _, k := range keys {
+		fmt.Fprintf(b, "%s=\"%s\"\n", k, contents[k])
+	}
+
+	if _, err := io.Copy(hash, b); err != nil {
+		return "", err
+	}
+
+	hashInBytes := hash.Sum(nil)[:16]
+	returnMD5String := hex.EncodeToString(hashInBytes)
+	return returnMD5String, nil
+}

--- a/pkg/splunk/enterprise/monitoringconsole_test.go
+++ b/pkg/splunk/enterprise/monitoringconsole_test.go
@@ -1,0 +1,252 @@
+// Copyright (c) 2018-2020 Splunk Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enterprise
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1alpha3"
+	spltest "github.com/splunk/splunk-operator/pkg/splunk/test"
+)
+
+func TestApplyMonitoringConsole(t *testing.T) {
+	//create secrets, take dummy URL pass it to my function
+	standaloneCR := enterprisev1.Standalone{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Standalone",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stack1",
+			Namespace: "test",
+		},
+	}
+	funcCalls := []spltest.MockFuncCall{
+		{MetaName: "*v1.Secret-test-splunk-test-secret"},
+		{MetaName: "*v1.Secret-test-splunk-test-monitoring-console-secret-v1"},
+		{MetaName: "*v1.Service-test-splunk-test-monitoring-console-service"},
+		{MetaName: "*v1.Service-test-splunk-test-monitoring-console-headless"},
+		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console-defaults"},
+		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console-defaults"},
+		{MetaName: "*v1.Deployment-test-splunk-test-monitoring-console"},
+	}
+	listOpts := []client.ListOption{
+		client.InNamespace("test"),
+	}
+	listmockCall := []spltest.MockFuncCall{
+		{ListOpts: listOpts}}
+
+	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[1], funcCalls[2], funcCalls[3], funcCalls[4], funcCalls[6]}, "List": {listmockCall[0]}}
+	updateCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Update": {funcCalls[6]}, "List": {listmockCall[0]}}
+	c := spltest.NewMockClient()
+
+	// Create namespace scoped secret
+	namespacescopedsecret, err := ApplyNamespaceScopedSecretObject(c, "test")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	standaloneCR.Spec.Defaults = "defaults-yaml"
+	standaloneRevised := standaloneCR.DeepCopy()
+	standaloneRevised.Spec.Image = "splunk/test"
+	env := []corev1.EnvVar{
+		{Name: "A", Value: "a"},
+	}
+	reconcile := func(c *spltest.MockClient, cr interface{}) error {
+		obj := cr.(*enterprisev1.Standalone)
+		err := ApplyMonitoringConsole(c, obj, obj.Spec.CommonSplunkSpec, env)
+		return err
+	}
+	spltest.ReconcileTester(t, "TestApplyMonitoringConsole", &standaloneCR, standaloneRevised, createCalls, updateCalls, reconcile, true, namespacescopedsecret)
+}
+
+func TestApplyMonitoringConsoleEnvConfigMap(t *testing.T) {
+	funcCalls := []spltest.MockFuncCall{
+		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console-defaults"},
+	}
+
+	env := []corev1.EnvVar{
+		{Name: "A", Value: "a"},
+	}
+
+	newURLsAdded := true
+	reconcile := func(c *spltest.MockClient, cr interface{}) error {
+		_, err := ApplyMonitoringConsoleEnvConfigMap(c, "test", env, newURLsAdded)
+		return err
+	}
+
+	//if monitoring-console env configMap doesn't exist, then create one
+	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": funcCalls}
+	updateCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls}
+
+	spltest.ReconcileTester(t, "TestApplyMonitoringConsoleEnvConfigMap", "test", "test", createCalls, updateCalls, reconcile, false)
+
+	//if configMap exists then update it
+	createCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls, "Update": funcCalls}
+	updateCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls}
+
+	newURLsAdded = true
+
+	current := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-test-monitoring-console-defaults",
+			Namespace: "test",
+		},
+		Data: map[string]string{"a": "b"},
+	}
+
+	spltest.ReconcileTester(t, "TestApplyMonitoringConsoleEnvConfigMap", "test", "test", createCalls, updateCalls, reconcile, false, &current)
+	//check for deletion
+	createCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls}
+	updateCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls}
+
+	newURLsAdded = false
+
+	current = corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-test-monitoring-console-defaults",
+			Namespace: "test",
+		},
+		Data: map[string]string{"a": "b"},
+	}
+
+	spltest.ReconcileTester(t, "TestApplyMonitoringConsoleEnvConfigMap", "test", "test", createCalls, updateCalls, reconcile, false, &current)
+
+	//no configMap exist and try to do deletion then just create a empty configMap
+	createCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": funcCalls}
+	updateCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls}
+
+	newURLsAdded = false
+
+	spltest.ReconcileTester(t, "TestApplyMonitoringConsoleEnvConfigMap", "test", "test", createCalls, updateCalls, reconcile, false)
+
+	//extra check for "SPLUNK_SEARCH_HEAD_URL"
+
+	createCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls, "Update": funcCalls}
+	updateCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls}
+
+	env = []corev1.EnvVar{
+		{Name: "SPLUNK_SEARCH_HEAD_URL", Value: "splunk-test-search-head-0.splunk-test-search-head-headless.default.svc.cluster.local"},
+	}
+	newURLsAdded = true
+
+	current = corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-test-monitoring-console-defaults",
+			Namespace: "test",
+		},
+		Data: map[string]string{"SPLUNK_SEARCH_HEAD_URL": "splunk-test-search-head-1.splunk-test-search-head-headless.default.svc.cluster.local,splunk-test-search-head-0.splunk-test-search-head-headless.default.svc.cluster.local,splunk-test-search-head-2.splunk-test-search-head-headless.default.svc.cluster.local"},
+	}
+	spltest.ReconcileTester(t, "TestApplyMonitoringConsoleEnvConfigMap", "test", "test", createCalls, updateCalls, reconcile, false, &current)
+
+	//more SH scenarios
+	//extra check for "SPLUNK_SEARCH_HEAD_URL"
+
+	createCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls, "Update": funcCalls}
+	updateCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls}
+
+	env = []corev1.EnvVar{
+		{Name: "SPLUNK_SEARCH_HEAD_URL", Value: "splunk-test-search-head-1.splunk-test-search-head-headless.default.svc.cluster.local,splunk-test-search-head-0.splunk-test-search-head-headless.default.svc.cluster.local,splunk-test-search-head-2.splunk-test-search-head-headless.default.svc.cluster.local"},
+	}
+	newURLsAdded = true
+
+	current = corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-test-monitoring-console-defaults",
+			Namespace: "test",
+		},
+		Data: map[string]string{"SPLUNK_SEARCH_HEAD_URL": "splunk-test-search-head-0.splunk-test-search-head-headless.default.svc.cluster.local"},
+	}
+	spltest.ReconcileTester(t, "TestApplyMonitoringConsoleEnvConfigMap", "test", "test", createCalls, updateCalls, reconcile, false, &current)
+
+	//extra check for "SPLUNK_SEARCH_HEAD_URL"
+
+	createCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls, "Update": funcCalls}
+	updateCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls}
+
+	env = []corev1.EnvVar{
+		{Name: "SPLUNK_SEARCH_HEAD_URL", Value: "splunk-test-search-head-1.splunk-test-search-head-headless.default.svc.cluster.local,splunk-test-search-head-0.splunk-test-search-head-headless.default.svc.cluster.local,splunk-test-search-head-2.splunk-test-search-head-headless.default.svc.cluster.local"},
+	}
+	newURLsAdded = true
+
+	current = corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-test-monitoring-console-defaults",
+			Namespace: "test",
+		},
+		Data: map[string]string{"SPLUNK_SEARCH_HEAD_URL": "splunk-test-search-head-0.splunk-test-search-head-headless.default.svc.cluster.local"},
+	}
+	spltest.ReconcileTester(t, "TestApplyMonitoringConsoleEnvConfigMap", "test", "test", createCalls, updateCalls, reconcile, false, &current)
+
+	//test if url.Value contains any prefix/suffix/,,
+	createCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls, "Update": funcCalls}
+	updateCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls}
+
+	newURLsAdded = false
+
+	current = corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-test-monitoring-console-defaults",
+			Namespace: "test",
+		},
+		Data: map[string]string{"a": "b,c"},
+	}
+
+	env = []corev1.EnvVar{
+		{Name: "a", Value: "b"},
+	}
+	spltest.ReconcileTester(t, "TestApplyMonitoringConsoleEnvConfigMap", "test", "test", createCalls, updateCalls, reconcile, false, &current)
+
+	//check more Deletion scenarios
+	createCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls, "Update": funcCalls}
+	updateCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls}
+
+	newURLsAdded = false
+
+	current = corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-test-monitoring-console-defaults",
+			Namespace: "test",
+		},
+		Data: map[string]string{"a": "b,a,c"},
+	}
+
+	env = []corev1.EnvVar{
+		{Name: "a", Value: "b"},
+	}
+	spltest.ReconcileTester(t, "TestApplyMonitoringConsoleEnvConfigMap", "test", "test", createCalls, updateCalls, reconcile, false, &current)
+
+	//check more Deletion scenarios
+	createCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls, "Update": funcCalls}
+	updateCalls = map[string][]spltest.MockFuncCall{"Get": funcCalls}
+
+	newURLsAdded = false
+
+	current = corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-test-monitoring-console-defaults",
+			Namespace: "test",
+		},
+		Data: map[string]string{"a": "b,a,c"},
+	}
+
+	env = []corev1.EnvVar{
+		{Name: "a", Value: "c"},
+	}
+	spltest.ReconcileTester(t, "TestApplyMonitoringConsoleEnvConfigMap", "test", "test", createCalls, updateCalls, reconcile, false, &current)
+}

--- a/pkg/splunk/enterprise/names.go
+++ b/pkg/splunk/enterprise/names.go
@@ -67,6 +67,11 @@ func GetSplunkStatefulsetName(instanceType InstanceType, identifier string) stri
 	return fmt.Sprintf(statefulSetTemplateStr, identifier, instanceType)
 }
 
+// GetSplunkMonitoringConsoleDeploymentName uses a template to name a Kubernetes Deployment for Splunk MC instance.
+func GetSplunkMonitoringConsoleDeploymentName(instanceType InstanceType, identifier string) string {
+	return fmt.Sprintf(deploymentTemplateStr, identifier, instanceType)
+}
+
 // GetSplunkStatefulsetPodName uses a template to name a specific pod within a Kubernetes StatefulSet for Splunk instances.
 func GetSplunkStatefulsetPodName(instanceType InstanceType, identifier string, index int32) string {
 	return fmt.Sprintf(statefulSetPodTemplateStr, identifier, instanceType, index)

--- a/pkg/splunk/enterprise/names_test.go
+++ b/pkg/splunk/enterprise/names_test.go
@@ -36,6 +36,14 @@ func TestGetSplunkStatefulsetName(t *testing.T) {
 	}
 }
 
+func TestGetSplunkMonitoringConsoleDeploymentName(t *testing.T) {
+	got := GetSplunkMonitoringConsoleDeploymentName(SplunkMonitoringConsole, "t2")
+	want := "splunk-t2-monitoring-console"
+	if got != want {
+		t.Errorf("GetSplunkMonitoringConsoleDeploymentName(\"%s\",\"%s\") = %s; want %s", SplunkMonitoringConsole.ToString(), "t2", got, want)
+	}
+}
+
 func TestGetSplunkStatefulsetPodName(t *testing.T) {
 	got := GetSplunkStatefulsetPodName(SplunkSearchHead, "t3", 2)
 	want := "splunk-t3-search-head-2"

--- a/pkg/splunk/enterprise/searchheadcluster_test.go
+++ b/pkg/splunk/enterprise/searchheadcluster_test.go
@@ -35,6 +35,13 @@ import (
 func TestApplySearchHeadCluster(t *testing.T) {
 	funcCalls := []spltest.MockFuncCall{
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
+		{MetaName: "*v1.Secret-test-splunk-test-secret"},
+		{MetaName: "*v1.Secret-test-splunk-test-monitoring-console-secret-v1"},
+		{MetaName: "*v1.Service-test-splunk-test-monitoring-console-service"},
+		{MetaName: "*v1.Service-test-splunk-test-monitoring-console-headless"},
+		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console-defaults"},
+		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console-defaults"},
+		{MetaName: "*v1.Deployment-test-splunk-test-monitoring-console"},
 		{MetaName: "*v1.Service-test-splunk-stack1-search-head-headless"},
 		{MetaName: "*v1.Service-test-splunk-stack1-search-head-service"},
 		{MetaName: "*v1.Service-test-splunk-stack1-deployer-service"},
@@ -51,8 +58,8 @@ func TestApplySearchHeadCluster(t *testing.T) {
 	listmockCall := []spltest.MockFuncCall{
 		{ListOpts: listOpts}}
 
-	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[0], funcCalls[1], funcCalls[2], funcCalls[3], funcCalls[5], funcCalls[6], funcCalls[8], funcCalls[9]}, "List": {listmockCall[0], listmockCall[0]}}
-	updateCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Update": {funcCalls[6], funcCalls[9]}, "List": {listmockCall[0], listmockCall[0]}}
+	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[0], funcCalls[2], funcCalls[3], funcCalls[4], funcCalls[5], funcCalls[7], funcCalls[8], funcCalls[9], funcCalls[10], funcCalls[12], funcCalls[13], funcCalls[15], funcCalls[16]}, "List": {listmockCall[0], listmockCall[0], listmockCall[0]}}
+	updateCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Update": {funcCalls[7], funcCalls[13], funcCalls[16]}, "List": {listmockCall[0], listmockCall[0], listmockCall[0]}}
 	statefulSet := enterprisev1.SearchHeadCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "SearchHeadCluster",

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -59,6 +59,17 @@ func ApplyStandalone(client splcommon.ControllerClient, cr *enterprisev1.Standal
 		client.Status().Update(context.TODO(), cr)
 	}()
 
+	// create or update general config resources
+	_, err = ApplySplunkConfig(client, cr, cr.Spec.CommonSplunkSpec, SplunkStandalone)
+	if err != nil {
+		return result, err
+	}
+
+	err = ApplyMonitoringConsole(client, cr, cr.Spec.CommonSplunkSpec, getStandaloneExtraEnv(cr, cr.Spec.Replicas))
+	if err != nil {
+		return result, err
+	}
+
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
 		terminating, err := splctrl.CheckForDeletion(cr, client)
@@ -67,12 +78,6 @@ func ApplyStandalone(client splcommon.ControllerClient, cr *enterprisev1.Standal
 		} else {
 			result.Requeue = false
 		}
-		return result, err
-	}
-
-	// create or update general config resources
-	_, err = ApplySplunkConfig(client, cr, cr.Spec.CommonSplunkSpec, SplunkStandalone)
-	if err != nil {
 		return result, err
 	}
 
@@ -137,4 +142,14 @@ func validateStandaloneSpec(spec *enterprisev1.StandaloneSpec) error {
 
 	spec.SparkImage = spark.GetSparkImage(spec.SparkImage)
 	return validateCommonSplunkSpec(&spec.CommonSplunkSpec)
+}
+
+// getStandaloneExtraEnv returns extra environment variables used by monitoring console
+func getStandaloneExtraEnv(cr splcommon.MetaObject, replicas int32) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  "SPLUNK_STANDALONE_URL",
+			Value: GetSplunkStatefulsetUrls(cr.GetNamespace(), SplunkStandalone, cr.GetName(), replicas, false),
+		},
+	}
 }

--- a/pkg/splunk/enterprise/standalone_test.go
+++ b/pkg/splunk/enterprise/standalone_test.go
@@ -30,6 +30,13 @@ import (
 func TestApplyStandalone(t *testing.T) {
 	funcCalls := []spltest.MockFuncCall{
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
+		{MetaName: "*v1.Secret-test-splunk-test-secret"},
+		{MetaName: "*v1.Secret-test-splunk-test-monitoring-console-secret-v1"},
+		{MetaName: "*v1.Service-test-splunk-test-monitoring-console-service"},
+		{MetaName: "*v1.Service-test-splunk-test-monitoring-console-headless"},
+		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console-defaults"},
+		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console-defaults"},
+		{MetaName: "*v1.Deployment-test-splunk-test-monitoring-console"},
 		{MetaName: "*v1.Service-test-splunk-stack1-standalone-headless"},
 		{MetaName: "*v1.Service-test-splunk-stack1-standalone-service"},
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
@@ -42,8 +49,8 @@ func TestApplyStandalone(t *testing.T) {
 	listmockCall := []spltest.MockFuncCall{
 		{ListOpts: listOpts}}
 
-	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[0], funcCalls[1], funcCalls[2], funcCalls[4], funcCalls[5]}, "List": {listmockCall[0]}}
-	updateCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Update": {funcCalls[5]}, "List": {listmockCall[0]}}
+	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[0], funcCalls[2], funcCalls[3], funcCalls[4], funcCalls[5], funcCalls[7], funcCalls[8], funcCalls[9], funcCalls[11], funcCalls[12]}, "List": {listmockCall[0], listmockCall[0]}}
+	updateCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Update": {funcCalls[7], funcCalls[12]}, "List": {listmockCall[0], listmockCall[0]}}
 
 	current := enterprisev1.Standalone{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/splunk/enterprise/types.go
+++ b/pkg/splunk/enterprise/types.go
@@ -35,6 +35,9 @@ const (
 
 	// SplunkLicenseMaster controls one or more license slaves
 	SplunkLicenseMaster InstanceType = "license-master"
+
+	// SplunkMonitoringConsole is a single instance of Splunk monitor for mc
+	SplunkMonitoringConsole InstanceType = "monitoring-console"
 )
 
 // ToString returns a string for a given InstanceType
@@ -58,6 +61,8 @@ func (instanceType InstanceType) ToRole() string {
 		role = "splunk_deployer"
 	case SplunkLicenseMaster:
 		role = "splunk_license_master"
+	case SplunkMonitoringConsole:
+		role = "splunk_monitor"
 	}
 	return role
 }
@@ -78,6 +83,8 @@ func (instanceType InstanceType) ToKind() string {
 		kind = "search-head"
 	case SplunkLicenseMaster:
 		kind = "license-master"
+	case SplunkMonitoringConsole:
+		kind = "monitoring-console"
 	}
 	return kind
 }

--- a/pkg/splunk/test/controller.go
+++ b/pkg/splunk/test/controller.go
@@ -170,7 +170,10 @@ func (c MockClient) List(ctx context.Context, obj runtime.Object, opts ...client
 	})
 	listObj := c.ListObj
 	if listObj != nil {
-		copyMockObject(obj, listObj.(runtime.Object))
+		//if obj.GetObjectKind() == listObj.(runtime.Object).GetObjectKind() {
+		if reflect.TypeOf(obj).String() == reflect.TypeOf(listObj.(runtime.Object)).String() {
+			copyMockObject(obj, listObj.(runtime.Object))
+		}
 		return nil
 	}
 	return c.NotFoundError


### PR DESCRIPTION
[CSPL-383] Adding a monitoring console. On implementation of Standalone/LicenseMaster/SearchHeadCluster custom resource, a Splunk monitoring console deployment will be deployed to monitor all Splunk instance in that namespace