### PR TITLE
Fixed formatting to resolve make fmt failure

### DIFF
--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -110,8 +110,7 @@ var _ = Describe("Smoke test", func() {
 				_ = deployment.GetInstance(instanceName, idc)
 				return idc.Status.Phase
 			}, ConsistentDuration, ConsistentPollInterval).Should(Equal(splcommon.PhaseReady))
-    
-			
+
 			// Ensure search head cluster go to Ready phase
 			shc := &enterprisev1.SearchHeadCluster{}
 			Eventually(func() splcommon.Phase {

--- a/test/testenv/deployment.go
+++ b/test/testenv/deployment.go
@@ -394,9 +394,9 @@ func (d *Deployment) DeploySingleSiteCluster(name string, indexerReplicas int) e
 	// Set Master URI
 	siteDefaults := fmt.Sprintf(`splunk:
   multisite_master: splunk-%s-cluster-master-service`, name)
-	
-   // Deploy Indxers
-    _, err = d.DeployIndexerCluster(name+"-"+"idx", licenseMaster, indexerReplicas, name, siteDefaults)
+
+	// Deploy Indxers
+	_, err = d.DeployIndexerCluster(name+"-"+"idx", licenseMaster, indexerReplicas, name, siteDefaults)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixed formatting errors causing `make fmt` to fail.