### PR TITLE
Automate splunk monitoring console app for indexer clustering

### DIFF
--- a/deploy/crds/enterprise.splunk.com_clustermasters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_clustermasters_crd.yaml
@@ -1,8 +1,13 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clustermasters.enterprise.splunk.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: Status of cluster master
+    name: Phase
+    type: string
   group: enterprise.splunk.com
   names:
     kind: ClusterMaster
@@ -12,2361 +17,2296 @@ spec:
     - cm-idxc
     singular: clustermaster
   scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: Status of cluster master
-      jsonPath: .status.phase
-      name: Phase
-      type: string
-    name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        description: ClusterMaster is the Schema for the clustermasters API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ClusterMasterSpec defines the desired state of ClusterMaster
-            properties:
-              Mock:
-                description: Mock to differentiate between UTs and actual reconcile
-                type: boolean
-              affinity:
-                description: Kubernetes Affinity rules that control how pods are assigned
-                  to particular nodes.
-                properties:
-                  nodeAffinity:
-                    description: Describes node affinity scheduling rules for the
-                      pod.
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node matches
-                          the corresponding matchExpressions; the node(s) with the
-                          highest sum are the most preferred.
-                        items:
-                          description: An empty preferred scheduling term matches
-                            all objects with implicit weight 0 (i.e. it's a no-op).
-                            A null preferred scheduling term matches no objects (i.e.
-                            is also a no-op).
-                          properties:
-                            preference:
-                              description: A node selector term, associated with the
-                                corresponding weight.
-                              properties:
-                                matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            weight:
-                              description: Weight associated with matching the corresponding
-                                nodeSelectorTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - preference
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to an update), the system may or may not try to
-                          eventually evict the pod from its node.
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ClusterMaster is the Schema for the clustermasters API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ClusterMasterSpec defines the desired state of ClusterMaster
+          properties:
+            Mock:
+              description: Mock to differentiate between UTs and actual reconcile
+              type: boolean
+            affinity:
+              description: Kubernetes Affinity rules that control how pods are assigned
+                to particular nodes.
+              properties:
+                nodeAffinity:
+                  description: Describes node affinity scheduling rules for the pod.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node matches the corresponding matchExpressions; the
+                        node(s) with the highest sum are the most preferred.
+                      items:
+                        description: An empty preferred scheduling term matches all
+                          objects with implicit weight 0 (i.e. it's a no-op). A null
+                          preferred scheduling term matches no objects (i.e. is also
+                          a no-op).
                         properties:
-                          nodeSelectorTerms:
-                            description: Required. A list of node selector terms.
-                              The terms are ORed.
-                            items:
-                              description: A null or empty node selector term matches
-                                no objects. The requirements of them are ANDed. The
-                                TopologySelectorTerm type implements a subset of the
-                                NodeSelectorTerm.
-                              properties:
-                                matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
+                          preference:
+                            description: A node selector term, associated with the
+                              corresponding weight.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
                                         type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
                                         type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            type: array
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          weight:
+                            description: Weight associated with matching the corresponding
+                              nodeSelectorTerm, in the range 1-100.
+                            format: int32
+                            type: integer
                         required:
-                        - nodeSelectorTerms
+                        - preference
+                        - weight
                         type: object
-                    type: object
-                  podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate
-                      this pod in the same node, zone, etc. as some other pod(s)).
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
-                        items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
-                          properties:
-                            podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to an update), the system may or may not try to
+                        eventually evict the pod from its node.
+                      properties:
+                        nodeSelectorTerms:
+                          description: Required. A list of node selector terms. The
+                            terms are ORed.
+                          items:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
                                   type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                      required:
+                      - nodeSelectorTerms
+                      type: object
+                  type: object
+                podAffinity:
+                  description: Describes pod affinity scheduling rules (e.g. co-locate
+                    this pod in the same node, zone, etc. as some other pod(s)).
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node has pods which matches the corresponding podAffinityTerm;
+                        the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Required. A pod affinity term, associated
+                              with the corresponding weight.
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
                                   type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to a pod label update), the system may or may not
+                        try to eventually evict the pod from its node. When there
+                        are multiple elements, the lists of nodes corresponding to
+                        each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources, in
+                              this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+                podAntiAffinity:
+                  description: Describes pod anti-affinity scheduling rules (e.g.
+                    avoid putting this pod in the same node, zone, etc. as some other
+                    pod(s)).
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the anti-affinity expressions specified by this
+                        field, but it may choose a node that violates one or more
+                        of the expressions. The node that is most preferred is the
+                        one with the greatest sum of weights, i.e. for each node that
+                        meets all of the scheduling requirements (resource request,
+                        requiredDuringScheduling anti-affinity expressions, etc.),
+                        compute a sum by iterating through the elements of this field
+                        and adding "weight" to the sum if the node has pods which
+                        matches the corresponding podAffinityTerm; the node(s) with
+                        the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Required. A pod affinity term, associated
+                              with the corresponding weight.
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the anti-affinity requirements specified by
+                        this field are not met at scheduling time, the pod will not
+                        be scheduled onto the node. If the anti-affinity requirements
+                        specified by this field cease to be met at some point during
+                        pod execution (e.g. due to a pod label update), the system
+                        may or may not try to eventually evict the pod from its node.
+                        When there are multiple elements, the lists of nodes corresponding
+                        to each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources, in
+                              this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            clusterMasterRef:
+              description: ClusterMasterRef refers to a Splunk Enterprise indexer
+                cluster managed by the operator within Kubernetes
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            defaults:
+              description: Inline map of default.yml overrides used to initialize
+                the environment
+              type: string
+            defaultsUrl:
+              description: Full path or URL for one or more default.yml files, separated
+                by commas
+              type: string
+            ephemeralStorage:
+              description: If true, ephemeral (emptyDir) storage will be used for
+                /opt/splunk/etc and /opt/splunk/var volumes
+              type: boolean
+            etcStorage:
+              description: Storage capacity to request for /opt/splunk/etc persistent
+                volume claims (default=”1Gi”)
+              type: string
+            image:
+              description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
+                environment variables)
+              type: string
+            imagePullPolicy:
+              description: 'Sets pull policy for all images (either “Always” or the
+                default: “IfNotPresent”)'
+              enum:
+              - Always
+              - IfNotPresent
+              type: string
+            licenseMasterRef:
+              description: LicenseMasterRef refers to a Splunk Enterprise license
+                master managed by the operator within Kubernetes
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            licenseUrl:
+              description: Full path or URL for a Splunk Enterprise license file
+              type: string
+            resources:
+              description: resource requirements for the pod containers
+              properties:
+                limits:
+                  additionalProperties:
+                    type: string
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    type: string
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
+            schedulerName:
+              description: Name of Scheduler to use for pod placement (defaults to
+                “default-scheduler”)
+              type: string
+            serviceTemplate:
+              description: ServiceTemplate is a template used to create Kubernetes
+                services
+              properties:
+                apiVersion:
+                  description: 'APIVersion defines the versioned schema of this representation
+                    of an object. Servers should convert recognized schemas to the
+                    latest internal value, and may reject unrecognized values. More
+                    info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                  type: string
+                kind:
+                  description: 'Kind is a string value representing the REST resource
+                    this object represents. Servers may infer this from the endpoint
+                    the client submits requests to. Cannot be updated. In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                metadata:
+                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                  type: object
+                spec:
+                  description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                  properties:
+                    clusterIP:
+                      description: 'clusterIP is the IP address of the service and
+                        is usually assigned randomly by the master. If an address
+                        is specified manually and is not in use by others, it will
+                        be allocated to the service; otherwise, creation of the service
+                        will fail. This field can not be changed through updates.
+                        Valid values are "None", empty string (""), or a valid IP
+                        address. "None" can be specified for headless services when
+                        proxying is not required. Only applies to types ClusterIP,
+                        NodePort, and LoadBalancer. Ignored if type is ExternalName.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    externalIPs:
+                      description: externalIPs is a list of IP addresses for which
+                        nodes in the cluster will also accept traffic for this service.  These
+                        IPs are not managed by Kubernetes.  The user is responsible
+                        for ensuring that traffic arrives at a node with this IP.  A
+                        common example is external load-balancers that are not part
+                        of the Kubernetes system.
+                      items:
+                        type: string
+                      type: array
+                    externalName:
+                      description: externalName is the external reference that kubedns
+                        or equivalent will return as a CNAME record for this service.
+                        No proxying will be involved. Must be a valid RFC-1123 hostname
+                        (https://tools.ietf.org/html/rfc1123) and requires Type to
+                        be ExternalName.
+                      type: string
+                    externalTrafficPolicy:
+                      description: externalTrafficPolicy denotes if this Service desires
+                        to route external traffic to node-local or cluster-wide endpoints.
+                        "Local" preserves the client source IP and avoids a second
+                        hop for LoadBalancer and Nodeport type services, but risks
+                        potentially imbalanced traffic spreading. "Cluster" obscures
+                        the client source IP and may cause a second hop to another
+                        node, but should have good overall load-spreading.
+                      type: string
+                    healthCheckNodePort:
+                      description: healthCheckNodePort specifies the healthcheck nodePort
+                        for the service. If not specified, HealthCheckNodePort is
+                        created by the service api backend with the allocated nodePort.
+                        Will use user-specified nodePort value if specified by the
+                        client. Only effects when Type is set to LoadBalancer and
+                        ExternalTrafficPolicy is set to Local.
+                      format: int32
+                      type: integer
+                    ipFamily:
+                      description: ipFamily specifies whether this Service has a preference
+                        for a particular IP family (e.g. IPv4 vs. IPv6).  If a specific
+                        IP family is requested, the clusterIP field will be allocated
+                        from that family, if it is available in the cluster.  If no
+                        IP family is requested, the cluster's primary IP family will
+                        be used. Other IP fields (loadBalancerIP, loadBalancerSourceRanges,
+                        externalIPs) and controllers which allocate external load-balancers
+                        should use the same IP family.  Endpoints for this Service
+                        will be of this family.  This field is immutable after creation.
+                        Assigning a ServiceIPFamily not available in the cluster (e.g.
+                        IPv6 in IPv4 only cluster) is an error condition and will
+                        fail during clusterIP assignment.
+                      type: string
+                    loadBalancerIP:
+                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                        will get created with the IP specified in this field. This
+                        feature depends on whether the underlying cloud-provider supports
+                        specifying the loadBalancerIP when a load balancer is created.
+                        This field will be ignored if the cloud-provider does not
+                        support the feature.'
+                      type: string
+                    loadBalancerSourceRanges:
+                      description: 'If specified and supported by the platform, this
+                        will restrict traffic through the cloud-provider load-balancer
+                        will be restricted to the specified client IPs. This field
+                        will be ignored if the cloud-provider does not support the
+                        feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: 'The list of ports that are exposed by this service.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      items:
+                        description: ServicePort contains information on service's
+                          port.
+                        properties:
+                          name:
+                            description: The name of this port within the service.
+                              This must be a DNS_LABEL. All ports within a ServiceSpec
+                              must have unique names. When considering the endpoints
+                              for a Service, this must match the 'name' field in the
+                              EndpointPort. Optional if only one ServicePort is defined
+                              on this service.
+                            type: string
+                          nodePort:
+                            description: 'The port on each node on which this service
+                              is exposed when type=NodePort or LoadBalancer. Usually
+                              assigned by the system. If specified, it will be allocated
+                              to the service if unused or else creation of the service
+                              will fail. Default is to auto-allocate a port if the
+                              ServiceType of this Service requires one. More info:
+                              https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                            format: int32
+                            type: integer
+                          port:
+                            description: The port that will be exposed by this service.
+                            format: int32
+                            type: integer
+                          protocol:
+                            description: The IP protocol for this port. Supports "TCP",
+                              "UDP", and "SCTP". Default is TCP.
+                            type: string
+                          targetPort:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: 'Number or name of the port to access on
+                              the pods targeted by the service. Number must be in
+                              the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              If this is a string, it will be looked up as a named
+                              port in the target Pod''s container ports. If this is
+                              not specified, the value of the ''port'' field is used
+                              (an identity map). This field is ignored for services
+                              with clusterIP=None, and should be omitted or set equal
+                              to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      type: array
+                    publishNotReadyAddresses:
+                      description: publishNotReadyAddresses, when set to true, indicates
+                        that DNS implementations must publish the notReadyAddresses
+                        of subsets for the Endpoints associated with the Service.
+                        The default value is false. The primary use case for setting
+                        this field is to use a StatefulSet's Headless Service to propagate
+                        SRV records for its Pods without respect to their readiness
+                        for purpose of peer discovery.
+                      type: boolean
+                    selector:
+                      additionalProperties:
+                        type: string
+                      description: 'Route service traffic to pods with label keys
+                        and values matching this selector. If empty or not present,
+                        the service is assumed to have an external process managing
+                        its endpoints, which Kubernetes will not modify. Only applies
+                        to types ClusterIP, NodePort, and LoadBalancer. Ignored if
+                        type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                      type: object
+                    sessionAffinity:
+                      description: 'Supports "ClientIP" and "None". Used to maintain
+                        session affinity. Enable client IP based session affinity.
+                        Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    sessionAffinityConfig:
+                      description: sessionAffinityConfig contains the configurations
+                        of session affinity.
+                      properties:
+                        clientIP:
+                          description: clientIP contains the configurations of Client
+                            IP based session affinity.
+                          properties:
+                            timeoutSeconds:
+                              description: timeoutSeconds specifies the seconds of
+                                ClientIP type session sticky time. The value must
+                                be >0 && <=86400(for 1 day) if ServiceAffinity ==
+                                "ClientIP". Default value is 10800(for 3 hours).
                               format: int32
                               type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
                           type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to a pod label update), the system may or may
-                          not try to eventually evict the pod from its node. When
-                          there are multiple elements, the lists of nodes corresponding
-                          to each podAffinityTerm are intersected, i.e. all terms
-                          must be satisfied.
-                        items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
-                          properties:
-                            labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            namespaces:
-                              description: namespaces specifies which namespaces the
-                                labelSelector applies to (matches against); null or
-                                empty list means "this pod's namespace"
-                              items:
+                      type: object
+                    type:
+                      description: 'type determines how the Service is exposed. Defaults
+                        to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort,
+                        and LoadBalancer. "ExternalName" maps to the specified externalName.
+                        "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                        to endpoints. Endpoints are determined by the selector or
+                        if that is not specified, by manual construction of an Endpoints
+                        object. If clusterIP is "None", no virtual IP is allocated
+                        and the endpoints are published as a set of endpoints rather
+                        than a stable IP. "NodePort" builds on ClusterIP and allocates
+                        a port on every node which routes to the clusterIP. "LoadBalancer"
+                        builds on NodePort and creates an external load-balancer (if
+                        supported in the current cloud) which routes to the clusterIP.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                      type: string
+                  type: object
+                status:
+                  description: 'Most recently observed status of the service. Populated
+                    by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                  properties:
+                    loadBalancer:
+                      description: LoadBalancer contains the current status of the
+                        load-balancer, if one is present.
+                      properties:
+                        ingress:
+                          description: Ingress is a list containing ingress points
+                            for the load-balancer. Traffic intended for the service
+                            should be sent to these ingress points.
+                          items:
+                            description: 'LoadBalancerIngress represents the status
+                              of a load-balancer ingress point: traffic intended for
+                              the service should be sent to an ingress point.'
+                            properties:
+                              hostname:
+                                description: Hostname is set for load-balancer ingress
+                                  points that are DNS based (typically AWS load-balancers)
                                 type: string
-                              type: array
-                            topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                  podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g.
-                      avoid putting this pod in the same node, zone, etc. as some
-                      other pod(s)).
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the anti-affinity expressions specified
-                          by this field, but it may choose a node that violates one
-                          or more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling anti-affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
-                        items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
-                          properties:
-                            podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the anti-affinity requirements specified by
-                          this field are not met at scheduling time, the pod will
-                          not be scheduled onto the node. If the anti-affinity requirements
-                          specified by this field cease to be met at some point during
-                          pod execution (e.g. due to a pod label update), the system
-                          may or may not try to eventually evict the pod from its
-                          node. When there are multiple elements, the lists of nodes
-                          corresponding to each podAffinityTerm are intersected, i.e.
-                          all terms must be satisfied.
-                        items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
-                          properties:
-                            labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            namespaces:
-                              description: namespaces specifies which namespaces the
-                                labelSelector applies to (matches against); null or
-                                empty list means "this pod's namespace"
-                              items:
+                              ip:
+                                description: IP is set for load-balancer ingress points
+                                  that are IP based (typically GCE or OpenStack load-balancers)
                                 type: string
-                              type: array
-                            topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                type: object
-              clusterMasterRef:
-                description: ClusterMasterRef refers to a Splunk Enterprise indexer
-                  cluster managed by the operator within Kubernetes
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              defaults:
-                description: Inline map of default.yml overrides used to initialize
-                  the environment
-                type: string
-              defaultsUrl:
-                description: Full path or URL for one or more default.yml files, separated
-                  by commas
-                type: string
-              ephemeralStorage:
-                description: If true, ephemeral (emptyDir) storage will be used for
-                  /opt/splunk/etc and /opt/splunk/var volumes
-                type: boolean
-              etcStorage:
-                description: Storage capacity to request for /opt/splunk/etc persistent
-                  volume claims (default=”1Gi”)
-                type: string
-              image:
-                description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
-                  environment variables)
-                type: string
-              imagePullPolicy:
-                description: 'Sets pull policy for all images (either “Always” or
-                  the default: “IfNotPresent”)'
-                enum:
-                - Always
-                - IfNotPresent
-                type: string
-              licenseMasterRef:
-                description: LicenseMasterRef refers to a Splunk Enterprise license
-                  master managed by the operator within Kubernetes
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              licenseUrl:
-                description: Full path or URL for a Splunk Enterprise license file
-                type: string
-              resources:
-                description: resource requirements for the pod containers
-                properties:
-                  limits:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                    type: object
-                  requests:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                    type: object
-                type: object
-              schedulerName:
-                description: Name of Scheduler to use for pod placement (defaults
-                  to “default-scheduler”)
-                type: string
-              serviceTemplate:
-                description: ServiceTemplate is a template used to create Kubernetes
-                  services
-                properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  metadata:
-                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                    type: object
-                  spec:
-                    description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+              type: object
+            smartstore:
+              description: Splunk Smartstore configuration. Refer to indexes.conf.spec
+                on docs.splunk.com
+              properties:
+                indexes:
+                  description: List of Splunk indexes
+                  items:
+                    description: IndexSpec defines Splunk index name and storage path
                     properties:
-                      clusterIP:
-                        description: 'clusterIP is the IP address of the service and
-                          is usually assigned randomly by the master. If an address
-                          is specified manually and is not in use by others, it will
-                          be allocated to the service; otherwise, creation of the
-                          service will fail. This field can not be changed through
-                          updates. Valid values are "None", empty string (""), or
-                          a valid IP address. "None" can be specified for headless
-                          services when proxying is not required. Only applies to
-                          types ClusterIP, NodePort, and LoadBalancer. Ignored if
-                          type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      name:
+                        description: Splunk index name
                         type: string
-                      externalIPs:
-                        description: externalIPs is a list of IP addresses for which
-                          nodes in the cluster will also accept traffic for this service.  These
-                          IPs are not managed by Kubernetes.  The user is responsible
-                          for ensuring that traffic arrives at a node with this IP.  A
-                          common example is external load-balancers that are not part
-                          of the Kubernetes system.
-                        items:
-                          type: string
-                        type: array
-                      externalName:
-                        description: externalName is the external reference that kubedns
-                          or equivalent will return as a CNAME record for this service.
-                          No proxying will be involved. Must be a valid RFC-1123 hostname
-                          (https://tools.ietf.org/html/rfc1123) and requires Type
-                          to be ExternalName.
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
                         type: string
-                      externalTrafficPolicy:
-                        description: externalTrafficPolicy denotes if this Service
-                          desires to route external traffic to node-local or cluster-wide
-                          endpoints. "Local" preserves the client source IP and avoids
-                          a second hop for LoadBalancer and Nodeport type services,
-                          but risks potentially imbalanced traffic spreading. "Cluster"
-                          obscures the client source IP and may cause a second hop
-                          to another node, but should have good overall load-spreading.
+                      volumeName:
+                        description: Remote Volume name
                         type: string
-                      healthCheckNodePort:
-                        description: healthCheckNodePort specifies the healthcheck
-                          nodePort for the service. If not specified, HealthCheckNodePort
-                          is created by the service api backend with the allocated
-                          nodePort. Will use user-specified nodePort value if specified
-                          by the client. Only effects when Type is set to LoadBalancer
-                          and ExternalTrafficPolicy is set to Local.
+                    type: object
+                  type: array
+                volumes:
+                  description: List of remote storage volumes
+                  items:
+                    description: VolumeSpec defines remote volume name and remote
+                      volume URI
+                    properties:
+                      endpoint:
+                        description: Remote volume URI
+                        type: string
+                      name:
+                        description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
+                        type: string
+                    type: object
+                  type: array
+              type: object
+            storageClassName:
+              description: Name of StorageClass to use for persistent volume claims
+              type: string
+            tolerations:
+              description: Pod's tolerations for Kubernetes node's taint
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+                type: object
+              type: array
+            varStorage:
+              description: Storage capacity to request for /opt/splunk/var persistent
+                volume claims (default=”50Gi”)
+              type: string
+            volumes:
+              description: List of one or more Kubernetes volumes. These will be mounted
+                in all pod containers as as /mnt/<name>
+              items:
+                description: Volume represents a named volume in a pod that may be
+                  accessed by any container in the pod.
+                properties:
+                  awsElasticBlockStore:
+                    description: 'AWSElasticBlockStore represents an AWS Disk resource
+                      that is attached to a kubelet''s host machine and then exposed
+                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty).'
                         format: int32
                         type: integer
-                      ipFamily:
-                        description: ipFamily specifies whether this Service has a
-                          preference for a particular IP family (e.g. IPv4 vs. IPv6).  If
-                          a specific IP family is requested, the clusterIP field will
-                          be allocated from that family, if it is available in the
-                          cluster.  If no IP family is requested, the cluster's primary
-                          IP family will be used. Other IP fields (loadBalancerIP,
-                          loadBalancerSourceRanges, externalIPs) and controllers which
-                          allocate external load-balancers should use the same IP
-                          family.  Endpoints for this Service will be of this family.  This
-                          field is immutable after creation. Assigning a ServiceIPFamily
-                          not available in the cluster (e.g. IPv6 in IPv4 only cluster)
-                          is an error condition and will fail during clusterIP assignment.
+                      readOnly:
+                        description: 'Specify "true" to force and set the ReadOnly
+                          property in VolumeMounts to "true". If omitted, the default
+                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: boolean
+                      volumeID:
+                        description: 'Unique ID of the persistent disk resource in
+                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                         type: string
-                      loadBalancerIP:
-                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                          will get created with the IP specified in this field. This
-                          feature depends on whether the underlying cloud-provider
-                          supports specifying the loadBalancerIP when a load balancer
-                          is created. This field will be ignored if the cloud-provider
-                          does not support the feature.'
+                    required:
+                    - volumeID
+                    type: object
+                  azureDisk:
+                    description: AzureDisk represents an Azure Data Disk mount on
+                      the host and bind mount to the pod.
+                    properties:
+                      cachingMode:
+                        description: 'Host Caching mode: None, Read Only, Read Write.'
                         type: string
-                      loadBalancerSourceRanges:
-                        description: 'If specified and supported by the platform,
-                          this will restrict traffic through the cloud-provider load-balancer
-                          will be restricted to the specified client IPs. This field
-                          will be ignored if the cloud-provider does not support the
-                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                      diskName:
+                        description: The Name of the data disk in the blob storage
+                        type: string
+                      diskURI:
+                        description: The URI the data disk in the blob storage
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      kind:
+                        description: 'Expected values Shared: multiple blob disks
+                          per storage account  Dedicated: single blob disk per storage
+                          account  Managed: azure managed data disk (only in managed
+                          availability set). defaults to shared'
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                    required:
+                    - diskName
+                    - diskURI
+                    type: object
+                  azureFile:
+                    description: AzureFile represents an Azure File Service mount
+                      on the host and bind mount to the pod.
+                    properties:
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretName:
+                        description: the name of secret that contains Azure Storage
+                          Account Name and Key
+                        type: string
+                      shareName:
+                        description: Share Name
+                        type: string
+                    required:
+                    - secretName
+                    - shareName
+                    type: object
+                  cephfs:
+                    description: CephFS represents a Ceph FS mount on the host that
+                      shares a pod's lifetime
+                    properties:
+                      monitors:
+                        description: 'Required: Monitors is a collection of Ceph monitors
+                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                         items:
                           type: string
                         type: array
-                      ports:
-                        description: 'The list of ports that are exposed by this service.
-                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      path:
+                        description: 'Optional: Used as the mounted root, rather than
+                          the full Ceph tree, default is /'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: boolean
+                      secretFile:
+                        description: 'Optional: SecretFile is the path to key ring
+                          for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                      secretRef:
+                        description: 'Optional: SecretRef is reference to the authentication
+                          secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      user:
+                        description: 'Optional: User is the rados user name, default
+                          is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                    required:
+                    - monitors
+                    type: object
+                  cinder:
+                    description: 'Cinder represents a cinder volume attached and mounted
+                      on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Examples: "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: boolean
+                      secretRef:
+                        description: 'Optional: points to a secret object containing
+                          parameters used to connect to OpenStack.'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      volumeID:
+                        description: 'volume id used to identify the volume in cinder.
+                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  configMap:
+                    description: ConfigMap represents a configMap that should populate
+                      this volume
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced ConfigMap will be projected into
+                          the volume as a file whose name is the key and content is
+                          the value. If specified, the listed keys will be projected
+                          into the specified paths, and unlisted keys will not be
+                          present. If a key is specified which is not present in the
+                          ConfigMap, the volume setup will error unless it is marked
+                          optional. Paths must be relative and may not contain the
+                          '..' path or start with '..'.
                         items:
-                          description: ServicePort contains information on service's
-                            port.
+                          description: Maps a string key to a path within a volume.
                           properties:
-                            name:
-                              description: The name of this port within the service.
-                                This must be a DNS_LABEL. All ports within a ServiceSpec
-                                must have unique names. When considering the endpoints
-                                for a Service, this must match the 'name' field in
-                                the EndpointPort. Optional if only one ServicePort
-                                is defined on this service.
+                            key:
+                              description: The key to project.
                               type: string
-                            nodePort:
-                              description: 'The port on each node on which this service
-                                is exposed when type=NodePort or LoadBalancer. Usually
-                                assigned by the system. If specified, it will be allocated
-                                to the service if unused or else creation of the service
-                                will fail. Default is to auto-allocate a port if the
-                                ServiceType of this Service requires one. More info:
-                                https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
                               format: int32
                               type: integer
-                            port:
-                              description: The port that will be exposed by this service.
-                              format: int32
-                              type: integer
-                            protocol:
-                              description: The IP protocol for this port. Supports
-                                "TCP", "UDP", and "SCTP". Default is TCP.
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
                               type: string
-                            targetPort:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              description: 'Number or name of the port to access on
-                                the pods targeted by the service. Number must be in
-                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                                If this is a string, it will be looked up as a named
-                                port in the target Pod''s container ports. If this
-                                is not specified, the value of the ''port'' field
-                                is used (an identity map). This field is ignored for
-                                services with clusterIP=None, and should be omitted
-                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
-                              x-kubernetes-int-or-string: true
                           required:
-                          - port
+                          - key
+                          - path
                           type: object
                         type: array
-                        x-kubernetes-list-map-keys:
-                        - port
-                        - protocol
-                        x-kubernetes-list-type: map
-                      publishNotReadyAddresses:
-                        description: publishNotReadyAddresses, when set to true, indicates
-                          that DNS implementations must publish the notReadyAddresses
-                          of subsets for the Endpoints associated with the Service.
-                          The default value is false. The primary use case for setting
-                          this field is to use a StatefulSet's Headless Service to
-                          propagate SRV records for its Pods without respect to their
-                          readiness for purpose of peer discovery.
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the ConfigMap or its keys must
+                          be defined
                         type: boolean
-                      selector:
+                    type: object
+                  csi:
+                    description: CSI (Container Storage Interface) represents storage
+                      that is handled by an external CSI driver (Alpha feature).
+                    properties:
+                      driver:
+                        description: Driver is the name of the CSI driver that handles
+                          this volume. Consult with your admin for the correct name
+                          as registered in the cluster.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Ex. "ext4", "xfs",
+                          "ntfs". If not provided, the empty value is passed to the
+                          associated CSI driver which will determine the default filesystem
+                          to apply.
+                        type: string
+                      nodePublishSecretRef:
+                        description: NodePublishSecretRef is a reference to the secret
+                          object containing sensitive information to pass to the CSI
+                          driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
+                          calls. This field is optional, and  may be empty if no secret
+                          is required. If the secret object contains more than one
+                          secret, all secret references are passed.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      readOnly:
+                        description: Specifies a read-only configuration for the volume.
+                          Defaults to false (read/write).
+                        type: boolean
+                      volumeAttributes:
                         additionalProperties:
                           type: string
-                        description: 'Route service traffic to pods with label keys
-                          and values matching this selector. If empty or not present,
-                          the service is assumed to have an external process managing
-                          its endpoints, which Kubernetes will not modify. Only applies
-                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
-                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                        description: VolumeAttributes stores driver-specific properties
+                          that are passed to the CSI driver. Consult your driver's
+                          documentation for supported values.
                         type: object
-                      sessionAffinity:
-                        description: 'Supports "ClientIP" and "None". Used to maintain
-                          session affinity. Enable client IP based session affinity.
-                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                        type: string
-                      sessionAffinityConfig:
-                        description: sessionAffinityConfig contains the configurations
-                          of session affinity.
-                        properties:
-                          clientIP:
-                            description: clientIP contains the configurations of Client
-                              IP based session affinity.
-                            properties:
-                              timeoutSeconds:
-                                description: timeoutSeconds specifies the seconds
-                                  of ClientIP type session sticky time. The value
-                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
-                                  == "ClientIP". Default value is 10800(for 3 hours).
-                                format: int32
-                                type: integer
-                            type: object
-                        type: object
-                      type:
-                        description: 'type determines how the Service is exposed.
-                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
-                          NodePort, and LoadBalancer. "ExternalName" maps to the specified
-                          externalName. "ClusterIP" allocates a cluster-internal IP
-                          address for load-balancing to endpoints. Endpoints are determined
-                          by the selector or if that is not specified, by manual construction
-                          of an Endpoints object. If clusterIP is "None", no virtual
-                          IP is allocated and the endpoints are published as a set
-                          of endpoints rather than a stable IP. "NodePort" builds
-                          on ClusterIP and allocates a port on every node which routes
-                          to the clusterIP. "LoadBalancer" builds on NodePort and
-                          creates an external load-balancer (if supported in the current
-                          cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
-                        type: string
+                    required:
+                    - driver
                     type: object
-                  status:
-                    description: 'Most recently observed status of the service. Populated
-                      by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                  downwardAPI:
+                    description: DownwardAPI represents downward API about the pod
+                      that should populate this volume
                     properties:
-                      loadBalancer:
-                        description: LoadBalancer contains the current status of the
-                          load-balancer, if one is present.
-                        properties:
-                          ingress:
-                            description: Ingress is a list containing ingress points
-                              for the load-balancer. Traffic intended for the service
-                              should be sent to these ingress points.
-                            items:
-                              description: 'LoadBalancerIngress represents the status
-                                of a load-balancer ingress point: traffic intended
-                                for the service should be sent to an ingress point.'
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: Items is a list of downward API volume file
+                        items:
+                          description: DownwardAPIVolumeFile represents information
+                            to create the file containing the pod field
+                          properties:
+                            fieldRef:
+                              description: 'Required: Selects a field of the pod:
+                                only annotations, labels, name and namespace are supported.'
                               properties:
-                                hostname:
-                                  description: Hostname is set for load-balancer ingress
-                                    points that are DNS based (typically AWS load-balancers)
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
                                   type: string
-                                ip:
-                                  description: IP is set for load-balancer ingress
-                                    points that are IP based (typically GCE or OpenStack
-                                    load-balancers)
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
                                   type: string
+                              required:
+                              - fieldPath
                               type: object
-                            type: array
-                        type: object
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: 'Required: Path is  the relative path name
+                                of the file to be created. Must not be absolute or
+                                contain the ''..'' path. Must be utf-8 encoded. The
+                                first item of the relative path must not start with
+                                ''..'''
+                              type: string
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                requests.cpu and requests.memory) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  type: string
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                          required:
+                          - path
+                          type: object
+                        type: array
                     type: object
-                type: object
-              smartstore:
-                description: Splunk Smartstore configuration. Refer to indexes.conf.spec
-                  on docs.splunk.com
-                properties:
-                  indexes:
-                    description: List of Splunk indexes
-                    items:
-                      description: IndexSpec defines Splunk index name and storage
-                        path
-                      properties:
-                        name:
-                          description: Splunk index name
-                          type: string
-                        remotePath:
-                          description: Index location relative to the remote volume
-                            path
-                          type: string
-                        volumeName:
-                          description: Remote Volume name
-                          type: string
-                      type: object
-                    type: array
-                  volumes:
-                    description: List of remote storage volumes
-                    items:
-                      description: VolumeSpec defines remote volume name and remote
-                        volume URI
-                      properties:
-                        endpoint:
-                          description: Remote volume URI
-                          type: string
-                        name:
-                          description: Remote volume name
-                          type: string
-                        path:
-                          description: Remote volume path
-                          type: string
-                      type: object
-                    type: array
-                type: object
-              storageClassName:
-                description: Name of StorageClass to use for persistent volume claims
-                type: string
-              tolerations:
-                description: Pod's tolerations for Kubernetes node's taint
-                items:
-                  description: The pod this Toleration is attached to tolerates any
-                    taint that matches the triple <key,value,effect> using the matching
-                    operator <operator>.
-                  properties:
-                    effect:
-                      description: Effect indicates the taint effect to match. Empty
-                        means match all taint effects. When specified, allowed values
-                        are NoSchedule, PreferNoSchedule and NoExecute.
-                      type: string
-                    key:
-                      description: Key is the taint key that the toleration applies
-                        to. Empty means match all taint keys. If the key is empty,
-                        operator must be Exists; this combination means to match all
-                        values and all keys.
-                      type: string
-                    operator:
-                      description: Operator represents a key's relationship to the
-                        value. Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod
-                        can tolerate all taints of a particular category.
-                      type: string
-                    tolerationSeconds:
-                      description: TolerationSeconds represents the period of time
-                        the toleration (which must be of effect NoExecute, otherwise
-                        this field is ignored) tolerates the taint. By default, it
-                        is not set, which means tolerate the taint forever (do not
-                        evict). Zero and negative values will be treated as 0 (evict
-                        immediately) by the system.
-                      format: int64
-                      type: integer
-                    value:
-                      description: Value is the taint value the toleration matches
-                        to. If the operator is Exists, the value should be empty,
-                        otherwise just a regular string.
-                      type: string
-                  type: object
-                type: array
-              varStorage:
-                description: Storage capacity to request for /opt/splunk/var persistent
-                  volume claims (default=”50Gi”)
-                type: string
-              volumes:
-                description: List of one or more Kubernetes volumes. These will be
-                  mounted in all pod containers as as /mnt/<name>
-                items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
-                  properties:
-                    awsElasticBlockStore:
-                      description: 'AWSElasticBlockStore represents an AWS Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        partition:
-                          description: 'The partition in the volume that you want
-                            to mount. If omitted, the default is to mount by volume
-                            name. Examples: For volume /dev/sda1, you specify the
-                            partition as "1". Similarly, the volume partition for
-                            /dev/sda is "0" (or you can leave the property empty).'
-                          format: int32
-                          type: integer
-                        readOnly:
-                          description: 'Specify "true" to force and set the ReadOnly
-                            property in VolumeMounts to "true". If omitted, the default
-                            is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                          type: boolean
-                        volumeID:
-                          description: 'Unique ID of the persistent disk resource
-                            in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    azureDisk:
-                      description: AzureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
-                      properties:
-                        cachingMode:
-                          description: 'Host Caching mode: None, Read Only, Read Write.'
-                          type: string
-                        diskName:
-                          description: The Name of the data disk in the blob storage
-                          type: string
-                        diskURI:
-                          description: The URI the data disk in the blob storage
-                          type: string
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        kind:
-                          description: 'Expected values Shared: multiple blob disks
-                            per storage account  Dedicated: single blob disk per storage
-                            account  Managed: azure managed data disk (only in managed
-                            availability set). defaults to shared'
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                      required:
-                      - diskName
-                      - diskURI
-                      type: object
-                    azureFile:
-                      description: AzureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
-                      properties:
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretName:
-                          description: the name of secret that contains Azure Storage
-                            Account Name and Key
-                          type: string
-                        shareName:
-                          description: Share Name
-                          type: string
-                      required:
-                      - secretName
-                      - shareName
-                      type: object
-                    cephfs:
-                      description: CephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
-                      properties:
-                        monitors:
-                          description: 'Required: Monitors is a collection of Ceph
-                            monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          items:
-                            type: string
-                          type: array
-                        path:
-                          description: 'Optional: Used as the mounted root, rather
-                            than the full Ceph tree, default is /'
-                          type: string
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: boolean
-                        secretFile:
-                          description: 'Optional: SecretFile is the path to key ring
-                            for User, default is /etc/ceph/user.secret More info:
-                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: string
-                        secretRef:
-                          description: 'Optional: SecretRef is reference to the authentication
-                            secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        user:
-                          description: 'Optional: User is the rados user name, default
-                            is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: string
-                      required:
-                      - monitors
-                      type: object
-                    cinder:
-                      description: 'Cinder represents a cinder volume attached and
-                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: string
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: boolean
-                        secretRef:
-                          description: 'Optional: points to a secret object containing
-                            parameters used to connect to OpenStack.'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        volumeID:
-                          description: 'volume id used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    configMap:
-                      description: ConfigMap represents a configMap that should populate
-                        this volume
-                      properties:
-                        defaultMode:
-                          description: 'Optional: mode bits to use on created files
-                            by default. Must be a value between 0 and 0777. Defaults
-                            to 0644. Directories within the path are not affected
-                            by this setting. This might be in conflict with other
-                            options that affect the file mode, like fsGroup, and the
-                            result can be other mode bits set.'
-                          format: int32
-                          type: integer
+                  emptyDir:
+                    description: 'EmptyDir represents a temporary directory that shares
+                      a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                    properties:
+                      medium:
+                        description: 'What type of storage medium should back this
+                          directory. The default is "" which means to use the node''s
+                          default medium. Must be an empty string (default) or Memory.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        type: string
+                      sizeLimit:
+                        description: 'Total amount of local storage required for this
+                          EmptyDir volume. The size limit is also applicable for memory
+                          medium. The maximum usage on memory medium EmptyDir would
+                          be the minimum value between the SizeLimit specified here
+                          and the sum of memory limits of all containers in a pod.
+                          The default is nil which means that the limit is undefined.
+                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                        type: string
+                    type: object
+                  fc:
+                    description: FC represents a Fibre Channel resource that is attached
+                      to a kubelet's host machine and then exposed to the pod.
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      lun:
+                        description: 'Optional: FC target lun number'
+                        format: int32
+                        type: integer
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      targetWWNs:
+                        description: 'Optional: FC target worldwide names (WWNs)'
                         items:
-                          description: If unspecified, each key-value pair in the
-                            Data field of the referenced ConfigMap will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the ConfigMap, the volume setup will error unless it is
-                            marked optional. Paths must be relative and may not contain
-                            the '..' path or start with '..'.
-                          items:
-                            description: Maps a string key to a path within a volume.
-                            properties:
-                              key:
-                                description: The key to project.
-                                type: string
-                              mode:
-                                description: 'Optional: mode bits to use on this file,
-                                  must be a value between 0 and 0777. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: The relative path of the file to map
-                                  the key to. May not be an absolute path. May not
-                                  contain the path element '..'. May not start with
-                                  the string '..'.
-                                type: string
-                            required:
-                            - key
-                            - path
-                            type: object
-                          type: array
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
-                        optional:
-                          description: Specify whether the ConfigMap or its keys must
-                            be defined
-                          type: boolean
-                      type: object
-                    csi:
-                      description: CSI (Container Storage Interface) represents storage
-                        that is handled by an external CSI driver (Alpha feature).
-                      properties:
-                        driver:
-                          description: Driver is the name of the CSI driver that handles
-                            this volume. Consult with your admin for the correct name
-                            as registered in the cluster.
-                          type: string
-                        fsType:
-                          description: Filesystem type to mount. Ex. "ext4", "xfs",
-                            "ntfs". If not provided, the empty value is passed to
-                            the associated CSI driver which will determine the default
-                            filesystem to apply.
-                          type: string
-                        nodePublishSecretRef:
-                          description: NodePublishSecretRef is a reference to the
-                            secret object containing sensitive information to pass
-                            to the CSI driver to complete the CSI NodePublishVolume
-                            and NodeUnpublishVolume calls. This field is optional,
-                            and  may be empty if no secret is required. If the secret
-                            object contains more than one secret, all secret references
-                            are passed.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        readOnly:
-                          description: Specifies a read-only configuration for the
-                            volume. Defaults to false (read/write).
-                          type: boolean
-                        volumeAttributes:
-                          additionalProperties:
-                            type: string
-                          description: VolumeAttributes stores driver-specific properties
-                            that are passed to the CSI driver. Consult your driver's
-                            documentation for supported values.
-                          type: object
-                      required:
-                      - driver
-                      type: object
-                    downwardAPI:
-                      description: DownwardAPI represents downward API about the pod
-                        that should populate this volume
-                      properties:
-                        defaultMode:
-                          description: 'Optional: mode bits to use on created files
-                            by default. Must be a value between 0 and 0777. Defaults
-                            to 0644. Directories within the path are not affected
-                            by this setting. This might be in conflict with other
-                            options that affect the file mode, like fsGroup, and the
-                            result can be other mode bits set.'
-                          format: int32
-                          type: integer
+                        type: array
+                      wwids:
+                        description: 'Optional: FC volume world wide identifiers (wwids)
+                          Either wwids or combination of targetWWNs and lun must be
+                          set, but not both simultaneously.'
                         items:
-                          description: Items is a list of downward API volume file
-                          items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
-                            properties:
-                              fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
-                                properties:
-                                  apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
-                                    type: string
-                                required:
-                                - fieldPath
-                                type: object
-                              mode:
-                                description: 'Optional: mode bits to use on this file,
-                                  must be a value between 0 and 0777. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
-                                type: string
-                              resourceFieldRef:
-                                description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, requests.cpu and requests.memory)
-                                  are currently supported.'
-                                properties:
-                                  containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: 'Required: resource to select'
-                                    type: string
-                                required:
-                                - resource
-                                type: object
-                            required:
-                            - path
-                            type: object
-                          type: array
-                      type: object
-                    emptyDir:
-                      description: 'EmptyDir represents a temporary directory that
-                        shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                      properties:
-                        medium:
-                          description: 'What type of storage medium should back this
-                            directory. The default is "" which means to use the node''s
-                            default medium. Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                           type: string
-                        sizeLimit:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          description: 'Total amount of local storage required for
-                            this EmptyDir volume. The size limit is also applicable
-                            for memory medium. The maximum usage on memory medium
-                            EmptyDir would be the minimum value between the SizeLimit
-                            specified here and the sum of memory limits of all containers
-                            in a pod. The default is nil which means that the limit
-                            is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                      type: object
-                    fc:
-                      description: FC represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
-                      properties:
-                        fsType:
-                          description: 'Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
+                        type: array
+                    type: object
+                  flexVolume:
+                    description: FlexVolume represents a generic volume resource that
+                      is provisioned/attached using an exec based plugin.
+                    properties:
+                      driver:
+                        description: Driver is the name of the driver to use for this
+                          volume.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". The default filesystem depends on FlexVolume
+                          script.
+                        type: string
+                      options:
+                        additionalProperties:
                           type: string
-                        lun:
-                          description: 'Optional: FC target lun number'
-                          format: int32
-                          type: integer
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
-                          type: boolean
-                        targetWWNs:
-                          description: 'Optional: FC target worldwide names (WWNs)'
-                          items:
+                        description: 'Optional: Extra command options if any.'
+                        type: object
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      secretRef:
+                        description: 'Optional: SecretRef is reference to the secret
+                          object containing sensitive information to pass to the plugin
+                          scripts. This may be empty if no secret object is specified.
+                          If the secret object contains more than one secret, all
+                          secrets are passed to the plugin scripts.'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
-                          type: array
-                        wwids:
-                          description: 'Optional: FC volume world wide identifiers
-                            (wwids) Either wwids or combination of targetWWNs and
-                            lun must be set, but not both simultaneously.'
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    flexVolume:
-                      description: FlexVolume represents a generic volume resource
-                        that is provisioned/attached using an exec based plugin.
-                      properties:
-                        driver:
-                          description: Driver is the name of the driver to use for
-                            this volume.
-                          type: string
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". The default filesystem depends on FlexVolume
-                            script.
-                          type: string
-                        options:
-                          additionalProperties:
-                            type: string
-                          description: 'Optional: Extra command options if any.'
-                          type: object
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
-                          type: boolean
-                        secretRef:
-                          description: 'Optional: SecretRef is reference to the secret
-                            object containing sensitive information to pass to the
-                            plugin scripts. This may be empty if no secret object
-                            is specified. If the secret object contains more than
-                            one secret, all secrets are passed to the plugin scripts.'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                      required:
-                      - driver
-                      type: object
-                    flocker:
-                      description: Flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
-                      properties:
-                        datasetName:
-                          description: Name of the dataset stored as metadata -> name
-                            on the dataset for Flocker should be considered as deprecated
-                          type: string
-                        datasetUUID:
-                          description: UUID of the dataset. This is unique identifier
-                            of a Flocker dataset
-                          type: string
-                      type: object
-                    gcePersistentDisk:
-                      description: 'GCEPersistentDisk represents a GCE Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        partition:
-                          description: 'The partition in the volume that you want
-                            to mount. If omitted, the default is to mount by volume
-                            name. Examples: For volume /dev/sda1, you specify the
-                            partition as "1". Similarly, the volume partition for
-                            /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          format: int32
-                          type: integer
-                        pdName:
-                          description: 'Unique name of the PD resource in GCE. Used
-                            to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          type: boolean
-                      required:
-                      - pdName
-                      type: object
-                    gitRepo:
-                      description: 'GitRepo represents a git repository at a particular
-                        revision. DEPRECATED: GitRepo is deprecated. To provision
-                        a container with a git repo, mount an EmptyDir into an InitContainer
-                        that clones the repo using git, then mount the EmptyDir into
-                        the Pod''s container.'
-                      properties:
-                        directory:
-                          description: Target directory name. Must not contain or
-                            start with '..'.  If '.' is supplied, the volume directory
-                            will be the git repository.  Otherwise, if specified,
-                            the volume will contain the git repository in the subdirectory
-                            with the given name.
-                          type: string
-                        repository:
-                          description: Repository URL
-                          type: string
-                        revision:
-                          description: Commit hash for the specified revision.
-                          type: string
-                      required:
-                      - repository
-                      type: object
-                    glusterfs:
-                      description: 'Glusterfs represents a Glusterfs mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
-                      properties:
-                        endpoints:
-                          description: 'EndpointsName is the endpoint name that details
-                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: string
-                        path:
-                          description: 'Path is the Glusterfs volume path. More info:
-                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the Glusterfs volume
-                            to be mounted with read-only permissions. Defaults to
-                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: boolean
-                      required:
-                      - endpoints
-                      - path
-                      type: object
-                    hostPath:
-                      description: 'HostPath represents a pre-existing file or directory
-                        on the host machine that is directly exposed to the container.
-                        This is generally used for system agents or other privileged
-                        things that are allowed to see the host machine. Most containers
-                        will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        --- TODO(jonesdl) We need to restrict who can use host directory
-                        mounts and who can/can not mount host directories as read/write.'
-                      properties:
-                        path:
-                          description: 'Path of the directory on the host. If the
-                            path is a symlink, it will follow the link to the real
-                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                          type: string
-                        type:
-                          description: 'Type for HostPath Volume Defaults to "" More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                          type: string
-                      required:
-                      - path
-                      type: object
-                    iscsi:
-                      description: 'ISCSI represents an ISCSI Disk resource that is
-                        attached to a kubelet''s host machine and then exposed to
-                        the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
-                      properties:
-                        chapAuthDiscovery:
-                          description: whether support iSCSI Discovery CHAP authentication
-                          type: boolean
-                        chapAuthSession:
-                          description: whether support iSCSI Session CHAP authentication
-                          type: boolean
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        initiatorName:
-                          description: Custom iSCSI Initiator Name. If initiatorName
-                            is specified with iscsiInterface simultaneously, new iSCSI
-                            interface <target portal>:<volume name> will be created
-                            for the connection.
-                          type: string
-                        iqn:
-                          description: Target iSCSI Qualified Name.
-                          type: string
-                        iscsiInterface:
-                          description: iSCSI Interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
-                          type: string
-                        lun:
-                          description: iSCSI Target Lun number.
-                          format: int32
-                          type: integer
-                        portals:
-                          description: iSCSI Target Portal List. The portal is either
-                            an IP or ip_addr:port if the port is other than default
-                            (typically TCP ports 860 and 3260).
-                          items:
-                            type: string
-                          type: array
-                        readOnly:
-                          description: ReadOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false.
-                          type: boolean
-                        secretRef:
-                          description: CHAP Secret for iSCSI target and initiator
-                            authentication
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        targetPortal:
-                          description: iSCSI Target Portal. The Portal is either an
-                            IP or ip_addr:port if the port is other than default (typically
-                            TCP ports 860 and 3260).
-                          type: string
-                      required:
-                      - iqn
-                      - lun
-                      - targetPortal
-                      type: object
-                    name:
-                      description: 'Volume''s name. Must be a DNS_LABEL and unique
-                        within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                      type: string
-                    nfs:
-                      description: 'NFS represents an NFS mount on the host that shares
-                        a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                      properties:
-                        path:
-                          description: 'Path that is exported by the NFS server. More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the NFS export to
-                            be mounted with read-only permissions. Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: boolean
-                        server:
-                          description: 'Server is the hostname or IP address of the
-                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: string
-                      required:
-                      - path
-                      - server
-                      type: object
-                    persistentVolumeClaim:
-                      description: 'PersistentVolumeClaimVolumeSource represents a
-                        reference to a PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                      properties:
-                        claimName:
-                          description: 'ClaimName is the name of a PersistentVolumeClaim
-                            in the same namespace as the pod using this volume. More
-                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                          type: string
-                        readOnly:
-                          description: Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
-                          type: boolean
-                      required:
-                      - claimName
-                      type: object
-                    photonPersistentDisk:
-                      description: PhotonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        pdID:
-                          description: ID that identifies Photon Controller persistent
-                            disk
-                          type: string
-                      required:
-                      - pdID
-                      type: object
-                    portworxVolume:
-                      description: PortworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: FSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating
-                            system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                            if unspecified.
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        volumeID:
-                          description: VolumeID uniquely identifies a Portworx volume
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    projected:
-                      description: Items for all in one resources secrets, configmaps,
-                        and downward API
-                      properties:
-                        defaultMode:
-                          description: Mode bits to use on created files by default.
-                            Must be a value between 0 and 0777. Directories within
-                            the path are not affected by this setting. This might
-                            be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits
-                            set.
-                          format: int32
-                          type: integer
-                        sources:
-                          description: list of volume projections
-                          items:
-                            description: Projection that may be projected along with
-                              other supported volume types
-                            properties:
-                              configMap:
-                                description: information about the configMap data
-                                  to project
-                                properties:
-                                  items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced ConfigMap
-                                      will be projected into the volume as a file
-                                      whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the ConfigMap, the volume
-                                      setup will error unless it is marked optional.
-                                      Paths must be relative and may not contain the
-                                      '..' path or start with '..'.
-                                    items:
-                                      description: Maps a string key to a path within
-                                        a volume.
-                                      properties:
-                                        key:
-                                          description: The key to project.
-                                          type: string
-                                        mode:
-                                          description: 'Optional: mode bits to use
-                                            on this file, must be a value between
-                                            0 and 0777. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element
-                                            '..'. May not start with the string '..'.
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or
-                                      its keys must be defined
-                                    type: boolean
-                                type: object
-                              downwardAPI:
-                                description: information about the downwardAPI data
-                                  to project
-                                properties:
-                                  items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
-                                    items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
-                                      properties:
-                                        fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
-                                          properties:
-                                            apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
-                                              type: string
-                                            fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
-                                              type: string
-                                          required:
-                                          - fieldPath
-                                          type: object
-                                        mode:
-                                          description: 'Optional: mode bits to use
-                                            on this file, must be a value between
-                                            0 and 0777. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
-                                          type: string
-                                        resourceFieldRef:
-                                          description: 'Selects a resource of the
-                                            container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu
-                                            and requests.memory) are currently supported.'
-                                          properties:
-                                            containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
-                                              type: string
-                                            divisor:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            resource:
-                                              description: 'Required: resource to
-                                                select'
-                                              type: string
-                                          required:
-                                          - resource
-                                          type: object
-                                      required:
-                                      - path
-                                      type: object
-                                    type: array
-                                type: object
-                              secret:
-                                description: information about the secret data to
-                                  project
-                                properties:
-                                  items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced Secret will
-                                      be projected into the volume as a file whose
-                                      name is the key and content is the value. If
-                                      specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the Secret, the volume setup
-                                      will error unless it is marked optional. Paths
-                                      must be relative and may not contain the '..'
-                                      path or start with '..'.
-                                    items:
-                                      description: Maps a string key to a path within
-                                        a volume.
-                                      properties:
-                                        key:
-                                          description: The key to project.
-                                          type: string
-                                        mode:
-                                          description: 'Optional: mode bits to use
-                                            on this file, must be a value between
-                                            0 and 0777. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element
-                                            '..'. May not start with the string '..'.
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
-                                    type: boolean
-                                type: object
-                              serviceAccountToken:
-                                description: information about the serviceAccountToken
-                                  data to project
-                                properties:
-                                  audience:
-                                    description: Audience is the intended audience
-                                      of the token. A recipient of a token must identify
-                                      itself with an identifier specified in the audience
-                                      of the token, and otherwise should reject the
-                                      token. The audience defaults to the identifier
-                                      of the apiserver.
-                                    type: string
-                                  expirationSeconds:
-                                    description: ExpirationSeconds is the requested
-                                      duration of validity of the service account
-                                      token. As the token approaches expiration, the
-                                      kubelet volume plugin will proactively rotate
-                                      the service account token. The kubelet will
-                                      start trying to rotate the token if the token
-                                      is older than 80 percent of its time to live
-                                      or if the token is older than 24 hours.Defaults
-                                      to 1 hour and must be at least 10 minutes.
-                                    format: int64
-                                    type: integer
-                                  path:
-                                    description: Path is the path relative to the
-                                      mount point of the file to project the token
-                                      into.
-                                    type: string
-                                required:
-                                - path
-                                type: object
-                            type: object
-                          type: array
-                      required:
-                      - sources
-                      type: object
-                    quobyte:
-                      description: Quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
-                      properties:
-                        group:
-                          description: Group to map volume access to Default is no
-                            group
-                          type: string
-                        readOnly:
-                          description: ReadOnly here will force the Quobyte volume
-                            to be mounted with read-only permissions. Defaults to
-                            false.
-                          type: boolean
-                        registry:
-                          description: Registry represents a single or multiple Quobyte
-                            Registry services specified as a string as host:port pair
-                            (multiple entries are separated with commas) which acts
-                            as the central registry for volumes
-                          type: string
-                        tenant:
-                          description: Tenant owning the given Quobyte volume in the
-                            Backend Used with dynamically provisioned Quobyte volumes,
-                            value is set by the plugin
-                          type: string
-                        user:
-                          description: User to map volume access to Defaults to serivceaccount
-                            user
-                          type: string
-                        volume:
-                          description: Volume is a string that references an already
-                            created Quobyte volume by name.
-                          type: string
-                      required:
-                      - registry
-                      - volume
-                      type: object
-                    rbd:
-                      description: 'RBD represents a Rados Block Device mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        image:
-                          description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        keyring:
-                          description: 'Keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        monitors:
-                          description: 'A collection of Ceph monitors. More info:
-                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          items:
-                            type: string
-                          type: array
-                        pool:
-                          description: 'The rados pool name. Default is rbd. More
-                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: boolean
-                        secretRef:
-                          description: 'SecretRef is name of the authentication secret
-                            for RBDUser. If provided overrides keyring. Default is
-                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        user:
-                          description: 'The rados user name. Default is admin. More
-                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                      required:
-                      - image
-                      - monitors
-                      type: object
-                    scaleIO:
-                      description: ScaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Default is "xfs".
-                          type: string
-                        gateway:
-                          description: The host address of the ScaleIO API Gateway.
-                          type: string
-                        protectionDomain:
-                          description: The name of the ScaleIO Protection Domain for
-                            the configured storage.
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretRef:
-                          description: SecretRef references to the secret for ScaleIO
-                            user and other sensitive information. If this is not provided,
-                            Login operation will fail.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        sslEnabled:
-                          description: Flag to enable/disable SSL communication with
-                            Gateway, default false
-                          type: boolean
-                        storageMode:
-                          description: Indicates whether the storage for a volume
-                            should be ThickProvisioned or ThinProvisioned. Default
-                            is ThinProvisioned.
-                          type: string
-                        storagePool:
-                          description: The ScaleIO Storage Pool associated with the
-                            protection domain.
-                          type: string
-                        system:
-                          description: The name of the storage system as configured
-                            in ScaleIO.
-                          type: string
-                        volumeName:
-                          description: The name of a volume already created in the
-                            ScaleIO system that is associated with this volume source.
-                          type: string
-                      required:
-                      - gateway
-                      - secretRef
-                      - system
-                      type: object
-                    secret:
-                      description: 'Secret represents a secret that should populate
-                        this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                      properties:
-                        defaultMode:
-                          description: 'Optional: mode bits to use on created files
-                            by default. Must be a value between 0 and 0777. Defaults
-                            to 0644. Directories within the path are not affected
-                            by this setting. This might be in conflict with other
-                            options that affect the file mode, like fsGroup, and the
-                            result can be other mode bits set.'
-                          format: int32
-                          type: integer
+                        type: object
+                    required:
+                    - driver
+                    type: object
+                  flocker:
+                    description: Flocker represents a Flocker volume attached to a
+                      kubelet's host machine. This depends on the Flocker control
+                      service being running
+                    properties:
+                      datasetName:
+                        description: Name of the dataset stored as metadata -> name
+                          on the dataset for Flocker should be considered as deprecated
+                        type: string
+                      datasetUUID:
+                        description: UUID of the dataset. This is unique identifier
+                          of a Flocker dataset
+                        type: string
+                    type: object
+                  gcePersistentDisk:
+                    description: 'GCEPersistentDisk represents a GCE Disk resource
+                      that is attached to a kubelet''s host machine and then exposed
+                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        format: int32
+                        type: integer
+                      pdName:
+                        description: 'Unique name of the PD resource in GCE. Used
+                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: boolean
+                    required:
+                    - pdName
+                    type: object
+                  gitRepo:
+                    description: 'GitRepo represents a git repository at a particular
+                      revision. DEPRECATED: GitRepo is deprecated. To provision a
+                      container with a git repo, mount an EmptyDir into an InitContainer
+                      that clones the repo using git, then mount the EmptyDir into
+                      the Pod''s container.'
+                    properties:
+                      directory:
+                        description: Target directory name. Must not contain or start
+                          with '..'.  If '.' is supplied, the volume directory will
+                          be the git repository.  Otherwise, if specified, the volume
+                          will contain the git repository in the subdirectory with
+                          the given name.
+                        type: string
+                      repository:
+                        description: Repository URL
+                        type: string
+                      revision:
+                        description: Commit hash for the specified revision.
+                        type: string
+                    required:
+                    - repository
+                    type: object
+                  glusterfs:
+                    description: 'Glusterfs represents a Glusterfs mount on the host
+                      that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                    properties:
+                      endpoints:
+                        description: 'EndpointsName is the endpoint name that details
+                          Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      path:
+                        description: 'Path is the Glusterfs volume path. More info:
+                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the Glusterfs volume
+                          to be mounted with read-only permissions. Defaults to false.
+                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: boolean
+                    required:
+                    - endpoints
+                    - path
+                    type: object
+                  hostPath:
+                    description: 'HostPath represents a pre-existing file or directory
+                      on the host machine that is directly exposed to the container.
+                      This is generally used for system agents or other privileged
+                      things that are allowed to see the host machine. Most containers
+                      will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                      --- TODO(jonesdl) We need to restrict who can use host directory
+                      mounts and who can/can not mount host directories as read/write.'
+                    properties:
+                      path:
+                        description: 'Path of the directory on the host. If the path
+                          is a symlink, it will follow the link to the real path.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                      type:
+                        description: 'Type for HostPath Volume Defaults to "" More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                    required:
+                    - path
+                    type: object
+                  iscsi:
+                    description: 'ISCSI represents an ISCSI Disk resource that is
+                      attached to a kubelet''s host machine and then exposed to the
+                      pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                    properties:
+                      chapAuthDiscovery:
+                        description: whether support iSCSI Discovery CHAP authentication
+                        type: boolean
+                      chapAuthSession:
+                        description: whether support iSCSI Session CHAP authentication
+                        type: boolean
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      initiatorName:
+                        description: Custom iSCSI Initiator Name. If initiatorName
+                          is specified with iscsiInterface simultaneously, new iSCSI
+                          interface <target portal>:<volume name> will be created
+                          for the connection.
+                        type: string
+                      iqn:
+                        description: Target iSCSI Qualified Name.
+                        type: string
+                      iscsiInterface:
+                        description: iSCSI Interface Name that uses an iSCSI transport.
+                          Defaults to 'default' (tcp).
+                        type: string
+                      lun:
+                        description: iSCSI Target Lun number.
+                        format: int32
+                        type: integer
+                      portals:
+                        description: iSCSI Target Portal List. The portal is either
+                          an IP or ip_addr:port if the port is other than default
+                          (typically TCP ports 860 and 3260).
                         items:
-                          description: If unspecified, each key-value pair in the
-                            Data field of the referenced Secret will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the Secret, the volume setup will error unless it is marked
-                            optional. Paths must be relative and may not contain the
-                            '..' path or start with '..'.
-                          items:
-                            description: Maps a string key to a path within a volume.
-                            properties:
-                              key:
-                                description: The key to project.
-                                type: string
-                              mode:
-                                description: 'Optional: mode bits to use on this file,
-                                  must be a value between 0 and 0777. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: The relative path of the file to map
-                                  the key to. May not be an absolute path. May not
-                                  contain the path element '..'. May not start with
-                                  the string '..'.
-                                type: string
-                            required:
-                            - key
-                            - path
-                            type: object
-                          type: array
-                        optional:
-                          description: Specify whether the Secret or its keys must
-                            be defined
-                          type: boolean
-                        secretName:
-                          description: 'Name of the secret in the pod''s namespace
-                            to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                           type: string
-                      type: object
-                    storageos:
-                      description: StorageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretRef:
-                          description: SecretRef specifies the secret to use for obtaining
-                            the StorageOS API credentials.  If not specified, default
-                            values will be attempted.
+                        type: array
+                      readOnly:
+                        description: ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false.
+                        type: boolean
+                      secretRef:
+                        description: CHAP Secret for iSCSI target and initiator authentication
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      targetPortal:
+                        description: iSCSI Target Portal. The Portal is either an
+                          IP or ip_addr:port if the port is other than default (typically
+                          TCP ports 860 and 3260).
+                        type: string
+                    required:
+                    - iqn
+                    - lun
+                    - targetPortal
+                    type: object
+                  name:
+                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
+                      the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  nfs:
+                    description: 'NFS represents an NFS mount on the host that shares
+                      a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                    properties:
+                      path:
+                        description: 'Path that is exported by the NFS server. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the NFS export to be
+                          mounted with read-only permissions. Defaults to false. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: boolean
+                      server:
+                        description: 'Server is the hostname or IP address of the
+                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                    required:
+                    - path
+                    - server
+                    type: object
+                  persistentVolumeClaim:
+                    description: 'PersistentVolumeClaimVolumeSource represents a reference
+                      to a PersistentVolumeClaim in the same namespace. More info:
+                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                    properties:
+                      claimName:
+                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                          in the same namespace as the pod using this volume. More
+                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        type: string
+                      readOnly:
+                        description: Will force the ReadOnly setting in VolumeMounts.
+                          Default false.
+                        type: boolean
+                    required:
+                    - claimName
+                    type: object
+                  photonPersistentDisk:
+                    description: PhotonPersistentDisk represents a PhotonController
+                      persistent disk attached and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      pdID:
+                        description: ID that identifies Photon Controller persistent
+                          disk
+                        type: string
+                    required:
+                    - pdID
+                    type: object
+                  portworxVolume:
+                    description: PortworxVolume represents a portworx volume attached
+                      and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: FSType represents the filesystem type to mount
+                          Must be a filesystem type supported by the host operating
+                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                          if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      volumeID:
+                        description: VolumeID uniquely identifies a Portworx volume
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  projected:
+                    description: Items for all in one resources secrets, configmaps,
+                      and downward API
+                    properties:
+                      defaultMode:
+                        description: Mode bits to use on created files by default.
+                          Must be a value between 0 and 0777. Directories within the
+                          path are not affected by this setting. This might be in
+                          conflict with other options that affect the file mode, like
+                          fsGroup, and the result can be other mode bits set.
+                        format: int32
+                        type: integer
+                      sources:
+                        description: list of volume projections
+                        items:
+                          description: Projection that may be projected along with
+                            other supported volume types
                           properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
+                            configMap:
+                              description: information about the configMap data to
+                                project
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    keys must be defined
+                                  type: boolean
+                              type: object
+                            downwardAPI:
+                              description: information about the downwardAPI data
+                                to project
+                              properties:
+                                items:
+                                  description: Items is a list of DownwardAPIVolume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, requests.cpu and requests.memory)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            secret:
+                              description: information about the secret data to project
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced Secret will
+                                    be projected into the volume as a file whose name
+                                    is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              type: object
+                            serviceAccountToken:
+                              description: information about the serviceAccountToken
+                                data to project
+                              properties:
+                                audience:
+                                  description: Audience is the intended audience of
+                                    the token. A recipient of a token must identify
+                                    itself with an identifier specified in the audience
+                                    of the token, and otherwise should reject the
+                                    token. The audience defaults to the identifier
+                                    of the apiserver.
+                                  type: string
+                                expirationSeconds:
+                                  description: ExpirationSeconds is the requested
+                                    duration of validity of the service account token.
+                                    As the token approaches expiration, the kubelet
+                                    volume plugin will proactively rotate the service
+                                    account token. The kubelet will start trying to
+                                    rotate the token if the token is older than 80
+                                    percent of its time to live or if the token is
+                                    older than 24 hours.Defaults to 1 hour and must
+                                    be at least 10 minutes.
+                                  format: int64
+                                  type: integer
+                                path:
+                                  description: Path is the path relative to the mount
+                                    point of the file to project the token into.
+                                  type: string
+                              required:
+                              - path
+                              type: object
                           type: object
-                        volumeName:
-                          description: VolumeName is the human-readable name of the
-                            StorageOS volume.  Volume names are only unique within
-                            a namespace.
+                        type: array
+                    required:
+                    - sources
+                    type: object
+                  quobyte:
+                    description: Quobyte represents a Quobyte mount on the host that
+                      shares a pod's lifetime
+                    properties:
+                      group:
+                        description: Group to map volume access to Default is no group
+                        type: string
+                      readOnly:
+                        description: ReadOnly here will force the Quobyte volume to
+                          be mounted with read-only permissions. Defaults to false.
+                        type: boolean
+                      registry:
+                        description: Registry represents a single or multiple Quobyte
+                          Registry services specified as a string as host:port pair
+                          (multiple entries are separated with commas) which acts
+                          as the central registry for volumes
+                        type: string
+                      tenant:
+                        description: Tenant owning the given Quobyte volume in the
+                          Backend Used with dynamically provisioned Quobyte volumes,
+                          value is set by the plugin
+                        type: string
+                      user:
+                        description: User to map volume access to Defaults to serivceaccount
+                          user
+                        type: string
+                      volume:
+                        description: Volume is a string that references an already
+                          created Quobyte volume by name.
+                        type: string
+                    required:
+                    - registry
+                    - volume
+                    type: object
+                  rbd:
+                    description: 'RBD represents a Rados Block Device mount on the
+                      host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      image:
+                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      keyring:
+                        description: 'Keyring is the path to key ring for RBDUser.
+                          Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      monitors:
+                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        items:
                           type: string
-                        volumeNamespace:
-                          description: VolumeNamespace specifies the scope of the
-                            volume within StorageOS.  If no namespace is specified
-                            then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS
-                            for tighter integration. Set VolumeName to any name to
-                            override the default behaviour. Set to "default" if you
-                            are not using namespaces within StorageOS. Namespaces
-                            that do not pre-exist within StorageOS will be created.
-                          type: string
-                      type: object
-                    vsphereVolume:
-                      description: VsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        storagePolicyID:
-                          description: Storage Policy Based Management (SPBM) profile
-                            ID associated with the StoragePolicyName.
-                          type: string
-                        storagePolicyName:
-                          description: Storage Policy Based Management (SPBM) profile
-                            name.
-                          type: string
-                        volumePath:
-                          description: Path that identifies vSphere volume vmdk
-                          type: string
-                      required:
-                      - volumePath
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
-            type: object
-          status:
-            description: ClusterMasterStatus defines the observed state of ClusterMaster
-            properties:
-              phase:
-                description: current phase of the cluster master
-                enum:
-                - Pending
-                - Ready
-                - Updating
-                - ScalingUp
-                - ScalingDown
-                - Terminating
-                - Error
-                type: string
-              selector:
-                description: selector for pods, used by HorizontalPodAutoscaler
-                type: string
-              smartstore:
-                description: Splunk Smartstore configuration. Refer to indexes.conf.spec
-                  on docs.splunk.com
-                properties:
-                  indexes:
-                    description: List of Splunk indexes
-                    items:
-                      description: IndexSpec defines Splunk index name and storage
-                        path
-                      properties:
-                        name:
-                          description: Splunk index name
-                          type: string
-                        remotePath:
-                          description: Index location relative to the remote volume
-                            path
-                          type: string
-                        volumeName:
-                          description: Remote Volume name
-                          type: string
-                      type: object
-                    type: array
-                  volumes:
-                    description: List of remote storage volumes
-                    items:
-                      description: VolumeSpec defines remote volume name and remote
-                        volume URI
-                      properties:
-                        endpoint:
-                          description: Remote volume URI
-                          type: string
-                        name:
-                          description: Remote volume name
-                          type: string
-                        path:
-                          description: Remote volume path
-                          type: string
-                      type: object
-                    type: array
+                        type: array
+                      pool:
+                        description: 'The rados pool name. Default is rbd. More info:
+                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: boolean
+                      secretRef:
+                        description: 'SecretRef is name of the authentication secret
+                          for RBDUser. If provided overrides keyring. Default is nil.
+                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      user:
+                        description: 'The rados user name. Default is admin. More
+                          info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                    required:
+                    - image
+                    - monitors
+                    type: object
+                  scaleIO:
+                    description: ScaleIO represents a ScaleIO persistent volume attached
+                      and mounted on Kubernetes nodes.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Default is "xfs".
+                        type: string
+                      gateway:
+                        description: The host address of the ScaleIO API Gateway.
+                        type: string
+                      protectionDomain:
+                        description: The name of the ScaleIO Protection Domain for
+                          the configured storage.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: SecretRef references to the secret for ScaleIO
+                          user and other sensitive information. If this is not provided,
+                          Login operation will fail.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      sslEnabled:
+                        description: Flag to enable/disable SSL communication with
+                          Gateway, default false
+                        type: boolean
+                      storageMode:
+                        description: Indicates whether the storage for a volume should
+                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                        type: string
+                      storagePool:
+                        description: The ScaleIO Storage Pool associated with the
+                          protection domain.
+                        type: string
+                      system:
+                        description: The name of the storage system as configured
+                          in ScaleIO.
+                        type: string
+                      volumeName:
+                        description: The name of a volume already created in the ScaleIO
+                          system that is associated with this volume source.
+                        type: string
+                    required:
+                    - gateway
+                    - secretRef
+                    - system
+                    type: object
+                  secret:
+                    description: 'Secret represents a secret that should populate
+                      this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced Secret will be projected into the
+                          volume as a file whose name is the key and content is the
+                          value. If specified, the listed keys will be projected into
+                          the specified paths, and unlisted keys will not be present.
+                          If a key is specified which is not present in the Secret,
+                          the volume setup will error unless it is marked optional.
+                          Paths must be relative and may not contain the '..' path
+                          or start with '..'.
+                        items:
+                          description: Maps a string key to a path within a volume.
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          type: object
+                        type: array
+                      optional:
+                        description: Specify whether the Secret or its keys must be
+                          defined
+                        type: boolean
+                      secretName:
+                        description: 'Name of the secret in the pod''s namespace to
+                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        type: string
+                    type: object
+                  storageos:
+                    description: StorageOS represents a StorageOS volume attached
+                      and mounted on Kubernetes nodes.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: SecretRef specifies the secret to use for obtaining
+                          the StorageOS API credentials.  If not specified, default
+                          values will be attempted.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      volumeName:
+                        description: VolumeName is the human-readable name of the
+                          StorageOS volume.  Volume names are only unique within a
+                          namespace.
+                        type: string
+                      volumeNamespace:
+                        description: VolumeNamespace specifies the scope of the volume
+                          within StorageOS.  If no namespace is specified then the
+                          Pod's namespace will be used.  This allows the Kubernetes
+                          name scoping to be mirrored within StorageOS for tighter
+                          integration. Set VolumeName to any name to override the
+                          default behaviour. Set to "default" if you are not using
+                          namespaces within StorageOS. Namespaces that do not pre-exist
+                          within StorageOS will be created.
+                        type: string
+                    type: object
+                  vsphereVolume:
+                    description: VsphereVolume represents a vSphere volume attached
+                      and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      storagePolicyID:
+                        description: Storage Policy Based Management (SPBM) profile
+                          ID associated with the StoragePolicyName.
+                        type: string
+                      storagePolicyName:
+                        description: Storage Policy Based Management (SPBM) profile
+                          name.
+                        type: string
+                      volumePath:
+                        description: Path that identifies vSphere volume vmdk
+                        type: string
+                    required:
+                    - volumePath
+                    type: object
+                required:
+                - name
                 type: object
-            type: object
-        type: object
+              type: array
+          type: object
+        status:
+          description: ClusterMasterStatus defines the observed state of ClusterMaster
+          properties:
+            phase:
+              description: current phase of the cluster master
+              enum:
+              - Pending
+              - Ready
+              - Updating
+              - ScalingUp
+              - ScalingDown
+              - Terminating
+              - Error
+              type: string
+            selector:
+              description: selector for pods, used by HorizontalPodAutoscaler
+              type: string
+            smartstore:
+              description: Splunk Smartstore configuration. Refer to indexes.conf.spec
+                on docs.splunk.com
+              properties:
+                indexes:
+                  description: List of Splunk indexes
+                  items:
+                    description: IndexSpec defines Splunk index name and storage path
+                    properties:
+                      name:
+                        description: Splunk index name
+                        type: string
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
+                        type: string
+                      volumeName:
+                        description: Remote Volume name
+                        type: string
+                    type: object
+                  type: array
+                volumes:
+                  description: List of remote storage volumes
+                  items:
+                    description: VolumeSpec defines remote volume name and remote
+                      volume URI
+                    properties:
+                      endpoint:
+                        description: Remote volume URI
+                        type: string
+                      name:
+                        description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+      type: object
+  version: v1alpha3
+  versions:
+  - name: v1alpha3
     served: true
     storage: true
-    subresources:
-      status: {}
+  - name: v1alpha2
+    served: true
+    storage: false

--- a/deploy/crds/enterprise.splunk.com_clustermasters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_clustermasters_crd.yaml
@@ -1,13 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clustermasters.enterprise.splunk.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: Status of cluster master
-    name: Phase
-    type: string
   group: enterprise.splunk.com
   names:
     kind: ClusterMaster
@@ -17,2293 +12,2361 @@ spec:
     - cm-idxc
     singular: clustermaster
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ClusterMaster is the Schema for the clustermasters API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ClusterMasterSpec defines the desired state of ClusterMaster
-          properties:
-            affinity:
-              description: Kubernetes Affinity rules that control how pods are assigned
-                to particular nodes.
-              properties:
-                nodeAffinity:
-                  description: Describes node affinity scheduling rules for the pod.
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node matches the corresponding matchExpressions; the
-                        node(s) with the highest sum are the most preferred.
-                      items:
-                        description: An empty preferred scheduling term matches all
-                          objects with implicit weight 0 (i.e. it's a no-op). A null
-                          preferred scheduling term matches no objects (i.e. is also
-                          a no-op).
+  versions:
+  - additionalPrinterColumns:
+    - description: Status of cluster master
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: ClusterMaster is the Schema for the clustermasters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterMasterSpec defines the desired state of ClusterMaster
+            properties:
+              Mock:
+                description: Mock to differentiate between UTs and actual reconcile
+                type: boolean
+              affinity:
+                description: Kubernetes Affinity rules that control how pods are assigned
+                  to particular nodes.
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
                         properties:
-                          preference:
-                            description: A node selector term, associated with the
-                              corresponding weight.
-                            properties:
-                              matchExpressions:
-                                description: A list of node selector requirements
-                                  by node's labels.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchFields:
-                                description: A list of node selector requirements
-                                  by node's fields.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
                                         type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                            type: object
-                          weight:
-                            description: Weight associated with matching the corresponding
-                              nodeSelectorTerm, in the range 1-100.
-                            format: int32
-                            type: integer
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
                         required:
-                        - preference
-                        - weight
+                        - nodeSelectorTerms
                         type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to an update), the system may or may not try to
-                        eventually evict the pod from its node.
-                      properties:
-                        nodeSelectorTerms:
-                          description: Required. A list of node selector terms. The
-                            terms are ORed.
-                          items:
-                            description: A null or empty node selector term matches
-                              no objects. The requirements of them are ANDed. The
-                              TopologySelectorTerm type implements a subset of the
-                              NodeSelectorTerm.
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              clusterMasterRef:
+                description: ClusterMasterRef refers to a Splunk Enterprise indexer
+                  cluster managed by the operator within Kubernetes
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              defaults:
+                description: Inline map of default.yml overrides used to initialize
+                  the environment
+                type: string
+              defaultsUrl:
+                description: Full path or URL for one or more default.yml files, separated
+                  by commas
+                type: string
+              ephemeralStorage:
+                description: If true, ephemeral (emptyDir) storage will be used for
+                  /opt/splunk/etc and /opt/splunk/var volumes
+                type: boolean
+              etcStorage:
+                description: Storage capacity to request for /opt/splunk/etc persistent
+                  volume claims (default=”1Gi”)
+                type: string
+              image:
+                description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
+                  environment variables)
+                type: string
+              imagePullPolicy:
+                description: 'Sets pull policy for all images (either “Always” or
+                  the default: “IfNotPresent”)'
+                enum:
+                - Always
+                - IfNotPresent
+                type: string
+              licenseMasterRef:
+                description: LicenseMasterRef refers to a Splunk Enterprise license
+                  master managed by the operator within Kubernetes
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              licenseUrl:
+                description: Full path or URL for a Splunk Enterprise license file
+                type: string
+              resources:
+                description: resource requirements for the pod containers
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+              schedulerName:
+                description: Name of Scheduler to use for pod placement (defaults
+                  to “default-scheduler”)
+                type: string
+              serviceTemplate:
+                description: ServiceTemplate is a template used to create Kubernetes
+                  services
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      clusterIP:
+                        description: 'clusterIP is the IP address of the service and
+                          is usually assigned randomly by the master. If an address
+                          is specified manually and is not in use by others, it will
+                          be allocated to the service; otherwise, creation of the
+                          service will fail. This field can not be changed through
+                          updates. Valid values are "None", empty string (""), or
+                          a valid IP address. "None" can be specified for headless
+                          services when proxying is not required. Only applies to
+                          types ClusterIP, NodePort, and LoadBalancer. Ignored if
+                          type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      externalIPs:
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for this service.  These
+                          IPs are not managed by Kubernetes.  The user is responsible
+                          for ensuring that traffic arrives at a node with this IP.  A
+                          common example is external load-balancers that are not part
+                          of the Kubernetes system.
+                        items:
+                          type: string
+                        type: array
+                      externalName:
+                        description: externalName is the external reference that kubedns
+                          or equivalent will return as a CNAME record for this service.
+                          No proxying will be involved. Must be a valid RFC-1123 hostname
+                          (https://tools.ietf.org/html/rfc1123) and requires Type
+                          to be ExternalName.
+                        type: string
+                      externalTrafficPolicy:
+                        description: externalTrafficPolicy denotes if this Service
+                          desires to route external traffic to node-local or cluster-wide
+                          endpoints. "Local" preserves the client source IP and avoids
+                          a second hop for LoadBalancer and Nodeport type services,
+                          but risks potentially imbalanced traffic spreading. "Cluster"
+                          obscures the client source IP and may cause a second hop
+                          to another node, but should have good overall load-spreading.
+                        type: string
+                      healthCheckNodePort:
+                        description: healthCheckNodePort specifies the healthcheck
+                          nodePort for the service. If not specified, HealthCheckNodePort
+                          is created by the service api backend with the allocated
+                          nodePort. Will use user-specified nodePort value if specified
+                          by the client. Only effects when Type is set to LoadBalancer
+                          and ExternalTrafficPolicy is set to Local.
+                        format: int32
+                        type: integer
+                      ipFamily:
+                        description: ipFamily specifies whether this Service has a
+                          preference for a particular IP family (e.g. IPv4 vs. IPv6).  If
+                          a specific IP family is requested, the clusterIP field will
+                          be allocated from that family, if it is available in the
+                          cluster.  If no IP family is requested, the cluster's primary
+                          IP family will be used. Other IP fields (loadBalancerIP,
+                          loadBalancerSourceRanges, externalIPs) and controllers which
+                          allocate external load-balancers should use the same IP
+                          family.  Endpoints for this Service will be of this family.  This
+                          field is immutable after creation. Assigning a ServiceIPFamily
+                          not available in the cluster (e.g. IPv6 in IPv4 only cluster)
+                          is an error condition and will fail during clusterIP assignment.
+                        type: string
+                      loadBalancerIP:
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in this field. This
+                          feature depends on whether the underlying cloud-provider
+                          supports specifying the loadBalancerIP when a load balancer
+                          is created. This field will be ignored if the cloud-provider
+                          does not support the feature.'
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: 'If specified and supported by the platform,
+                          this will restrict traffic through the cloud-provider load-balancer
+                          will be restricted to the specified client IPs. This field
+                          will be ignored if the cloud-provider does not support the
+                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        description: 'The list of ports that are exposed by this service.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            name:
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names. When considering the endpoints
+                                for a Service, this must match the 'name' field in
+                                the EndpointPort. Optional if only one ServicePort
+                                is defined on this service.
+                              type: string
+                            nodePort:
+                              description: 'The port on each node on which this service
+                                is exposed when type=NodePort or LoadBalancer. Usually
+                                assigned by the system. If specified, it will be allocated
+                                to the service if unused or else creation of the service
+                                will fail. Default is to auto-allocate a port if the
+                                ServiceType of this Service requires one. More info:
+                                https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'Number or name of the port to access on
+                                the pods targeted by the service. Number must be in
+                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                If this is a string, it will be looked up as a named
+                                port in the target Pod''s container ports. If this
+                                is not specified, the value of the ''port'' field
+                                is used (an identity map). This field is ignored for
+                                services with clusterIP=None, and should be omitted
+                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        description: publishNotReadyAddresses, when set to true, indicates
+                          that DNS implementations must publish the notReadyAddresses
+                          of subsets for the Endpoints associated with the Service.
+                          The default value is false. The primary use case for setting
+                          this field is to use a StatefulSet's Headless Service to
+                          propagate SRV records for its Pods without respect to their
+                          readiness for purpose of peer discovery.
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: 'Route service traffic to pods with label keys
+                          and values matching this selector. If empty or not present,
+                          the service is assumed to have an external process managing
+                          its endpoints, which Kubernetes will not modify. Only applies
+                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
+                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                        type: object
+                      sessionAffinity:
+                        description: 'Supports "ClientIP" and "None". Used to maintain
+                          session affinity. Enable client IP based session affinity.
+                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
                             properties:
-                              matchExpressions:
-                                description: A list of node selector requirements
-                                  by node's labels.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchFields:
-                                description: A list of node selector requirements
-                                  by node's fields.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
+                              timeoutSeconds:
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time. The value
+                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                  == "ClientIP". Default value is 10800(for 3 hours).
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      type:
+                        description: 'type determines how the Service is exposed.
+                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
+                          NodePort, and LoadBalancer. "ExternalName" maps to the specified
+                          externalName. "ClusterIP" allocates a cluster-internal IP
+                          address for load-balancing to endpoints. Endpoints are determined
+                          by the selector or if that is not specified, by manual construction
+                          of an Endpoints object. If clusterIP is "None", no virtual
+                          IP is allocated and the endpoints are published as a set
+                          of endpoints rather than a stable IP. "NodePort" builds
+                          on ClusterIP and allocates a port on every node which routes
+                          to the clusterIP. "LoadBalancer" builds on NodePort and
+                          creates an external load-balancer (if supported in the current
+                          cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                        type: string
+                    type: object
+                  status:
+                    description: 'Most recently observed status of the service. Populated
+                      by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      loadBalancer:
+                        description: LoadBalancer contains the current status of the
+                          load-balancer, if one is present.
+                        properties:
+                          ingress:
+                            description: Ingress is a list containing ingress points
+                              for the load-balancer. Traffic intended for the service
+                              should be sent to these ingress points.
+                            items:
+                              description: 'LoadBalancerIngress represents the status
+                                of a load-balancer ingress point: traffic intended
+                                for the service should be sent to an ingress point.'
+                              properties:
+                                hostname:
+                                  description: Hostname is set for load-balancer ingress
+                                    points that are DNS based (typically AWS load-balancers)
+                                  type: string
+                                ip:
+                                  description: IP is set for load-balancer ingress
+                                    points that are IP based (typically GCE or OpenStack
+                                    load-balancers)
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                type: object
+              smartstore:
+                description: Splunk Smartstore configuration. Refer to indexes.conf.spec
+                  on docs.splunk.com
+                properties:
+                  indexes:
+                    description: List of Splunk indexes
+                    items:
+                      description: IndexSpec defines Splunk index name and storage
+                        path
+                      properties:
+                        name:
+                          description: Splunk index name
+                          type: string
+                        remotePath:
+                          description: Index location relative to the remote volume
+                            path
+                          type: string
+                        volumeName:
+                          description: Remote Volume name
+                          type: string
+                      type: object
+                    type: array
+                  volumes:
+                    description: List of remote storage volumes
+                    items:
+                      description: VolumeSpec defines remote volume name and remote
+                        volume URI
+                      properties:
+                        endpoint:
+                          description: Remote volume URI
+                          type: string
+                        name:
+                          description: Remote volume name
+                          type: string
+                        path:
+                          description: Remote volume path
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              storageClassName:
+                description: Name of StorageClass to use for persistent volume claims
+                type: string
+              tolerations:
+                description: Pod's tolerations for Kubernetes node's taint
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              varStorage:
+                description: Storage capacity to request for /opt/splunk/var persistent
+                  volume claims (default=”50Gi”)
+                type: string
+              volumes:
+                description: List of one or more Kubernetes volumes. These will be
+                  mounted in all pod containers as as /mnt/<name>
+                items:
+                  description: Volume represents a named volume in a pod that may
+                    be accessed by any container in the pod.
+                  properties:
+                    awsElasticBlockStore:
+                      description: 'AWSElasticBlockStore represents an AWS Disk resource
+                        that is attached to a kubelet''s host machine and then exposed
+                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      properties:
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        partition:
+                          description: 'The partition in the volume that you want
+                            to mount. If omitted, the default is to mount by volume
+                            name. Examples: For volume /dev/sda1, you specify the
+                            partition as "1". Similarly, the volume partition for
+                            /dev/sda is "0" (or you can leave the property empty).'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: 'Specify "true" to force and set the ReadOnly
+                            property in VolumeMounts to "true". If omitted, the default
+                            is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          type: boolean
+                        volumeID:
+                          description: 'Unique ID of the persistent disk resource
+                            in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    azureDisk:
+                      description: AzureDisk represents an Azure Data Disk mount on
+                        the host and bind mount to the pod.
+                      properties:
+                        cachingMode:
+                          description: 'Host Caching mode: None, Read Only, Read Write.'
+                          type: string
+                        diskName:
+                          description: The Name of the data disk in the blob storage
+                          type: string
+                        diskURI:
+                          description: The URI the data disk in the blob storage
+                          type: string
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        kind:
+                          description: 'Expected values Shared: multiple blob disks
+                            per storage account  Dedicated: single blob disk per storage
+                            account  Managed: azure managed data disk (only in managed
+                            availability set). defaults to shared'
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                      required:
+                      - diskName
+                      - diskURI
+                      type: object
+                    azureFile:
+                      description: AzureFile represents an Azure File Service mount
+                        on the host and bind mount to the pod.
+                      properties:
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretName:
+                          description: the name of secret that contains Azure Storage
+                            Account Name and Key
+                          type: string
+                        shareName:
+                          description: Share Name
+                          type: string
+                      required:
+                      - secretName
+                      - shareName
+                      type: object
+                    cephfs:
+                      description: CephFS represents a Ceph FS mount on the host that
+                        shares a pod's lifetime
+                      properties:
+                        monitors:
+                          description: 'Required: Monitors is a collection of Ceph
+                            monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          items:
+                            type: string
+                          type: array
+                        path:
+                          description: 'Optional: Used as the mounted root, rather
+                            than the full Ceph tree, default is /'
+                          type: string
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: boolean
+                        secretFile:
+                          description: 'Optional: SecretFile is the path to key ring
+                            for User, default is /etc/ceph/user.secret More info:
+                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: string
+                        secretRef:
+                          description: 'Optional: SecretRef is reference to the authentication
+                            secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        user:
+                          description: 'Optional: User is the rados user name, default
+                            is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: string
+                      required:
+                      - monitors
+                      type: object
+                    cinder:
+                      description: 'Cinder represents a cinder volume attached and
+                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      properties:
+                        fsType:
+                          description: 'Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: string
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: boolean
+                        secretRef:
+                          description: 'Optional: points to a secret object containing
+                            parameters used to connect to OpenStack.'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        volumeID:
+                          description: 'volume id used to identify the volume in cinder.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    configMap:
+                      description: ConfigMap represents a configMap that should populate
+                        this volume
+                      properties:
+                        defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default. Must be a value between 0 and 0777. Defaults
+                            to 0644. Directories within the path are not affected
+                            by this setting. This might be in conflict with other
+                            options that affect the file mode, like fsGroup, and the
+                            result can be other mode bits set.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: If unspecified, each key-value pair in the
+                            Data field of the referenced ConfigMap will be projected
+                            into the volume as a file whose name is the key and content
+                            is the value. If specified, the listed keys will be projected
+                            into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in
+                            the ConfigMap, the volume setup will error unless it is
+                            marked optional. Paths must be relative and may not contain
+                            the '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
+                            properties:
+                              key:
+                                description: The key to project.
+                                type: string
+                              mode:
+                                description: 'Optional: mode bits to use on this file,
+                                  must be a value between 0 and 0777. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: The relative path of the file to map
+                                  the key to. May not be an absolute path. May not
+                                  contain the path element '..'. May not start with
+                                  the string '..'.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap or its keys must
+                            be defined
+                          type: boolean
+                      type: object
+                    csi:
+                      description: CSI (Container Storage Interface) represents storage
+                        that is handled by an external CSI driver (Alpha feature).
+                      properties:
+                        driver:
+                          description: Driver is the name of the CSI driver that handles
+                            this volume. Consult with your admin for the correct name
+                            as registered in the cluster.
+                          type: string
+                        fsType:
+                          description: Filesystem type to mount. Ex. "ext4", "xfs",
+                            "ntfs". If not provided, the empty value is passed to
+                            the associated CSI driver which will determine the default
+                            filesystem to apply.
+                          type: string
+                        nodePublishSecretRef:
+                          description: NodePublishSecretRef is a reference to the
+                            secret object containing sensitive information to pass
+                            to the CSI driver to complete the CSI NodePublishVolume
+                            and NodeUnpublishVolume calls. This field is optional,
+                            and  may be empty if no secret is required. If the secret
+                            object contains more than one secret, all secret references
+                            are passed.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        readOnly:
+                          description: Specifies a read-only configuration for the
+                            volume. Defaults to false (read/write).
+                          type: boolean
+                        volumeAttributes:
+                          additionalProperties:
+                            type: string
+                          description: VolumeAttributes stores driver-specific properties
+                            that are passed to the CSI driver. Consult your driver's
+                            documentation for supported values.
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    downwardAPI:
+                      description: DownwardAPI represents downward API about the pod
+                        that should populate this volume
+                      properties:
+                        defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default. Must be a value between 0 and 0777. Defaults
+                            to 0644. Directories within the path are not affected
+                            by this setting. This might be in conflict with other
+                            options that affect the file mode, like fsGroup, and the
+                            result can be other mode bits set.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: Items is a list of downward API volume file
+                          items:
+                            description: DownwardAPIVolumeFile represents information
+                              to create the file containing the pod field
+                            properties:
+                              fieldRef:
+                                description: 'Required: Selects a field of the pod:
+                                  only annotations, labels, name and namespace are
+                                  supported.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                              mode:
+                                description: 'Optional: mode bits to use on this file,
+                                  must be a value between 0 and 0777. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: 'Required: Path is  the relative path
+                                  name of the file to be created. Must not be absolute
+                                  or contain the ''..'' path. Must be utf-8 encoded.
+                                  The first item of the relative path must not start
+                                  with ''..'''
+                                type: string
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, requests.cpu and requests.memory)
+                                  are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                            required:
+                            - path
+                            type: object
+                          type: array
+                      type: object
+                    emptyDir:
+                      description: 'EmptyDir represents a temporary directory that
+                        shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      properties:
+                        medium:
+                          description: 'What type of storage medium should back this
+                            directory. The default is "" which means to use the node''s
+                            default medium. Must be an empty string (default) or Memory.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          type: string
+                        sizeLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'Total amount of local storage required for
+                            this EmptyDir volume. The size limit is also applicable
+                            for memory medium. The maximum usage on memory medium
+                            EmptyDir would be the minimum value between the SizeLimit
+                            specified here and the sum of memory limits of all containers
+                            in a pod. The default is nil which means that the limit
+                            is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    fc:
+                      description: FC represents a Fibre Channel resource that is
+                        attached to a kubelet's host machine and then exposed to the
+                        pod.
+                      properties:
+                        fsType:
+                          description: 'Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        lun:
+                          description: 'Optional: FC target lun number'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                          type: boolean
+                        targetWWNs:
+                          description: 'Optional: FC target worldwide names (WWNs)'
+                          items:
+                            type: string
+                          type: array
+                        wwids:
+                          description: 'Optional: FC volume world wide identifiers
+                            (wwids) Either wwids or combination of targetWWNs and
+                            lun must be set, but not both simultaneously.'
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    flexVolume:
+                      description: FlexVolume represents a generic volume resource
+                        that is provisioned/attached using an exec based plugin.
+                      properties:
+                        driver:
+                          description: Driver is the name of the driver to use for
+                            this volume.
+                          type: string
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". The default filesystem depends on FlexVolume
+                            script.
+                          type: string
+                        options:
+                          additionalProperties:
+                            type: string
+                          description: 'Optional: Extra command options if any.'
+                          type: object
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                          type: boolean
+                        secretRef:
+                          description: 'Optional: SecretRef is reference to the secret
+                            object containing sensitive information to pass to the
+                            plugin scripts. This may be empty if no secret object
+                            is specified. If the secret object contains more than
+                            one secret, all secrets are passed to the plugin scripts.'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    flocker:
+                      description: Flocker represents a Flocker volume attached to
+                        a kubelet's host machine. This depends on the Flocker control
+                        service being running
+                      properties:
+                        datasetName:
+                          description: Name of the dataset stored as metadata -> name
+                            on the dataset for Flocker should be considered as deprecated
+                          type: string
+                        datasetUUID:
+                          description: UUID of the dataset. This is unique identifier
+                            of a Flocker dataset
+                          type: string
+                      type: object
+                    gcePersistentDisk:
+                      description: 'GCEPersistentDisk represents a GCE Disk resource
+                        that is attached to a kubelet''s host machine and then exposed
+                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      properties:
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        partition:
+                          description: 'The partition in the volume that you want
+                            to mount. If omitted, the default is to mount by volume
+                            name. Examples: For volume /dev/sda1, you specify the
+                            partition as "1". Similarly, the volume partition for
+                            /dev/sda is "0" (or you can leave the property empty).
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          format: int32
+                          type: integer
+                        pdName:
+                          description: 'Unique name of the PD resource in GCE. Used
+                            to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          type: boolean
+                      required:
+                      - pdName
+                      type: object
+                    gitRepo:
+                      description: 'GitRepo represents a git repository at a particular
+                        revision. DEPRECATED: GitRepo is deprecated. To provision
+                        a container with a git repo, mount an EmptyDir into an InitContainer
+                        that clones the repo using git, then mount the EmptyDir into
+                        the Pod''s container.'
+                      properties:
+                        directory:
+                          description: Target directory name. Must not contain or
+                            start with '..'.  If '.' is supplied, the volume directory
+                            will be the git repository.  Otherwise, if specified,
+                            the volume will contain the git repository in the subdirectory
+                            with the given name.
+                          type: string
+                        repository:
+                          description: Repository URL
+                          type: string
+                        revision:
+                          description: Commit hash for the specified revision.
+                          type: string
+                      required:
+                      - repository
+                      type: object
+                    glusterfs:
+                      description: 'Glusterfs represents a Glusterfs mount on the
+                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                      properties:
+                        endpoints:
+                          description: 'EndpointsName is the endpoint name that details
+                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: string
+                        path:
+                          description: 'Path is the Glusterfs volume path. More info:
+                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the Glusterfs volume
+                            to be mounted with read-only permissions. Defaults to
+                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: boolean
+                      required:
+                      - endpoints
+                      - path
+                      type: object
+                    hostPath:
+                      description: 'HostPath represents a pre-existing file or directory
+                        on the host machine that is directly exposed to the container.
+                        This is generally used for system agents or other privileged
+                        things that are allowed to see the host machine. Most containers
+                        will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                        --- TODO(jonesdl) We need to restrict who can use host directory
+                        mounts and who can/can not mount host directories as read/write.'
+                      properties:
+                        path:
+                          description: 'Path of the directory on the host. If the
+                            path is a symlink, it will follow the link to the real
+                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          type: string
+                        type:
+                          description: 'Type for HostPath Volume Defaults to "" More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    iscsi:
+                      description: 'ISCSI represents an ISCSI Disk resource that is
+                        attached to a kubelet''s host machine and then exposed to
+                        the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                      properties:
+                        chapAuthDiscovery:
+                          description: whether support iSCSI Discovery CHAP authentication
+                          type: boolean
+                        chapAuthSession:
+                          description: whether support iSCSI Session CHAP authentication
+                          type: boolean
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        initiatorName:
+                          description: Custom iSCSI Initiator Name. If initiatorName
+                            is specified with iscsiInterface simultaneously, new iSCSI
+                            interface <target portal>:<volume name> will be created
+                            for the connection.
+                          type: string
+                        iqn:
+                          description: Target iSCSI Qualified Name.
+                          type: string
+                        iscsiInterface:
+                          description: iSCSI Interface Name that uses an iSCSI transport.
+                            Defaults to 'default' (tcp).
+                          type: string
+                        lun:
+                          description: iSCSI Target Lun number.
+                          format: int32
+                          type: integer
+                        portals:
+                          description: iSCSI Target Portal List. The portal is either
+                            an IP or ip_addr:port if the port is other than default
+                            (typically TCP ports 860 and 3260).
+                          items:
+                            type: string
+                          type: array
+                        readOnly:
+                          description: ReadOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false.
+                          type: boolean
+                        secretRef:
+                          description: CHAP Secret for iSCSI target and initiator
+                            authentication
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        targetPortal:
+                          description: iSCSI Target Portal. The Portal is either an
+                            IP or ip_addr:port if the port is other than default (typically
+                            TCP ports 860 and 3260).
+                          type: string
+                      required:
+                      - iqn
+                      - lun
+                      - targetPortal
+                      type: object
+                    name:
+                      description: 'Volume''s name. Must be a DNS_LABEL and unique
+                        within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    nfs:
+                      description: 'NFS represents an NFS mount on the host that shares
+                        a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      properties:
+                        path:
+                          description: 'Path that is exported by the NFS server. More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the NFS export to
+                            be mounted with read-only permissions. Defaults to false.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: boolean
+                        server:
+                          description: 'Server is the hostname or IP address of the
+                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: string
+                      required:
+                      - path
+                      - server
+                      type: object
+                    persistentVolumeClaim:
+                      description: 'PersistentVolumeClaimVolumeSource represents a
+                        reference to a PersistentVolumeClaim in the same namespace.
+                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                      properties:
+                        claimName:
+                          description: 'ClaimName is the name of a PersistentVolumeClaim
+                            in the same namespace as the pod using this volume. More
+                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          type: string
+                        readOnly:
+                          description: Will force the ReadOnly setting in VolumeMounts.
+                            Default false.
+                          type: boolean
+                      required:
+                      - claimName
+                      type: object
+                    photonPersistentDisk:
+                      description: PhotonPersistentDisk represents a PhotonController
+                        persistent disk attached and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        pdID:
+                          description: ID that identifies Photon Controller persistent
+                            disk
+                          type: string
+                      required:
+                      - pdID
+                      type: object
+                    portworxVolume:
+                      description: PortworxVolume represents a portworx volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: FSType represents the filesystem type to mount
+                            Must be a filesystem type supported by the host operating
+                            system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        volumeID:
+                          description: VolumeID uniquely identifies a Portworx volume
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    projected:
+                      description: Items for all in one resources secrets, configmaps,
+                        and downward API
+                      properties:
+                        defaultMode:
+                          description: Mode bits to use on created files by default.
+                            Must be a value between 0 and 0777. Directories within
+                            the path are not affected by this setting. This might
+                            be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits
+                            set.
+                          format: int32
+                          type: integer
+                        sources:
+                          description: list of volume projections
+                          items:
+                            description: Projection that may be projected along with
+                              other supported volume types
+                            properties:
+                              configMap:
+                                description: information about the configMap data
+                                  to project
+                                properties:
+                                  items:
+                                    description: If unspecified, each key-value pair
+                                      in the Data field of the referenced ConfigMap
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the ConfigMap, the volume
+                                      setup will error unless it is marked optional.
+                                      Paths must be relative and may not contain the
+                                      '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: The key to project.
+                                          type: string
+                                        mode:
+                                          description: 'Optional: mode bits to use
+                                            on this file, must be a value between
+                                            0 and 0777. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: The relative path of the file
+                                            to map the key to. May not be an absolute
+                                            path. May not contain the path element
+                                            '..'. May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its keys must be defined
+                                    type: boolean
+                                type: object
+                              downwardAPI:
+                                description: information about the downwardAPI data
+                                  to project
+                                properties:
+                                  items:
+                                    description: Items is a list of DownwardAPIVolume
+                                      file
+                                    items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
+                                      properties:
+                                        fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name and namespace are supported.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                        mode:
+                                          description: 'Optional: mode bits to use
+                                            on this file, must be a value between
+                                            0 and 0777. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path. Must be utf-8 encoded. The first
+                                            item of the relative path must not start
+                                            with ''..'''
+                                          type: string
+                                        resourceFieldRef:
+                                          description: 'Selects a resource of the
+                                            container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu
+                                            and requests.memory) are currently supported.'
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                type: object
+                              secret:
+                                description: information about the secret data to
+                                  project
+                                properties:
+                                  items:
+                                    description: If unspecified, each key-value pair
+                                      in the Data field of the referenced Secret will
+                                      be projected into the volume as a file whose
+                                      name is the key and content is the value. If
+                                      specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the Secret, the volume setup
+                                      will error unless it is marked optional. Paths
+                                      must be relative and may not contain the '..'
+                                      path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: The key to project.
+                                          type: string
+                                        mode:
+                                          description: 'Optional: mode bits to use
+                                            on this file, must be a value between
+                                            0 and 0777. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: The relative path of the file
+                                            to map the key to. May not be an absolute
+                                            path. May not contain the path element
+                                            '..'. May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                type: object
+                              serviceAccountToken:
+                                description: information about the serviceAccountToken
+                                  data to project
+                                properties:
+                                  audience:
+                                    description: Audience is the intended audience
+                                      of the token. A recipient of a token must identify
+                                      itself with an identifier specified in the audience
+                                      of the token, and otherwise should reject the
+                                      token. The audience defaults to the identifier
+                                      of the apiserver.
+                                    type: string
+                                  expirationSeconds:
+                                    description: ExpirationSeconds is the requested
+                                      duration of validity of the service account
+                                      token. As the token approaches expiration, the
+                                      kubelet volume plugin will proactively rotate
+                                      the service account token. The kubelet will
+                                      start trying to rotate the token if the token
+                                      is older than 80 percent of its time to live
+                                      or if the token is older than 24 hours.Defaults
+                                      to 1 hour and must be at least 10 minutes.
+                                    format: int64
+                                    type: integer
+                                  path:
+                                    description: Path is the path relative to the
+                                      mount point of the file to project the token
+                                      into.
+                                    type: string
+                                required:
+                                - path
+                                type: object
                             type: object
                           type: array
                       required:
-                      - nodeSelectorTerms
+                      - sources
                       type: object
-                  type: object
-                podAffinity:
-                  description: Describes pod affinity scheduling rules (e.g. co-locate
-                    this pod in the same node, zone, etc. as some other pod(s)).
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node has pods which matches the corresponding podAffinityTerm;
-                        the node(s) with the highest sum are the most preferred.
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            format: int32
-                            type: integer
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to a pod label update), the system may or may not
-                        try to eventually evict the pod from its node. When there
-                        are multiple elements, the lists of nodes corresponding to
-                        each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            items:
-                              type: string
-                            type: array
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-                        required:
-                        - topologyKey
-                        type: object
-                      type: array
-                  type: object
-                podAntiAffinity:
-                  description: Describes pod anti-affinity scheduling rules (e.g.
-                    avoid putting this pod in the same node, zone, etc. as some other
-                    pod(s)).
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the anti-affinity expressions specified by this
-                        field, but it may choose a node that violates one or more
-                        of the expressions. The node that is most preferred is the
-                        one with the greatest sum of weights, i.e. for each node that
-                        meets all of the scheduling requirements (resource request,
-                        requiredDuringScheduling anti-affinity expressions, etc.),
-                        compute a sum by iterating through the elements of this field
-                        and adding "weight" to the sum if the node has pods which
-                        matches the corresponding podAffinityTerm; the node(s) with
-                        the highest sum are the most preferred.
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            format: int32
-                            type: integer
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the anti-affinity requirements specified by
-                        this field are not met at scheduling time, the pod will not
-                        be scheduled onto the node. If the anti-affinity requirements
-                        specified by this field cease to be met at some point during
-                        pod execution (e.g. due to a pod label update), the system
-                        may or may not try to eventually evict the pod from its node.
-                        When there are multiple elements, the lists of nodes corresponding
-                        to each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            items:
-                              type: string
-                            type: array
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-                        required:
-                        - topologyKey
-                        type: object
-                      type: array
-                  type: object
-              type: object
-            clusterMasterRef:
-              description: ClusterMasterRef refers to a Splunk Enterprise indexer
-                cluster managed by the operator within Kubernetes
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            defaults:
-              description: Inline map of default.yml overrides used to initialize
-                the environment
-              type: string
-            defaultsUrl:
-              description: Full path or URL for one or more default.yml files, separated
-                by commas
-              type: string
-            ephemeralStorage:
-              description: If true, ephemeral (emptyDir) storage will be used for
-                /opt/splunk/etc and /opt/splunk/var volumes
-              type: boolean
-            etcStorage:
-              description: Storage capacity to request for /opt/splunk/etc persistent
-                volume claims (default=”1Gi”)
-              type: string
-            image:
-              description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
-                environment variables)
-              type: string
-            imagePullPolicy:
-              description: 'Sets pull policy for all images (either “Always” or the
-                default: “IfNotPresent”)'
-              enum:
-              - Always
-              - IfNotPresent
-              type: string
-            licenseMasterRef:
-              description: LicenseMasterRef refers to a Splunk Enterprise license
-                master managed by the operator within Kubernetes
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            licenseUrl:
-              description: Full path or URL for a Splunk Enterprise license file
-              type: string
-            resources:
-              description: resource requirements for the pod containers
-              properties:
-                limits:
-                  additionalProperties:
-                    type: string
-                  description: 'Limits describes the maximum amount of compute resources
-                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                requests:
-                  additionalProperties:
-                    type: string
-                  description: 'Requests describes the minimum amount of compute resources
-                    required. If Requests is omitted for a container, it defaults
-                    to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-              type: object
-            schedulerName:
-              description: Name of Scheduler to use for pod placement (defaults to
-                “default-scheduler”)
-              type: string
-            serviceTemplate:
-              description: ServiceTemplate is a template used to create Kubernetes
-                services
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                    of an object. Servers should convert recognized schemas to the
-                    latest internal value, and may reject unrecognized values. More
-                    info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource
-                    this object represents. Servers may infer this from the endpoint
-                    the client submits requests to. Cannot be updated. In CamelCase.
-                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                  type: object
-                spec:
-                  description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                  properties:
-                    clusterIP:
-                      description: 'clusterIP is the IP address of the service and
-                        is usually assigned randomly by the master. If an address
-                        is specified manually and is not in use by others, it will
-                        be allocated to the service; otherwise, creation of the service
-                        will fail. This field can not be changed through updates.
-                        Valid values are "None", empty string (""), or a valid IP
-                        address. "None" can be specified for headless services when
-                        proxying is not required. Only applies to types ClusterIP,
-                        NodePort, and LoadBalancer. Ignored if type is ExternalName.
-                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                      type: string
-                    externalIPs:
-                      description: externalIPs is a list of IP addresses for which
-                        nodes in the cluster will also accept traffic for this service.  These
-                        IPs are not managed by Kubernetes.  The user is responsible
-                        for ensuring that traffic arrives at a node with this IP.  A
-                        common example is external load-balancers that are not part
-                        of the Kubernetes system.
-                      items:
-                        type: string
-                      type: array
-                    externalName:
-                      description: externalName is the external reference that kubedns
-                        or equivalent will return as a CNAME record for this service.
-                        No proxying will be involved. Must be a valid RFC-1123 hostname
-                        (https://tools.ietf.org/html/rfc1123) and requires Type to
-                        be ExternalName.
-                      type: string
-                    externalTrafficPolicy:
-                      description: externalTrafficPolicy denotes if this Service desires
-                        to route external traffic to node-local or cluster-wide endpoints.
-                        "Local" preserves the client source IP and avoids a second
-                        hop for LoadBalancer and Nodeport type services, but risks
-                        potentially imbalanced traffic spreading. "Cluster" obscures
-                        the client source IP and may cause a second hop to another
-                        node, but should have good overall load-spreading.
-                      type: string
-                    healthCheckNodePort:
-                      description: healthCheckNodePort specifies the healthcheck nodePort
-                        for the service. If not specified, HealthCheckNodePort is
-                        created by the service api backend with the allocated nodePort.
-                        Will use user-specified nodePort value if specified by the
-                        client. Only effects when Type is set to LoadBalancer and
-                        ExternalTrafficPolicy is set to Local.
-                      format: int32
-                      type: integer
-                    ipFamily:
-                      description: ipFamily specifies whether this Service has a preference
-                        for a particular IP family (e.g. IPv4 vs. IPv6).  If a specific
-                        IP family is requested, the clusterIP field will be allocated
-                        from that family, if it is available in the cluster.  If no
-                        IP family is requested, the cluster's primary IP family will
-                        be used. Other IP fields (loadBalancerIP, loadBalancerSourceRanges,
-                        externalIPs) and controllers which allocate external load-balancers
-                        should use the same IP family.  Endpoints for this Service
-                        will be of this family.  This field is immutable after creation.
-                        Assigning a ServiceIPFamily not available in the cluster (e.g.
-                        IPv6 in IPv4 only cluster) is an error condition and will
-                        fail during clusterIP assignment.
-                      type: string
-                    loadBalancerIP:
-                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                        will get created with the IP specified in this field. This
-                        feature depends on whether the underlying cloud-provider supports
-                        specifying the loadBalancerIP when a load balancer is created.
-                        This field will be ignored if the cloud-provider does not
-                        support the feature.'
-                      type: string
-                    loadBalancerSourceRanges:
-                      description: 'If specified and supported by the platform, this
-                        will restrict traffic through the cloud-provider load-balancer
-                        will be restricted to the specified client IPs. This field
-                        will be ignored if the cloud-provider does not support the
-                        feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
-                      items:
-                        type: string
-                      type: array
-                    ports:
-                      description: 'The list of ports that are exposed by this service.
-                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                      items:
-                        description: ServicePort contains information on service's
-                          port.
-                        properties:
-                          name:
-                            description: The name of this port within the service.
-                              This must be a DNS_LABEL. All ports within a ServiceSpec
-                              must have unique names. When considering the endpoints
-                              for a Service, this must match the 'name' field in the
-                              EndpointPort. Optional if only one ServicePort is defined
-                              on this service.
-                            type: string
-                          nodePort:
-                            description: 'The port on each node on which this service
-                              is exposed when type=NodePort or LoadBalancer. Usually
-                              assigned by the system. If specified, it will be allocated
-                              to the service if unused or else creation of the service
-                              will fail. Default is to auto-allocate a port if the
-                              ServiceType of this Service requires one. More info:
-                              https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
-                            format: int32
-                            type: integer
-                          port:
-                            description: The port that will be exposed by this service.
-                            format: int32
-                            type: integer
-                          protocol:
-                            description: The IP protocol for this port. Supports "TCP",
-                              "UDP", and "SCTP". Default is TCP.
-                            type: string
-                          targetPort:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: 'Number or name of the port to access on
-                              the pods targeted by the service. Number must be in
-                              the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                              If this is a string, it will be looked up as a named
-                              port in the target Pod''s container ports. If this is
-                              not specified, the value of the ''port'' field is used
-                              (an identity map). This field is ignored for services
-                              with clusterIP=None, and should be omitted or set equal
-                              to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
-                            x-kubernetes-int-or-string: true
-                        required:
-                        - port
-                        type: object
-                      type: array
-                    publishNotReadyAddresses:
-                      description: publishNotReadyAddresses, when set to true, indicates
-                        that DNS implementations must publish the notReadyAddresses
-                        of subsets for the Endpoints associated with the Service.
-                        The default value is false. The primary use case for setting
-                        this field is to use a StatefulSet's Headless Service to propagate
-                        SRV records for its Pods without respect to their readiness
-                        for purpose of peer discovery.
-                      type: boolean
-                    selector:
-                      additionalProperties:
-                        type: string
-                      description: 'Route service traffic to pods with label keys
-                        and values matching this selector. If empty or not present,
-                        the service is assumed to have an external process managing
-                        its endpoints, which Kubernetes will not modify. Only applies
-                        to types ClusterIP, NodePort, and LoadBalancer. Ignored if
-                        type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
-                      type: object
-                    sessionAffinity:
-                      description: 'Supports "ClientIP" and "None". Used to maintain
-                        session affinity. Enable client IP based session affinity.
-                        Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                      type: string
-                    sessionAffinityConfig:
-                      description: sessionAffinityConfig contains the configurations
-                        of session affinity.
+                    quobyte:
+                      description: Quobyte represents a Quobyte mount on the host
+                        that shares a pod's lifetime
                       properties:
-                        clientIP:
-                          description: clientIP contains the configurations of Client
-                            IP based session affinity.
-                          properties:
-                            timeoutSeconds:
-                              description: timeoutSeconds specifies the seconds of
-                                ClientIP type session sticky time. The value must
-                                be >0 && <=86400(for 1 day) if ServiceAffinity ==
-                                "ClientIP". Default value is 10800(for 3 hours).
-                              format: int32
-                              type: integer
-                          type: object
+                        group:
+                          description: Group to map volume access to Default is no
+                            group
+                          type: string
+                        readOnly:
+                          description: ReadOnly here will force the Quobyte volume
+                            to be mounted with read-only permissions. Defaults to
+                            false.
+                          type: boolean
+                        registry:
+                          description: Registry represents a single or multiple Quobyte
+                            Registry services specified as a string as host:port pair
+                            (multiple entries are separated with commas) which acts
+                            as the central registry for volumes
+                          type: string
+                        tenant:
+                          description: Tenant owning the given Quobyte volume in the
+                            Backend Used with dynamically provisioned Quobyte volumes,
+                            value is set by the plugin
+                          type: string
+                        user:
+                          description: User to map volume access to Defaults to serivceaccount
+                            user
+                          type: string
+                        volume:
+                          description: Volume is a string that references an already
+                            created Quobyte volume by name.
+                          type: string
+                      required:
+                      - registry
+                      - volume
                       type: object
-                    type:
-                      description: 'type determines how the Service is exposed. Defaults
-                        to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort,
-                        and LoadBalancer. "ExternalName" maps to the specified externalName.
-                        "ClusterIP" allocates a cluster-internal IP address for load-balancing
-                        to endpoints. Endpoints are determined by the selector or
-                        if that is not specified, by manual construction of an Endpoints
-                        object. If clusterIP is "None", no virtual IP is allocated
-                        and the endpoints are published as a set of endpoints rather
-                        than a stable IP. "NodePort" builds on ClusterIP and allocates
-                        a port on every node which routes to the clusterIP. "LoadBalancer"
-                        builds on NodePort and creates an external load-balancer (if
-                        supported in the current cloud) which routes to the clusterIP.
-                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
-                      type: string
-                  type: object
-                status:
-                  description: 'Most recently observed status of the service. Populated
-                    by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-                  properties:
-                    loadBalancer:
-                      description: LoadBalancer contains the current status of the
-                        load-balancer, if one is present.
+                    rbd:
+                      description: 'RBD represents a Rados Block Device mount on the
+                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                       properties:
-                        ingress:
-                          description: Ingress is a list containing ingress points
-                            for the load-balancer. Traffic intended for the service
-                            should be sent to these ingress points.
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        image:
+                          description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        keyring:
+                          description: 'Keyring is the path to key ring for RBDUser.
+                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        monitors:
+                          description: 'A collection of Ceph monitors. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           items:
-                            description: 'LoadBalancerIngress represents the status
-                              of a load-balancer ingress point: traffic intended for
-                              the service should be sent to an ingress point.'
+                            type: string
+                          type: array
+                        pool:
+                          description: 'The rados pool name. Default is rbd. More
+                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: boolean
+                        secretRef:
+                          description: 'SecretRef is name of the authentication secret
+                            for RBDUser. If provided overrides keyring. Default is
+                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        user:
+                          description: 'The rados user name. Default is admin. More
+                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                      required:
+                      - image
+                      - monitors
+                      type: object
+                    scaleIO:
+                      description: ScaleIO represents a ScaleIO persistent volume
+                        attached and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Default is "xfs".
+                          type: string
+                        gateway:
+                          description: The host address of the ScaleIO API Gateway.
+                          type: string
+                        protectionDomain:
+                          description: The name of the ScaleIO Protection Domain for
+                            the configured storage.
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: SecretRef references to the secret for ScaleIO
+                            user and other sensitive information. If this is not provided,
+                            Login operation will fail.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        sslEnabled:
+                          description: Flag to enable/disable SSL communication with
+                            Gateway, default false
+                          type: boolean
+                        storageMode:
+                          description: Indicates whether the storage for a volume
+                            should be ThickProvisioned or ThinProvisioned. Default
+                            is ThinProvisioned.
+                          type: string
+                        storagePool:
+                          description: The ScaleIO Storage Pool associated with the
+                            protection domain.
+                          type: string
+                        system:
+                          description: The name of the storage system as configured
+                            in ScaleIO.
+                          type: string
+                        volumeName:
+                          description: The name of a volume already created in the
+                            ScaleIO system that is associated with this volume source.
+                          type: string
+                      required:
+                      - gateway
+                      - secretRef
+                      - system
+                      type: object
+                    secret:
+                      description: 'Secret represents a secret that should populate
+                        this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                      properties:
+                        defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default. Must be a value between 0 and 0777. Defaults
+                            to 0644. Directories within the path are not affected
+                            by this setting. This might be in conflict with other
+                            options that affect the file mode, like fsGroup, and the
+                            result can be other mode bits set.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: If unspecified, each key-value pair in the
+                            Data field of the referenced Secret will be projected
+                            into the volume as a file whose name is the key and content
+                            is the value. If specified, the listed keys will be projected
+                            into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in
+                            the Secret, the volume setup will error unless it is marked
+                            optional. Paths must be relative and may not contain the
+                            '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
                             properties:
-                              hostname:
-                                description: Hostname is set for load-balancer ingress
-                                  points that are DNS based (typically AWS load-balancers)
+                              key:
+                                description: The key to project.
                                 type: string
-                              ip:
-                                description: IP is set for load-balancer ingress points
-                                  that are IP based (typically GCE or OpenStack load-balancers)
+                              mode:
+                                description: 'Optional: mode bits to use on this file,
+                                  must be a value between 0 and 0777. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: The relative path of the file to map
+                                  the key to. May not be an absolute path. May not
+                                  contain the path element '..'. May not start with
+                                  the string '..'.
                                 type: string
+                            required:
+                            - key
+                            - path
                             type: object
                           type: array
+                        optional:
+                          description: Specify whether the Secret or its keys must
+                            be defined
+                          type: boolean
+                        secretName:
+                          description: 'Name of the secret in the pod''s namespace
+                            to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                          type: string
                       type: object
+                    storageos:
+                      description: StorageOS represents a StorageOS volume attached
+                        and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: SecretRef specifies the secret to use for obtaining
+                            the StorageOS API credentials.  If not specified, default
+                            values will be attempted.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        volumeName:
+                          description: VolumeName is the human-readable name of the
+                            StorageOS volume.  Volume names are only unique within
+                            a namespace.
+                          type: string
+                        volumeNamespace:
+                          description: VolumeNamespace specifies the scope of the
+                            volume within StorageOS.  If no namespace is specified
+                            then the Pod's namespace will be used.  This allows the
+                            Kubernetes name scoping to be mirrored within StorageOS
+                            for tighter integration. Set VolumeName to any name to
+                            override the default behaviour. Set to "default" if you
+                            are not using namespaces within StorageOS. Namespaces
+                            that do not pre-exist within StorageOS will be created.
+                          type: string
+                      type: object
+                    vsphereVolume:
+                      description: VsphereVolume represents a vSphere volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        storagePolicyID:
+                          description: Storage Policy Based Management (SPBM) profile
+                            ID associated with the StoragePolicyName.
+                          type: string
+                        storagePolicyName:
+                          description: Storage Policy Based Management (SPBM) profile
+                            name.
+                          type: string
+                        volumePath:
+                          description: Path that identifies vSphere volume vmdk
+                          type: string
+                      required:
+                      - volumePath
+                      type: object
+                  required:
+                  - name
                   type: object
-              type: object
-            smartstore:
-              description: Splunk Smartstore configuration. Refer to indexes.conf.spec
-                on docs.splunk.com
-              properties:
-                indexes:
-                  description: List of Splunk indexes
-                  items:
-                    description: IndexSpec defines Splunk index name and storage path
-                    properties:
-                      name:
-                        description: Splunk index name
-                        type: string
-                      remotePath:
-                        description: Index location relative to the remote volume
-                          path
-                        type: string
-                      volumeName:
-                        description: Remote Volume name
-                        type: string
-                    type: object
-                  type: array
-                volumes:
-                  description: List of remote storage volumes
-                  items:
-                    description: VolumeSpec defines remote volume name and remote
-                      volume URI
-                    properties:
-                      endpoint:
-                        description: Remote volume URI
-                        type: string
-                      name:
-                        description: Remote volume name
-                        type: string
-                      path:
-                        description: Remote volume path
-                        type: string
-                    type: object
-                  type: array
-              type: object
-            storageClassName:
-              description: Name of StorageClass to use for persistent volume claims
-              type: string
-            tolerations:
-              description: Pod's tolerations for Kubernetes node's taint
-              items:
-                description: The pod this Toleration is attached to tolerates any
-                  taint that matches the triple <key,value,effect> using the matching
-                  operator <operator>.
+                type: array
+            type: object
+          status:
+            description: ClusterMasterStatus defines the observed state of ClusterMaster
+            properties:
+              phase:
+                description: current phase of the cluster master
+                enum:
+                - Pending
+                - Ready
+                - Updating
+                - ScalingUp
+                - ScalingDown
+                - Terminating
+                - Error
+                type: string
+              selector:
+                description: selector for pods, used by HorizontalPodAutoscaler
+                type: string
+              smartstore:
+                description: Splunk Smartstore configuration. Refer to indexes.conf.spec
+                  on docs.splunk.com
                 properties:
-                  effect:
-                    description: Effect indicates the taint effect to match. Empty
-                      means match all taint effects. When specified, allowed values
-                      are NoSchedule, PreferNoSchedule and NoExecute.
-                    type: string
-                  key:
-                    description: Key is the taint key that the toleration applies
-                      to. Empty means match all taint keys. If the key is empty, operator
-                      must be Exists; this combination means to match all values and
-                      all keys.
-                    type: string
-                  operator:
-                    description: Operator represents a key's relationship to the value.
-                      Valid operators are Exists and Equal. Defaults to Equal. Exists
-                      is equivalent to wildcard for value, so that a pod can tolerate
-                      all taints of a particular category.
-                    type: string
-                  tolerationSeconds:
-                    description: TolerationSeconds represents the period of time the
-                      toleration (which must be of effect NoExecute, otherwise this
-                      field is ignored) tolerates the taint. By default, it is not
-                      set, which means tolerate the taint forever (do not evict).
-                      Zero and negative values will be treated as 0 (evict immediately)
-                      by the system.
-                    format: int64
-                    type: integer
-                  value:
-                    description: Value is the taint value the toleration matches to.
-                      If the operator is Exists, the value should be empty, otherwise
-                      just a regular string.
-                    type: string
+                  indexes:
+                    description: List of Splunk indexes
+                    items:
+                      description: IndexSpec defines Splunk index name and storage
+                        path
+                      properties:
+                        name:
+                          description: Splunk index name
+                          type: string
+                        remotePath:
+                          description: Index location relative to the remote volume
+                            path
+                          type: string
+                        volumeName:
+                          description: Remote Volume name
+                          type: string
+                      type: object
+                    type: array
+                  volumes:
+                    description: List of remote storage volumes
+                    items:
+                      description: VolumeSpec defines remote volume name and remote
+                        volume URI
+                      properties:
+                        endpoint:
+                          description: Remote volume URI
+                          type: string
+                        name:
+                          description: Remote volume name
+                          type: string
+                        path:
+                          description: Remote volume path
+                          type: string
+                      type: object
+                    type: array
                 type: object
-              type: array
-            varStorage:
-              description: Storage capacity to request for /opt/splunk/var persistent
-                volume claims (default=”50Gi”)
-              type: string
-            volumes:
-              description: List of one or more Kubernetes volumes. These will be mounted
-                in all pod containers as as /mnt/<name>
-              items:
-                description: Volume represents a named volume in a pod that may be
-                  accessed by any container in the pod.
-                properties:
-                  awsElasticBlockStore:
-                    description: 'AWSElasticBlockStore represents an AWS Disk resource
-                      that is attached to a kubelet''s host machine and then exposed
-                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      partition:
-                        description: 'The partition in the volume that you want to
-                          mount. If omitted, the default is to mount by volume name.
-                          Examples: For volume /dev/sda1, you specify the partition
-                          as "1". Similarly, the volume partition for /dev/sda is
-                          "0" (or you can leave the property empty).'
-                        format: int32
-                        type: integer
-                      readOnly:
-                        description: 'Specify "true" to force and set the ReadOnly
-                          property in VolumeMounts to "true". If omitted, the default
-                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                        type: boolean
-                      volumeID:
-                        description: 'Unique ID of the persistent disk resource in
-                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  azureDisk:
-                    description: AzureDisk represents an Azure Data Disk mount on
-                      the host and bind mount to the pod.
-                    properties:
-                      cachingMode:
-                        description: 'Host Caching mode: None, Read Only, Read Write.'
-                        type: string
-                      diskName:
-                        description: The Name of the data disk in the blob storage
-                        type: string
-                      diskURI:
-                        description: The URI the data disk in the blob storage
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      kind:
-                        description: 'Expected values Shared: multiple blob disks
-                          per storage account  Dedicated: single blob disk per storage
-                          account  Managed: azure managed data disk (only in managed
-                          availability set). defaults to shared'
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                    required:
-                    - diskName
-                    - diskURI
-                    type: object
-                  azureFile:
-                    description: AzureFile represents an Azure File Service mount
-                      on the host and bind mount to the pod.
-                    properties:
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretName:
-                        description: the name of secret that contains Azure Storage
-                          Account Name and Key
-                        type: string
-                      shareName:
-                        description: Share Name
-                        type: string
-                    required:
-                    - secretName
-                    - shareName
-                    type: object
-                  cephfs:
-                    description: CephFS represents a Ceph FS mount on the host that
-                      shares a pod's lifetime
-                    properties:
-                      monitors:
-                        description: 'Required: Monitors is a collection of Ceph monitors
-                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        items:
-                          type: string
-                        type: array
-                      path:
-                        description: 'Optional: Used as the mounted root, rather than
-                          the full Ceph tree, default is /'
-                        type: string
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts. More
-                          info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: boolean
-                      secretFile:
-                        description: 'Optional: SecretFile is the path to key ring
-                          for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: string
-                      secretRef:
-                        description: 'Optional: SecretRef is reference to the authentication
-                          secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      user:
-                        description: 'Optional: User is the rados user name, default
-                          is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: string
-                    required:
-                    - monitors
-                    type: object
-                  cinder:
-                    description: 'Cinder represents a cinder volume attached and mounted
-                      on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Examples: "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: string
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts. More
-                          info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: boolean
-                      secretRef:
-                        description: 'Optional: points to a secret object containing
-                          parameters used to connect to OpenStack.'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      volumeID:
-                        description: 'volume id used to identify the volume in cinder.
-                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  configMap:
-                    description: ConfigMap represents a configMap that should populate
-                      this volume
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: If unspecified, each key-value pair in the Data
-                          field of the referenced ConfigMap will be projected into
-                          the volume as a file whose name is the key and content is
-                          the value. If specified, the listed keys will be projected
-                          into the specified paths, and unlisted keys will not be
-                          present. If a key is specified which is not present in the
-                          ConfigMap, the volume setup will error unless it is marked
-                          optional. Paths must be relative and may not contain the
-                          '..' path or start with '..'.
-                        items:
-                          description: Maps a string key to a path within a volume.
-                          properties:
-                            key:
-                              description: The key to project.
-                              type: string
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: The relative path of the file to map the
-                                key to. May not be an absolute path. May not contain
-                                the path element '..'. May not start with the string
-                                '..'.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          type: object
-                        type: array
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
-                        type: string
-                      optional:
-                        description: Specify whether the ConfigMap or its keys must
-                          be defined
-                        type: boolean
-                    type: object
-                  csi:
-                    description: CSI (Container Storage Interface) represents storage
-                      that is handled by an external CSI driver (Alpha feature).
-                    properties:
-                      driver:
-                        description: Driver is the name of the CSI driver that handles
-                          this volume. Consult with your admin for the correct name
-                          as registered in the cluster.
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Ex. "ext4", "xfs",
-                          "ntfs". If not provided, the empty value is passed to the
-                          associated CSI driver which will determine the default filesystem
-                          to apply.
-                        type: string
-                      nodePublishSecretRef:
-                        description: NodePublishSecretRef is a reference to the secret
-                          object containing sensitive information to pass to the CSI
-                          driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
-                          calls. This field is optional, and  may be empty if no secret
-                          is required. If the secret object contains more than one
-                          secret, all secret references are passed.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      readOnly:
-                        description: Specifies a read-only configuration for the volume.
-                          Defaults to false (read/write).
-                        type: boolean
-                      volumeAttributes:
-                        additionalProperties:
-                          type: string
-                        description: VolumeAttributes stores driver-specific properties
-                          that are passed to the CSI driver. Consult your driver's
-                          documentation for supported values.
-                        type: object
-                    required:
-                    - driver
-                    type: object
-                  downwardAPI:
-                    description: DownwardAPI represents downward API about the pod
-                      that should populate this volume
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: Items is a list of downward API volume file
-                        items:
-                          description: DownwardAPIVolumeFile represents information
-                            to create the file containing the pod field
-                          properties:
-                            fieldRef:
-                              description: 'Required: Selects a field of the pod:
-                                only annotations, labels, name and namespace are supported.'
-                              properties:
-                                apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
-                                  type: string
-                                fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
-                                  type: string
-                              required:
-                              - fieldPath
-                              type: object
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: 'Required: Path is  the relative path name
-                                of the file to be created. Must not be absolute or
-                                contain the ''..'' path. Must be utf-8 encoded. The
-                                first item of the relative path must not start with
-                                ''..'''
-                              type: string
-                            resourceFieldRef:
-                              description: 'Selects a resource of the container: only
-                                resources limits and requests (limits.cpu, limits.memory,
-                                requests.cpu and requests.memory) are currently supported.'
-                              properties:
-                                containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
-                                  type: string
-                                divisor:
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
-                                  type: string
-                                resource:
-                                  description: 'Required: resource to select'
-                                  type: string
-                              required:
-                              - resource
-                              type: object
-                          required:
-                          - path
-                          type: object
-                        type: array
-                    type: object
-                  emptyDir:
-                    description: 'EmptyDir represents a temporary directory that shares
-                      a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                    properties:
-                      medium:
-                        description: 'What type of storage medium should back this
-                          directory. The default is "" which means to use the node''s
-                          default medium. Must be an empty string (default) or Memory.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                        type: string
-                      sizeLimit:
-                        description: 'Total amount of local storage required for this
-                          EmptyDir volume. The size limit is also applicable for memory
-                          medium. The maximum usage on memory medium EmptyDir would
-                          be the minimum value between the SizeLimit specified here
-                          and the sum of memory limits of all containers in a pod.
-                          The default is nil which means that the limit is undefined.
-                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                        type: string
-                    type: object
-                  fc:
-                    description: FC represents a Fibre Channel resource that is attached
-                      to a kubelet's host machine and then exposed to the pod.
-                    properties:
-                      fsType:
-                        description: 'Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      lun:
-                        description: 'Optional: FC target lun number'
-                        format: int32
-                        type: integer
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts.'
-                        type: boolean
-                      targetWWNs:
-                        description: 'Optional: FC target worldwide names (WWNs)'
-                        items:
-                          type: string
-                        type: array
-                      wwids:
-                        description: 'Optional: FC volume world wide identifiers (wwids)
-                          Either wwids or combination of targetWWNs and lun must be
-                          set, but not both simultaneously.'
-                        items:
-                          type: string
-                        type: array
-                    type: object
-                  flexVolume:
-                    description: FlexVolume represents a generic volume resource that
-                      is provisioned/attached using an exec based plugin.
-                    properties:
-                      driver:
-                        description: Driver is the name of the driver to use for this
-                          volume.
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". The default filesystem depends on FlexVolume
-                          script.
-                        type: string
-                      options:
-                        additionalProperties:
-                          type: string
-                        description: 'Optional: Extra command options if any.'
-                        type: object
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts.'
-                        type: boolean
-                      secretRef:
-                        description: 'Optional: SecretRef is reference to the secret
-                          object containing sensitive information to pass to the plugin
-                          scripts. This may be empty if no secret object is specified.
-                          If the secret object contains more than one secret, all
-                          secrets are passed to the plugin scripts.'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                    required:
-                    - driver
-                    type: object
-                  flocker:
-                    description: Flocker represents a Flocker volume attached to a
-                      kubelet's host machine. This depends on the Flocker control
-                      service being running
-                    properties:
-                      datasetName:
-                        description: Name of the dataset stored as metadata -> name
-                          on the dataset for Flocker should be considered as deprecated
-                        type: string
-                      datasetUUID:
-                        description: UUID of the dataset. This is unique identifier
-                          of a Flocker dataset
-                        type: string
-                    type: object
-                  gcePersistentDisk:
-                    description: 'GCEPersistentDisk represents a GCE Disk resource
-                      that is attached to a kubelet''s host machine and then exposed
-                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      partition:
-                        description: 'The partition in the volume that you want to
-                          mount. If omitted, the default is to mount by volume name.
-                          Examples: For volume /dev/sda1, you specify the partition
-                          as "1". Similarly, the volume partition for /dev/sda is
-                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        format: int32
-                        type: integer
-                      pdName:
-                        description: 'Unique name of the PD resource in GCE. Used
-                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        type: boolean
-                    required:
-                    - pdName
-                    type: object
-                  gitRepo:
-                    description: 'GitRepo represents a git repository at a particular
-                      revision. DEPRECATED: GitRepo is deprecated. To provision a
-                      container with a git repo, mount an EmptyDir into an InitContainer
-                      that clones the repo using git, then mount the EmptyDir into
-                      the Pod''s container.'
-                    properties:
-                      directory:
-                        description: Target directory name. Must not contain or start
-                          with '..'.  If '.' is supplied, the volume directory will
-                          be the git repository.  Otherwise, if specified, the volume
-                          will contain the git repository in the subdirectory with
-                          the given name.
-                        type: string
-                      repository:
-                        description: Repository URL
-                        type: string
-                      revision:
-                        description: Commit hash for the specified revision.
-                        type: string
-                    required:
-                    - repository
-                    type: object
-                  glusterfs:
-                    description: 'Glusterfs represents a Glusterfs mount on the host
-                      that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
-                    properties:
-                      endpoints:
-                        description: 'EndpointsName is the endpoint name that details
-                          Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: string
-                      path:
-                        description: 'Path is the Glusterfs volume path. More info:
-                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the Glusterfs volume
-                          to be mounted with read-only permissions. Defaults to false.
-                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: boolean
-                    required:
-                    - endpoints
-                    - path
-                    type: object
-                  hostPath:
-                    description: 'HostPath represents a pre-existing file or directory
-                      on the host machine that is directly exposed to the container.
-                      This is generally used for system agents or other privileged
-                      things that are allowed to see the host machine. Most containers
-                      will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                      --- TODO(jonesdl) We need to restrict who can use host directory
-                      mounts and who can/can not mount host directories as read/write.'
-                    properties:
-                      path:
-                        description: 'Path of the directory on the host. If the path
-                          is a symlink, it will follow the link to the real path.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                        type: string
-                      type:
-                        description: 'Type for HostPath Volume Defaults to "" More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                        type: string
-                    required:
-                    - path
-                    type: object
-                  iscsi:
-                    description: 'ISCSI represents an ISCSI Disk resource that is
-                      attached to a kubelet''s host machine and then exposed to the
-                      pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
-                    properties:
-                      chapAuthDiscovery:
-                        description: whether support iSCSI Discovery CHAP authentication
-                        type: boolean
-                      chapAuthSession:
-                        description: whether support iSCSI Session CHAP authentication
-                        type: boolean
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      initiatorName:
-                        description: Custom iSCSI Initiator Name. If initiatorName
-                          is specified with iscsiInterface simultaneously, new iSCSI
-                          interface <target portal>:<volume name> will be created
-                          for the connection.
-                        type: string
-                      iqn:
-                        description: Target iSCSI Qualified Name.
-                        type: string
-                      iscsiInterface:
-                        description: iSCSI Interface Name that uses an iSCSI transport.
-                          Defaults to 'default' (tcp).
-                        type: string
-                      lun:
-                        description: iSCSI Target Lun number.
-                        format: int32
-                        type: integer
-                      portals:
-                        description: iSCSI Target Portal List. The portal is either
-                          an IP or ip_addr:port if the port is other than default
-                          (typically TCP ports 860 and 3260).
-                        items:
-                          type: string
-                        type: array
-                      readOnly:
-                        description: ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false.
-                        type: boolean
-                      secretRef:
-                        description: CHAP Secret for iSCSI target and initiator authentication
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      targetPortal:
-                        description: iSCSI Target Portal. The Portal is either an
-                          IP or ip_addr:port if the port is other than default (typically
-                          TCP ports 860 and 3260).
-                        type: string
-                    required:
-                    - iqn
-                    - lun
-                    - targetPortal
-                    type: object
-                  name:
-                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
-                      the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  nfs:
-                    description: 'NFS represents an NFS mount on the host that shares
-                      a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                    properties:
-                      path:
-                        description: 'Path that is exported by the NFS server. More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the NFS export to be
-                          mounted with read-only permissions. Defaults to false. More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: boolean
-                      server:
-                        description: 'Server is the hostname or IP address of the
-                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: string
-                    required:
-                    - path
-                    - server
-                    type: object
-                  persistentVolumeClaim:
-                    description: 'PersistentVolumeClaimVolumeSource represents a reference
-                      to a PersistentVolumeClaim in the same namespace. More info:
-                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                    properties:
-                      claimName:
-                        description: 'ClaimName is the name of a PersistentVolumeClaim
-                          in the same namespace as the pod using this volume. More
-                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                        type: string
-                      readOnly:
-                        description: Will force the ReadOnly setting in VolumeMounts.
-                          Default false.
-                        type: boolean
-                    required:
-                    - claimName
-                    type: object
-                  photonPersistentDisk:
-                    description: PhotonPersistentDisk represents a PhotonController
-                      persistent disk attached and mounted on kubelets host machine
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      pdID:
-                        description: ID that identifies Photon Controller persistent
-                          disk
-                        type: string
-                    required:
-                    - pdID
-                    type: object
-                  portworxVolume:
-                    description: PortworxVolume represents a portworx volume attached
-                      and mounted on kubelets host machine
-                    properties:
-                      fsType:
-                        description: FSType represents the filesystem type to mount
-                          Must be a filesystem type supported by the host operating
-                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                          if unspecified.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      volumeID:
-                        description: VolumeID uniquely identifies a Portworx volume
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  projected:
-                    description: Items for all in one resources secrets, configmaps,
-                      and downward API
-                    properties:
-                      defaultMode:
-                        description: Mode bits to use on created files by default.
-                          Must be a value between 0 and 0777. Directories within the
-                          path are not affected by this setting. This might be in
-                          conflict with other options that affect the file mode, like
-                          fsGroup, and the result can be other mode bits set.
-                        format: int32
-                        type: integer
-                      sources:
-                        description: list of volume projections
-                        items:
-                          description: Projection that may be projected along with
-                            other supported volume types
-                          properties:
-                            configMap:
-                              description: information about the configMap data to
-                                project
-                              properties:
-                                items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced ConfigMap
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the ConfigMap, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
-                                  items:
-                                    description: Maps a string key to a path within
-                                      a volume.
-                                    properties:
-                                      key:
-                                        description: The key to project.
-                                        type: string
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap or its
-                                    keys must be defined
-                                  type: boolean
-                              type: object
-                            downwardAPI:
-                              description: information about the downwardAPI data
-                                to project
-                              properties:
-                                items:
-                                  description: Items is a list of DownwardAPIVolume
-                                    file
-                                  items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
-                                    properties:
-                                      fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
-                                        properties:
-                                          apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
-                                            type: string
-                                          fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
-                                        type: string
-                                      resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, requests.cpu and requests.memory)
-                                          are currently supported.'
-                                        properties:
-                                          containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
-                                            type: string
-                                          divisor:
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
-                                            type: string
-                                          resource:
-                                            description: 'Required: resource to select'
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                    required:
-                                    - path
-                                    type: object
-                                  type: array
-                              type: object
-                            secret:
-                              description: information about the secret data to project
-                              properties:
-                                items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced Secret will
-                                    be projected into the volume as a file whose name
-                                    is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the Secret, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
-                                  items:
-                                    description: Maps a string key to a path within
-                                      a volume.
-                                    properties:
-                                      key:
-                                        description: The key to project.
-                                        type: string
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
-                                  type: boolean
-                              type: object
-                            serviceAccountToken:
-                              description: information about the serviceAccountToken
-                                data to project
-                              properties:
-                                audience:
-                                  description: Audience is the intended audience of
-                                    the token. A recipient of a token must identify
-                                    itself with an identifier specified in the audience
-                                    of the token, and otherwise should reject the
-                                    token. The audience defaults to the identifier
-                                    of the apiserver.
-                                  type: string
-                                expirationSeconds:
-                                  description: ExpirationSeconds is the requested
-                                    duration of validity of the service account token.
-                                    As the token approaches expiration, the kubelet
-                                    volume plugin will proactively rotate the service
-                                    account token. The kubelet will start trying to
-                                    rotate the token if the token is older than 80
-                                    percent of its time to live or if the token is
-                                    older than 24 hours.Defaults to 1 hour and must
-                                    be at least 10 minutes.
-                                  format: int64
-                                  type: integer
-                                path:
-                                  description: Path is the path relative to the mount
-                                    point of the file to project the token into.
-                                  type: string
-                              required:
-                              - path
-                              type: object
-                          type: object
-                        type: array
-                    required:
-                    - sources
-                    type: object
-                  quobyte:
-                    description: Quobyte represents a Quobyte mount on the host that
-                      shares a pod's lifetime
-                    properties:
-                      group:
-                        description: Group to map volume access to Default is no group
-                        type: string
-                      readOnly:
-                        description: ReadOnly here will force the Quobyte volume to
-                          be mounted with read-only permissions. Defaults to false.
-                        type: boolean
-                      registry:
-                        description: Registry represents a single or multiple Quobyte
-                          Registry services specified as a string as host:port pair
-                          (multiple entries are separated with commas) which acts
-                          as the central registry for volumes
-                        type: string
-                      tenant:
-                        description: Tenant owning the given Quobyte volume in the
-                          Backend Used with dynamically provisioned Quobyte volumes,
-                          value is set by the plugin
-                        type: string
-                      user:
-                        description: User to map volume access to Defaults to serivceaccount
-                          user
-                        type: string
-                      volume:
-                        description: Volume is a string that references an already
-                          created Quobyte volume by name.
-                        type: string
-                    required:
-                    - registry
-                    - volume
-                    type: object
-                  rbd:
-                    description: 'RBD represents a Rados Block Device mount on the
-                      host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      image:
-                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      keyring:
-                        description: 'Keyring is the path to key ring for RBDUser.
-                          Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      monitors:
-                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        items:
-                          type: string
-                        type: array
-                      pool:
-                        description: 'The rados pool name. Default is rbd. More info:
-                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: boolean
-                      secretRef:
-                        description: 'SecretRef is name of the authentication secret
-                          for RBDUser. If provided overrides keyring. Default is nil.
-                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      user:
-                        description: 'The rados user name. Default is admin. More
-                          info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                    required:
-                    - image
-                    - monitors
-                    type: object
-                  scaleIO:
-                    description: ScaleIO represents a ScaleIO persistent volume attached
-                      and mounted on Kubernetes nodes.
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Default is "xfs".
-                        type: string
-                      gateway:
-                        description: The host address of the ScaleIO API Gateway.
-                        type: string
-                      protectionDomain:
-                        description: The name of the ScaleIO Protection Domain for
-                          the configured storage.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretRef:
-                        description: SecretRef references to the secret for ScaleIO
-                          user and other sensitive information. If this is not provided,
-                          Login operation will fail.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      sslEnabled:
-                        description: Flag to enable/disable SSL communication with
-                          Gateway, default false
-                        type: boolean
-                      storageMode:
-                        description: Indicates whether the storage for a volume should
-                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
-                        type: string
-                      storagePool:
-                        description: The ScaleIO Storage Pool associated with the
-                          protection domain.
-                        type: string
-                      system:
-                        description: The name of the storage system as configured
-                          in ScaleIO.
-                        type: string
-                      volumeName:
-                        description: The name of a volume already created in the ScaleIO
-                          system that is associated with this volume source.
-                        type: string
-                    required:
-                    - gateway
-                    - secretRef
-                    - system
-                    type: object
-                  secret:
-                    description: 'Secret represents a secret that should populate
-                      this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: If unspecified, each key-value pair in the Data
-                          field of the referenced Secret will be projected into the
-                          volume as a file whose name is the key and content is the
-                          value. If specified, the listed keys will be projected into
-                          the specified paths, and unlisted keys will not be present.
-                          If a key is specified which is not present in the Secret,
-                          the volume setup will error unless it is marked optional.
-                          Paths must be relative and may not contain the '..' path
-                          or start with '..'.
-                        items:
-                          description: Maps a string key to a path within a volume.
-                          properties:
-                            key:
-                              description: The key to project.
-                              type: string
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: The relative path of the file to map the
-                                key to. May not be an absolute path. May not contain
-                                the path element '..'. May not start with the string
-                                '..'.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          type: object
-                        type: array
-                      optional:
-                        description: Specify whether the Secret or its keys must be
-                          defined
-                        type: boolean
-                      secretName:
-                        description: 'Name of the secret in the pod''s namespace to
-                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                        type: string
-                    type: object
-                  storageos:
-                    description: StorageOS represents a StorageOS volume attached
-                      and mounted on Kubernetes nodes.
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretRef:
-                        description: SecretRef specifies the secret to use for obtaining
-                          the StorageOS API credentials.  If not specified, default
-                          values will be attempted.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      volumeName:
-                        description: VolumeName is the human-readable name of the
-                          StorageOS volume.  Volume names are only unique within a
-                          namespace.
-                        type: string
-                      volumeNamespace:
-                        description: VolumeNamespace specifies the scope of the volume
-                          within StorageOS.  If no namespace is specified then the
-                          Pod's namespace will be used.  This allows the Kubernetes
-                          name scoping to be mirrored within StorageOS for tighter
-                          integration. Set VolumeName to any name to override the
-                          default behaviour. Set to "default" if you are not using
-                          namespaces within StorageOS. Namespaces that do not pre-exist
-                          within StorageOS will be created.
-                        type: string
-                    type: object
-                  vsphereVolume:
-                    description: VsphereVolume represents a vSphere volume attached
-                      and mounted on kubelets host machine
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      storagePolicyID:
-                        description: Storage Policy Based Management (SPBM) profile
-                          ID associated with the StoragePolicyName.
-                        type: string
-                      storagePolicyName:
-                        description: Storage Policy Based Management (SPBM) profile
-                          name.
-                        type: string
-                      volumePath:
-                        description: Path that identifies vSphere volume vmdk
-                        type: string
-                    required:
-                    - volumePath
-                    type: object
-                required:
-                - name
-                type: object
-              type: array
-          type: object
-        status:
-          description: ClusterMasterStatus defines the observed state of ClusterMaster
-          properties:
-            phase:
-              description: current phase of the cluster master
-              enum:
-              - Pending
-              - Ready
-              - Updating
-              - ScalingUp
-              - ScalingDown
-              - Terminating
-              - Error
-              type: string
-            selector:
-              description: selector for pods, used by HorizontalPodAutoscaler
-              type: string
-            smartstore:
-              description: Splunk Smartstore configuration. Refer to indexes.conf.spec
-                on docs.splunk.com
-              properties:
-                indexes:
-                  description: List of Splunk indexes
-                  items:
-                    description: IndexSpec defines Splunk index name and storage path
-                    properties:
-                      name:
-                        description: Splunk index name
-                        type: string
-                      remotePath:
-                        description: Index location relative to the remote volume
-                          path
-                        type: string
-                      volumeName:
-                        description: Remote Volume name
-                        type: string
-                    type: object
-                  type: array
-                volumes:
-                  description: List of remote storage volumes
-                  items:
-                    description: VolumeSpec defines remote volume name and remote
-                      volume URI
-                    properties:
-                      endpoint:
-                        description: Remote volume URI
-                        type: string
-                      name:
-                        description: Remote volume name
-                        type: string
-                      path:
-                        description: Remote volume path
-                        type: string
-                    type: object
-                  type: array
-              type: object
-          type: object
-      type: object
-  version: v1alpha3
-  versions:
-  - name: v1alpha3
+            type: object
+        type: object
     served: true
     storage: true
-  - name: v1alpha2
-    served: true
-    storage: false
+    subresources:
+      status: {}

--- a/deploy/crds/enterprise.splunk.com_indexerclusters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_indexerclusters_crd.yaml
@@ -1,29 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: indexerclusters.enterprise.splunk.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: Status of indexer cluster
-    name: Phase
-    type: string
-  - JSONPath: .status.clusterMasterPhase
-    description: Status of cluster master
-    name: Master
-    type: string
-  - JSONPath: .status.replicas
-    description: Desired number of indexer peers
-    name: Desired
-    type: integer
-  - JSONPath: .status.readyReplicas
-    description: Current number of ready indexer peers
-    name: Ready
-    type: integer
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of indexer cluster
-    name: Age
-    type: date
   group: enterprise.splunk.com
   names:
     kind: IndexerCluster
@@ -34,2296 +13,2380 @@ spec:
     - idxc
     singular: indexercluster
   scope: Namespaced
-  subresources:
-    scale:
-      labelSelectorPath: .status.selector
-      specReplicasPath: .spec.replicas
-      statusReplicasPath: .status.replicas
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: IndexerCluster is the Schema for a Splunk Enterprise indexer cluster
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: IndexerClusterSpec defines the desired state of a Splunk Enterprise
-            indexer cluster
-          properties:
-            affinity:
-              description: Kubernetes Affinity rules that control how pods are assigned
-                to particular nodes.
-              properties:
-                nodeAffinity:
-                  description: Describes node affinity scheduling rules for the pod.
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node matches the corresponding matchExpressions; the
-                        node(s) with the highest sum are the most preferred.
-                      items:
-                        description: An empty preferred scheduling term matches all
-                          objects with implicit weight 0 (i.e. it's a no-op). A null
-                          preferred scheduling term matches no objects (i.e. is also
-                          a no-op).
+  versions:
+  - additionalPrinterColumns:
+    - description: Status of indexer cluster
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Status of cluster master
+      jsonPath: .status.clusterMasterPhase
+      name: Master
+      type: string
+    - description: Desired number of indexer peers
+      jsonPath: .status.replicas
+      name: Desired
+      type: integer
+    - description: Current number of ready indexer peers
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Age of indexer cluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: IndexerCluster is the Schema for a Splunk Enterprise indexer
+          cluster
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IndexerClusterSpec defines the desired state of a Splunk
+              Enterprise indexer cluster
+            properties:
+              Mock:
+                description: Mock to differentiate between UTs and actual reconcile
+                type: boolean
+              affinity:
+                description: Kubernetes Affinity rules that control how pods are assigned
+                  to particular nodes.
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
                         properties:
-                          preference:
-                            description: A node selector term, associated with the
-                              corresponding weight.
-                            properties:
-                              matchExpressions:
-                                description: A list of node selector requirements
-                                  by node's labels.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchFields:
-                                description: A list of node selector requirements
-                                  by node's fields.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
                                         type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                            type: object
-                          weight:
-                            description: Weight associated with matching the corresponding
-                              nodeSelectorTerm, in the range 1-100.
-                            format: int32
-                            type: integer
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
                         required:
-                        - preference
-                        - weight
+                        - nodeSelectorTerms
                         type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to an update), the system may or may not try to
-                        eventually evict the pod from its node.
-                      properties:
-                        nodeSelectorTerms:
-                          description: Required. A list of node selector terms. The
-                            terms are ORed.
-                          items:
-                            description: A null or empty node selector term matches
-                              no objects. The requirements of them are ANDed. The
-                              TopologySelectorTerm type implements a subset of the
-                              NodeSelectorTerm.
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              clusterMasterRef:
+                description: ClusterMasterRef refers to a Splunk Enterprise indexer
+                  cluster managed by the operator within Kubernetes
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              defaults:
+                description: Inline map of default.yml overrides used to initialize
+                  the environment
+                type: string
+              defaultsUrl:
+                description: Full path or URL for one or more default.yml files, separated
+                  by commas
+                type: string
+              ephemeralStorage:
+                description: If true, ephemeral (emptyDir) storage will be used for
+                  /opt/splunk/etc and /opt/splunk/var volumes
+                type: boolean
+              etcStorage:
+                description: Storage capacity to request for /opt/splunk/etc persistent
+                  volume claims (default=”1Gi”)
+                type: string
+              image:
+                description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
+                  environment variables)
+                type: string
+              imagePullPolicy:
+                description: 'Sets pull policy for all images (either “Always” or
+                  the default: “IfNotPresent”)'
+                enum:
+                - Always
+                - IfNotPresent
+                type: string
+              licenseMasterRef:
+                description: LicenseMasterRef refers to a Splunk Enterprise license
+                  master managed by the operator within Kubernetes
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              licenseUrl:
+                description: Full path or URL for a Splunk Enterprise license file
+                type: string
+              replicas:
+                description: Number of search head pods; a search head cluster will
+                  be created if > 1
+                format: int32
+                type: integer
+              resources:
+                description: resource requirements for the pod containers
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+              schedulerName:
+                description: Name of Scheduler to use for pod placement (defaults
+                  to “default-scheduler”)
+                type: string
+              serviceTemplate:
+                description: ServiceTemplate is a template used to create Kubernetes
+                  services
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      clusterIP:
+                        description: 'clusterIP is the IP address of the service and
+                          is usually assigned randomly by the master. If an address
+                          is specified manually and is not in use by others, it will
+                          be allocated to the service; otherwise, creation of the
+                          service will fail. This field can not be changed through
+                          updates. Valid values are "None", empty string (""), or
+                          a valid IP address. "None" can be specified for headless
+                          services when proxying is not required. Only applies to
+                          types ClusterIP, NodePort, and LoadBalancer. Ignored if
+                          type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      externalIPs:
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for this service.  These
+                          IPs are not managed by Kubernetes.  The user is responsible
+                          for ensuring that traffic arrives at a node with this IP.  A
+                          common example is external load-balancers that are not part
+                          of the Kubernetes system.
+                        items:
+                          type: string
+                        type: array
+                      externalName:
+                        description: externalName is the external reference that kubedns
+                          or equivalent will return as a CNAME record for this service.
+                          No proxying will be involved. Must be a valid RFC-1123 hostname
+                          (https://tools.ietf.org/html/rfc1123) and requires Type
+                          to be ExternalName.
+                        type: string
+                      externalTrafficPolicy:
+                        description: externalTrafficPolicy denotes if this Service
+                          desires to route external traffic to node-local or cluster-wide
+                          endpoints. "Local" preserves the client source IP and avoids
+                          a second hop for LoadBalancer and Nodeport type services,
+                          but risks potentially imbalanced traffic spreading. "Cluster"
+                          obscures the client source IP and may cause a second hop
+                          to another node, but should have good overall load-spreading.
+                        type: string
+                      healthCheckNodePort:
+                        description: healthCheckNodePort specifies the healthcheck
+                          nodePort for the service. If not specified, HealthCheckNodePort
+                          is created by the service api backend with the allocated
+                          nodePort. Will use user-specified nodePort value if specified
+                          by the client. Only effects when Type is set to LoadBalancer
+                          and ExternalTrafficPolicy is set to Local.
+                        format: int32
+                        type: integer
+                      ipFamily:
+                        description: ipFamily specifies whether this Service has a
+                          preference for a particular IP family (e.g. IPv4 vs. IPv6).  If
+                          a specific IP family is requested, the clusterIP field will
+                          be allocated from that family, if it is available in the
+                          cluster.  If no IP family is requested, the cluster's primary
+                          IP family will be used. Other IP fields (loadBalancerIP,
+                          loadBalancerSourceRanges, externalIPs) and controllers which
+                          allocate external load-balancers should use the same IP
+                          family.  Endpoints for this Service will be of this family.  This
+                          field is immutable after creation. Assigning a ServiceIPFamily
+                          not available in the cluster (e.g. IPv6 in IPv4 only cluster)
+                          is an error condition and will fail during clusterIP assignment.
+                        type: string
+                      loadBalancerIP:
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in this field. This
+                          feature depends on whether the underlying cloud-provider
+                          supports specifying the loadBalancerIP when a load balancer
+                          is created. This field will be ignored if the cloud-provider
+                          does not support the feature.'
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: 'If specified and supported by the platform,
+                          this will restrict traffic through the cloud-provider load-balancer
+                          will be restricted to the specified client IPs. This field
+                          will be ignored if the cloud-provider does not support the
+                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        description: 'The list of ports that are exposed by this service.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            name:
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names. When considering the endpoints
+                                for a Service, this must match the 'name' field in
+                                the EndpointPort. Optional if only one ServicePort
+                                is defined on this service.
+                              type: string
+                            nodePort:
+                              description: 'The port on each node on which this service
+                                is exposed when type=NodePort or LoadBalancer. Usually
+                                assigned by the system. If specified, it will be allocated
+                                to the service if unused or else creation of the service
+                                will fail. Default is to auto-allocate a port if the
+                                ServiceType of this Service requires one. More info:
+                                https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'Number or name of the port to access on
+                                the pods targeted by the service. Number must be in
+                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                If this is a string, it will be looked up as a named
+                                port in the target Pod''s container ports. If this
+                                is not specified, the value of the ''port'' field
+                                is used (an identity map). This field is ignored for
+                                services with clusterIP=None, and should be omitted
+                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        description: publishNotReadyAddresses, when set to true, indicates
+                          that DNS implementations must publish the notReadyAddresses
+                          of subsets for the Endpoints associated with the Service.
+                          The default value is false. The primary use case for setting
+                          this field is to use a StatefulSet's Headless Service to
+                          propagate SRV records for its Pods without respect to their
+                          readiness for purpose of peer discovery.
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: 'Route service traffic to pods with label keys
+                          and values matching this selector. If empty or not present,
+                          the service is assumed to have an external process managing
+                          its endpoints, which Kubernetes will not modify. Only applies
+                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
+                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                        type: object
+                      sessionAffinity:
+                        description: 'Supports "ClientIP" and "None". Used to maintain
+                          session affinity. Enable client IP based session affinity.
+                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
                             properties:
-                              matchExpressions:
-                                description: A list of node selector requirements
-                                  by node's labels.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchFields:
-                                description: A list of node selector requirements
-                                  by node's fields.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
+                              timeoutSeconds:
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time. The value
+                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                  == "ClientIP". Default value is 10800(for 3 hours).
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      type:
+                        description: 'type determines how the Service is exposed.
+                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
+                          NodePort, and LoadBalancer. "ExternalName" maps to the specified
+                          externalName. "ClusterIP" allocates a cluster-internal IP
+                          address for load-balancing to endpoints. Endpoints are determined
+                          by the selector or if that is not specified, by manual construction
+                          of an Endpoints object. If clusterIP is "None", no virtual
+                          IP is allocated and the endpoints are published as a set
+                          of endpoints rather than a stable IP. "NodePort" builds
+                          on ClusterIP and allocates a port on every node which routes
+                          to the clusterIP. "LoadBalancer" builds on NodePort and
+                          creates an external load-balancer (if supported in the current
+                          cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                        type: string
+                    type: object
+                  status:
+                    description: 'Most recently observed status of the service. Populated
+                      by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      loadBalancer:
+                        description: LoadBalancer contains the current status of the
+                          load-balancer, if one is present.
+                        properties:
+                          ingress:
+                            description: Ingress is a list containing ingress points
+                              for the load-balancer. Traffic intended for the service
+                              should be sent to these ingress points.
+                            items:
+                              description: 'LoadBalancerIngress represents the status
+                                of a load-balancer ingress point: traffic intended
+                                for the service should be sent to an ingress point.'
+                              properties:
+                                hostname:
+                                  description: Hostname is set for load-balancer ingress
+                                    points that are DNS based (typically AWS load-balancers)
+                                  type: string
+                                ip:
+                                  description: IP is set for load-balancer ingress
+                                    points that are IP based (typically GCE or OpenStack
+                                    load-balancers)
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                type: object
+              storageClassName:
+                description: Name of StorageClass to use for persistent volume claims
+                type: string
+              tolerations:
+                description: Pod's tolerations for Kubernetes node's taint
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              varStorage:
+                description: Storage capacity to request for /opt/splunk/var persistent
+                  volume claims (default=”50Gi”)
+                type: string
+              volumes:
+                description: List of one or more Kubernetes volumes. These will be
+                  mounted in all pod containers as as /mnt/<name>
+                items:
+                  description: Volume represents a named volume in a pod that may
+                    be accessed by any container in the pod.
+                  properties:
+                    awsElasticBlockStore:
+                      description: 'AWSElasticBlockStore represents an AWS Disk resource
+                        that is attached to a kubelet''s host machine and then exposed
+                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      properties:
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        partition:
+                          description: 'The partition in the volume that you want
+                            to mount. If omitted, the default is to mount by volume
+                            name. Examples: For volume /dev/sda1, you specify the
+                            partition as "1". Similarly, the volume partition for
+                            /dev/sda is "0" (or you can leave the property empty).'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: 'Specify "true" to force and set the ReadOnly
+                            property in VolumeMounts to "true". If omitted, the default
+                            is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          type: boolean
+                        volumeID:
+                          description: 'Unique ID of the persistent disk resource
+                            in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    azureDisk:
+                      description: AzureDisk represents an Azure Data Disk mount on
+                        the host and bind mount to the pod.
+                      properties:
+                        cachingMode:
+                          description: 'Host Caching mode: None, Read Only, Read Write.'
+                          type: string
+                        diskName:
+                          description: The Name of the data disk in the blob storage
+                          type: string
+                        diskURI:
+                          description: The URI the data disk in the blob storage
+                          type: string
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        kind:
+                          description: 'Expected values Shared: multiple blob disks
+                            per storage account  Dedicated: single blob disk per storage
+                            account  Managed: azure managed data disk (only in managed
+                            availability set). defaults to shared'
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                      required:
+                      - diskName
+                      - diskURI
+                      type: object
+                    azureFile:
+                      description: AzureFile represents an Azure File Service mount
+                        on the host and bind mount to the pod.
+                      properties:
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretName:
+                          description: the name of secret that contains Azure Storage
+                            Account Name and Key
+                          type: string
+                        shareName:
+                          description: Share Name
+                          type: string
+                      required:
+                      - secretName
+                      - shareName
+                      type: object
+                    cephfs:
+                      description: CephFS represents a Ceph FS mount on the host that
+                        shares a pod's lifetime
+                      properties:
+                        monitors:
+                          description: 'Required: Monitors is a collection of Ceph
+                            monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          items:
+                            type: string
+                          type: array
+                        path:
+                          description: 'Optional: Used as the mounted root, rather
+                            than the full Ceph tree, default is /'
+                          type: string
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: boolean
+                        secretFile:
+                          description: 'Optional: SecretFile is the path to key ring
+                            for User, default is /etc/ceph/user.secret More info:
+                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: string
+                        secretRef:
+                          description: 'Optional: SecretRef is reference to the authentication
+                            secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        user:
+                          description: 'Optional: User is the rados user name, default
+                            is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: string
+                      required:
+                      - monitors
+                      type: object
+                    cinder:
+                      description: 'Cinder represents a cinder volume attached and
+                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      properties:
+                        fsType:
+                          description: 'Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: string
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: boolean
+                        secretRef:
+                          description: 'Optional: points to a secret object containing
+                            parameters used to connect to OpenStack.'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        volumeID:
+                          description: 'volume id used to identify the volume in cinder.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    configMap:
+                      description: ConfigMap represents a configMap that should populate
+                        this volume
+                      properties:
+                        defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default. Must be a value between 0 and 0777. Defaults
+                            to 0644. Directories within the path are not affected
+                            by this setting. This might be in conflict with other
+                            options that affect the file mode, like fsGroup, and the
+                            result can be other mode bits set.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: If unspecified, each key-value pair in the
+                            Data field of the referenced ConfigMap will be projected
+                            into the volume as a file whose name is the key and content
+                            is the value. If specified, the listed keys will be projected
+                            into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in
+                            the ConfigMap, the volume setup will error unless it is
+                            marked optional. Paths must be relative and may not contain
+                            the '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
+                            properties:
+                              key:
+                                description: The key to project.
+                                type: string
+                              mode:
+                                description: 'Optional: mode bits to use on this file,
+                                  must be a value between 0 and 0777. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: The relative path of the file to map
+                                  the key to. May not be an absolute path. May not
+                                  contain the path element '..'. May not start with
+                                  the string '..'.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap or its keys must
+                            be defined
+                          type: boolean
+                      type: object
+                    csi:
+                      description: CSI (Container Storage Interface) represents storage
+                        that is handled by an external CSI driver (Alpha feature).
+                      properties:
+                        driver:
+                          description: Driver is the name of the CSI driver that handles
+                            this volume. Consult with your admin for the correct name
+                            as registered in the cluster.
+                          type: string
+                        fsType:
+                          description: Filesystem type to mount. Ex. "ext4", "xfs",
+                            "ntfs". If not provided, the empty value is passed to
+                            the associated CSI driver which will determine the default
+                            filesystem to apply.
+                          type: string
+                        nodePublishSecretRef:
+                          description: NodePublishSecretRef is a reference to the
+                            secret object containing sensitive information to pass
+                            to the CSI driver to complete the CSI NodePublishVolume
+                            and NodeUnpublishVolume calls. This field is optional,
+                            and  may be empty if no secret is required. If the secret
+                            object contains more than one secret, all secret references
+                            are passed.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        readOnly:
+                          description: Specifies a read-only configuration for the
+                            volume. Defaults to false (read/write).
+                          type: boolean
+                        volumeAttributes:
+                          additionalProperties:
+                            type: string
+                          description: VolumeAttributes stores driver-specific properties
+                            that are passed to the CSI driver. Consult your driver's
+                            documentation for supported values.
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    downwardAPI:
+                      description: DownwardAPI represents downward API about the pod
+                        that should populate this volume
+                      properties:
+                        defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default. Must be a value between 0 and 0777. Defaults
+                            to 0644. Directories within the path are not affected
+                            by this setting. This might be in conflict with other
+                            options that affect the file mode, like fsGroup, and the
+                            result can be other mode bits set.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: Items is a list of downward API volume file
+                          items:
+                            description: DownwardAPIVolumeFile represents information
+                              to create the file containing the pod field
+                            properties:
+                              fieldRef:
+                                description: 'Required: Selects a field of the pod:
+                                  only annotations, labels, name and namespace are
+                                  supported.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                              mode:
+                                description: 'Optional: mode bits to use on this file,
+                                  must be a value between 0 and 0777. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: 'Required: Path is  the relative path
+                                  name of the file to be created. Must not be absolute
+                                  or contain the ''..'' path. Must be utf-8 encoded.
+                                  The first item of the relative path must not start
+                                  with ''..'''
+                                type: string
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, requests.cpu and requests.memory)
+                                  are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                            required:
+                            - path
+                            type: object
+                          type: array
+                      type: object
+                    emptyDir:
+                      description: 'EmptyDir represents a temporary directory that
+                        shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      properties:
+                        medium:
+                          description: 'What type of storage medium should back this
+                            directory. The default is "" which means to use the node''s
+                            default medium. Must be an empty string (default) or Memory.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          type: string
+                        sizeLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'Total amount of local storage required for
+                            this EmptyDir volume. The size limit is also applicable
+                            for memory medium. The maximum usage on memory medium
+                            EmptyDir would be the minimum value between the SizeLimit
+                            specified here and the sum of memory limits of all containers
+                            in a pod. The default is nil which means that the limit
+                            is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    fc:
+                      description: FC represents a Fibre Channel resource that is
+                        attached to a kubelet's host machine and then exposed to the
+                        pod.
+                      properties:
+                        fsType:
+                          description: 'Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        lun:
+                          description: 'Optional: FC target lun number'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                          type: boolean
+                        targetWWNs:
+                          description: 'Optional: FC target worldwide names (WWNs)'
+                          items:
+                            type: string
+                          type: array
+                        wwids:
+                          description: 'Optional: FC volume world wide identifiers
+                            (wwids) Either wwids or combination of targetWWNs and
+                            lun must be set, but not both simultaneously.'
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    flexVolume:
+                      description: FlexVolume represents a generic volume resource
+                        that is provisioned/attached using an exec based plugin.
+                      properties:
+                        driver:
+                          description: Driver is the name of the driver to use for
+                            this volume.
+                          type: string
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". The default filesystem depends on FlexVolume
+                            script.
+                          type: string
+                        options:
+                          additionalProperties:
+                            type: string
+                          description: 'Optional: Extra command options if any.'
+                          type: object
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                          type: boolean
+                        secretRef:
+                          description: 'Optional: SecretRef is reference to the secret
+                            object containing sensitive information to pass to the
+                            plugin scripts. This may be empty if no secret object
+                            is specified. If the secret object contains more than
+                            one secret, all secrets are passed to the plugin scripts.'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    flocker:
+                      description: Flocker represents a Flocker volume attached to
+                        a kubelet's host machine. This depends on the Flocker control
+                        service being running
+                      properties:
+                        datasetName:
+                          description: Name of the dataset stored as metadata -> name
+                            on the dataset for Flocker should be considered as deprecated
+                          type: string
+                        datasetUUID:
+                          description: UUID of the dataset. This is unique identifier
+                            of a Flocker dataset
+                          type: string
+                      type: object
+                    gcePersistentDisk:
+                      description: 'GCEPersistentDisk represents a GCE Disk resource
+                        that is attached to a kubelet''s host machine and then exposed
+                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      properties:
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        partition:
+                          description: 'The partition in the volume that you want
+                            to mount. If omitted, the default is to mount by volume
+                            name. Examples: For volume /dev/sda1, you specify the
+                            partition as "1". Similarly, the volume partition for
+                            /dev/sda is "0" (or you can leave the property empty).
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          format: int32
+                          type: integer
+                        pdName:
+                          description: 'Unique name of the PD resource in GCE. Used
+                            to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          type: boolean
+                      required:
+                      - pdName
+                      type: object
+                    gitRepo:
+                      description: 'GitRepo represents a git repository at a particular
+                        revision. DEPRECATED: GitRepo is deprecated. To provision
+                        a container with a git repo, mount an EmptyDir into an InitContainer
+                        that clones the repo using git, then mount the EmptyDir into
+                        the Pod''s container.'
+                      properties:
+                        directory:
+                          description: Target directory name. Must not contain or
+                            start with '..'.  If '.' is supplied, the volume directory
+                            will be the git repository.  Otherwise, if specified,
+                            the volume will contain the git repository in the subdirectory
+                            with the given name.
+                          type: string
+                        repository:
+                          description: Repository URL
+                          type: string
+                        revision:
+                          description: Commit hash for the specified revision.
+                          type: string
+                      required:
+                      - repository
+                      type: object
+                    glusterfs:
+                      description: 'Glusterfs represents a Glusterfs mount on the
+                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                      properties:
+                        endpoints:
+                          description: 'EndpointsName is the endpoint name that details
+                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: string
+                        path:
+                          description: 'Path is the Glusterfs volume path. More info:
+                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the Glusterfs volume
+                            to be mounted with read-only permissions. Defaults to
+                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: boolean
+                      required:
+                      - endpoints
+                      - path
+                      type: object
+                    hostPath:
+                      description: 'HostPath represents a pre-existing file or directory
+                        on the host machine that is directly exposed to the container.
+                        This is generally used for system agents or other privileged
+                        things that are allowed to see the host machine. Most containers
+                        will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                        --- TODO(jonesdl) We need to restrict who can use host directory
+                        mounts and who can/can not mount host directories as read/write.'
+                      properties:
+                        path:
+                          description: 'Path of the directory on the host. If the
+                            path is a symlink, it will follow the link to the real
+                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          type: string
+                        type:
+                          description: 'Type for HostPath Volume Defaults to "" More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    iscsi:
+                      description: 'ISCSI represents an ISCSI Disk resource that is
+                        attached to a kubelet''s host machine and then exposed to
+                        the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                      properties:
+                        chapAuthDiscovery:
+                          description: whether support iSCSI Discovery CHAP authentication
+                          type: boolean
+                        chapAuthSession:
+                          description: whether support iSCSI Session CHAP authentication
+                          type: boolean
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        initiatorName:
+                          description: Custom iSCSI Initiator Name. If initiatorName
+                            is specified with iscsiInterface simultaneously, new iSCSI
+                            interface <target portal>:<volume name> will be created
+                            for the connection.
+                          type: string
+                        iqn:
+                          description: Target iSCSI Qualified Name.
+                          type: string
+                        iscsiInterface:
+                          description: iSCSI Interface Name that uses an iSCSI transport.
+                            Defaults to 'default' (tcp).
+                          type: string
+                        lun:
+                          description: iSCSI Target Lun number.
+                          format: int32
+                          type: integer
+                        portals:
+                          description: iSCSI Target Portal List. The portal is either
+                            an IP or ip_addr:port if the port is other than default
+                            (typically TCP ports 860 and 3260).
+                          items:
+                            type: string
+                          type: array
+                        readOnly:
+                          description: ReadOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false.
+                          type: boolean
+                        secretRef:
+                          description: CHAP Secret for iSCSI target and initiator
+                            authentication
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        targetPortal:
+                          description: iSCSI Target Portal. The Portal is either an
+                            IP or ip_addr:port if the port is other than default (typically
+                            TCP ports 860 and 3260).
+                          type: string
+                      required:
+                      - iqn
+                      - lun
+                      - targetPortal
+                      type: object
+                    name:
+                      description: 'Volume''s name. Must be a DNS_LABEL and unique
+                        within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    nfs:
+                      description: 'NFS represents an NFS mount on the host that shares
+                        a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      properties:
+                        path:
+                          description: 'Path that is exported by the NFS server. More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the NFS export to
+                            be mounted with read-only permissions. Defaults to false.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: boolean
+                        server:
+                          description: 'Server is the hostname or IP address of the
+                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: string
+                      required:
+                      - path
+                      - server
+                      type: object
+                    persistentVolumeClaim:
+                      description: 'PersistentVolumeClaimVolumeSource represents a
+                        reference to a PersistentVolumeClaim in the same namespace.
+                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                      properties:
+                        claimName:
+                          description: 'ClaimName is the name of a PersistentVolumeClaim
+                            in the same namespace as the pod using this volume. More
+                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          type: string
+                        readOnly:
+                          description: Will force the ReadOnly setting in VolumeMounts.
+                            Default false.
+                          type: boolean
+                      required:
+                      - claimName
+                      type: object
+                    photonPersistentDisk:
+                      description: PhotonPersistentDisk represents a PhotonController
+                        persistent disk attached and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        pdID:
+                          description: ID that identifies Photon Controller persistent
+                            disk
+                          type: string
+                      required:
+                      - pdID
+                      type: object
+                    portworxVolume:
+                      description: PortworxVolume represents a portworx volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: FSType represents the filesystem type to mount
+                            Must be a filesystem type supported by the host operating
+                            system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        volumeID:
+                          description: VolumeID uniquely identifies a Portworx volume
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    projected:
+                      description: Items for all in one resources secrets, configmaps,
+                        and downward API
+                      properties:
+                        defaultMode:
+                          description: Mode bits to use on created files by default.
+                            Must be a value between 0 and 0777. Directories within
+                            the path are not affected by this setting. This might
+                            be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits
+                            set.
+                          format: int32
+                          type: integer
+                        sources:
+                          description: list of volume projections
+                          items:
+                            description: Projection that may be projected along with
+                              other supported volume types
+                            properties:
+                              configMap:
+                                description: information about the configMap data
+                                  to project
+                                properties:
+                                  items:
+                                    description: If unspecified, each key-value pair
+                                      in the Data field of the referenced ConfigMap
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the ConfigMap, the volume
+                                      setup will error unless it is marked optional.
+                                      Paths must be relative and may not contain the
+                                      '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: The key to project.
+                                          type: string
+                                        mode:
+                                          description: 'Optional: mode bits to use
+                                            on this file, must be a value between
+                                            0 and 0777. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: The relative path of the file
+                                            to map the key to. May not be an absolute
+                                            path. May not contain the path element
+                                            '..'. May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its keys must be defined
+                                    type: boolean
+                                type: object
+                              downwardAPI:
+                                description: information about the downwardAPI data
+                                  to project
+                                properties:
+                                  items:
+                                    description: Items is a list of DownwardAPIVolume
+                                      file
+                                    items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
+                                      properties:
+                                        fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name and namespace are supported.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                        mode:
+                                          description: 'Optional: mode bits to use
+                                            on this file, must be a value between
+                                            0 and 0777. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path. Must be utf-8 encoded. The first
+                                            item of the relative path must not start
+                                            with ''..'''
+                                          type: string
+                                        resourceFieldRef:
+                                          description: 'Selects a resource of the
+                                            container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu
+                                            and requests.memory) are currently supported.'
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                type: object
+                              secret:
+                                description: information about the secret data to
+                                  project
+                                properties:
+                                  items:
+                                    description: If unspecified, each key-value pair
+                                      in the Data field of the referenced Secret will
+                                      be projected into the volume as a file whose
+                                      name is the key and content is the value. If
+                                      specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the Secret, the volume setup
+                                      will error unless it is marked optional. Paths
+                                      must be relative and may not contain the '..'
+                                      path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: The key to project.
+                                          type: string
+                                        mode:
+                                          description: 'Optional: mode bits to use
+                                            on this file, must be a value between
+                                            0 and 0777. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: The relative path of the file
+                                            to map the key to. May not be an absolute
+                                            path. May not contain the path element
+                                            '..'. May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                type: object
+                              serviceAccountToken:
+                                description: information about the serviceAccountToken
+                                  data to project
+                                properties:
+                                  audience:
+                                    description: Audience is the intended audience
+                                      of the token. A recipient of a token must identify
+                                      itself with an identifier specified in the audience
+                                      of the token, and otherwise should reject the
+                                      token. The audience defaults to the identifier
+                                      of the apiserver.
+                                    type: string
+                                  expirationSeconds:
+                                    description: ExpirationSeconds is the requested
+                                      duration of validity of the service account
+                                      token. As the token approaches expiration, the
+                                      kubelet volume plugin will proactively rotate
+                                      the service account token. The kubelet will
+                                      start trying to rotate the token if the token
+                                      is older than 80 percent of its time to live
+                                      or if the token is older than 24 hours.Defaults
+                                      to 1 hour and must be at least 10 minutes.
+                                    format: int64
+                                    type: integer
+                                  path:
+                                    description: Path is the path relative to the
+                                      mount point of the file to project the token
+                                      into.
+                                    type: string
+                                required:
+                                - path
+                                type: object
                             type: object
                           type: array
                       required:
-                      - nodeSelectorTerms
+                      - sources
                       type: object
-                  type: object
-                podAffinity:
-                  description: Describes pod affinity scheduling rules (e.g. co-locate
-                    this pod in the same node, zone, etc. as some other pod(s)).
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node has pods which matches the corresponding podAffinityTerm;
-                        the node(s) with the highest sum are the most preferred.
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            format: int32
-                            type: integer
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to a pod label update), the system may or may not
-                        try to eventually evict the pod from its node. When there
-                        are multiple elements, the lists of nodes corresponding to
-                        each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            items:
-                              type: string
-                            type: array
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-                        required:
-                        - topologyKey
-                        type: object
-                      type: array
-                  type: object
-                podAntiAffinity:
-                  description: Describes pod anti-affinity scheduling rules (e.g.
-                    avoid putting this pod in the same node, zone, etc. as some other
-                    pod(s)).
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the anti-affinity expressions specified by this
-                        field, but it may choose a node that violates one or more
-                        of the expressions. The node that is most preferred is the
-                        one with the greatest sum of weights, i.e. for each node that
-                        meets all of the scheduling requirements (resource request,
-                        requiredDuringScheduling anti-affinity expressions, etc.),
-                        compute a sum by iterating through the elements of this field
-                        and adding "weight" to the sum if the node has pods which
-                        matches the corresponding podAffinityTerm; the node(s) with
-                        the highest sum are the most preferred.
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            format: int32
-                            type: integer
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the anti-affinity requirements specified by
-                        this field are not met at scheduling time, the pod will not
-                        be scheduled onto the node. If the anti-affinity requirements
-                        specified by this field cease to be met at some point during
-                        pod execution (e.g. due to a pod label update), the system
-                        may or may not try to eventually evict the pod from its node.
-                        When there are multiple elements, the lists of nodes corresponding
-                        to each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            items:
-                              type: string
-                            type: array
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-                        required:
-                        - topologyKey
-                        type: object
-                      type: array
-                  type: object
-              type: object
-            clusterMasterRef:
-              description: ClusterMasterRef refers to a Splunk Enterprise indexer
-                cluster managed by the operator within Kubernetes
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            defaults:
-              description: Inline map of default.yml overrides used to initialize
-                the environment
-              type: string
-            defaultsUrl:
-              description: Full path or URL for one or more default.yml files, separated
-                by commas
-              type: string
-            ephemeralStorage:
-              description: If true, ephemeral (emptyDir) storage will be used for
-                /opt/splunk/etc and /opt/splunk/var volumes
-              type: boolean
-            etcStorage:
-              description: Storage capacity to request for /opt/splunk/etc persistent
-                volume claims (default=”1Gi”)
-              type: string
-            image:
-              description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
-                environment variables)
-              type: string
-            imagePullPolicy:
-              description: 'Sets pull policy for all images (either “Always” or the
-                default: “IfNotPresent”)'
-              enum:
-              - Always
-              - IfNotPresent
-              type: string
-            licenseMasterRef:
-              description: LicenseMasterRef refers to a Splunk Enterprise license
-                master managed by the operator within Kubernetes
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            licenseUrl:
-              description: Full path or URL for a Splunk Enterprise license file
-              type: string
-            replicas:
-              description: Number of search head pods; a search head cluster will
-                be created if > 1
-              format: int32
-              type: integer
-            resources:
-              description: resource requirements for the pod containers
-              properties:
-                limits:
-                  additionalProperties:
-                    type: string
-                  description: 'Limits describes the maximum amount of compute resources
-                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                requests:
-                  additionalProperties:
-                    type: string
-                  description: 'Requests describes the minimum amount of compute resources
-                    required. If Requests is omitted for a container, it defaults
-                    to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-              type: object
-            schedulerName:
-              description: Name of Scheduler to use for pod placement (defaults to
-                “default-scheduler”)
-              type: string
-            serviceTemplate:
-              description: ServiceTemplate is a template used to create Kubernetes
-                services
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                    of an object. Servers should convert recognized schemas to the
-                    latest internal value, and may reject unrecognized values. More
-                    info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource
-                    this object represents. Servers may infer this from the endpoint
-                    the client submits requests to. Cannot be updated. In CamelCase.
-                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                  type: object
-                spec:
-                  description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                  properties:
-                    clusterIP:
-                      description: 'clusterIP is the IP address of the service and
-                        is usually assigned randomly by the master. If an address
-                        is specified manually and is not in use by others, it will
-                        be allocated to the service; otherwise, creation of the service
-                        will fail. This field can not be changed through updates.
-                        Valid values are "None", empty string (""), or a valid IP
-                        address. "None" can be specified for headless services when
-                        proxying is not required. Only applies to types ClusterIP,
-                        NodePort, and LoadBalancer. Ignored if type is ExternalName.
-                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                      type: string
-                    externalIPs:
-                      description: externalIPs is a list of IP addresses for which
-                        nodes in the cluster will also accept traffic for this service.  These
-                        IPs are not managed by Kubernetes.  The user is responsible
-                        for ensuring that traffic arrives at a node with this IP.  A
-                        common example is external load-balancers that are not part
-                        of the Kubernetes system.
-                      items:
-                        type: string
-                      type: array
-                    externalName:
-                      description: externalName is the external reference that kubedns
-                        or equivalent will return as a CNAME record for this service.
-                        No proxying will be involved. Must be a valid RFC-1123 hostname
-                        (https://tools.ietf.org/html/rfc1123) and requires Type to
-                        be ExternalName.
-                      type: string
-                    externalTrafficPolicy:
-                      description: externalTrafficPolicy denotes if this Service desires
-                        to route external traffic to node-local or cluster-wide endpoints.
-                        "Local" preserves the client source IP and avoids a second
-                        hop for LoadBalancer and Nodeport type services, but risks
-                        potentially imbalanced traffic spreading. "Cluster" obscures
-                        the client source IP and may cause a second hop to another
-                        node, but should have good overall load-spreading.
-                      type: string
-                    healthCheckNodePort:
-                      description: healthCheckNodePort specifies the healthcheck nodePort
-                        for the service. If not specified, HealthCheckNodePort is
-                        created by the service api backend with the allocated nodePort.
-                        Will use user-specified nodePort value if specified by the
-                        client. Only effects when Type is set to LoadBalancer and
-                        ExternalTrafficPolicy is set to Local.
-                      format: int32
-                      type: integer
-                    ipFamily:
-                      description: ipFamily specifies whether this Service has a preference
-                        for a particular IP family (e.g. IPv4 vs. IPv6).  If a specific
-                        IP family is requested, the clusterIP field will be allocated
-                        from that family, if it is available in the cluster.  If no
-                        IP family is requested, the cluster's primary IP family will
-                        be used. Other IP fields (loadBalancerIP, loadBalancerSourceRanges,
-                        externalIPs) and controllers which allocate external load-balancers
-                        should use the same IP family.  Endpoints for this Service
-                        will be of this family.  This field is immutable after creation.
-                        Assigning a ServiceIPFamily not available in the cluster (e.g.
-                        IPv6 in IPv4 only cluster) is an error condition and will
-                        fail during clusterIP assignment.
-                      type: string
-                    loadBalancerIP:
-                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                        will get created with the IP specified in this field. This
-                        feature depends on whether the underlying cloud-provider supports
-                        specifying the loadBalancerIP when a load balancer is created.
-                        This field will be ignored if the cloud-provider does not
-                        support the feature.'
-                      type: string
-                    loadBalancerSourceRanges:
-                      description: 'If specified and supported by the platform, this
-                        will restrict traffic through the cloud-provider load-balancer
-                        will be restricted to the specified client IPs. This field
-                        will be ignored if the cloud-provider does not support the
-                        feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
-                      items:
-                        type: string
-                      type: array
-                    ports:
-                      description: 'The list of ports that are exposed by this service.
-                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                      items:
-                        description: ServicePort contains information on service's
-                          port.
-                        properties:
-                          name:
-                            description: The name of this port within the service.
-                              This must be a DNS_LABEL. All ports within a ServiceSpec
-                              must have unique names. When considering the endpoints
-                              for a Service, this must match the 'name' field in the
-                              EndpointPort. Optional if only one ServicePort is defined
-                              on this service.
-                            type: string
-                          nodePort:
-                            description: 'The port on each node on which this service
-                              is exposed when type=NodePort or LoadBalancer. Usually
-                              assigned by the system. If specified, it will be allocated
-                              to the service if unused or else creation of the service
-                              will fail. Default is to auto-allocate a port if the
-                              ServiceType of this Service requires one. More info:
-                              https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
-                            format: int32
-                            type: integer
-                          port:
-                            description: The port that will be exposed by this service.
-                            format: int32
-                            type: integer
-                          protocol:
-                            description: The IP protocol for this port. Supports "TCP",
-                              "UDP", and "SCTP". Default is TCP.
-                            type: string
-                          targetPort:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: 'Number or name of the port to access on
-                              the pods targeted by the service. Number must be in
-                              the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                              If this is a string, it will be looked up as a named
-                              port in the target Pod''s container ports. If this is
-                              not specified, the value of the ''port'' field is used
-                              (an identity map). This field is ignored for services
-                              with clusterIP=None, and should be omitted or set equal
-                              to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
-                            x-kubernetes-int-or-string: true
-                        required:
-                        - port
-                        type: object
-                      type: array
-                    publishNotReadyAddresses:
-                      description: publishNotReadyAddresses, when set to true, indicates
-                        that DNS implementations must publish the notReadyAddresses
-                        of subsets for the Endpoints associated with the Service.
-                        The default value is false. The primary use case for setting
-                        this field is to use a StatefulSet's Headless Service to propagate
-                        SRV records for its Pods without respect to their readiness
-                        for purpose of peer discovery.
-                      type: boolean
-                    selector:
-                      additionalProperties:
-                        type: string
-                      description: 'Route service traffic to pods with label keys
-                        and values matching this selector. If empty or not present,
-                        the service is assumed to have an external process managing
-                        its endpoints, which Kubernetes will not modify. Only applies
-                        to types ClusterIP, NodePort, and LoadBalancer. Ignored if
-                        type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
-                      type: object
-                    sessionAffinity:
-                      description: 'Supports "ClientIP" and "None". Used to maintain
-                        session affinity. Enable client IP based session affinity.
-                        Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                      type: string
-                    sessionAffinityConfig:
-                      description: sessionAffinityConfig contains the configurations
-                        of session affinity.
+                    quobyte:
+                      description: Quobyte represents a Quobyte mount on the host
+                        that shares a pod's lifetime
                       properties:
-                        clientIP:
-                          description: clientIP contains the configurations of Client
-                            IP based session affinity.
-                          properties:
-                            timeoutSeconds:
-                              description: timeoutSeconds specifies the seconds of
-                                ClientIP type session sticky time. The value must
-                                be >0 && <=86400(for 1 day) if ServiceAffinity ==
-                                "ClientIP". Default value is 10800(for 3 hours).
-                              format: int32
-                              type: integer
-                          type: object
+                        group:
+                          description: Group to map volume access to Default is no
+                            group
+                          type: string
+                        readOnly:
+                          description: ReadOnly here will force the Quobyte volume
+                            to be mounted with read-only permissions. Defaults to
+                            false.
+                          type: boolean
+                        registry:
+                          description: Registry represents a single or multiple Quobyte
+                            Registry services specified as a string as host:port pair
+                            (multiple entries are separated with commas) which acts
+                            as the central registry for volumes
+                          type: string
+                        tenant:
+                          description: Tenant owning the given Quobyte volume in the
+                            Backend Used with dynamically provisioned Quobyte volumes,
+                            value is set by the plugin
+                          type: string
+                        user:
+                          description: User to map volume access to Defaults to serivceaccount
+                            user
+                          type: string
+                        volume:
+                          description: Volume is a string that references an already
+                            created Quobyte volume by name.
+                          type: string
+                      required:
+                      - registry
+                      - volume
                       type: object
-                    type:
-                      description: 'type determines how the Service is exposed. Defaults
-                        to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort,
-                        and LoadBalancer. "ExternalName" maps to the specified externalName.
-                        "ClusterIP" allocates a cluster-internal IP address for load-balancing
-                        to endpoints. Endpoints are determined by the selector or
-                        if that is not specified, by manual construction of an Endpoints
-                        object. If clusterIP is "None", no virtual IP is allocated
-                        and the endpoints are published as a set of endpoints rather
-                        than a stable IP. "NodePort" builds on ClusterIP and allocates
-                        a port on every node which routes to the clusterIP. "LoadBalancer"
-                        builds on NodePort and creates an external load-balancer (if
-                        supported in the current cloud) which routes to the clusterIP.
-                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
-                      type: string
-                  type: object
-                status:
-                  description: 'Most recently observed status of the service. Populated
-                    by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-                  properties:
-                    loadBalancer:
-                      description: LoadBalancer contains the current status of the
-                        load-balancer, if one is present.
+                    rbd:
+                      description: 'RBD represents a Rados Block Device mount on the
+                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                       properties:
-                        ingress:
-                          description: Ingress is a list containing ingress points
-                            for the load-balancer. Traffic intended for the service
-                            should be sent to these ingress points.
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        image:
+                          description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        keyring:
+                          description: 'Keyring is the path to key ring for RBDUser.
+                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        monitors:
+                          description: 'A collection of Ceph monitors. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           items:
-                            description: 'LoadBalancerIngress represents the status
-                              of a load-balancer ingress point: traffic intended for
-                              the service should be sent to an ingress point.'
+                            type: string
+                          type: array
+                        pool:
+                          description: 'The rados pool name. Default is rbd. More
+                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: boolean
+                        secretRef:
+                          description: 'SecretRef is name of the authentication secret
+                            for RBDUser. If provided overrides keyring. Default is
+                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        user:
+                          description: 'The rados user name. Default is admin. More
+                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                      required:
+                      - image
+                      - monitors
+                      type: object
+                    scaleIO:
+                      description: ScaleIO represents a ScaleIO persistent volume
+                        attached and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Default is "xfs".
+                          type: string
+                        gateway:
+                          description: The host address of the ScaleIO API Gateway.
+                          type: string
+                        protectionDomain:
+                          description: The name of the ScaleIO Protection Domain for
+                            the configured storage.
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: SecretRef references to the secret for ScaleIO
+                            user and other sensitive information. If this is not provided,
+                            Login operation will fail.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        sslEnabled:
+                          description: Flag to enable/disable SSL communication with
+                            Gateway, default false
+                          type: boolean
+                        storageMode:
+                          description: Indicates whether the storage for a volume
+                            should be ThickProvisioned or ThinProvisioned. Default
+                            is ThinProvisioned.
+                          type: string
+                        storagePool:
+                          description: The ScaleIO Storage Pool associated with the
+                            protection domain.
+                          type: string
+                        system:
+                          description: The name of the storage system as configured
+                            in ScaleIO.
+                          type: string
+                        volumeName:
+                          description: The name of a volume already created in the
+                            ScaleIO system that is associated with this volume source.
+                          type: string
+                      required:
+                      - gateway
+                      - secretRef
+                      - system
+                      type: object
+                    secret:
+                      description: 'Secret represents a secret that should populate
+                        this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                      properties:
+                        defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default. Must be a value between 0 and 0777. Defaults
+                            to 0644. Directories within the path are not affected
+                            by this setting. This might be in conflict with other
+                            options that affect the file mode, like fsGroup, and the
+                            result can be other mode bits set.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: If unspecified, each key-value pair in the
+                            Data field of the referenced Secret will be projected
+                            into the volume as a file whose name is the key and content
+                            is the value. If specified, the listed keys will be projected
+                            into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in
+                            the Secret, the volume setup will error unless it is marked
+                            optional. Paths must be relative and may not contain the
+                            '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
                             properties:
-                              hostname:
-                                description: Hostname is set for load-balancer ingress
-                                  points that are DNS based (typically AWS load-balancers)
+                              key:
+                                description: The key to project.
                                 type: string
-                              ip:
-                                description: IP is set for load-balancer ingress points
-                                  that are IP based (typically GCE or OpenStack load-balancers)
+                              mode:
+                                description: 'Optional: mode bits to use on this file,
+                                  must be a value between 0 and 0777. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: The relative path of the file to map
+                                  the key to. May not be an absolute path. May not
+                                  contain the path element '..'. May not start with
+                                  the string '..'.
                                 type: string
+                            required:
+                            - key
+                            - path
                             type: object
                           type: array
+                        optional:
+                          description: Specify whether the Secret or its keys must
+                            be defined
+                          type: boolean
+                        secretName:
+                          description: 'Name of the secret in the pod''s namespace
+                            to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                          type: string
                       type: object
+                    storageos:
+                      description: StorageOS represents a StorageOS volume attached
+                        and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: SecretRef specifies the secret to use for obtaining
+                            the StorageOS API credentials.  If not specified, default
+                            values will be attempted.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        volumeName:
+                          description: VolumeName is the human-readable name of the
+                            StorageOS volume.  Volume names are only unique within
+                            a namespace.
+                          type: string
+                        volumeNamespace:
+                          description: VolumeNamespace specifies the scope of the
+                            volume within StorageOS.  If no namespace is specified
+                            then the Pod's namespace will be used.  This allows the
+                            Kubernetes name scoping to be mirrored within StorageOS
+                            for tighter integration. Set VolumeName to any name to
+                            override the default behaviour. Set to "default" if you
+                            are not using namespaces within StorageOS. Namespaces
+                            that do not pre-exist within StorageOS will be created.
+                          type: string
+                      type: object
+                    vsphereVolume:
+                      description: VsphereVolume represents a vSphere volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        storagePolicyID:
+                          description: Storage Policy Based Management (SPBM) profile
+                            ID associated with the StoragePolicyName.
+                          type: string
+                        storagePolicyName:
+                          description: Storage Policy Based Management (SPBM) profile
+                            name.
+                          type: string
+                        volumePath:
+                          description: Path that identifies vSphere volume vmdk
+                          type: string
+                      required:
+                      - volumePath
+                      type: object
+                  required:
+                  - name
                   type: object
-              type: object
-            storageClassName:
-              description: Name of StorageClass to use for persistent volume claims
-              type: string
-            tolerations:
-              description: Pod's tolerations for Kubernetes node's taint
-              items:
-                description: The pod this Toleration is attached to tolerates any
-                  taint that matches the triple <key,value,effect> using the matching
-                  operator <operator>.
-                properties:
-                  effect:
-                    description: Effect indicates the taint effect to match. Empty
-                      means match all taint effects. When specified, allowed values
-                      are NoSchedule, PreferNoSchedule and NoExecute.
-                    type: string
-                  key:
-                    description: Key is the taint key that the toleration applies
-                      to. Empty means match all taint keys. If the key is empty, operator
-                      must be Exists; this combination means to match all values and
-                      all keys.
-                    type: string
-                  operator:
-                    description: Operator represents a key's relationship to the value.
-                      Valid operators are Exists and Equal. Defaults to Equal. Exists
-                      is equivalent to wildcard for value, so that a pod can tolerate
-                      all taints of a particular category.
-                    type: string
-                  tolerationSeconds:
-                    description: TolerationSeconds represents the period of time the
-                      toleration (which must be of effect NoExecute, otherwise this
-                      field is ignored) tolerates the taint. By default, it is not
-                      set, which means tolerate the taint forever (do not evict).
-                      Zero and negative values will be treated as 0 (evict immediately)
-                      by the system.
-                    format: int64
-                    type: integer
-                  value:
-                    description: Value is the taint value the toleration matches to.
-                      If the operator is Exists, the value should be empty, otherwise
-                      just a regular string.
-                    type: string
-                type: object
-              type: array
-            varStorage:
-              description: Storage capacity to request for /opt/splunk/var persistent
-                volume claims (default=”50Gi”)
-              type: string
-            volumes:
-              description: List of one or more Kubernetes volumes. These will be mounted
-                in all pod containers as as /mnt/<name>
-              items:
-                description: Volume represents a named volume in a pod that may be
-                  accessed by any container in the pod.
-                properties:
-                  awsElasticBlockStore:
-                    description: 'AWSElasticBlockStore represents an AWS Disk resource
-                      that is attached to a kubelet''s host machine and then exposed
-                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      partition:
-                        description: 'The partition in the volume that you want to
-                          mount. If omitted, the default is to mount by volume name.
-                          Examples: For volume /dev/sda1, you specify the partition
-                          as "1". Similarly, the volume partition for /dev/sda is
-                          "0" (or you can leave the property empty).'
-                        format: int32
-                        type: integer
-                      readOnly:
-                        description: 'Specify "true" to force and set the ReadOnly
-                          property in VolumeMounts to "true". If omitted, the default
-                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                        type: boolean
-                      volumeID:
-                        description: 'Unique ID of the persistent disk resource in
-                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  azureDisk:
-                    description: AzureDisk represents an Azure Data Disk mount on
-                      the host and bind mount to the pod.
-                    properties:
-                      cachingMode:
-                        description: 'Host Caching mode: None, Read Only, Read Write.'
-                        type: string
-                      diskName:
-                        description: The Name of the data disk in the blob storage
-                        type: string
-                      diskURI:
-                        description: The URI the data disk in the blob storage
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      kind:
-                        description: 'Expected values Shared: multiple blob disks
-                          per storage account  Dedicated: single blob disk per storage
-                          account  Managed: azure managed data disk (only in managed
-                          availability set). defaults to shared'
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                    required:
-                    - diskName
-                    - diskURI
-                    type: object
-                  azureFile:
-                    description: AzureFile represents an Azure File Service mount
-                      on the host and bind mount to the pod.
-                    properties:
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretName:
-                        description: the name of secret that contains Azure Storage
-                          Account Name and Key
-                        type: string
-                      shareName:
-                        description: Share Name
-                        type: string
-                    required:
-                    - secretName
-                    - shareName
-                    type: object
-                  cephfs:
-                    description: CephFS represents a Ceph FS mount on the host that
-                      shares a pod's lifetime
-                    properties:
-                      monitors:
-                        description: 'Required: Monitors is a collection of Ceph monitors
-                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        items:
-                          type: string
-                        type: array
-                      path:
-                        description: 'Optional: Used as the mounted root, rather than
-                          the full Ceph tree, default is /'
-                        type: string
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts. More
-                          info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: boolean
-                      secretFile:
-                        description: 'Optional: SecretFile is the path to key ring
-                          for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: string
-                      secretRef:
-                        description: 'Optional: SecretRef is reference to the authentication
-                          secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      user:
-                        description: 'Optional: User is the rados user name, default
-                          is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: string
-                    required:
-                    - monitors
-                    type: object
-                  cinder:
-                    description: 'Cinder represents a cinder volume attached and mounted
-                      on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Examples: "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: string
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts. More
-                          info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: boolean
-                      secretRef:
-                        description: 'Optional: points to a secret object containing
-                          parameters used to connect to OpenStack.'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      volumeID:
-                        description: 'volume id used to identify the volume in cinder.
-                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  configMap:
-                    description: ConfigMap represents a configMap that should populate
-                      this volume
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: If unspecified, each key-value pair in the Data
-                          field of the referenced ConfigMap will be projected into
-                          the volume as a file whose name is the key and content is
-                          the value. If specified, the listed keys will be projected
-                          into the specified paths, and unlisted keys will not be
-                          present. If a key is specified which is not present in the
-                          ConfigMap, the volume setup will error unless it is marked
-                          optional. Paths must be relative and may not contain the
-                          '..' path or start with '..'.
-                        items:
-                          description: Maps a string key to a path within a volume.
-                          properties:
-                            key:
-                              description: The key to project.
-                              type: string
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: The relative path of the file to map the
-                                key to. May not be an absolute path. May not contain
-                                the path element '..'. May not start with the string
-                                '..'.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          type: object
-                        type: array
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
-                        type: string
-                      optional:
-                        description: Specify whether the ConfigMap or its keys must
-                          be defined
-                        type: boolean
-                    type: object
-                  csi:
-                    description: CSI (Container Storage Interface) represents storage
-                      that is handled by an external CSI driver (Alpha feature).
-                    properties:
-                      driver:
-                        description: Driver is the name of the CSI driver that handles
-                          this volume. Consult with your admin for the correct name
-                          as registered in the cluster.
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Ex. "ext4", "xfs",
-                          "ntfs". If not provided, the empty value is passed to the
-                          associated CSI driver which will determine the default filesystem
-                          to apply.
-                        type: string
-                      nodePublishSecretRef:
-                        description: NodePublishSecretRef is a reference to the secret
-                          object containing sensitive information to pass to the CSI
-                          driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
-                          calls. This field is optional, and  may be empty if no secret
-                          is required. If the secret object contains more than one
-                          secret, all secret references are passed.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      readOnly:
-                        description: Specifies a read-only configuration for the volume.
-                          Defaults to false (read/write).
-                        type: boolean
-                      volumeAttributes:
-                        additionalProperties:
-                          type: string
-                        description: VolumeAttributes stores driver-specific properties
-                          that are passed to the CSI driver. Consult your driver's
-                          documentation for supported values.
-                        type: object
-                    required:
-                    - driver
-                    type: object
-                  downwardAPI:
-                    description: DownwardAPI represents downward API about the pod
-                      that should populate this volume
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: Items is a list of downward API volume file
-                        items:
-                          description: DownwardAPIVolumeFile represents information
-                            to create the file containing the pod field
-                          properties:
-                            fieldRef:
-                              description: 'Required: Selects a field of the pod:
-                                only annotations, labels, name and namespace are supported.'
-                              properties:
-                                apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
-                                  type: string
-                                fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
-                                  type: string
-                              required:
-                              - fieldPath
-                              type: object
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: 'Required: Path is  the relative path name
-                                of the file to be created. Must not be absolute or
-                                contain the ''..'' path. Must be utf-8 encoded. The
-                                first item of the relative path must not start with
-                                ''..'''
-                              type: string
-                            resourceFieldRef:
-                              description: 'Selects a resource of the container: only
-                                resources limits and requests (limits.cpu, limits.memory,
-                                requests.cpu and requests.memory) are currently supported.'
-                              properties:
-                                containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
-                                  type: string
-                                divisor:
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
-                                  type: string
-                                resource:
-                                  description: 'Required: resource to select'
-                                  type: string
-                              required:
-                              - resource
-                              type: object
-                          required:
-                          - path
-                          type: object
-                        type: array
-                    type: object
-                  emptyDir:
-                    description: 'EmptyDir represents a temporary directory that shares
-                      a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                    properties:
-                      medium:
-                        description: 'What type of storage medium should back this
-                          directory. The default is "" which means to use the node''s
-                          default medium. Must be an empty string (default) or Memory.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                        type: string
-                      sizeLimit:
-                        description: 'Total amount of local storage required for this
-                          EmptyDir volume. The size limit is also applicable for memory
-                          medium. The maximum usage on memory medium EmptyDir would
-                          be the minimum value between the SizeLimit specified here
-                          and the sum of memory limits of all containers in a pod.
-                          The default is nil which means that the limit is undefined.
-                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                        type: string
-                    type: object
-                  fc:
-                    description: FC represents a Fibre Channel resource that is attached
-                      to a kubelet's host machine and then exposed to the pod.
-                    properties:
-                      fsType:
-                        description: 'Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      lun:
-                        description: 'Optional: FC target lun number'
-                        format: int32
-                        type: integer
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts.'
-                        type: boolean
-                      targetWWNs:
-                        description: 'Optional: FC target worldwide names (WWNs)'
-                        items:
-                          type: string
-                        type: array
-                      wwids:
-                        description: 'Optional: FC volume world wide identifiers (wwids)
-                          Either wwids or combination of targetWWNs and lun must be
-                          set, but not both simultaneously.'
-                        items:
-                          type: string
-                        type: array
-                    type: object
-                  flexVolume:
-                    description: FlexVolume represents a generic volume resource that
-                      is provisioned/attached using an exec based plugin.
-                    properties:
-                      driver:
-                        description: Driver is the name of the driver to use for this
-                          volume.
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". The default filesystem depends on FlexVolume
-                          script.
-                        type: string
-                      options:
-                        additionalProperties:
-                          type: string
-                        description: 'Optional: Extra command options if any.'
-                        type: object
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts.'
-                        type: boolean
-                      secretRef:
-                        description: 'Optional: SecretRef is reference to the secret
-                          object containing sensitive information to pass to the plugin
-                          scripts. This may be empty if no secret object is specified.
-                          If the secret object contains more than one secret, all
-                          secrets are passed to the plugin scripts.'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                    required:
-                    - driver
-                    type: object
-                  flocker:
-                    description: Flocker represents a Flocker volume attached to a
-                      kubelet's host machine. This depends on the Flocker control
-                      service being running
-                    properties:
-                      datasetName:
-                        description: Name of the dataset stored as metadata -> name
-                          on the dataset for Flocker should be considered as deprecated
-                        type: string
-                      datasetUUID:
-                        description: UUID of the dataset. This is unique identifier
-                          of a Flocker dataset
-                        type: string
-                    type: object
-                  gcePersistentDisk:
-                    description: 'GCEPersistentDisk represents a GCE Disk resource
-                      that is attached to a kubelet''s host machine and then exposed
-                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      partition:
-                        description: 'The partition in the volume that you want to
-                          mount. If omitted, the default is to mount by volume name.
-                          Examples: For volume /dev/sda1, you specify the partition
-                          as "1". Similarly, the volume partition for /dev/sda is
-                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        format: int32
-                        type: integer
-                      pdName:
-                        description: 'Unique name of the PD resource in GCE. Used
-                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        type: boolean
-                    required:
-                    - pdName
-                    type: object
-                  gitRepo:
-                    description: 'GitRepo represents a git repository at a particular
-                      revision. DEPRECATED: GitRepo is deprecated. To provision a
-                      container with a git repo, mount an EmptyDir into an InitContainer
-                      that clones the repo using git, then mount the EmptyDir into
-                      the Pod''s container.'
-                    properties:
-                      directory:
-                        description: Target directory name. Must not contain or start
-                          with '..'.  If '.' is supplied, the volume directory will
-                          be the git repository.  Otherwise, if specified, the volume
-                          will contain the git repository in the subdirectory with
-                          the given name.
-                        type: string
-                      repository:
-                        description: Repository URL
-                        type: string
-                      revision:
-                        description: Commit hash for the specified revision.
-                        type: string
-                    required:
-                    - repository
-                    type: object
-                  glusterfs:
-                    description: 'Glusterfs represents a Glusterfs mount on the host
-                      that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
-                    properties:
-                      endpoints:
-                        description: 'EndpointsName is the endpoint name that details
-                          Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: string
-                      path:
-                        description: 'Path is the Glusterfs volume path. More info:
-                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the Glusterfs volume
-                          to be mounted with read-only permissions. Defaults to false.
-                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: boolean
-                    required:
-                    - endpoints
-                    - path
-                    type: object
-                  hostPath:
-                    description: 'HostPath represents a pre-existing file or directory
-                      on the host machine that is directly exposed to the container.
-                      This is generally used for system agents or other privileged
-                      things that are allowed to see the host machine. Most containers
-                      will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                      --- TODO(jonesdl) We need to restrict who can use host directory
-                      mounts and who can/can not mount host directories as read/write.'
-                    properties:
-                      path:
-                        description: 'Path of the directory on the host. If the path
-                          is a symlink, it will follow the link to the real path.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                        type: string
-                      type:
-                        description: 'Type for HostPath Volume Defaults to "" More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                        type: string
-                    required:
-                    - path
-                    type: object
-                  iscsi:
-                    description: 'ISCSI represents an ISCSI Disk resource that is
-                      attached to a kubelet''s host machine and then exposed to the
-                      pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
-                    properties:
-                      chapAuthDiscovery:
-                        description: whether support iSCSI Discovery CHAP authentication
-                        type: boolean
-                      chapAuthSession:
-                        description: whether support iSCSI Session CHAP authentication
-                        type: boolean
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      initiatorName:
-                        description: Custom iSCSI Initiator Name. If initiatorName
-                          is specified with iscsiInterface simultaneously, new iSCSI
-                          interface <target portal>:<volume name> will be created
-                          for the connection.
-                        type: string
-                      iqn:
-                        description: Target iSCSI Qualified Name.
-                        type: string
-                      iscsiInterface:
-                        description: iSCSI Interface Name that uses an iSCSI transport.
-                          Defaults to 'default' (tcp).
-                        type: string
-                      lun:
-                        description: iSCSI Target Lun number.
-                        format: int32
-                        type: integer
-                      portals:
-                        description: iSCSI Target Portal List. The portal is either
-                          an IP or ip_addr:port if the port is other than default
-                          (typically TCP ports 860 and 3260).
-                        items:
-                          type: string
-                        type: array
-                      readOnly:
-                        description: ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false.
-                        type: boolean
-                      secretRef:
-                        description: CHAP Secret for iSCSI target and initiator authentication
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      targetPortal:
-                        description: iSCSI Target Portal. The Portal is either an
-                          IP or ip_addr:port if the port is other than default (typically
-                          TCP ports 860 and 3260).
-                        type: string
-                    required:
-                    - iqn
-                    - lun
-                    - targetPortal
-                    type: object
-                  name:
-                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
-                      the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  nfs:
-                    description: 'NFS represents an NFS mount on the host that shares
-                      a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                    properties:
-                      path:
-                        description: 'Path that is exported by the NFS server. More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the NFS export to be
-                          mounted with read-only permissions. Defaults to false. More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: boolean
-                      server:
-                        description: 'Server is the hostname or IP address of the
-                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: string
-                    required:
-                    - path
-                    - server
-                    type: object
-                  persistentVolumeClaim:
-                    description: 'PersistentVolumeClaimVolumeSource represents a reference
-                      to a PersistentVolumeClaim in the same namespace. More info:
-                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                    properties:
-                      claimName:
-                        description: 'ClaimName is the name of a PersistentVolumeClaim
-                          in the same namespace as the pod using this volume. More
-                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                        type: string
-                      readOnly:
-                        description: Will force the ReadOnly setting in VolumeMounts.
-                          Default false.
-                        type: boolean
-                    required:
-                    - claimName
-                    type: object
-                  photonPersistentDisk:
-                    description: PhotonPersistentDisk represents a PhotonController
-                      persistent disk attached and mounted on kubelets host machine
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      pdID:
-                        description: ID that identifies Photon Controller persistent
-                          disk
-                        type: string
-                    required:
-                    - pdID
-                    type: object
-                  portworxVolume:
-                    description: PortworxVolume represents a portworx volume attached
-                      and mounted on kubelets host machine
-                    properties:
-                      fsType:
-                        description: FSType represents the filesystem type to mount
-                          Must be a filesystem type supported by the host operating
-                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                          if unspecified.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      volumeID:
-                        description: VolumeID uniquely identifies a Portworx volume
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  projected:
-                    description: Items for all in one resources secrets, configmaps,
-                      and downward API
-                    properties:
-                      defaultMode:
-                        description: Mode bits to use on created files by default.
-                          Must be a value between 0 and 0777. Directories within the
-                          path are not affected by this setting. This might be in
-                          conflict with other options that affect the file mode, like
-                          fsGroup, and the result can be other mode bits set.
-                        format: int32
-                        type: integer
-                      sources:
-                        description: list of volume projections
-                        items:
-                          description: Projection that may be projected along with
-                            other supported volume types
-                          properties:
-                            configMap:
-                              description: information about the configMap data to
-                                project
-                              properties:
-                                items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced ConfigMap
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the ConfigMap, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
-                                  items:
-                                    description: Maps a string key to a path within
-                                      a volume.
-                                    properties:
-                                      key:
-                                        description: The key to project.
-                                        type: string
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap or its
-                                    keys must be defined
-                                  type: boolean
-                              type: object
-                            downwardAPI:
-                              description: information about the downwardAPI data
-                                to project
-                              properties:
-                                items:
-                                  description: Items is a list of DownwardAPIVolume
-                                    file
-                                  items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
-                                    properties:
-                                      fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
-                                        properties:
-                                          apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
-                                            type: string
-                                          fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
-                                        type: string
-                                      resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, requests.cpu and requests.memory)
-                                          are currently supported.'
-                                        properties:
-                                          containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
-                                            type: string
-                                          divisor:
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
-                                            type: string
-                                          resource:
-                                            description: 'Required: resource to select'
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                    required:
-                                    - path
-                                    type: object
-                                  type: array
-                              type: object
-                            secret:
-                              description: information about the secret data to project
-                              properties:
-                                items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced Secret will
-                                    be projected into the volume as a file whose name
-                                    is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the Secret, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
-                                  items:
-                                    description: Maps a string key to a path within
-                                      a volume.
-                                    properties:
-                                      key:
-                                        description: The key to project.
-                                        type: string
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
-                                  type: boolean
-                              type: object
-                            serviceAccountToken:
-                              description: information about the serviceAccountToken
-                                data to project
-                              properties:
-                                audience:
-                                  description: Audience is the intended audience of
-                                    the token. A recipient of a token must identify
-                                    itself with an identifier specified in the audience
-                                    of the token, and otherwise should reject the
-                                    token. The audience defaults to the identifier
-                                    of the apiserver.
-                                  type: string
-                                expirationSeconds:
-                                  description: ExpirationSeconds is the requested
-                                    duration of validity of the service account token.
-                                    As the token approaches expiration, the kubelet
-                                    volume plugin will proactively rotate the service
-                                    account token. The kubelet will start trying to
-                                    rotate the token if the token is older than 80
-                                    percent of its time to live or if the token is
-                                    older than 24 hours.Defaults to 1 hour and must
-                                    be at least 10 minutes.
-                                  format: int64
-                                  type: integer
-                                path:
-                                  description: Path is the path relative to the mount
-                                    point of the file to project the token into.
-                                  type: string
-                              required:
-                              - path
-                              type: object
-                          type: object
-                        type: array
-                    required:
-                    - sources
-                    type: object
-                  quobyte:
-                    description: Quobyte represents a Quobyte mount on the host that
-                      shares a pod's lifetime
-                    properties:
-                      group:
-                        description: Group to map volume access to Default is no group
-                        type: string
-                      readOnly:
-                        description: ReadOnly here will force the Quobyte volume to
-                          be mounted with read-only permissions. Defaults to false.
-                        type: boolean
-                      registry:
-                        description: Registry represents a single or multiple Quobyte
-                          Registry services specified as a string as host:port pair
-                          (multiple entries are separated with commas) which acts
-                          as the central registry for volumes
-                        type: string
-                      tenant:
-                        description: Tenant owning the given Quobyte volume in the
-                          Backend Used with dynamically provisioned Quobyte volumes,
-                          value is set by the plugin
-                        type: string
-                      user:
-                        description: User to map volume access to Defaults to serivceaccount
-                          user
-                        type: string
-                      volume:
-                        description: Volume is a string that references an already
-                          created Quobyte volume by name.
-                        type: string
-                    required:
-                    - registry
-                    - volume
-                    type: object
-                  rbd:
-                    description: 'RBD represents a Rados Block Device mount on the
-                      host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      image:
-                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      keyring:
-                        description: 'Keyring is the path to key ring for RBDUser.
-                          Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      monitors:
-                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        items:
-                          type: string
-                        type: array
-                      pool:
-                        description: 'The rados pool name. Default is rbd. More info:
-                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: boolean
-                      secretRef:
-                        description: 'SecretRef is name of the authentication secret
-                          for RBDUser. If provided overrides keyring. Default is nil.
-                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      user:
-                        description: 'The rados user name. Default is admin. More
-                          info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                    required:
-                    - image
-                    - monitors
-                    type: object
-                  scaleIO:
-                    description: ScaleIO represents a ScaleIO persistent volume attached
-                      and mounted on Kubernetes nodes.
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Default is "xfs".
-                        type: string
-                      gateway:
-                        description: The host address of the ScaleIO API Gateway.
-                        type: string
-                      protectionDomain:
-                        description: The name of the ScaleIO Protection Domain for
-                          the configured storage.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretRef:
-                        description: SecretRef references to the secret for ScaleIO
-                          user and other sensitive information. If this is not provided,
-                          Login operation will fail.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      sslEnabled:
-                        description: Flag to enable/disable SSL communication with
-                          Gateway, default false
-                        type: boolean
-                      storageMode:
-                        description: Indicates whether the storage for a volume should
-                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
-                        type: string
-                      storagePool:
-                        description: The ScaleIO Storage Pool associated with the
-                          protection domain.
-                        type: string
-                      system:
-                        description: The name of the storage system as configured
-                          in ScaleIO.
-                        type: string
-                      volumeName:
-                        description: The name of a volume already created in the ScaleIO
-                          system that is associated with this volume source.
-                        type: string
-                    required:
-                    - gateway
-                    - secretRef
-                    - system
-                    type: object
-                  secret:
-                    description: 'Secret represents a secret that should populate
-                      this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: If unspecified, each key-value pair in the Data
-                          field of the referenced Secret will be projected into the
-                          volume as a file whose name is the key and content is the
-                          value. If specified, the listed keys will be projected into
-                          the specified paths, and unlisted keys will not be present.
-                          If a key is specified which is not present in the Secret,
-                          the volume setup will error unless it is marked optional.
-                          Paths must be relative and may not contain the '..' path
-                          or start with '..'.
-                        items:
-                          description: Maps a string key to a path within a volume.
-                          properties:
-                            key:
-                              description: The key to project.
-                              type: string
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: The relative path of the file to map the
-                                key to. May not be an absolute path. May not contain
-                                the path element '..'. May not start with the string
-                                '..'.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          type: object
-                        type: array
-                      optional:
-                        description: Specify whether the Secret or its keys must be
-                          defined
-                        type: boolean
-                      secretName:
-                        description: 'Name of the secret in the pod''s namespace to
-                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                        type: string
-                    type: object
-                  storageos:
-                    description: StorageOS represents a StorageOS volume attached
-                      and mounted on Kubernetes nodes.
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretRef:
-                        description: SecretRef specifies the secret to use for obtaining
-                          the StorageOS API credentials.  If not specified, default
-                          values will be attempted.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      volumeName:
-                        description: VolumeName is the human-readable name of the
-                          StorageOS volume.  Volume names are only unique within a
-                          namespace.
-                        type: string
-                      volumeNamespace:
-                        description: VolumeNamespace specifies the scope of the volume
-                          within StorageOS.  If no namespace is specified then the
-                          Pod's namespace will be used.  This allows the Kubernetes
-                          name scoping to be mirrored within StorageOS for tighter
-                          integration. Set VolumeName to any name to override the
-                          default behaviour. Set to "default" if you are not using
-                          namespaces within StorageOS. Namespaces that do not pre-exist
-                          within StorageOS will be created.
-                        type: string
-                    type: object
-                  vsphereVolume:
-                    description: VsphereVolume represents a vSphere volume attached
-                      and mounted on kubelets host machine
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      storagePolicyID:
-                        description: Storage Policy Based Management (SPBM) profile
-                          ID associated with the StoragePolicyName.
-                        type: string
-                      storagePolicyName:
-                        description: Storage Policy Based Management (SPBM) profile
-                          name.
-                        type: string
-                      volumePath:
-                        description: Path that identifies vSphere volume vmdk
-                        type: string
-                    required:
-                    - volumePath
-                    type: object
-                required:
-                - name
-                type: object
-              type: array
-          type: object
-        status:
-          description: IndexerClusterStatus defines the observed state of a Splunk
-            Enterprise indexer cluster
-          properties:
-            clusterMasterPhase:
-              description: current phase of the cluster master
-              enum:
-              - Pending
-              - Ready
-              - Updating
-              - ScalingUp
-              - ScalingDown
-              - Terminating
-              - Error
-              type: string
-            indexer_secret_changed_flag:
-              description: Indicates when the idxc_secret has been changed for a peer
-              items:
+                type: array
+            type: object
+          status:
+            description: IndexerClusterStatus defines the observed state of a Splunk
+              Enterprise indexer cluster
+            properties:
+              clusterMasterPhase:
+                description: current phase of the cluster master
+                enum:
+                - Pending
+                - Ready
+                - Updating
+                - ScalingUp
+                - ScalingDown
+                - Terminating
+                - Error
+                type: string
+              indexer_secret_changed_flag:
+                description: Indicates when the idxc_secret has been changed for a
+                  peer
+                items:
+                  type: boolean
+                type: array
+              indexing_ready_flag:
+                description: Indicates if the cluster is ready for indexing.
                 type: boolean
-              type: array
-            indexing_ready_flag:
-              description: Indicates if the cluster is ready for indexing.
-              type: boolean
-            initialized_flag:
-              description: Indicates if the cluster is initialized.
-              type: boolean
-            maintenance_mode:
-              description: Indicates if the cluster is in maintenance mode.
-              type: boolean
-            namespace_scoped_secret_resource_version:
-              description: Indicates resource version of namespace scoped secret
-              type: string
-            peers:
-              description: status of each indexer cluster peer
-              items:
-                description: IndexerClusterMemberStatus is used to track the status
-                  of each indexer cluster peer.
-                properties:
-                  active_bundle_id:
-                    description: The ID of the configuration bundle currently being
-                      used by the master.
-                    type: string
-                  bucket_count:
-                    description: Count of the number of buckets on this peer, across
-                      all indexes.
-                    format: int64
-                    type: integer
-                  guid:
-                    description: Unique identifier or GUID for the peer
-                    type: string
-                  is_searchable:
-                    description: Flag indicating if this peer belongs to the current
-                      committed generation and is searchable.
-                    type: boolean
-                  name:
-                    description: Name of the indexer cluster peer
-                    type: string
-                  status:
-                    description: Status of the indexer cluster peer
-                    type: string
-                type: object
-              type: array
-            phase:
-              description: current phase of the indexer cluster
-              enum:
-              - Pending
-              - Ready
-              - Updating
-              - ScalingUp
-              - ScalingDown
-              - Terminating
-              - Error
-              type: string
-            readyReplicas:
-              description: current number of ready indexer peers
-              format: int32
-              type: integer
-            replicas:
-              description: desired number of indexer peers
-              format: int32
-              type: integer
-            selector:
-              description: selector for pods, used by HorizontalPodAutoscaler
-              type: string
-            service_ready_flag:
-              description: Indicates whether the master is ready to begin servicing,
-                based on whether it is initialized.
-              type: boolean
-          type: object
-      type: object
-  version: v1alpha3
-  versions:
-  - name: v1alpha3
+              initialized_flag:
+                description: Indicates if the cluster is initialized.
+                type: boolean
+              maintenance_mode:
+                description: Indicates if the cluster is in maintenance mode.
+                type: boolean
+              namespace_scoped_secret_resource_version:
+                description: Indicates resource version of namespace scoped secret
+                type: string
+              peers:
+                description: status of each indexer cluster peer
+                items:
+                  description: IndexerClusterMemberStatus is used to track the status
+                    of each indexer cluster peer.
+                  properties:
+                    active_bundle_id:
+                      description: The ID of the configuration bundle currently being
+                        used by the master.
+                      type: string
+                    bucket_count:
+                      description: Count of the number of buckets on this peer, across
+                        all indexes.
+                      format: int64
+                      type: integer
+                    guid:
+                      description: Unique identifier or GUID for the peer
+                      type: string
+                    is_searchable:
+                      description: Flag indicating if this peer belongs to the current
+                        committed generation and is searchable.
+                      type: boolean
+                    name:
+                      description: Name of the indexer cluster peer
+                      type: string
+                    status:
+                      description: Status of the indexer cluster peer
+                      type: string
+                  type: object
+                type: array
+              phase:
+                description: current phase of the indexer cluster
+                enum:
+                - Pending
+                - Ready
+                - Updating
+                - ScalingUp
+                - ScalingDown
+                - Terminating
+                - Error
+                type: string
+              readyReplicas:
+                description: current number of ready indexer peers
+                format: int32
+                type: integer
+              replicas:
+                description: desired number of indexer peers
+                format: int32
+                type: integer
+              selector:
+                description: selector for pods, used by HorizontalPodAutoscaler
+                type: string
+              service_ready_flag:
+                description: Indicates whether the master is ready to begin servicing,
+                  based on whether it is initialized.
+                type: boolean
+            type: object
+        type: object
     served: true
     storage: true
-  - name: v1alpha2
-    served: true
-    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/deploy/crds/enterprise.splunk.com_indexerclusters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_indexerclusters_crd.yaml
@@ -1,8 +1,29 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: indexerclusters.enterprise.splunk.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: Status of indexer cluster
+    name: Phase
+    type: string
+  - JSONPath: .status.clusterMasterPhase
+    description: Status of cluster master
+    name: Master
+    type: string
+  - JSONPath: .status.replicas
+    description: Desired number of indexer peers
+    name: Desired
+    type: integer
+  - JSONPath: .status.readyReplicas
+    description: Current number of ready indexer peers
+    name: Ready
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of indexer cluster
+    name: Age
+    type: date
   group: enterprise.splunk.com
   names:
     kind: IndexerCluster
@@ -13,2380 +34,2299 @@ spec:
     - idxc
     singular: indexercluster
   scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: Status of indexer cluster
-      jsonPath: .status.phase
-      name: Phase
-      type: string
-    - description: Status of cluster master
-      jsonPath: .status.clusterMasterPhase
-      name: Master
-      type: string
-    - description: Desired number of indexer peers
-      jsonPath: .status.replicas
-      name: Desired
-      type: integer
-    - description: Current number of ready indexer peers
-      jsonPath: .status.readyReplicas
-      name: Ready
-      type: integer
-    - description: Age of indexer cluster
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        description: IndexerCluster is the Schema for a Splunk Enterprise indexer
-          cluster
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: IndexerClusterSpec defines the desired state of a Splunk
-              Enterprise indexer cluster
-            properties:
-              Mock:
-                description: Mock to differentiate between UTs and actual reconcile
-                type: boolean
-              affinity:
-                description: Kubernetes Affinity rules that control how pods are assigned
-                  to particular nodes.
-                properties:
-                  nodeAffinity:
-                    description: Describes node affinity scheduling rules for the
-                      pod.
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node matches
-                          the corresponding matchExpressions; the node(s) with the
-                          highest sum are the most preferred.
-                        items:
-                          description: An empty preferred scheduling term matches
-                            all objects with implicit weight 0 (i.e. it's a no-op).
-                            A null preferred scheduling term matches no objects (i.e.
-                            is also a no-op).
-                          properties:
-                            preference:
-                              description: A node selector term, associated with the
-                                corresponding weight.
-                              properties:
-                                matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            weight:
-                              description: Weight associated with matching the corresponding
-                                nodeSelectorTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - preference
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to an update), the system may or may not try to
-                          eventually evict the pod from its node.
+  subresources:
+    scale:
+      labelSelectorPath: .status.selector
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: IndexerCluster is the Schema for a Splunk Enterprise indexer cluster
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IndexerClusterSpec defines the desired state of a Splunk Enterprise
+            indexer cluster
+          properties:
+            Mock:
+              description: Mock to differentiate between UTs and actual reconcile
+              type: boolean
+            affinity:
+              description: Kubernetes Affinity rules that control how pods are assigned
+                to particular nodes.
+              properties:
+                nodeAffinity:
+                  description: Describes node affinity scheduling rules for the pod.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node matches the corresponding matchExpressions; the
+                        node(s) with the highest sum are the most preferred.
+                      items:
+                        description: An empty preferred scheduling term matches all
+                          objects with implicit weight 0 (i.e. it's a no-op). A null
+                          preferred scheduling term matches no objects (i.e. is also
+                          a no-op).
                         properties:
-                          nodeSelectorTerms:
-                            description: Required. A list of node selector terms.
-                              The terms are ORed.
-                            items:
-                              description: A null or empty node selector term matches
-                                no objects. The requirements of them are ANDed. The
-                                TopologySelectorTerm type implements a subset of the
-                                NodeSelectorTerm.
-                              properties:
-                                matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
+                          preference:
+                            description: A node selector term, associated with the
+                              corresponding weight.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
                                         type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
                                         type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            type: array
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          weight:
+                            description: Weight associated with matching the corresponding
+                              nodeSelectorTerm, in the range 1-100.
+                            format: int32
+                            type: integer
                         required:
-                        - nodeSelectorTerms
+                        - preference
+                        - weight
                         type: object
-                    type: object
-                  podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate
-                      this pod in the same node, zone, etc. as some other pod(s)).
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
-                        items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
-                          properties:
-                            podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to an update), the system may or may not try to
+                        eventually evict the pod from its node.
+                      properties:
+                        nodeSelectorTerms:
+                          description: Required. A list of node selector terms. The
+                            terms are ORed.
+                          items:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
                                   type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                      required:
+                      - nodeSelectorTerms
+                      type: object
+                  type: object
+                podAffinity:
+                  description: Describes pod affinity scheduling rules (e.g. co-locate
+                    this pod in the same node, zone, etc. as some other pod(s)).
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node has pods which matches the corresponding podAffinityTerm;
+                        the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Required. A pod affinity term, associated
+                              with the corresponding weight.
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
                                   type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to a pod label update), the system may or may not
+                        try to eventually evict the pod from its node. When there
+                        are multiple elements, the lists of nodes corresponding to
+                        each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources, in
+                              this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+                podAntiAffinity:
+                  description: Describes pod anti-affinity scheduling rules (e.g.
+                    avoid putting this pod in the same node, zone, etc. as some other
+                    pod(s)).
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the anti-affinity expressions specified by this
+                        field, but it may choose a node that violates one or more
+                        of the expressions. The node that is most preferred is the
+                        one with the greatest sum of weights, i.e. for each node that
+                        meets all of the scheduling requirements (resource request,
+                        requiredDuringScheduling anti-affinity expressions, etc.),
+                        compute a sum by iterating through the elements of this field
+                        and adding "weight" to the sum if the node has pods which
+                        matches the corresponding podAffinityTerm; the node(s) with
+                        the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Required. A pod affinity term, associated
+                              with the corresponding weight.
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the anti-affinity requirements specified by
+                        this field are not met at scheduling time, the pod will not
+                        be scheduled onto the node. If the anti-affinity requirements
+                        specified by this field cease to be met at some point during
+                        pod execution (e.g. due to a pod label update), the system
+                        may or may not try to eventually evict the pod from its node.
+                        When there are multiple elements, the lists of nodes corresponding
+                        to each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources, in
+                              this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            clusterMasterRef:
+              description: ClusterMasterRef refers to a Splunk Enterprise indexer
+                cluster managed by the operator within Kubernetes
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            defaults:
+              description: Inline map of default.yml overrides used to initialize
+                the environment
+              type: string
+            defaultsUrl:
+              description: Full path or URL for one or more default.yml files, separated
+                by commas
+              type: string
+            ephemeralStorage:
+              description: If true, ephemeral (emptyDir) storage will be used for
+                /opt/splunk/etc and /opt/splunk/var volumes
+              type: boolean
+            etcStorage:
+              description: Storage capacity to request for /opt/splunk/etc persistent
+                volume claims (default=”1Gi”)
+              type: string
+            image:
+              description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
+                environment variables)
+              type: string
+            imagePullPolicy:
+              description: 'Sets pull policy for all images (either “Always” or the
+                default: “IfNotPresent”)'
+              enum:
+              - Always
+              - IfNotPresent
+              type: string
+            licenseMasterRef:
+              description: LicenseMasterRef refers to a Splunk Enterprise license
+                master managed by the operator within Kubernetes
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            licenseUrl:
+              description: Full path or URL for a Splunk Enterprise license file
+              type: string
+            replicas:
+              description: Number of search head pods; a search head cluster will
+                be created if > 1
+              format: int32
+              type: integer
+            resources:
+              description: resource requirements for the pod containers
+              properties:
+                limits:
+                  additionalProperties:
+                    type: string
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    type: string
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
+            schedulerName:
+              description: Name of Scheduler to use for pod placement (defaults to
+                “default-scheduler”)
+              type: string
+            serviceTemplate:
+              description: ServiceTemplate is a template used to create Kubernetes
+                services
+              properties:
+                apiVersion:
+                  description: 'APIVersion defines the versioned schema of this representation
+                    of an object. Servers should convert recognized schemas to the
+                    latest internal value, and may reject unrecognized values. More
+                    info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                  type: string
+                kind:
+                  description: 'Kind is a string value representing the REST resource
+                    this object represents. Servers may infer this from the endpoint
+                    the client submits requests to. Cannot be updated. In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                metadata:
+                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                  type: object
+                spec:
+                  description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                  properties:
+                    clusterIP:
+                      description: 'clusterIP is the IP address of the service and
+                        is usually assigned randomly by the master. If an address
+                        is specified manually and is not in use by others, it will
+                        be allocated to the service; otherwise, creation of the service
+                        will fail. This field can not be changed through updates.
+                        Valid values are "None", empty string (""), or a valid IP
+                        address. "None" can be specified for headless services when
+                        proxying is not required. Only applies to types ClusterIP,
+                        NodePort, and LoadBalancer. Ignored if type is ExternalName.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    externalIPs:
+                      description: externalIPs is a list of IP addresses for which
+                        nodes in the cluster will also accept traffic for this service.  These
+                        IPs are not managed by Kubernetes.  The user is responsible
+                        for ensuring that traffic arrives at a node with this IP.  A
+                        common example is external load-balancers that are not part
+                        of the Kubernetes system.
+                      items:
+                        type: string
+                      type: array
+                    externalName:
+                      description: externalName is the external reference that kubedns
+                        or equivalent will return as a CNAME record for this service.
+                        No proxying will be involved. Must be a valid RFC-1123 hostname
+                        (https://tools.ietf.org/html/rfc1123) and requires Type to
+                        be ExternalName.
+                      type: string
+                    externalTrafficPolicy:
+                      description: externalTrafficPolicy denotes if this Service desires
+                        to route external traffic to node-local or cluster-wide endpoints.
+                        "Local" preserves the client source IP and avoids a second
+                        hop for LoadBalancer and Nodeport type services, but risks
+                        potentially imbalanced traffic spreading. "Cluster" obscures
+                        the client source IP and may cause a second hop to another
+                        node, but should have good overall load-spreading.
+                      type: string
+                    healthCheckNodePort:
+                      description: healthCheckNodePort specifies the healthcheck nodePort
+                        for the service. If not specified, HealthCheckNodePort is
+                        created by the service api backend with the allocated nodePort.
+                        Will use user-specified nodePort value if specified by the
+                        client. Only effects when Type is set to LoadBalancer and
+                        ExternalTrafficPolicy is set to Local.
+                      format: int32
+                      type: integer
+                    ipFamily:
+                      description: ipFamily specifies whether this Service has a preference
+                        for a particular IP family (e.g. IPv4 vs. IPv6).  If a specific
+                        IP family is requested, the clusterIP field will be allocated
+                        from that family, if it is available in the cluster.  If no
+                        IP family is requested, the cluster's primary IP family will
+                        be used. Other IP fields (loadBalancerIP, loadBalancerSourceRanges,
+                        externalIPs) and controllers which allocate external load-balancers
+                        should use the same IP family.  Endpoints for this Service
+                        will be of this family.  This field is immutable after creation.
+                        Assigning a ServiceIPFamily not available in the cluster (e.g.
+                        IPv6 in IPv4 only cluster) is an error condition and will
+                        fail during clusterIP assignment.
+                      type: string
+                    loadBalancerIP:
+                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                        will get created with the IP specified in this field. This
+                        feature depends on whether the underlying cloud-provider supports
+                        specifying the loadBalancerIP when a load balancer is created.
+                        This field will be ignored if the cloud-provider does not
+                        support the feature.'
+                      type: string
+                    loadBalancerSourceRanges:
+                      description: 'If specified and supported by the platform, this
+                        will restrict traffic through the cloud-provider load-balancer
+                        will be restricted to the specified client IPs. This field
+                        will be ignored if the cloud-provider does not support the
+                        feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: 'The list of ports that are exposed by this service.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      items:
+                        description: ServicePort contains information on service's
+                          port.
+                        properties:
+                          name:
+                            description: The name of this port within the service.
+                              This must be a DNS_LABEL. All ports within a ServiceSpec
+                              must have unique names. When considering the endpoints
+                              for a Service, this must match the 'name' field in the
+                              EndpointPort. Optional if only one ServicePort is defined
+                              on this service.
+                            type: string
+                          nodePort:
+                            description: 'The port on each node on which this service
+                              is exposed when type=NodePort or LoadBalancer. Usually
+                              assigned by the system. If specified, it will be allocated
+                              to the service if unused or else creation of the service
+                              will fail. Default is to auto-allocate a port if the
+                              ServiceType of this Service requires one. More info:
+                              https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                            format: int32
+                            type: integer
+                          port:
+                            description: The port that will be exposed by this service.
+                            format: int32
+                            type: integer
+                          protocol:
+                            description: The IP protocol for this port. Supports "TCP",
+                              "UDP", and "SCTP". Default is TCP.
+                            type: string
+                          targetPort:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: 'Number or name of the port to access on
+                              the pods targeted by the service. Number must be in
+                              the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              If this is a string, it will be looked up as a named
+                              port in the target Pod''s container ports. If this is
+                              not specified, the value of the ''port'' field is used
+                              (an identity map). This field is ignored for services
+                              with clusterIP=None, and should be omitted or set equal
+                              to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      type: array
+                    publishNotReadyAddresses:
+                      description: publishNotReadyAddresses, when set to true, indicates
+                        that DNS implementations must publish the notReadyAddresses
+                        of subsets for the Endpoints associated with the Service.
+                        The default value is false. The primary use case for setting
+                        this field is to use a StatefulSet's Headless Service to propagate
+                        SRV records for its Pods without respect to their readiness
+                        for purpose of peer discovery.
+                      type: boolean
+                    selector:
+                      additionalProperties:
+                        type: string
+                      description: 'Route service traffic to pods with label keys
+                        and values matching this selector. If empty or not present,
+                        the service is assumed to have an external process managing
+                        its endpoints, which Kubernetes will not modify. Only applies
+                        to types ClusterIP, NodePort, and LoadBalancer. Ignored if
+                        type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                      type: object
+                    sessionAffinity:
+                      description: 'Supports "ClientIP" and "None". Used to maintain
+                        session affinity. Enable client IP based session affinity.
+                        Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    sessionAffinityConfig:
+                      description: sessionAffinityConfig contains the configurations
+                        of session affinity.
+                      properties:
+                        clientIP:
+                          description: clientIP contains the configurations of Client
+                            IP based session affinity.
+                          properties:
+                            timeoutSeconds:
+                              description: timeoutSeconds specifies the seconds of
+                                ClientIP type session sticky time. The value must
+                                be >0 && <=86400(for 1 day) if ServiceAffinity ==
+                                "ClientIP". Default value is 10800(for 3 hours).
                               format: int32
                               type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
                           type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to a pod label update), the system may or may
-                          not try to eventually evict the pod from its node. When
-                          there are multiple elements, the lists of nodes corresponding
-                          to each podAffinityTerm are intersected, i.e. all terms
-                          must be satisfied.
-                        items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
-                          properties:
-                            labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            namespaces:
-                              description: namespaces specifies which namespaces the
-                                labelSelector applies to (matches against); null or
-                                empty list means "this pod's namespace"
-                              items:
+                      type: object
+                    type:
+                      description: 'type determines how the Service is exposed. Defaults
+                        to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort,
+                        and LoadBalancer. "ExternalName" maps to the specified externalName.
+                        "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                        to endpoints. Endpoints are determined by the selector or
+                        if that is not specified, by manual construction of an Endpoints
+                        object. If clusterIP is "None", no virtual IP is allocated
+                        and the endpoints are published as a set of endpoints rather
+                        than a stable IP. "NodePort" builds on ClusterIP and allocates
+                        a port on every node which routes to the clusterIP. "LoadBalancer"
+                        builds on NodePort and creates an external load-balancer (if
+                        supported in the current cloud) which routes to the clusterIP.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                      type: string
+                  type: object
+                status:
+                  description: 'Most recently observed status of the service. Populated
+                    by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                  properties:
+                    loadBalancer:
+                      description: LoadBalancer contains the current status of the
+                        load-balancer, if one is present.
+                      properties:
+                        ingress:
+                          description: Ingress is a list containing ingress points
+                            for the load-balancer. Traffic intended for the service
+                            should be sent to these ingress points.
+                          items:
+                            description: 'LoadBalancerIngress represents the status
+                              of a load-balancer ingress point: traffic intended for
+                              the service should be sent to an ingress point.'
+                            properties:
+                              hostname:
+                                description: Hostname is set for load-balancer ingress
+                                  points that are DNS based (typically AWS load-balancers)
                                 type: string
-                              type: array
-                            topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                  podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g.
-                      avoid putting this pod in the same node, zone, etc. as some
-                      other pod(s)).
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the anti-affinity expressions specified
-                          by this field, but it may choose a node that violates one
-                          or more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling anti-affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
-                        items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
-                          properties:
-                            podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the anti-affinity requirements specified by
-                          this field are not met at scheduling time, the pod will
-                          not be scheduled onto the node. If the anti-affinity requirements
-                          specified by this field cease to be met at some point during
-                          pod execution (e.g. due to a pod label update), the system
-                          may or may not try to eventually evict the pod from its
-                          node. When there are multiple elements, the lists of nodes
-                          corresponding to each podAffinityTerm are intersected, i.e.
-                          all terms must be satisfied.
-                        items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
-                          properties:
-                            labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            namespaces:
-                              description: namespaces specifies which namespaces the
-                                labelSelector applies to (matches against); null or
-                                empty list means "this pod's namespace"
-                              items:
+                              ip:
+                                description: IP is set for load-balancer ingress points
+                                  that are IP based (typically GCE or OpenStack load-balancers)
                                 type: string
-                              type: array
-                            topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                type: object
-              clusterMasterRef:
-                description: ClusterMasterRef refers to a Splunk Enterprise indexer
-                  cluster managed by the operator within Kubernetes
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+              type: object
+            storageClassName:
+              description: Name of StorageClass to use for persistent volume claims
+              type: string
+            tolerations:
+              description: Pod's tolerations for Kubernetes node's taint
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
                 properties:
-                  apiVersion:
-                    description: API version of the referent.
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
                     type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
                     type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
                     type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
                     type: string
                 type: object
-              defaults:
-                description: Inline map of default.yml overrides used to initialize
-                  the environment
-                type: string
-              defaultsUrl:
-                description: Full path or URL for one or more default.yml files, separated
-                  by commas
-                type: string
-              ephemeralStorage:
-                description: If true, ephemeral (emptyDir) storage will be used for
-                  /opt/splunk/etc and /opt/splunk/var volumes
-                type: boolean
-              etcStorage:
-                description: Storage capacity to request for /opt/splunk/etc persistent
-                  volume claims (default=”1Gi”)
-                type: string
-              image:
-                description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
-                  environment variables)
-                type: string
-              imagePullPolicy:
-                description: 'Sets pull policy for all images (either “Always” or
-                  the default: “IfNotPresent”)'
-                enum:
-                - Always
-                - IfNotPresent
-                type: string
-              licenseMasterRef:
-                description: LicenseMasterRef refers to a Splunk Enterprise license
-                  master managed by the operator within Kubernetes
+              type: array
+            varStorage:
+              description: Storage capacity to request for /opt/splunk/var persistent
+                volume claims (default=”50Gi”)
+              type: string
+            volumes:
+              description: List of one or more Kubernetes volumes. These will be mounted
+                in all pod containers as as /mnt/<name>
+              items:
+                description: Volume represents a named volume in a pod that may be
+                  accessed by any container in the pod.
                 properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              licenseUrl:
-                description: Full path or URL for a Splunk Enterprise license file
-                type: string
-              replicas:
-                description: Number of search head pods; a search head cluster will
-                  be created if > 1
-                format: int32
-                type: integer
-              resources:
-                description: resource requirements for the pod containers
-                properties:
-                  limits:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                    type: object
-                  requests:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                    type: object
-                type: object
-              schedulerName:
-                description: Name of Scheduler to use for pod placement (defaults
-                  to “default-scheduler”)
-                type: string
-              serviceTemplate:
-                description: ServiceTemplate is a template used to create Kubernetes
-                  services
-                properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  metadata:
-                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                    type: object
-                  spec:
-                    description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                  awsElasticBlockStore:
+                    description: 'AWSElasticBlockStore represents an AWS Disk resource
+                      that is attached to a kubelet''s host machine and then exposed
+                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                     properties:
-                      clusterIP:
-                        description: 'clusterIP is the IP address of the service and
-                          is usually assigned randomly by the master. If an address
-                          is specified manually and is not in use by others, it will
-                          be allocated to the service; otherwise, creation of the
-                          service will fail. This field can not be changed through
-                          updates. Valid values are "None", empty string (""), or
-                          a valid IP address. "None" can be specified for headless
-                          services when proxying is not required. Only applies to
-                          types ClusterIP, NodePort, and LoadBalancer. Ignored if
-                          type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
                         type: string
-                      externalIPs:
-                        description: externalIPs is a list of IP addresses for which
-                          nodes in the cluster will also accept traffic for this service.  These
-                          IPs are not managed by Kubernetes.  The user is responsible
-                          for ensuring that traffic arrives at a node with this IP.  A
-                          common example is external load-balancers that are not part
-                          of the Kubernetes system.
-                        items:
-                          type: string
-                        type: array
-                      externalName:
-                        description: externalName is the external reference that kubedns
-                          or equivalent will return as a CNAME record for this service.
-                          No proxying will be involved. Must be a valid RFC-1123 hostname
-                          (https://tools.ietf.org/html/rfc1123) and requires Type
-                          to be ExternalName.
-                        type: string
-                      externalTrafficPolicy:
-                        description: externalTrafficPolicy denotes if this Service
-                          desires to route external traffic to node-local or cluster-wide
-                          endpoints. "Local" preserves the client source IP and avoids
-                          a second hop for LoadBalancer and Nodeport type services,
-                          but risks potentially imbalanced traffic spreading. "Cluster"
-                          obscures the client source IP and may cause a second hop
-                          to another node, but should have good overall load-spreading.
-                        type: string
-                      healthCheckNodePort:
-                        description: healthCheckNodePort specifies the healthcheck
-                          nodePort for the service. If not specified, HealthCheckNodePort
-                          is created by the service api backend with the allocated
-                          nodePort. Will use user-specified nodePort value if specified
-                          by the client. Only effects when Type is set to LoadBalancer
-                          and ExternalTrafficPolicy is set to Local.
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty).'
                         format: int32
                         type: integer
-                      ipFamily:
-                        description: ipFamily specifies whether this Service has a
-                          preference for a particular IP family (e.g. IPv4 vs. IPv6).  If
-                          a specific IP family is requested, the clusterIP field will
-                          be allocated from that family, if it is available in the
-                          cluster.  If no IP family is requested, the cluster's primary
-                          IP family will be used. Other IP fields (loadBalancerIP,
-                          loadBalancerSourceRanges, externalIPs) and controllers which
-                          allocate external load-balancers should use the same IP
-                          family.  Endpoints for this Service will be of this family.  This
-                          field is immutable after creation. Assigning a ServiceIPFamily
-                          not available in the cluster (e.g. IPv6 in IPv4 only cluster)
-                          is an error condition and will fail during clusterIP assignment.
+                      readOnly:
+                        description: 'Specify "true" to force and set the ReadOnly
+                          property in VolumeMounts to "true". If omitted, the default
+                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: boolean
+                      volumeID:
+                        description: 'Unique ID of the persistent disk resource in
+                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                         type: string
-                      loadBalancerIP:
-                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                          will get created with the IP specified in this field. This
-                          feature depends on whether the underlying cloud-provider
-                          supports specifying the loadBalancerIP when a load balancer
-                          is created. This field will be ignored if the cloud-provider
-                          does not support the feature.'
+                    required:
+                    - volumeID
+                    type: object
+                  azureDisk:
+                    description: AzureDisk represents an Azure Data Disk mount on
+                      the host and bind mount to the pod.
+                    properties:
+                      cachingMode:
+                        description: 'Host Caching mode: None, Read Only, Read Write.'
                         type: string
-                      loadBalancerSourceRanges:
-                        description: 'If specified and supported by the platform,
-                          this will restrict traffic through the cloud-provider load-balancer
-                          will be restricted to the specified client IPs. This field
-                          will be ignored if the cloud-provider does not support the
-                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                      diskName:
+                        description: The Name of the data disk in the blob storage
+                        type: string
+                      diskURI:
+                        description: The URI the data disk in the blob storage
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      kind:
+                        description: 'Expected values Shared: multiple blob disks
+                          per storage account  Dedicated: single blob disk per storage
+                          account  Managed: azure managed data disk (only in managed
+                          availability set). defaults to shared'
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                    required:
+                    - diskName
+                    - diskURI
+                    type: object
+                  azureFile:
+                    description: AzureFile represents an Azure File Service mount
+                      on the host and bind mount to the pod.
+                    properties:
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretName:
+                        description: the name of secret that contains Azure Storage
+                          Account Name and Key
+                        type: string
+                      shareName:
+                        description: Share Name
+                        type: string
+                    required:
+                    - secretName
+                    - shareName
+                    type: object
+                  cephfs:
+                    description: CephFS represents a Ceph FS mount on the host that
+                      shares a pod's lifetime
+                    properties:
+                      monitors:
+                        description: 'Required: Monitors is a collection of Ceph monitors
+                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                         items:
                           type: string
                         type: array
-                      ports:
-                        description: 'The list of ports that are exposed by this service.
-                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      path:
+                        description: 'Optional: Used as the mounted root, rather than
+                          the full Ceph tree, default is /'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: boolean
+                      secretFile:
+                        description: 'Optional: SecretFile is the path to key ring
+                          for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                      secretRef:
+                        description: 'Optional: SecretRef is reference to the authentication
+                          secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      user:
+                        description: 'Optional: User is the rados user name, default
+                          is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                    required:
+                    - monitors
+                    type: object
+                  cinder:
+                    description: 'Cinder represents a cinder volume attached and mounted
+                      on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Examples: "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: boolean
+                      secretRef:
+                        description: 'Optional: points to a secret object containing
+                          parameters used to connect to OpenStack.'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      volumeID:
+                        description: 'volume id used to identify the volume in cinder.
+                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  configMap:
+                    description: ConfigMap represents a configMap that should populate
+                      this volume
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced ConfigMap will be projected into
+                          the volume as a file whose name is the key and content is
+                          the value. If specified, the listed keys will be projected
+                          into the specified paths, and unlisted keys will not be
+                          present. If a key is specified which is not present in the
+                          ConfigMap, the volume setup will error unless it is marked
+                          optional. Paths must be relative and may not contain the
+                          '..' path or start with '..'.
                         items:
-                          description: ServicePort contains information on service's
-                            port.
+                          description: Maps a string key to a path within a volume.
                           properties:
-                            name:
-                              description: The name of this port within the service.
-                                This must be a DNS_LABEL. All ports within a ServiceSpec
-                                must have unique names. When considering the endpoints
-                                for a Service, this must match the 'name' field in
-                                the EndpointPort. Optional if only one ServicePort
-                                is defined on this service.
+                            key:
+                              description: The key to project.
                               type: string
-                            nodePort:
-                              description: 'The port on each node on which this service
-                                is exposed when type=NodePort or LoadBalancer. Usually
-                                assigned by the system. If specified, it will be allocated
-                                to the service if unused or else creation of the service
-                                will fail. Default is to auto-allocate a port if the
-                                ServiceType of this Service requires one. More info:
-                                https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
                               format: int32
                               type: integer
-                            port:
-                              description: The port that will be exposed by this service.
-                              format: int32
-                              type: integer
-                            protocol:
-                              description: The IP protocol for this port. Supports
-                                "TCP", "UDP", and "SCTP". Default is TCP.
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
                               type: string
-                            targetPort:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              description: 'Number or name of the port to access on
-                                the pods targeted by the service. Number must be in
-                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                                If this is a string, it will be looked up as a named
-                                port in the target Pod''s container ports. If this
-                                is not specified, the value of the ''port'' field
-                                is used (an identity map). This field is ignored for
-                                services with clusterIP=None, and should be omitted
-                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
-                              x-kubernetes-int-or-string: true
                           required:
-                          - port
+                          - key
+                          - path
                           type: object
                         type: array
-                        x-kubernetes-list-map-keys:
-                        - port
-                        - protocol
-                        x-kubernetes-list-type: map
-                      publishNotReadyAddresses:
-                        description: publishNotReadyAddresses, when set to true, indicates
-                          that DNS implementations must publish the notReadyAddresses
-                          of subsets for the Endpoints associated with the Service.
-                          The default value is false. The primary use case for setting
-                          this field is to use a StatefulSet's Headless Service to
-                          propagate SRV records for its Pods without respect to their
-                          readiness for purpose of peer discovery.
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the ConfigMap or its keys must
+                          be defined
                         type: boolean
-                      selector:
+                    type: object
+                  csi:
+                    description: CSI (Container Storage Interface) represents storage
+                      that is handled by an external CSI driver (Alpha feature).
+                    properties:
+                      driver:
+                        description: Driver is the name of the CSI driver that handles
+                          this volume. Consult with your admin for the correct name
+                          as registered in the cluster.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Ex. "ext4", "xfs",
+                          "ntfs". If not provided, the empty value is passed to the
+                          associated CSI driver which will determine the default filesystem
+                          to apply.
+                        type: string
+                      nodePublishSecretRef:
+                        description: NodePublishSecretRef is a reference to the secret
+                          object containing sensitive information to pass to the CSI
+                          driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
+                          calls. This field is optional, and  may be empty if no secret
+                          is required. If the secret object contains more than one
+                          secret, all secret references are passed.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      readOnly:
+                        description: Specifies a read-only configuration for the volume.
+                          Defaults to false (read/write).
+                        type: boolean
+                      volumeAttributes:
                         additionalProperties:
                           type: string
-                        description: 'Route service traffic to pods with label keys
-                          and values matching this selector. If empty or not present,
-                          the service is assumed to have an external process managing
-                          its endpoints, which Kubernetes will not modify. Only applies
-                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
-                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                        description: VolumeAttributes stores driver-specific properties
+                          that are passed to the CSI driver. Consult your driver's
+                          documentation for supported values.
                         type: object
-                      sessionAffinity:
-                        description: 'Supports "ClientIP" and "None". Used to maintain
-                          session affinity. Enable client IP based session affinity.
-                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                        type: string
-                      sessionAffinityConfig:
-                        description: sessionAffinityConfig contains the configurations
-                          of session affinity.
-                        properties:
-                          clientIP:
-                            description: clientIP contains the configurations of Client
-                              IP based session affinity.
-                            properties:
-                              timeoutSeconds:
-                                description: timeoutSeconds specifies the seconds
-                                  of ClientIP type session sticky time. The value
-                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
-                                  == "ClientIP". Default value is 10800(for 3 hours).
-                                format: int32
-                                type: integer
-                            type: object
-                        type: object
-                      type:
-                        description: 'type determines how the Service is exposed.
-                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
-                          NodePort, and LoadBalancer. "ExternalName" maps to the specified
-                          externalName. "ClusterIP" allocates a cluster-internal IP
-                          address for load-balancing to endpoints. Endpoints are determined
-                          by the selector or if that is not specified, by manual construction
-                          of an Endpoints object. If clusterIP is "None", no virtual
-                          IP is allocated and the endpoints are published as a set
-                          of endpoints rather than a stable IP. "NodePort" builds
-                          on ClusterIP and allocates a port on every node which routes
-                          to the clusterIP. "LoadBalancer" builds on NodePort and
-                          creates an external load-balancer (if supported in the current
-                          cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
-                        type: string
+                    required:
+                    - driver
                     type: object
-                  status:
-                    description: 'Most recently observed status of the service. Populated
-                      by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                  downwardAPI:
+                    description: DownwardAPI represents downward API about the pod
+                      that should populate this volume
                     properties:
-                      loadBalancer:
-                        description: LoadBalancer contains the current status of the
-                          load-balancer, if one is present.
-                        properties:
-                          ingress:
-                            description: Ingress is a list containing ingress points
-                              for the load-balancer. Traffic intended for the service
-                              should be sent to these ingress points.
-                            items:
-                              description: 'LoadBalancerIngress represents the status
-                                of a load-balancer ingress point: traffic intended
-                                for the service should be sent to an ingress point.'
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: Items is a list of downward API volume file
+                        items:
+                          description: DownwardAPIVolumeFile represents information
+                            to create the file containing the pod field
+                          properties:
+                            fieldRef:
+                              description: 'Required: Selects a field of the pod:
+                                only annotations, labels, name and namespace are supported.'
                               properties:
-                                hostname:
-                                  description: Hostname is set for load-balancer ingress
-                                    points that are DNS based (typically AWS load-balancers)
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
                                   type: string
-                                ip:
-                                  description: IP is set for load-balancer ingress
-                                    points that are IP based (typically GCE or OpenStack
-                                    load-balancers)
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
                                   type: string
+                              required:
+                              - fieldPath
                               type: object
-                            type: array
-                        type: object
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: 'Required: Path is  the relative path name
+                                of the file to be created. Must not be absolute or
+                                contain the ''..'' path. Must be utf-8 encoded. The
+                                first item of the relative path must not start with
+                                ''..'''
+                              type: string
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                requests.cpu and requests.memory) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  type: string
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                          required:
+                          - path
+                          type: object
+                        type: array
                     type: object
+                  emptyDir:
+                    description: 'EmptyDir represents a temporary directory that shares
+                      a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                    properties:
+                      medium:
+                        description: 'What type of storage medium should back this
+                          directory. The default is "" which means to use the node''s
+                          default medium. Must be an empty string (default) or Memory.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        type: string
+                      sizeLimit:
+                        description: 'Total amount of local storage required for this
+                          EmptyDir volume. The size limit is also applicable for memory
+                          medium. The maximum usage on memory medium EmptyDir would
+                          be the minimum value between the SizeLimit specified here
+                          and the sum of memory limits of all containers in a pod.
+                          The default is nil which means that the limit is undefined.
+                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                        type: string
+                    type: object
+                  fc:
+                    description: FC represents a Fibre Channel resource that is attached
+                      to a kubelet's host machine and then exposed to the pod.
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      lun:
+                        description: 'Optional: FC target lun number'
+                        format: int32
+                        type: integer
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      targetWWNs:
+                        description: 'Optional: FC target worldwide names (WWNs)'
+                        items:
+                          type: string
+                        type: array
+                      wwids:
+                        description: 'Optional: FC volume world wide identifiers (wwids)
+                          Either wwids or combination of targetWWNs and lun must be
+                          set, but not both simultaneously.'
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  flexVolume:
+                    description: FlexVolume represents a generic volume resource that
+                      is provisioned/attached using an exec based plugin.
+                    properties:
+                      driver:
+                        description: Driver is the name of the driver to use for this
+                          volume.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". The default filesystem depends on FlexVolume
+                          script.
+                        type: string
+                      options:
+                        additionalProperties:
+                          type: string
+                        description: 'Optional: Extra command options if any.'
+                        type: object
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      secretRef:
+                        description: 'Optional: SecretRef is reference to the secret
+                          object containing sensitive information to pass to the plugin
+                          scripts. This may be empty if no secret object is specified.
+                          If the secret object contains more than one secret, all
+                          secrets are passed to the plugin scripts.'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                    required:
+                    - driver
+                    type: object
+                  flocker:
+                    description: Flocker represents a Flocker volume attached to a
+                      kubelet's host machine. This depends on the Flocker control
+                      service being running
+                    properties:
+                      datasetName:
+                        description: Name of the dataset stored as metadata -> name
+                          on the dataset for Flocker should be considered as deprecated
+                        type: string
+                      datasetUUID:
+                        description: UUID of the dataset. This is unique identifier
+                          of a Flocker dataset
+                        type: string
+                    type: object
+                  gcePersistentDisk:
+                    description: 'GCEPersistentDisk represents a GCE Disk resource
+                      that is attached to a kubelet''s host machine and then exposed
+                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        format: int32
+                        type: integer
+                      pdName:
+                        description: 'Unique name of the PD resource in GCE. Used
+                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: boolean
+                    required:
+                    - pdName
+                    type: object
+                  gitRepo:
+                    description: 'GitRepo represents a git repository at a particular
+                      revision. DEPRECATED: GitRepo is deprecated. To provision a
+                      container with a git repo, mount an EmptyDir into an InitContainer
+                      that clones the repo using git, then mount the EmptyDir into
+                      the Pod''s container.'
+                    properties:
+                      directory:
+                        description: Target directory name. Must not contain or start
+                          with '..'.  If '.' is supplied, the volume directory will
+                          be the git repository.  Otherwise, if specified, the volume
+                          will contain the git repository in the subdirectory with
+                          the given name.
+                        type: string
+                      repository:
+                        description: Repository URL
+                        type: string
+                      revision:
+                        description: Commit hash for the specified revision.
+                        type: string
+                    required:
+                    - repository
+                    type: object
+                  glusterfs:
+                    description: 'Glusterfs represents a Glusterfs mount on the host
+                      that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                    properties:
+                      endpoints:
+                        description: 'EndpointsName is the endpoint name that details
+                          Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      path:
+                        description: 'Path is the Glusterfs volume path. More info:
+                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the Glusterfs volume
+                          to be mounted with read-only permissions. Defaults to false.
+                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: boolean
+                    required:
+                    - endpoints
+                    - path
+                    type: object
+                  hostPath:
+                    description: 'HostPath represents a pre-existing file or directory
+                      on the host machine that is directly exposed to the container.
+                      This is generally used for system agents or other privileged
+                      things that are allowed to see the host machine. Most containers
+                      will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                      --- TODO(jonesdl) We need to restrict who can use host directory
+                      mounts and who can/can not mount host directories as read/write.'
+                    properties:
+                      path:
+                        description: 'Path of the directory on the host. If the path
+                          is a symlink, it will follow the link to the real path.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                      type:
+                        description: 'Type for HostPath Volume Defaults to "" More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                    required:
+                    - path
+                    type: object
+                  iscsi:
+                    description: 'ISCSI represents an ISCSI Disk resource that is
+                      attached to a kubelet''s host machine and then exposed to the
+                      pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                    properties:
+                      chapAuthDiscovery:
+                        description: whether support iSCSI Discovery CHAP authentication
+                        type: boolean
+                      chapAuthSession:
+                        description: whether support iSCSI Session CHAP authentication
+                        type: boolean
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      initiatorName:
+                        description: Custom iSCSI Initiator Name. If initiatorName
+                          is specified with iscsiInterface simultaneously, new iSCSI
+                          interface <target portal>:<volume name> will be created
+                          for the connection.
+                        type: string
+                      iqn:
+                        description: Target iSCSI Qualified Name.
+                        type: string
+                      iscsiInterface:
+                        description: iSCSI Interface Name that uses an iSCSI transport.
+                          Defaults to 'default' (tcp).
+                        type: string
+                      lun:
+                        description: iSCSI Target Lun number.
+                        format: int32
+                        type: integer
+                      portals:
+                        description: iSCSI Target Portal List. The portal is either
+                          an IP or ip_addr:port if the port is other than default
+                          (typically TCP ports 860 and 3260).
+                        items:
+                          type: string
+                        type: array
+                      readOnly:
+                        description: ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false.
+                        type: boolean
+                      secretRef:
+                        description: CHAP Secret for iSCSI target and initiator authentication
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      targetPortal:
+                        description: iSCSI Target Portal. The Portal is either an
+                          IP or ip_addr:port if the port is other than default (typically
+                          TCP ports 860 and 3260).
+                        type: string
+                    required:
+                    - iqn
+                    - lun
+                    - targetPortal
+                    type: object
+                  name:
+                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
+                      the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  nfs:
+                    description: 'NFS represents an NFS mount on the host that shares
+                      a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                    properties:
+                      path:
+                        description: 'Path that is exported by the NFS server. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the NFS export to be
+                          mounted with read-only permissions. Defaults to false. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: boolean
+                      server:
+                        description: 'Server is the hostname or IP address of the
+                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                    required:
+                    - path
+                    - server
+                    type: object
+                  persistentVolumeClaim:
+                    description: 'PersistentVolumeClaimVolumeSource represents a reference
+                      to a PersistentVolumeClaim in the same namespace. More info:
+                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                    properties:
+                      claimName:
+                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                          in the same namespace as the pod using this volume. More
+                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        type: string
+                      readOnly:
+                        description: Will force the ReadOnly setting in VolumeMounts.
+                          Default false.
+                        type: boolean
+                    required:
+                    - claimName
+                    type: object
+                  photonPersistentDisk:
+                    description: PhotonPersistentDisk represents a PhotonController
+                      persistent disk attached and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      pdID:
+                        description: ID that identifies Photon Controller persistent
+                          disk
+                        type: string
+                    required:
+                    - pdID
+                    type: object
+                  portworxVolume:
+                    description: PortworxVolume represents a portworx volume attached
+                      and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: FSType represents the filesystem type to mount
+                          Must be a filesystem type supported by the host operating
+                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                          if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      volumeID:
+                        description: VolumeID uniquely identifies a Portworx volume
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  projected:
+                    description: Items for all in one resources secrets, configmaps,
+                      and downward API
+                    properties:
+                      defaultMode:
+                        description: Mode bits to use on created files by default.
+                          Must be a value between 0 and 0777. Directories within the
+                          path are not affected by this setting. This might be in
+                          conflict with other options that affect the file mode, like
+                          fsGroup, and the result can be other mode bits set.
+                        format: int32
+                        type: integer
+                      sources:
+                        description: list of volume projections
+                        items:
+                          description: Projection that may be projected along with
+                            other supported volume types
+                          properties:
+                            configMap:
+                              description: information about the configMap data to
+                                project
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    keys must be defined
+                                  type: boolean
+                              type: object
+                            downwardAPI:
+                              description: information about the downwardAPI data
+                                to project
+                              properties:
+                                items:
+                                  description: Items is a list of DownwardAPIVolume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, requests.cpu and requests.memory)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            secret:
+                              description: information about the secret data to project
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced Secret will
+                                    be projected into the volume as a file whose name
+                                    is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              type: object
+                            serviceAccountToken:
+                              description: information about the serviceAccountToken
+                                data to project
+                              properties:
+                                audience:
+                                  description: Audience is the intended audience of
+                                    the token. A recipient of a token must identify
+                                    itself with an identifier specified in the audience
+                                    of the token, and otherwise should reject the
+                                    token. The audience defaults to the identifier
+                                    of the apiserver.
+                                  type: string
+                                expirationSeconds:
+                                  description: ExpirationSeconds is the requested
+                                    duration of validity of the service account token.
+                                    As the token approaches expiration, the kubelet
+                                    volume plugin will proactively rotate the service
+                                    account token. The kubelet will start trying to
+                                    rotate the token if the token is older than 80
+                                    percent of its time to live or if the token is
+                                    older than 24 hours.Defaults to 1 hour and must
+                                    be at least 10 minutes.
+                                  format: int64
+                                  type: integer
+                                path:
+                                  description: Path is the path relative to the mount
+                                    point of the file to project the token into.
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                          type: object
+                        type: array
+                    required:
+                    - sources
+                    type: object
+                  quobyte:
+                    description: Quobyte represents a Quobyte mount on the host that
+                      shares a pod's lifetime
+                    properties:
+                      group:
+                        description: Group to map volume access to Default is no group
+                        type: string
+                      readOnly:
+                        description: ReadOnly here will force the Quobyte volume to
+                          be mounted with read-only permissions. Defaults to false.
+                        type: boolean
+                      registry:
+                        description: Registry represents a single or multiple Quobyte
+                          Registry services specified as a string as host:port pair
+                          (multiple entries are separated with commas) which acts
+                          as the central registry for volumes
+                        type: string
+                      tenant:
+                        description: Tenant owning the given Quobyte volume in the
+                          Backend Used with dynamically provisioned Quobyte volumes,
+                          value is set by the plugin
+                        type: string
+                      user:
+                        description: User to map volume access to Defaults to serivceaccount
+                          user
+                        type: string
+                      volume:
+                        description: Volume is a string that references an already
+                          created Quobyte volume by name.
+                        type: string
+                    required:
+                    - registry
+                    - volume
+                    type: object
+                  rbd:
+                    description: 'RBD represents a Rados Block Device mount on the
+                      host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      image:
+                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      keyring:
+                        description: 'Keyring is the path to key ring for RBDUser.
+                          Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      monitors:
+                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        items:
+                          type: string
+                        type: array
+                      pool:
+                        description: 'The rados pool name. Default is rbd. More info:
+                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: boolean
+                      secretRef:
+                        description: 'SecretRef is name of the authentication secret
+                          for RBDUser. If provided overrides keyring. Default is nil.
+                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      user:
+                        description: 'The rados user name. Default is admin. More
+                          info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                    required:
+                    - image
+                    - monitors
+                    type: object
+                  scaleIO:
+                    description: ScaleIO represents a ScaleIO persistent volume attached
+                      and mounted on Kubernetes nodes.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Default is "xfs".
+                        type: string
+                      gateway:
+                        description: The host address of the ScaleIO API Gateway.
+                        type: string
+                      protectionDomain:
+                        description: The name of the ScaleIO Protection Domain for
+                          the configured storage.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: SecretRef references to the secret for ScaleIO
+                          user and other sensitive information. If this is not provided,
+                          Login operation will fail.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      sslEnabled:
+                        description: Flag to enable/disable SSL communication with
+                          Gateway, default false
+                        type: boolean
+                      storageMode:
+                        description: Indicates whether the storage for a volume should
+                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                        type: string
+                      storagePool:
+                        description: The ScaleIO Storage Pool associated with the
+                          protection domain.
+                        type: string
+                      system:
+                        description: The name of the storage system as configured
+                          in ScaleIO.
+                        type: string
+                      volumeName:
+                        description: The name of a volume already created in the ScaleIO
+                          system that is associated with this volume source.
+                        type: string
+                    required:
+                    - gateway
+                    - secretRef
+                    - system
+                    type: object
+                  secret:
+                    description: 'Secret represents a secret that should populate
+                      this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced Secret will be projected into the
+                          volume as a file whose name is the key and content is the
+                          value. If specified, the listed keys will be projected into
+                          the specified paths, and unlisted keys will not be present.
+                          If a key is specified which is not present in the Secret,
+                          the volume setup will error unless it is marked optional.
+                          Paths must be relative and may not contain the '..' path
+                          or start with '..'.
+                        items:
+                          description: Maps a string key to a path within a volume.
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          type: object
+                        type: array
+                      optional:
+                        description: Specify whether the Secret or its keys must be
+                          defined
+                        type: boolean
+                      secretName:
+                        description: 'Name of the secret in the pod''s namespace to
+                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        type: string
+                    type: object
+                  storageos:
+                    description: StorageOS represents a StorageOS volume attached
+                      and mounted on Kubernetes nodes.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: SecretRef specifies the secret to use for obtaining
+                          the StorageOS API credentials.  If not specified, default
+                          values will be attempted.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      volumeName:
+                        description: VolumeName is the human-readable name of the
+                          StorageOS volume.  Volume names are only unique within a
+                          namespace.
+                        type: string
+                      volumeNamespace:
+                        description: VolumeNamespace specifies the scope of the volume
+                          within StorageOS.  If no namespace is specified then the
+                          Pod's namespace will be used.  This allows the Kubernetes
+                          name scoping to be mirrored within StorageOS for tighter
+                          integration. Set VolumeName to any name to override the
+                          default behaviour. Set to "default" if you are not using
+                          namespaces within StorageOS. Namespaces that do not pre-exist
+                          within StorageOS will be created.
+                        type: string
+                    type: object
+                  vsphereVolume:
+                    description: VsphereVolume represents a vSphere volume attached
+                      and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      storagePolicyID:
+                        description: Storage Policy Based Management (SPBM) profile
+                          ID associated with the StoragePolicyName.
+                        type: string
+                      storagePolicyName:
+                        description: Storage Policy Based Management (SPBM) profile
+                          name.
+                        type: string
+                      volumePath:
+                        description: Path that identifies vSphere volume vmdk
+                        type: string
+                    required:
+                    - volumePath
+                    type: object
+                required:
+                - name
                 type: object
-              storageClassName:
-                description: Name of StorageClass to use for persistent volume claims
-                type: string
-              tolerations:
-                description: Pod's tolerations for Kubernetes node's taint
-                items:
-                  description: The pod this Toleration is attached to tolerates any
-                    taint that matches the triple <key,value,effect> using the matching
-                    operator <operator>.
-                  properties:
-                    effect:
-                      description: Effect indicates the taint effect to match. Empty
-                        means match all taint effects. When specified, allowed values
-                        are NoSchedule, PreferNoSchedule and NoExecute.
-                      type: string
-                    key:
-                      description: Key is the taint key that the toleration applies
-                        to. Empty means match all taint keys. If the key is empty,
-                        operator must be Exists; this combination means to match all
-                        values and all keys.
-                      type: string
-                    operator:
-                      description: Operator represents a key's relationship to the
-                        value. Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod
-                        can tolerate all taints of a particular category.
-                      type: string
-                    tolerationSeconds:
-                      description: TolerationSeconds represents the period of time
-                        the toleration (which must be of effect NoExecute, otherwise
-                        this field is ignored) tolerates the taint. By default, it
-                        is not set, which means tolerate the taint forever (do not
-                        evict). Zero and negative values will be treated as 0 (evict
-                        immediately) by the system.
-                      format: int64
-                      type: integer
-                    value:
-                      description: Value is the taint value the toleration matches
-                        to. If the operator is Exists, the value should be empty,
-                        otherwise just a regular string.
-                      type: string
-                  type: object
-                type: array
-              varStorage:
-                description: Storage capacity to request for /opt/splunk/var persistent
-                  volume claims (default=”50Gi”)
-                type: string
-              volumes:
-                description: List of one or more Kubernetes volumes. These will be
-                  mounted in all pod containers as as /mnt/<name>
-                items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
-                  properties:
-                    awsElasticBlockStore:
-                      description: 'AWSElasticBlockStore represents an AWS Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        partition:
-                          description: 'The partition in the volume that you want
-                            to mount. If omitted, the default is to mount by volume
-                            name. Examples: For volume /dev/sda1, you specify the
-                            partition as "1". Similarly, the volume partition for
-                            /dev/sda is "0" (or you can leave the property empty).'
-                          format: int32
-                          type: integer
-                        readOnly:
-                          description: 'Specify "true" to force and set the ReadOnly
-                            property in VolumeMounts to "true". If omitted, the default
-                            is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                          type: boolean
-                        volumeID:
-                          description: 'Unique ID of the persistent disk resource
-                            in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    azureDisk:
-                      description: AzureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
-                      properties:
-                        cachingMode:
-                          description: 'Host Caching mode: None, Read Only, Read Write.'
-                          type: string
-                        diskName:
-                          description: The Name of the data disk in the blob storage
-                          type: string
-                        diskURI:
-                          description: The URI the data disk in the blob storage
-                          type: string
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        kind:
-                          description: 'Expected values Shared: multiple blob disks
-                            per storage account  Dedicated: single blob disk per storage
-                            account  Managed: azure managed data disk (only in managed
-                            availability set). defaults to shared'
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                      required:
-                      - diskName
-                      - diskURI
-                      type: object
-                    azureFile:
-                      description: AzureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
-                      properties:
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretName:
-                          description: the name of secret that contains Azure Storage
-                            Account Name and Key
-                          type: string
-                        shareName:
-                          description: Share Name
-                          type: string
-                      required:
-                      - secretName
-                      - shareName
-                      type: object
-                    cephfs:
-                      description: CephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
-                      properties:
-                        monitors:
-                          description: 'Required: Monitors is a collection of Ceph
-                            monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          items:
-                            type: string
-                          type: array
-                        path:
-                          description: 'Optional: Used as the mounted root, rather
-                            than the full Ceph tree, default is /'
-                          type: string
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: boolean
-                        secretFile:
-                          description: 'Optional: SecretFile is the path to key ring
-                            for User, default is /etc/ceph/user.secret More info:
-                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: string
-                        secretRef:
-                          description: 'Optional: SecretRef is reference to the authentication
-                            secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        user:
-                          description: 'Optional: User is the rados user name, default
-                            is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: string
-                      required:
-                      - monitors
-                      type: object
-                    cinder:
-                      description: 'Cinder represents a cinder volume attached and
-                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: string
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: boolean
-                        secretRef:
-                          description: 'Optional: points to a secret object containing
-                            parameters used to connect to OpenStack.'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        volumeID:
-                          description: 'volume id used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    configMap:
-                      description: ConfigMap represents a configMap that should populate
-                        this volume
-                      properties:
-                        defaultMode:
-                          description: 'Optional: mode bits to use on created files
-                            by default. Must be a value between 0 and 0777. Defaults
-                            to 0644. Directories within the path are not affected
-                            by this setting. This might be in conflict with other
-                            options that affect the file mode, like fsGroup, and the
-                            result can be other mode bits set.'
-                          format: int32
-                          type: integer
-                        items:
-                          description: If unspecified, each key-value pair in the
-                            Data field of the referenced ConfigMap will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the ConfigMap, the volume setup will error unless it is
-                            marked optional. Paths must be relative and may not contain
-                            the '..' path or start with '..'.
-                          items:
-                            description: Maps a string key to a path within a volume.
-                            properties:
-                              key:
-                                description: The key to project.
-                                type: string
-                              mode:
-                                description: 'Optional: mode bits to use on this file,
-                                  must be a value between 0 and 0777. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: The relative path of the file to map
-                                  the key to. May not be an absolute path. May not
-                                  contain the path element '..'. May not start with
-                                  the string '..'.
-                                type: string
-                            required:
-                            - key
-                            - path
-                            type: object
-                          type: array
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                        optional:
-                          description: Specify whether the ConfigMap or its keys must
-                            be defined
-                          type: boolean
-                      type: object
-                    csi:
-                      description: CSI (Container Storage Interface) represents storage
-                        that is handled by an external CSI driver (Alpha feature).
-                      properties:
-                        driver:
-                          description: Driver is the name of the CSI driver that handles
-                            this volume. Consult with your admin for the correct name
-                            as registered in the cluster.
-                          type: string
-                        fsType:
-                          description: Filesystem type to mount. Ex. "ext4", "xfs",
-                            "ntfs". If not provided, the empty value is passed to
-                            the associated CSI driver which will determine the default
-                            filesystem to apply.
-                          type: string
-                        nodePublishSecretRef:
-                          description: NodePublishSecretRef is a reference to the
-                            secret object containing sensitive information to pass
-                            to the CSI driver to complete the CSI NodePublishVolume
-                            and NodeUnpublishVolume calls. This field is optional,
-                            and  may be empty if no secret is required. If the secret
-                            object contains more than one secret, all secret references
-                            are passed.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        readOnly:
-                          description: Specifies a read-only configuration for the
-                            volume. Defaults to false (read/write).
-                          type: boolean
-                        volumeAttributes:
-                          additionalProperties:
-                            type: string
-                          description: VolumeAttributes stores driver-specific properties
-                            that are passed to the CSI driver. Consult your driver's
-                            documentation for supported values.
-                          type: object
-                      required:
-                      - driver
-                      type: object
-                    downwardAPI:
-                      description: DownwardAPI represents downward API about the pod
-                        that should populate this volume
-                      properties:
-                        defaultMode:
-                          description: 'Optional: mode bits to use on created files
-                            by default. Must be a value between 0 and 0777. Defaults
-                            to 0644. Directories within the path are not affected
-                            by this setting. This might be in conflict with other
-                            options that affect the file mode, like fsGroup, and the
-                            result can be other mode bits set.'
-                          format: int32
-                          type: integer
-                        items:
-                          description: Items is a list of downward API volume file
-                          items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
-                            properties:
-                              fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
-                                properties:
-                                  apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
-                                    type: string
-                                required:
-                                - fieldPath
-                                type: object
-                              mode:
-                                description: 'Optional: mode bits to use on this file,
-                                  must be a value between 0 and 0777. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
-                                type: string
-                              resourceFieldRef:
-                                description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, requests.cpu and requests.memory)
-                                  are currently supported.'
-                                properties:
-                                  containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: 'Required: resource to select'
-                                    type: string
-                                required:
-                                - resource
-                                type: object
-                            required:
-                            - path
-                            type: object
-                          type: array
-                      type: object
-                    emptyDir:
-                      description: 'EmptyDir represents a temporary directory that
-                        shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                      properties:
-                        medium:
-                          description: 'What type of storage medium should back this
-                            directory. The default is "" which means to use the node''s
-                            default medium. Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                          type: string
-                        sizeLimit:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          description: 'Total amount of local storage required for
-                            this EmptyDir volume. The size limit is also applicable
-                            for memory medium. The maximum usage on memory medium
-                            EmptyDir would be the minimum value between the SizeLimit
-                            specified here and the sum of memory limits of all containers
-                            in a pod. The default is nil which means that the limit
-                            is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                      type: object
-                    fc:
-                      description: FC represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
-                      properties:
-                        fsType:
-                          description: 'Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        lun:
-                          description: 'Optional: FC target lun number'
-                          format: int32
-                          type: integer
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
-                          type: boolean
-                        targetWWNs:
-                          description: 'Optional: FC target worldwide names (WWNs)'
-                          items:
-                            type: string
-                          type: array
-                        wwids:
-                          description: 'Optional: FC volume world wide identifiers
-                            (wwids) Either wwids or combination of targetWWNs and
-                            lun must be set, but not both simultaneously.'
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    flexVolume:
-                      description: FlexVolume represents a generic volume resource
-                        that is provisioned/attached using an exec based plugin.
-                      properties:
-                        driver:
-                          description: Driver is the name of the driver to use for
-                            this volume.
-                          type: string
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". The default filesystem depends on FlexVolume
-                            script.
-                          type: string
-                        options:
-                          additionalProperties:
-                            type: string
-                          description: 'Optional: Extra command options if any.'
-                          type: object
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
-                          type: boolean
-                        secretRef:
-                          description: 'Optional: SecretRef is reference to the secret
-                            object containing sensitive information to pass to the
-                            plugin scripts. This may be empty if no secret object
-                            is specified. If the secret object contains more than
-                            one secret, all secrets are passed to the plugin scripts.'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                      required:
-                      - driver
-                      type: object
-                    flocker:
-                      description: Flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
-                      properties:
-                        datasetName:
-                          description: Name of the dataset stored as metadata -> name
-                            on the dataset for Flocker should be considered as deprecated
-                          type: string
-                        datasetUUID:
-                          description: UUID of the dataset. This is unique identifier
-                            of a Flocker dataset
-                          type: string
-                      type: object
-                    gcePersistentDisk:
-                      description: 'GCEPersistentDisk represents a GCE Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        partition:
-                          description: 'The partition in the volume that you want
-                            to mount. If omitted, the default is to mount by volume
-                            name. Examples: For volume /dev/sda1, you specify the
-                            partition as "1". Similarly, the volume partition for
-                            /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          format: int32
-                          type: integer
-                        pdName:
-                          description: 'Unique name of the PD resource in GCE. Used
-                            to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          type: boolean
-                      required:
-                      - pdName
-                      type: object
-                    gitRepo:
-                      description: 'GitRepo represents a git repository at a particular
-                        revision. DEPRECATED: GitRepo is deprecated. To provision
-                        a container with a git repo, mount an EmptyDir into an InitContainer
-                        that clones the repo using git, then mount the EmptyDir into
-                        the Pod''s container.'
-                      properties:
-                        directory:
-                          description: Target directory name. Must not contain or
-                            start with '..'.  If '.' is supplied, the volume directory
-                            will be the git repository.  Otherwise, if specified,
-                            the volume will contain the git repository in the subdirectory
-                            with the given name.
-                          type: string
-                        repository:
-                          description: Repository URL
-                          type: string
-                        revision:
-                          description: Commit hash for the specified revision.
-                          type: string
-                      required:
-                      - repository
-                      type: object
-                    glusterfs:
-                      description: 'Glusterfs represents a Glusterfs mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
-                      properties:
-                        endpoints:
-                          description: 'EndpointsName is the endpoint name that details
-                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: string
-                        path:
-                          description: 'Path is the Glusterfs volume path. More info:
-                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the Glusterfs volume
-                            to be mounted with read-only permissions. Defaults to
-                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: boolean
-                      required:
-                      - endpoints
-                      - path
-                      type: object
-                    hostPath:
-                      description: 'HostPath represents a pre-existing file or directory
-                        on the host machine that is directly exposed to the container.
-                        This is generally used for system agents or other privileged
-                        things that are allowed to see the host machine. Most containers
-                        will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        --- TODO(jonesdl) We need to restrict who can use host directory
-                        mounts and who can/can not mount host directories as read/write.'
-                      properties:
-                        path:
-                          description: 'Path of the directory on the host. If the
-                            path is a symlink, it will follow the link to the real
-                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                          type: string
-                        type:
-                          description: 'Type for HostPath Volume Defaults to "" More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                          type: string
-                      required:
-                      - path
-                      type: object
-                    iscsi:
-                      description: 'ISCSI represents an ISCSI Disk resource that is
-                        attached to a kubelet''s host machine and then exposed to
-                        the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
-                      properties:
-                        chapAuthDiscovery:
-                          description: whether support iSCSI Discovery CHAP authentication
-                          type: boolean
-                        chapAuthSession:
-                          description: whether support iSCSI Session CHAP authentication
-                          type: boolean
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        initiatorName:
-                          description: Custom iSCSI Initiator Name. If initiatorName
-                            is specified with iscsiInterface simultaneously, new iSCSI
-                            interface <target portal>:<volume name> will be created
-                            for the connection.
-                          type: string
-                        iqn:
-                          description: Target iSCSI Qualified Name.
-                          type: string
-                        iscsiInterface:
-                          description: iSCSI Interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
-                          type: string
-                        lun:
-                          description: iSCSI Target Lun number.
-                          format: int32
-                          type: integer
-                        portals:
-                          description: iSCSI Target Portal List. The portal is either
-                            an IP or ip_addr:port if the port is other than default
-                            (typically TCP ports 860 and 3260).
-                          items:
-                            type: string
-                          type: array
-                        readOnly:
-                          description: ReadOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false.
-                          type: boolean
-                        secretRef:
-                          description: CHAP Secret for iSCSI target and initiator
-                            authentication
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        targetPortal:
-                          description: iSCSI Target Portal. The Portal is either an
-                            IP or ip_addr:port if the port is other than default (typically
-                            TCP ports 860 and 3260).
-                          type: string
-                      required:
-                      - iqn
-                      - lun
-                      - targetPortal
-                      type: object
-                    name:
-                      description: 'Volume''s name. Must be a DNS_LABEL and unique
-                        within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                      type: string
-                    nfs:
-                      description: 'NFS represents an NFS mount on the host that shares
-                        a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                      properties:
-                        path:
-                          description: 'Path that is exported by the NFS server. More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the NFS export to
-                            be mounted with read-only permissions. Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: boolean
-                        server:
-                          description: 'Server is the hostname or IP address of the
-                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: string
-                      required:
-                      - path
-                      - server
-                      type: object
-                    persistentVolumeClaim:
-                      description: 'PersistentVolumeClaimVolumeSource represents a
-                        reference to a PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                      properties:
-                        claimName:
-                          description: 'ClaimName is the name of a PersistentVolumeClaim
-                            in the same namespace as the pod using this volume. More
-                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                          type: string
-                        readOnly:
-                          description: Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
-                          type: boolean
-                      required:
-                      - claimName
-                      type: object
-                    photonPersistentDisk:
-                      description: PhotonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        pdID:
-                          description: ID that identifies Photon Controller persistent
-                            disk
-                          type: string
-                      required:
-                      - pdID
-                      type: object
-                    portworxVolume:
-                      description: PortworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: FSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating
-                            system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                            if unspecified.
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        volumeID:
-                          description: VolumeID uniquely identifies a Portworx volume
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    projected:
-                      description: Items for all in one resources secrets, configmaps,
-                        and downward API
-                      properties:
-                        defaultMode:
-                          description: Mode bits to use on created files by default.
-                            Must be a value between 0 and 0777. Directories within
-                            the path are not affected by this setting. This might
-                            be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits
-                            set.
-                          format: int32
-                          type: integer
-                        sources:
-                          description: list of volume projections
-                          items:
-                            description: Projection that may be projected along with
-                              other supported volume types
-                            properties:
-                              configMap:
-                                description: information about the configMap data
-                                  to project
-                                properties:
-                                  items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced ConfigMap
-                                      will be projected into the volume as a file
-                                      whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the ConfigMap, the volume
-                                      setup will error unless it is marked optional.
-                                      Paths must be relative and may not contain the
-                                      '..' path or start with '..'.
-                                    items:
-                                      description: Maps a string key to a path within
-                                        a volume.
-                                      properties:
-                                        key:
-                                          description: The key to project.
-                                          type: string
-                                        mode:
-                                          description: 'Optional: mode bits to use
-                                            on this file, must be a value between
-                                            0 and 0777. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element
-                                            '..'. May not start with the string '..'.
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or
-                                      its keys must be defined
-                                    type: boolean
-                                type: object
-                              downwardAPI:
-                                description: information about the downwardAPI data
-                                  to project
-                                properties:
-                                  items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
-                                    items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
-                                      properties:
-                                        fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
-                                          properties:
-                                            apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
-                                              type: string
-                                            fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
-                                              type: string
-                                          required:
-                                          - fieldPath
-                                          type: object
-                                        mode:
-                                          description: 'Optional: mode bits to use
-                                            on this file, must be a value between
-                                            0 and 0777. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
-                                          type: string
-                                        resourceFieldRef:
-                                          description: 'Selects a resource of the
-                                            container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu
-                                            and requests.memory) are currently supported.'
-                                          properties:
-                                            containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
-                                              type: string
-                                            divisor:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            resource:
-                                              description: 'Required: resource to
-                                                select'
-                                              type: string
-                                          required:
-                                          - resource
-                                          type: object
-                                      required:
-                                      - path
-                                      type: object
-                                    type: array
-                                type: object
-                              secret:
-                                description: information about the secret data to
-                                  project
-                                properties:
-                                  items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced Secret will
-                                      be projected into the volume as a file whose
-                                      name is the key and content is the value. If
-                                      specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the Secret, the volume setup
-                                      will error unless it is marked optional. Paths
-                                      must be relative and may not contain the '..'
-                                      path or start with '..'.
-                                    items:
-                                      description: Maps a string key to a path within
-                                        a volume.
-                                      properties:
-                                        key:
-                                          description: The key to project.
-                                          type: string
-                                        mode:
-                                          description: 'Optional: mode bits to use
-                                            on this file, must be a value between
-                                            0 and 0777. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element
-                                            '..'. May not start with the string '..'.
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
-                                    type: boolean
-                                type: object
-                              serviceAccountToken:
-                                description: information about the serviceAccountToken
-                                  data to project
-                                properties:
-                                  audience:
-                                    description: Audience is the intended audience
-                                      of the token. A recipient of a token must identify
-                                      itself with an identifier specified in the audience
-                                      of the token, and otherwise should reject the
-                                      token. The audience defaults to the identifier
-                                      of the apiserver.
-                                    type: string
-                                  expirationSeconds:
-                                    description: ExpirationSeconds is the requested
-                                      duration of validity of the service account
-                                      token. As the token approaches expiration, the
-                                      kubelet volume plugin will proactively rotate
-                                      the service account token. The kubelet will
-                                      start trying to rotate the token if the token
-                                      is older than 80 percent of its time to live
-                                      or if the token is older than 24 hours.Defaults
-                                      to 1 hour and must be at least 10 minutes.
-                                    format: int64
-                                    type: integer
-                                  path:
-                                    description: Path is the path relative to the
-                                      mount point of the file to project the token
-                                      into.
-                                    type: string
-                                required:
-                                - path
-                                type: object
-                            type: object
-                          type: array
-                      required:
-                      - sources
-                      type: object
-                    quobyte:
-                      description: Quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
-                      properties:
-                        group:
-                          description: Group to map volume access to Default is no
-                            group
-                          type: string
-                        readOnly:
-                          description: ReadOnly here will force the Quobyte volume
-                            to be mounted with read-only permissions. Defaults to
-                            false.
-                          type: boolean
-                        registry:
-                          description: Registry represents a single or multiple Quobyte
-                            Registry services specified as a string as host:port pair
-                            (multiple entries are separated with commas) which acts
-                            as the central registry for volumes
-                          type: string
-                        tenant:
-                          description: Tenant owning the given Quobyte volume in the
-                            Backend Used with dynamically provisioned Quobyte volumes,
-                            value is set by the plugin
-                          type: string
-                        user:
-                          description: User to map volume access to Defaults to serivceaccount
-                            user
-                          type: string
-                        volume:
-                          description: Volume is a string that references an already
-                            created Quobyte volume by name.
-                          type: string
-                      required:
-                      - registry
-                      - volume
-                      type: object
-                    rbd:
-                      description: 'RBD represents a Rados Block Device mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        image:
-                          description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        keyring:
-                          description: 'Keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        monitors:
-                          description: 'A collection of Ceph monitors. More info:
-                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          items:
-                            type: string
-                          type: array
-                        pool:
-                          description: 'The rados pool name. Default is rbd. More
-                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: boolean
-                        secretRef:
-                          description: 'SecretRef is name of the authentication secret
-                            for RBDUser. If provided overrides keyring. Default is
-                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        user:
-                          description: 'The rados user name. Default is admin. More
-                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                      required:
-                      - image
-                      - monitors
-                      type: object
-                    scaleIO:
-                      description: ScaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Default is "xfs".
-                          type: string
-                        gateway:
-                          description: The host address of the ScaleIO API Gateway.
-                          type: string
-                        protectionDomain:
-                          description: The name of the ScaleIO Protection Domain for
-                            the configured storage.
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretRef:
-                          description: SecretRef references to the secret for ScaleIO
-                            user and other sensitive information. If this is not provided,
-                            Login operation will fail.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        sslEnabled:
-                          description: Flag to enable/disable SSL communication with
-                            Gateway, default false
-                          type: boolean
-                        storageMode:
-                          description: Indicates whether the storage for a volume
-                            should be ThickProvisioned or ThinProvisioned. Default
-                            is ThinProvisioned.
-                          type: string
-                        storagePool:
-                          description: The ScaleIO Storage Pool associated with the
-                            protection domain.
-                          type: string
-                        system:
-                          description: The name of the storage system as configured
-                            in ScaleIO.
-                          type: string
-                        volumeName:
-                          description: The name of a volume already created in the
-                            ScaleIO system that is associated with this volume source.
-                          type: string
-                      required:
-                      - gateway
-                      - secretRef
-                      - system
-                      type: object
-                    secret:
-                      description: 'Secret represents a secret that should populate
-                        this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                      properties:
-                        defaultMode:
-                          description: 'Optional: mode bits to use on created files
-                            by default. Must be a value between 0 and 0777. Defaults
-                            to 0644. Directories within the path are not affected
-                            by this setting. This might be in conflict with other
-                            options that affect the file mode, like fsGroup, and the
-                            result can be other mode bits set.'
-                          format: int32
-                          type: integer
-                        items:
-                          description: If unspecified, each key-value pair in the
-                            Data field of the referenced Secret will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the Secret, the volume setup will error unless it is marked
-                            optional. Paths must be relative and may not contain the
-                            '..' path or start with '..'.
-                          items:
-                            description: Maps a string key to a path within a volume.
-                            properties:
-                              key:
-                                description: The key to project.
-                                type: string
-                              mode:
-                                description: 'Optional: mode bits to use on this file,
-                                  must be a value between 0 and 0777. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: The relative path of the file to map
-                                  the key to. May not be an absolute path. May not
-                                  contain the path element '..'. May not start with
-                                  the string '..'.
-                                type: string
-                            required:
-                            - key
-                            - path
-                            type: object
-                          type: array
-                        optional:
-                          description: Specify whether the Secret or its keys must
-                            be defined
-                          type: boolean
-                        secretName:
-                          description: 'Name of the secret in the pod''s namespace
-                            to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                          type: string
-                      type: object
-                    storageos:
-                      description: StorageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretRef:
-                          description: SecretRef specifies the secret to use for obtaining
-                            the StorageOS API credentials.  If not specified, default
-                            values will be attempted.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        volumeName:
-                          description: VolumeName is the human-readable name of the
-                            StorageOS volume.  Volume names are only unique within
-                            a namespace.
-                          type: string
-                        volumeNamespace:
-                          description: VolumeNamespace specifies the scope of the
-                            volume within StorageOS.  If no namespace is specified
-                            then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS
-                            for tighter integration. Set VolumeName to any name to
-                            override the default behaviour. Set to "default" if you
-                            are not using namespaces within StorageOS. Namespaces
-                            that do not pre-exist within StorageOS will be created.
-                          type: string
-                      type: object
-                    vsphereVolume:
-                      description: VsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        storagePolicyID:
-                          description: Storage Policy Based Management (SPBM) profile
-                            ID associated with the StoragePolicyName.
-                          type: string
-                        storagePolicyName:
-                          description: Storage Policy Based Management (SPBM) profile
-                            name.
-                          type: string
-                        volumePath:
-                          description: Path that identifies vSphere volume vmdk
-                          type: string
-                      required:
-                      - volumePath
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
-            type: object
-          status:
-            description: IndexerClusterStatus defines the observed state of a Splunk
-              Enterprise indexer cluster
-            properties:
-              clusterMasterPhase:
-                description: current phase of the cluster master
-                enum:
-                - Pending
-                - Ready
-                - Updating
-                - ScalingUp
-                - ScalingDown
-                - Terminating
-                - Error
-                type: string
-              indexer_secret_changed_flag:
-                description: Indicates when the idxc_secret has been changed for a
-                  peer
-                items:
-                  type: boolean
-                type: array
-              indexing_ready_flag:
-                description: Indicates if the cluster is ready for indexing.
+              type: array
+          type: object
+        status:
+          description: IndexerClusterStatus defines the observed state of a Splunk
+            Enterprise indexer cluster
+          properties:
+            clusterMasterPhase:
+              description: current phase of the cluster master
+              enum:
+              - Pending
+              - Ready
+              - Updating
+              - ScalingUp
+              - ScalingDown
+              - Terminating
+              - Error
+              type: string
+            indexer_secret_changed_flag:
+              description: Indicates when the idxc_secret has been changed for a peer
+              items:
                 type: boolean
-              initialized_flag:
-                description: Indicates if the cluster is initialized.
-                type: boolean
-              maintenance_mode:
-                description: Indicates if the cluster is in maintenance mode.
-                type: boolean
-              namespace_scoped_secret_resource_version:
-                description: Indicates resource version of namespace scoped secret
-                type: string
-              peers:
-                description: status of each indexer cluster peer
-                items:
-                  description: IndexerClusterMemberStatus is used to track the status
-                    of each indexer cluster peer.
-                  properties:
-                    active_bundle_id:
-                      description: The ID of the configuration bundle currently being
-                        used by the master.
-                      type: string
-                    bucket_count:
-                      description: Count of the number of buckets on this peer, across
-                        all indexes.
-                      format: int64
-                      type: integer
-                    guid:
-                      description: Unique identifier or GUID for the peer
-                      type: string
-                    is_searchable:
-                      description: Flag indicating if this peer belongs to the current
-                        committed generation and is searchable.
-                      type: boolean
-                    name:
-                      description: Name of the indexer cluster peer
-                      type: string
-                    status:
-                      description: Status of the indexer cluster peer
-                      type: string
-                  type: object
-                type: array
-              phase:
-                description: current phase of the indexer cluster
-                enum:
-                - Pending
-                - Ready
-                - Updating
-                - ScalingUp
-                - ScalingDown
-                - Terminating
-                - Error
-                type: string
-              readyReplicas:
-                description: current number of ready indexer peers
-                format: int32
-                type: integer
-              replicas:
-                description: desired number of indexer peers
-                format: int32
-                type: integer
-              selector:
-                description: selector for pods, used by HorizontalPodAutoscaler
-                type: string
-              service_ready_flag:
-                description: Indicates whether the master is ready to begin servicing,
-                  based on whether it is initialized.
-                type: boolean
-            type: object
-        type: object
+              type: array
+            indexing_ready_flag:
+              description: Indicates if the cluster is ready for indexing.
+              type: boolean
+            initialized_flag:
+              description: Indicates if the cluster is initialized.
+              type: boolean
+            maintenance_mode:
+              description: Indicates if the cluster is in maintenance mode.
+              type: boolean
+            namespace_scoped_secret_resource_version:
+              description: Indicates resource version of namespace scoped secret
+              type: string
+            peers:
+              description: status of each indexer cluster peer
+              items:
+                description: IndexerClusterMemberStatus is used to track the status
+                  of each indexer cluster peer.
+                properties:
+                  active_bundle_id:
+                    description: The ID of the configuration bundle currently being
+                      used by the master.
+                    type: string
+                  bucket_count:
+                    description: Count of the number of buckets on this peer, across
+                      all indexes.
+                    format: int64
+                    type: integer
+                  guid:
+                    description: Unique identifier or GUID for the peer
+                    type: string
+                  is_searchable:
+                    description: Flag indicating if this peer belongs to the current
+                      committed generation and is searchable.
+                    type: boolean
+                  name:
+                    description: Name of the indexer cluster peer
+                    type: string
+                  status:
+                    description: Status of the indexer cluster peer
+                    type: string
+                type: object
+              type: array
+            phase:
+              description: current phase of the indexer cluster
+              enum:
+              - Pending
+              - Ready
+              - Updating
+              - ScalingUp
+              - ScalingDown
+              - Terminating
+              - Error
+              type: string
+            readyReplicas:
+              description: current number of ready indexer peers
+              format: int32
+              type: integer
+            replicas:
+              description: desired number of indexer peers
+              format: int32
+              type: integer
+            selector:
+              description: selector for pods, used by HorizontalPodAutoscaler
+              type: string
+            service_ready_flag:
+              description: Indicates whether the master is ready to begin servicing,
+                based on whether it is initialized.
+              type: boolean
+          type: object
+      type: object
+  version: v1alpha3
+  versions:
+  - name: v1alpha3
     served: true
     storage: true
-    subresources:
-      scale:
-        labelSelectorPath: .status.selector
-        specReplicasPath: .spec.replicas
-        statusReplicasPath: .status.replicas
-      status: {}
+  - name: v1alpha2
+    served: true
+    storage: false

--- a/deploy/crds/enterprise.splunk.com_licensemasters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_licensemasters_crd.yaml
@@ -1,17 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: licensemasters.enterprise.splunk.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: Status of license master
-    name: Phase
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of license master
-    name: Age
-    type: date
   group: enterprise.splunk.com
   names:
     kind: LicenseMaster
@@ -21,2214 +12,2284 @@ spec:
     - lm
     singular: licensemaster
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: LicenseMaster is the Schema for a Splunk Enterprise license master.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: LicenseMasterSpec defines the desired state of a Splunk Enterprise
-            license master.
-          properties:
-            affinity:
-              description: Kubernetes Affinity rules that control how pods are assigned
-                to particular nodes.
-              properties:
-                nodeAffinity:
-                  description: Describes node affinity scheduling rules for the pod.
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node matches the corresponding matchExpressions; the
-                        node(s) with the highest sum are the most preferred.
-                      items:
-                        description: An empty preferred scheduling term matches all
-                          objects with implicit weight 0 (i.e. it's a no-op). A null
-                          preferred scheduling term matches no objects (i.e. is also
-                          a no-op).
+  versions:
+  - additionalPrinterColumns:
+    - description: Status of license master
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Age of license master
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: LicenseMaster is the Schema for a Splunk Enterprise license master.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LicenseMasterSpec defines the desired state of a Splunk Enterprise
+              license master.
+            properties:
+              Mock:
+                description: Mock to differentiate between UTs and actual reconcile
+                type: boolean
+              affinity:
+                description: Kubernetes Affinity rules that control how pods are assigned
+                  to particular nodes.
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
                         properties:
-                          preference:
-                            description: A node selector term, associated with the
-                              corresponding weight.
-                            properties:
-                              matchExpressions:
-                                description: A list of node selector requirements
-                                  by node's labels.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchFields:
-                                description: A list of node selector requirements
-                                  by node's fields.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
                                         type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                            type: object
-                          weight:
-                            description: Weight associated with matching the corresponding
-                              nodeSelectorTerm, in the range 1-100.
-                            format: int32
-                            type: integer
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
                         required:
-                        - preference
-                        - weight
+                        - nodeSelectorTerms
                         type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to an update), the system may or may not try to
-                        eventually evict the pod from its node.
-                      properties:
-                        nodeSelectorTerms:
-                          description: Required. A list of node selector terms. The
-                            terms are ORed.
-                          items:
-                            description: A null or empty node selector term matches
-                              no objects. The requirements of them are ANDed. The
-                              TopologySelectorTerm type implements a subset of the
-                              NodeSelectorTerm.
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              clusterMasterRef:
+                description: ClusterMasterRef refers to a Splunk Enterprise indexer
+                  cluster managed by the operator within Kubernetes
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              defaults:
+                description: Inline map of default.yml overrides used to initialize
+                  the environment
+                type: string
+              defaultsUrl:
+                description: Full path or URL for one or more default.yml files, separated
+                  by commas
+                type: string
+              ephemeralStorage:
+                description: If true, ephemeral (emptyDir) storage will be used for
+                  /opt/splunk/etc and /opt/splunk/var volumes
+                type: boolean
+              etcStorage:
+                description: Storage capacity to request for /opt/splunk/etc persistent
+                  volume claims (default=”1Gi”)
+                type: string
+              image:
+                description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
+                  environment variables)
+                type: string
+              imagePullPolicy:
+                description: 'Sets pull policy for all images (either “Always” or
+                  the default: “IfNotPresent”)'
+                enum:
+                - Always
+                - IfNotPresent
+                type: string
+              licenseMasterRef:
+                description: LicenseMasterRef refers to a Splunk Enterprise license
+                  master managed by the operator within Kubernetes
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              licenseUrl:
+                description: Full path or URL for a Splunk Enterprise license file
+                type: string
+              resources:
+                description: resource requirements for the pod containers
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+              schedulerName:
+                description: Name of Scheduler to use for pod placement (defaults
+                  to “default-scheduler”)
+                type: string
+              serviceTemplate:
+                description: ServiceTemplate is a template used to create Kubernetes
+                  services
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      clusterIP:
+                        description: 'clusterIP is the IP address of the service and
+                          is usually assigned randomly by the master. If an address
+                          is specified manually and is not in use by others, it will
+                          be allocated to the service; otherwise, creation of the
+                          service will fail. This field can not be changed through
+                          updates. Valid values are "None", empty string (""), or
+                          a valid IP address. "None" can be specified for headless
+                          services when proxying is not required. Only applies to
+                          types ClusterIP, NodePort, and LoadBalancer. Ignored if
+                          type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      externalIPs:
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for this service.  These
+                          IPs are not managed by Kubernetes.  The user is responsible
+                          for ensuring that traffic arrives at a node with this IP.  A
+                          common example is external load-balancers that are not part
+                          of the Kubernetes system.
+                        items:
+                          type: string
+                        type: array
+                      externalName:
+                        description: externalName is the external reference that kubedns
+                          or equivalent will return as a CNAME record for this service.
+                          No proxying will be involved. Must be a valid RFC-1123 hostname
+                          (https://tools.ietf.org/html/rfc1123) and requires Type
+                          to be ExternalName.
+                        type: string
+                      externalTrafficPolicy:
+                        description: externalTrafficPolicy denotes if this Service
+                          desires to route external traffic to node-local or cluster-wide
+                          endpoints. "Local" preserves the client source IP and avoids
+                          a second hop for LoadBalancer and Nodeport type services,
+                          but risks potentially imbalanced traffic spreading. "Cluster"
+                          obscures the client source IP and may cause a second hop
+                          to another node, but should have good overall load-spreading.
+                        type: string
+                      healthCheckNodePort:
+                        description: healthCheckNodePort specifies the healthcheck
+                          nodePort for the service. If not specified, HealthCheckNodePort
+                          is created by the service api backend with the allocated
+                          nodePort. Will use user-specified nodePort value if specified
+                          by the client. Only effects when Type is set to LoadBalancer
+                          and ExternalTrafficPolicy is set to Local.
+                        format: int32
+                        type: integer
+                      ipFamily:
+                        description: ipFamily specifies whether this Service has a
+                          preference for a particular IP family (e.g. IPv4 vs. IPv6).  If
+                          a specific IP family is requested, the clusterIP field will
+                          be allocated from that family, if it is available in the
+                          cluster.  If no IP family is requested, the cluster's primary
+                          IP family will be used. Other IP fields (loadBalancerIP,
+                          loadBalancerSourceRanges, externalIPs) and controllers which
+                          allocate external load-balancers should use the same IP
+                          family.  Endpoints for this Service will be of this family.  This
+                          field is immutable after creation. Assigning a ServiceIPFamily
+                          not available in the cluster (e.g. IPv6 in IPv4 only cluster)
+                          is an error condition and will fail during clusterIP assignment.
+                        type: string
+                      loadBalancerIP:
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in this field. This
+                          feature depends on whether the underlying cloud-provider
+                          supports specifying the loadBalancerIP when a load balancer
+                          is created. This field will be ignored if the cloud-provider
+                          does not support the feature.'
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: 'If specified and supported by the platform,
+                          this will restrict traffic through the cloud-provider load-balancer
+                          will be restricted to the specified client IPs. This field
+                          will be ignored if the cloud-provider does not support the
+                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        description: 'The list of ports that are exposed by this service.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            name:
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names. When considering the endpoints
+                                for a Service, this must match the 'name' field in
+                                the EndpointPort. Optional if only one ServicePort
+                                is defined on this service.
+                              type: string
+                            nodePort:
+                              description: 'The port on each node on which this service
+                                is exposed when type=NodePort or LoadBalancer. Usually
+                                assigned by the system. If specified, it will be allocated
+                                to the service if unused or else creation of the service
+                                will fail. Default is to auto-allocate a port if the
+                                ServiceType of this Service requires one. More info:
+                                https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'Number or name of the port to access on
+                                the pods targeted by the service. Number must be in
+                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                If this is a string, it will be looked up as a named
+                                port in the target Pod''s container ports. If this
+                                is not specified, the value of the ''port'' field
+                                is used (an identity map). This field is ignored for
+                                services with clusterIP=None, and should be omitted
+                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        description: publishNotReadyAddresses, when set to true, indicates
+                          that DNS implementations must publish the notReadyAddresses
+                          of subsets for the Endpoints associated with the Service.
+                          The default value is false. The primary use case for setting
+                          this field is to use a StatefulSet's Headless Service to
+                          propagate SRV records for its Pods without respect to their
+                          readiness for purpose of peer discovery.
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: 'Route service traffic to pods with label keys
+                          and values matching this selector. If empty or not present,
+                          the service is assumed to have an external process managing
+                          its endpoints, which Kubernetes will not modify. Only applies
+                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
+                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                        type: object
+                      sessionAffinity:
+                        description: 'Supports "ClientIP" and "None". Used to maintain
+                          session affinity. Enable client IP based session affinity.
+                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
                             properties:
-                              matchExpressions:
-                                description: A list of node selector requirements
-                                  by node's labels.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchFields:
-                                description: A list of node selector requirements
-                                  by node's fields.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
+                              timeoutSeconds:
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time. The value
+                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                  == "ClientIP". Default value is 10800(for 3 hours).
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      type:
+                        description: 'type determines how the Service is exposed.
+                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
+                          NodePort, and LoadBalancer. "ExternalName" maps to the specified
+                          externalName. "ClusterIP" allocates a cluster-internal IP
+                          address for load-balancing to endpoints. Endpoints are determined
+                          by the selector or if that is not specified, by manual construction
+                          of an Endpoints object. If clusterIP is "None", no virtual
+                          IP is allocated and the endpoints are published as a set
+                          of endpoints rather than a stable IP. "NodePort" builds
+                          on ClusterIP and allocates a port on every node which routes
+                          to the clusterIP. "LoadBalancer" builds on NodePort and
+                          creates an external load-balancer (if supported in the current
+                          cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                        type: string
+                    type: object
+                  status:
+                    description: 'Most recently observed status of the service. Populated
+                      by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      loadBalancer:
+                        description: LoadBalancer contains the current status of the
+                          load-balancer, if one is present.
+                        properties:
+                          ingress:
+                            description: Ingress is a list containing ingress points
+                              for the load-balancer. Traffic intended for the service
+                              should be sent to these ingress points.
+                            items:
+                              description: 'LoadBalancerIngress represents the status
+                                of a load-balancer ingress point: traffic intended
+                                for the service should be sent to an ingress point.'
+                              properties:
+                                hostname:
+                                  description: Hostname is set for load-balancer ingress
+                                    points that are DNS based (typically AWS load-balancers)
+                                  type: string
+                                ip:
+                                  description: IP is set for load-balancer ingress
+                                    points that are IP based (typically GCE or OpenStack
+                                    load-balancers)
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                type: object
+              storageClassName:
+                description: Name of StorageClass to use for persistent volume claims
+                type: string
+              tolerations:
+                description: Pod's tolerations for Kubernetes node's taint
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              varStorage:
+                description: Storage capacity to request for /opt/splunk/var persistent
+                  volume claims (default=”50Gi”)
+                type: string
+              volumes:
+                description: List of one or more Kubernetes volumes. These will be
+                  mounted in all pod containers as as /mnt/<name>
+                items:
+                  description: Volume represents a named volume in a pod that may
+                    be accessed by any container in the pod.
+                  properties:
+                    awsElasticBlockStore:
+                      description: 'AWSElasticBlockStore represents an AWS Disk resource
+                        that is attached to a kubelet''s host machine and then exposed
+                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      properties:
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        partition:
+                          description: 'The partition in the volume that you want
+                            to mount. If omitted, the default is to mount by volume
+                            name. Examples: For volume /dev/sda1, you specify the
+                            partition as "1". Similarly, the volume partition for
+                            /dev/sda is "0" (or you can leave the property empty).'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: 'Specify "true" to force and set the ReadOnly
+                            property in VolumeMounts to "true". If omitted, the default
+                            is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          type: boolean
+                        volumeID:
+                          description: 'Unique ID of the persistent disk resource
+                            in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    azureDisk:
+                      description: AzureDisk represents an Azure Data Disk mount on
+                        the host and bind mount to the pod.
+                      properties:
+                        cachingMode:
+                          description: 'Host Caching mode: None, Read Only, Read Write.'
+                          type: string
+                        diskName:
+                          description: The Name of the data disk in the blob storage
+                          type: string
+                        diskURI:
+                          description: The URI the data disk in the blob storage
+                          type: string
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        kind:
+                          description: 'Expected values Shared: multiple blob disks
+                            per storage account  Dedicated: single blob disk per storage
+                            account  Managed: azure managed data disk (only in managed
+                            availability set). defaults to shared'
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                      required:
+                      - diskName
+                      - diskURI
+                      type: object
+                    azureFile:
+                      description: AzureFile represents an Azure File Service mount
+                        on the host and bind mount to the pod.
+                      properties:
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretName:
+                          description: the name of secret that contains Azure Storage
+                            Account Name and Key
+                          type: string
+                        shareName:
+                          description: Share Name
+                          type: string
+                      required:
+                      - secretName
+                      - shareName
+                      type: object
+                    cephfs:
+                      description: CephFS represents a Ceph FS mount on the host that
+                        shares a pod's lifetime
+                      properties:
+                        monitors:
+                          description: 'Required: Monitors is a collection of Ceph
+                            monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          items:
+                            type: string
+                          type: array
+                        path:
+                          description: 'Optional: Used as the mounted root, rather
+                            than the full Ceph tree, default is /'
+                          type: string
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: boolean
+                        secretFile:
+                          description: 'Optional: SecretFile is the path to key ring
+                            for User, default is /etc/ceph/user.secret More info:
+                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: string
+                        secretRef:
+                          description: 'Optional: SecretRef is reference to the authentication
+                            secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        user:
+                          description: 'Optional: User is the rados user name, default
+                            is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: string
+                      required:
+                      - monitors
+                      type: object
+                    cinder:
+                      description: 'Cinder represents a cinder volume attached and
+                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      properties:
+                        fsType:
+                          description: 'Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: string
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: boolean
+                        secretRef:
+                          description: 'Optional: points to a secret object containing
+                            parameters used to connect to OpenStack.'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        volumeID:
+                          description: 'volume id used to identify the volume in cinder.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    configMap:
+                      description: ConfigMap represents a configMap that should populate
+                        this volume
+                      properties:
+                        defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default. Must be a value between 0 and 0777. Defaults
+                            to 0644. Directories within the path are not affected
+                            by this setting. This might be in conflict with other
+                            options that affect the file mode, like fsGroup, and the
+                            result can be other mode bits set.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: If unspecified, each key-value pair in the
+                            Data field of the referenced ConfigMap will be projected
+                            into the volume as a file whose name is the key and content
+                            is the value. If specified, the listed keys will be projected
+                            into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in
+                            the ConfigMap, the volume setup will error unless it is
+                            marked optional. Paths must be relative and may not contain
+                            the '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
+                            properties:
+                              key:
+                                description: The key to project.
+                                type: string
+                              mode:
+                                description: 'Optional: mode bits to use on this file,
+                                  must be a value between 0 and 0777. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: The relative path of the file to map
+                                  the key to. May not be an absolute path. May not
+                                  contain the path element '..'. May not start with
+                                  the string '..'.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap or its keys must
+                            be defined
+                          type: boolean
+                      type: object
+                    csi:
+                      description: CSI (Container Storage Interface) represents storage
+                        that is handled by an external CSI driver (Alpha feature).
+                      properties:
+                        driver:
+                          description: Driver is the name of the CSI driver that handles
+                            this volume. Consult with your admin for the correct name
+                            as registered in the cluster.
+                          type: string
+                        fsType:
+                          description: Filesystem type to mount. Ex. "ext4", "xfs",
+                            "ntfs". If not provided, the empty value is passed to
+                            the associated CSI driver which will determine the default
+                            filesystem to apply.
+                          type: string
+                        nodePublishSecretRef:
+                          description: NodePublishSecretRef is a reference to the
+                            secret object containing sensitive information to pass
+                            to the CSI driver to complete the CSI NodePublishVolume
+                            and NodeUnpublishVolume calls. This field is optional,
+                            and  may be empty if no secret is required. If the secret
+                            object contains more than one secret, all secret references
+                            are passed.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        readOnly:
+                          description: Specifies a read-only configuration for the
+                            volume. Defaults to false (read/write).
+                          type: boolean
+                        volumeAttributes:
+                          additionalProperties:
+                            type: string
+                          description: VolumeAttributes stores driver-specific properties
+                            that are passed to the CSI driver. Consult your driver's
+                            documentation for supported values.
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    downwardAPI:
+                      description: DownwardAPI represents downward API about the pod
+                        that should populate this volume
+                      properties:
+                        defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default. Must be a value between 0 and 0777. Defaults
+                            to 0644. Directories within the path are not affected
+                            by this setting. This might be in conflict with other
+                            options that affect the file mode, like fsGroup, and the
+                            result can be other mode bits set.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: Items is a list of downward API volume file
+                          items:
+                            description: DownwardAPIVolumeFile represents information
+                              to create the file containing the pod field
+                            properties:
+                              fieldRef:
+                                description: 'Required: Selects a field of the pod:
+                                  only annotations, labels, name and namespace are
+                                  supported.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                              mode:
+                                description: 'Optional: mode bits to use on this file,
+                                  must be a value between 0 and 0777. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: 'Required: Path is  the relative path
+                                  name of the file to be created. Must not be absolute
+                                  or contain the ''..'' path. Must be utf-8 encoded.
+                                  The first item of the relative path must not start
+                                  with ''..'''
+                                type: string
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, requests.cpu and requests.memory)
+                                  are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                            required:
+                            - path
+                            type: object
+                          type: array
+                      type: object
+                    emptyDir:
+                      description: 'EmptyDir represents a temporary directory that
+                        shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      properties:
+                        medium:
+                          description: 'What type of storage medium should back this
+                            directory. The default is "" which means to use the node''s
+                            default medium. Must be an empty string (default) or Memory.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          type: string
+                        sizeLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'Total amount of local storage required for
+                            this EmptyDir volume. The size limit is also applicable
+                            for memory medium. The maximum usage on memory medium
+                            EmptyDir would be the minimum value between the SizeLimit
+                            specified here and the sum of memory limits of all containers
+                            in a pod. The default is nil which means that the limit
+                            is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    fc:
+                      description: FC represents a Fibre Channel resource that is
+                        attached to a kubelet's host machine and then exposed to the
+                        pod.
+                      properties:
+                        fsType:
+                          description: 'Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        lun:
+                          description: 'Optional: FC target lun number'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                          type: boolean
+                        targetWWNs:
+                          description: 'Optional: FC target worldwide names (WWNs)'
+                          items:
+                            type: string
+                          type: array
+                        wwids:
+                          description: 'Optional: FC volume world wide identifiers
+                            (wwids) Either wwids or combination of targetWWNs and
+                            lun must be set, but not both simultaneously.'
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    flexVolume:
+                      description: FlexVolume represents a generic volume resource
+                        that is provisioned/attached using an exec based plugin.
+                      properties:
+                        driver:
+                          description: Driver is the name of the driver to use for
+                            this volume.
+                          type: string
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". The default filesystem depends on FlexVolume
+                            script.
+                          type: string
+                        options:
+                          additionalProperties:
+                            type: string
+                          description: 'Optional: Extra command options if any.'
+                          type: object
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                          type: boolean
+                        secretRef:
+                          description: 'Optional: SecretRef is reference to the secret
+                            object containing sensitive information to pass to the
+                            plugin scripts. This may be empty if no secret object
+                            is specified. If the secret object contains more than
+                            one secret, all secrets are passed to the plugin scripts.'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    flocker:
+                      description: Flocker represents a Flocker volume attached to
+                        a kubelet's host machine. This depends on the Flocker control
+                        service being running
+                      properties:
+                        datasetName:
+                          description: Name of the dataset stored as metadata -> name
+                            on the dataset for Flocker should be considered as deprecated
+                          type: string
+                        datasetUUID:
+                          description: UUID of the dataset. This is unique identifier
+                            of a Flocker dataset
+                          type: string
+                      type: object
+                    gcePersistentDisk:
+                      description: 'GCEPersistentDisk represents a GCE Disk resource
+                        that is attached to a kubelet''s host machine and then exposed
+                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      properties:
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        partition:
+                          description: 'The partition in the volume that you want
+                            to mount. If omitted, the default is to mount by volume
+                            name. Examples: For volume /dev/sda1, you specify the
+                            partition as "1". Similarly, the volume partition for
+                            /dev/sda is "0" (or you can leave the property empty).
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          format: int32
+                          type: integer
+                        pdName:
+                          description: 'Unique name of the PD resource in GCE. Used
+                            to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          type: boolean
+                      required:
+                      - pdName
+                      type: object
+                    gitRepo:
+                      description: 'GitRepo represents a git repository at a particular
+                        revision. DEPRECATED: GitRepo is deprecated. To provision
+                        a container with a git repo, mount an EmptyDir into an InitContainer
+                        that clones the repo using git, then mount the EmptyDir into
+                        the Pod''s container.'
+                      properties:
+                        directory:
+                          description: Target directory name. Must not contain or
+                            start with '..'.  If '.' is supplied, the volume directory
+                            will be the git repository.  Otherwise, if specified,
+                            the volume will contain the git repository in the subdirectory
+                            with the given name.
+                          type: string
+                        repository:
+                          description: Repository URL
+                          type: string
+                        revision:
+                          description: Commit hash for the specified revision.
+                          type: string
+                      required:
+                      - repository
+                      type: object
+                    glusterfs:
+                      description: 'Glusterfs represents a Glusterfs mount on the
+                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                      properties:
+                        endpoints:
+                          description: 'EndpointsName is the endpoint name that details
+                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: string
+                        path:
+                          description: 'Path is the Glusterfs volume path. More info:
+                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the Glusterfs volume
+                            to be mounted with read-only permissions. Defaults to
+                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: boolean
+                      required:
+                      - endpoints
+                      - path
+                      type: object
+                    hostPath:
+                      description: 'HostPath represents a pre-existing file or directory
+                        on the host machine that is directly exposed to the container.
+                        This is generally used for system agents or other privileged
+                        things that are allowed to see the host machine. Most containers
+                        will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                        --- TODO(jonesdl) We need to restrict who can use host directory
+                        mounts and who can/can not mount host directories as read/write.'
+                      properties:
+                        path:
+                          description: 'Path of the directory on the host. If the
+                            path is a symlink, it will follow the link to the real
+                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          type: string
+                        type:
+                          description: 'Type for HostPath Volume Defaults to "" More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    iscsi:
+                      description: 'ISCSI represents an ISCSI Disk resource that is
+                        attached to a kubelet''s host machine and then exposed to
+                        the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                      properties:
+                        chapAuthDiscovery:
+                          description: whether support iSCSI Discovery CHAP authentication
+                          type: boolean
+                        chapAuthSession:
+                          description: whether support iSCSI Session CHAP authentication
+                          type: boolean
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        initiatorName:
+                          description: Custom iSCSI Initiator Name. If initiatorName
+                            is specified with iscsiInterface simultaneously, new iSCSI
+                            interface <target portal>:<volume name> will be created
+                            for the connection.
+                          type: string
+                        iqn:
+                          description: Target iSCSI Qualified Name.
+                          type: string
+                        iscsiInterface:
+                          description: iSCSI Interface Name that uses an iSCSI transport.
+                            Defaults to 'default' (tcp).
+                          type: string
+                        lun:
+                          description: iSCSI Target Lun number.
+                          format: int32
+                          type: integer
+                        portals:
+                          description: iSCSI Target Portal List. The portal is either
+                            an IP or ip_addr:port if the port is other than default
+                            (typically TCP ports 860 and 3260).
+                          items:
+                            type: string
+                          type: array
+                        readOnly:
+                          description: ReadOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false.
+                          type: boolean
+                        secretRef:
+                          description: CHAP Secret for iSCSI target and initiator
+                            authentication
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        targetPortal:
+                          description: iSCSI Target Portal. The Portal is either an
+                            IP or ip_addr:port if the port is other than default (typically
+                            TCP ports 860 and 3260).
+                          type: string
+                      required:
+                      - iqn
+                      - lun
+                      - targetPortal
+                      type: object
+                    name:
+                      description: 'Volume''s name. Must be a DNS_LABEL and unique
+                        within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    nfs:
+                      description: 'NFS represents an NFS mount on the host that shares
+                        a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      properties:
+                        path:
+                          description: 'Path that is exported by the NFS server. More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the NFS export to
+                            be mounted with read-only permissions. Defaults to false.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: boolean
+                        server:
+                          description: 'Server is the hostname or IP address of the
+                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: string
+                      required:
+                      - path
+                      - server
+                      type: object
+                    persistentVolumeClaim:
+                      description: 'PersistentVolumeClaimVolumeSource represents a
+                        reference to a PersistentVolumeClaim in the same namespace.
+                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                      properties:
+                        claimName:
+                          description: 'ClaimName is the name of a PersistentVolumeClaim
+                            in the same namespace as the pod using this volume. More
+                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          type: string
+                        readOnly:
+                          description: Will force the ReadOnly setting in VolumeMounts.
+                            Default false.
+                          type: boolean
+                      required:
+                      - claimName
+                      type: object
+                    photonPersistentDisk:
+                      description: PhotonPersistentDisk represents a PhotonController
+                        persistent disk attached and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        pdID:
+                          description: ID that identifies Photon Controller persistent
+                            disk
+                          type: string
+                      required:
+                      - pdID
+                      type: object
+                    portworxVolume:
+                      description: PortworxVolume represents a portworx volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: FSType represents the filesystem type to mount
+                            Must be a filesystem type supported by the host operating
+                            system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        volumeID:
+                          description: VolumeID uniquely identifies a Portworx volume
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    projected:
+                      description: Items for all in one resources secrets, configmaps,
+                        and downward API
+                      properties:
+                        defaultMode:
+                          description: Mode bits to use on created files by default.
+                            Must be a value between 0 and 0777. Directories within
+                            the path are not affected by this setting. This might
+                            be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits
+                            set.
+                          format: int32
+                          type: integer
+                        sources:
+                          description: list of volume projections
+                          items:
+                            description: Projection that may be projected along with
+                              other supported volume types
+                            properties:
+                              configMap:
+                                description: information about the configMap data
+                                  to project
+                                properties:
+                                  items:
+                                    description: If unspecified, each key-value pair
+                                      in the Data field of the referenced ConfigMap
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the ConfigMap, the volume
+                                      setup will error unless it is marked optional.
+                                      Paths must be relative and may not contain the
+                                      '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: The key to project.
+                                          type: string
+                                        mode:
+                                          description: 'Optional: mode bits to use
+                                            on this file, must be a value between
+                                            0 and 0777. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: The relative path of the file
+                                            to map the key to. May not be an absolute
+                                            path. May not contain the path element
+                                            '..'. May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its keys must be defined
+                                    type: boolean
+                                type: object
+                              downwardAPI:
+                                description: information about the downwardAPI data
+                                  to project
+                                properties:
+                                  items:
+                                    description: Items is a list of DownwardAPIVolume
+                                      file
+                                    items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
+                                      properties:
+                                        fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name and namespace are supported.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                        mode:
+                                          description: 'Optional: mode bits to use
+                                            on this file, must be a value between
+                                            0 and 0777. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path. Must be utf-8 encoded. The first
+                                            item of the relative path must not start
+                                            with ''..'''
+                                          type: string
+                                        resourceFieldRef:
+                                          description: 'Selects a resource of the
+                                            container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu
+                                            and requests.memory) are currently supported.'
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                type: object
+                              secret:
+                                description: information about the secret data to
+                                  project
+                                properties:
+                                  items:
+                                    description: If unspecified, each key-value pair
+                                      in the Data field of the referenced Secret will
+                                      be projected into the volume as a file whose
+                                      name is the key and content is the value. If
+                                      specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the Secret, the volume setup
+                                      will error unless it is marked optional. Paths
+                                      must be relative and may not contain the '..'
+                                      path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: The key to project.
+                                          type: string
+                                        mode:
+                                          description: 'Optional: mode bits to use
+                                            on this file, must be a value between
+                                            0 and 0777. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: The relative path of the file
+                                            to map the key to. May not be an absolute
+                                            path. May not contain the path element
+                                            '..'. May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                type: object
+                              serviceAccountToken:
+                                description: information about the serviceAccountToken
+                                  data to project
+                                properties:
+                                  audience:
+                                    description: Audience is the intended audience
+                                      of the token. A recipient of a token must identify
+                                      itself with an identifier specified in the audience
+                                      of the token, and otherwise should reject the
+                                      token. The audience defaults to the identifier
+                                      of the apiserver.
+                                    type: string
+                                  expirationSeconds:
+                                    description: ExpirationSeconds is the requested
+                                      duration of validity of the service account
+                                      token. As the token approaches expiration, the
+                                      kubelet volume plugin will proactively rotate
+                                      the service account token. The kubelet will
+                                      start trying to rotate the token if the token
+                                      is older than 80 percent of its time to live
+                                      or if the token is older than 24 hours.Defaults
+                                      to 1 hour and must be at least 10 minutes.
+                                    format: int64
+                                    type: integer
+                                  path:
+                                    description: Path is the path relative to the
+                                      mount point of the file to project the token
+                                      into.
+                                    type: string
+                                required:
+                                - path
+                                type: object
                             type: object
                           type: array
                       required:
-                      - nodeSelectorTerms
+                      - sources
                       type: object
-                  type: object
-                podAffinity:
-                  description: Describes pod affinity scheduling rules (e.g. co-locate
-                    this pod in the same node, zone, etc. as some other pod(s)).
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node has pods which matches the corresponding podAffinityTerm;
-                        the node(s) with the highest sum are the most preferred.
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            format: int32
-                            type: integer
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to a pod label update), the system may or may not
-                        try to eventually evict the pod from its node. When there
-                        are multiple elements, the lists of nodes corresponding to
-                        each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            items:
-                              type: string
-                            type: array
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-                        required:
-                        - topologyKey
-                        type: object
-                      type: array
-                  type: object
-                podAntiAffinity:
-                  description: Describes pod anti-affinity scheduling rules (e.g.
-                    avoid putting this pod in the same node, zone, etc. as some other
-                    pod(s)).
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the anti-affinity expressions specified by this
-                        field, but it may choose a node that violates one or more
-                        of the expressions. The node that is most preferred is the
-                        one with the greatest sum of weights, i.e. for each node that
-                        meets all of the scheduling requirements (resource request,
-                        requiredDuringScheduling anti-affinity expressions, etc.),
-                        compute a sum by iterating through the elements of this field
-                        and adding "weight" to the sum if the node has pods which
-                        matches the corresponding podAffinityTerm; the node(s) with
-                        the highest sum are the most preferred.
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            format: int32
-                            type: integer
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the anti-affinity requirements specified by
-                        this field are not met at scheduling time, the pod will not
-                        be scheduled onto the node. If the anti-affinity requirements
-                        specified by this field cease to be met at some point during
-                        pod execution (e.g. due to a pod label update), the system
-                        may or may not try to eventually evict the pod from its node.
-                        When there are multiple elements, the lists of nodes corresponding
-                        to each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            items:
-                              type: string
-                            type: array
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-                        required:
-                        - topologyKey
-                        type: object
-                      type: array
-                  type: object
-              type: object
-            clusterMasterRef:
-              description: ClusterMasterRef refers to a Splunk Enterprise indexer
-                cluster managed by the operator within Kubernetes
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            defaults:
-              description: Inline map of default.yml overrides used to initialize
-                the environment
-              type: string
-            defaultsUrl:
-              description: Full path or URL for one or more default.yml files, separated
-                by commas
-              type: string
-            ephemeralStorage:
-              description: If true, ephemeral (emptyDir) storage will be used for
-                /opt/splunk/etc and /opt/splunk/var volumes
-              type: boolean
-            etcStorage:
-              description: Storage capacity to request for /opt/splunk/etc persistent
-                volume claims (default=”1Gi”)
-              type: string
-            image:
-              description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
-                environment variables)
-              type: string
-            imagePullPolicy:
-              description: 'Sets pull policy for all images (either “Always” or the
-                default: “IfNotPresent”)'
-              enum:
-              - Always
-              - IfNotPresent
-              type: string
-            licenseMasterRef:
-              description: LicenseMasterRef refers to a Splunk Enterprise license
-                master managed by the operator within Kubernetes
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            licenseUrl:
-              description: Full path or URL for a Splunk Enterprise license file
-              type: string
-            resources:
-              description: resource requirements for the pod containers
-              properties:
-                limits:
-                  additionalProperties:
-                    type: string
-                  description: 'Limits describes the maximum amount of compute resources
-                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                requests:
-                  additionalProperties:
-                    type: string
-                  description: 'Requests describes the minimum amount of compute resources
-                    required. If Requests is omitted for a container, it defaults
-                    to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-              type: object
-            schedulerName:
-              description: Name of Scheduler to use for pod placement (defaults to
-                “default-scheduler”)
-              type: string
-            serviceTemplate:
-              description: ServiceTemplate is a template used to create Kubernetes
-                services
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                    of an object. Servers should convert recognized schemas to the
-                    latest internal value, and may reject unrecognized values. More
-                    info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource
-                    this object represents. Servers may infer this from the endpoint
-                    the client submits requests to. Cannot be updated. In CamelCase.
-                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                  type: object
-                spec:
-                  description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                  properties:
-                    clusterIP:
-                      description: 'clusterIP is the IP address of the service and
-                        is usually assigned randomly by the master. If an address
-                        is specified manually and is not in use by others, it will
-                        be allocated to the service; otherwise, creation of the service
-                        will fail. This field can not be changed through updates.
-                        Valid values are "None", empty string (""), or a valid IP
-                        address. "None" can be specified for headless services when
-                        proxying is not required. Only applies to types ClusterIP,
-                        NodePort, and LoadBalancer. Ignored if type is ExternalName.
-                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                      type: string
-                    externalIPs:
-                      description: externalIPs is a list of IP addresses for which
-                        nodes in the cluster will also accept traffic for this service.  These
-                        IPs are not managed by Kubernetes.  The user is responsible
-                        for ensuring that traffic arrives at a node with this IP.  A
-                        common example is external load-balancers that are not part
-                        of the Kubernetes system.
-                      items:
-                        type: string
-                      type: array
-                    externalName:
-                      description: externalName is the external reference that kubedns
-                        or equivalent will return as a CNAME record for this service.
-                        No proxying will be involved. Must be a valid RFC-1123 hostname
-                        (https://tools.ietf.org/html/rfc1123) and requires Type to
-                        be ExternalName.
-                      type: string
-                    externalTrafficPolicy:
-                      description: externalTrafficPolicy denotes if this Service desires
-                        to route external traffic to node-local or cluster-wide endpoints.
-                        "Local" preserves the client source IP and avoids a second
-                        hop for LoadBalancer and Nodeport type services, but risks
-                        potentially imbalanced traffic spreading. "Cluster" obscures
-                        the client source IP and may cause a second hop to another
-                        node, but should have good overall load-spreading.
-                      type: string
-                    healthCheckNodePort:
-                      description: healthCheckNodePort specifies the healthcheck nodePort
-                        for the service. If not specified, HealthCheckNodePort is
-                        created by the service api backend with the allocated nodePort.
-                        Will use user-specified nodePort value if specified by the
-                        client. Only effects when Type is set to LoadBalancer and
-                        ExternalTrafficPolicy is set to Local.
-                      format: int32
-                      type: integer
-                    ipFamily:
-                      description: ipFamily specifies whether this Service has a preference
-                        for a particular IP family (e.g. IPv4 vs. IPv6).  If a specific
-                        IP family is requested, the clusterIP field will be allocated
-                        from that family, if it is available in the cluster.  If no
-                        IP family is requested, the cluster's primary IP family will
-                        be used. Other IP fields (loadBalancerIP, loadBalancerSourceRanges,
-                        externalIPs) and controllers which allocate external load-balancers
-                        should use the same IP family.  Endpoints for this Service
-                        will be of this family.  This field is immutable after creation.
-                        Assigning a ServiceIPFamily not available in the cluster (e.g.
-                        IPv6 in IPv4 only cluster) is an error condition and will
-                        fail during clusterIP assignment.
-                      type: string
-                    loadBalancerIP:
-                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                        will get created with the IP specified in this field. This
-                        feature depends on whether the underlying cloud-provider supports
-                        specifying the loadBalancerIP when a load balancer is created.
-                        This field will be ignored if the cloud-provider does not
-                        support the feature.'
-                      type: string
-                    loadBalancerSourceRanges:
-                      description: 'If specified and supported by the platform, this
-                        will restrict traffic through the cloud-provider load-balancer
-                        will be restricted to the specified client IPs. This field
-                        will be ignored if the cloud-provider does not support the
-                        feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
-                      items:
-                        type: string
-                      type: array
-                    ports:
-                      description: 'The list of ports that are exposed by this service.
-                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                      items:
-                        description: ServicePort contains information on service's
-                          port.
-                        properties:
-                          name:
-                            description: The name of this port within the service.
-                              This must be a DNS_LABEL. All ports within a ServiceSpec
-                              must have unique names. When considering the endpoints
-                              for a Service, this must match the 'name' field in the
-                              EndpointPort. Optional if only one ServicePort is defined
-                              on this service.
-                            type: string
-                          nodePort:
-                            description: 'The port on each node on which this service
-                              is exposed when type=NodePort or LoadBalancer. Usually
-                              assigned by the system. If specified, it will be allocated
-                              to the service if unused or else creation of the service
-                              will fail. Default is to auto-allocate a port if the
-                              ServiceType of this Service requires one. More info:
-                              https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
-                            format: int32
-                            type: integer
-                          port:
-                            description: The port that will be exposed by this service.
-                            format: int32
-                            type: integer
-                          protocol:
-                            description: The IP protocol for this port. Supports "TCP",
-                              "UDP", and "SCTP". Default is TCP.
-                            type: string
-                          targetPort:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: 'Number or name of the port to access on
-                              the pods targeted by the service. Number must be in
-                              the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                              If this is a string, it will be looked up as a named
-                              port in the target Pod''s container ports. If this is
-                              not specified, the value of the ''port'' field is used
-                              (an identity map). This field is ignored for services
-                              with clusterIP=None, and should be omitted or set equal
-                              to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
-                            x-kubernetes-int-or-string: true
-                        required:
-                        - port
-                        type: object
-                      type: array
-                    publishNotReadyAddresses:
-                      description: publishNotReadyAddresses, when set to true, indicates
-                        that DNS implementations must publish the notReadyAddresses
-                        of subsets for the Endpoints associated with the Service.
-                        The default value is false. The primary use case for setting
-                        this field is to use a StatefulSet's Headless Service to propagate
-                        SRV records for its Pods without respect to their readiness
-                        for purpose of peer discovery.
-                      type: boolean
-                    selector:
-                      additionalProperties:
-                        type: string
-                      description: 'Route service traffic to pods with label keys
-                        and values matching this selector. If empty or not present,
-                        the service is assumed to have an external process managing
-                        its endpoints, which Kubernetes will not modify. Only applies
-                        to types ClusterIP, NodePort, and LoadBalancer. Ignored if
-                        type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
-                      type: object
-                    sessionAffinity:
-                      description: 'Supports "ClientIP" and "None". Used to maintain
-                        session affinity. Enable client IP based session affinity.
-                        Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                      type: string
-                    sessionAffinityConfig:
-                      description: sessionAffinityConfig contains the configurations
-                        of session affinity.
+                    quobyte:
+                      description: Quobyte represents a Quobyte mount on the host
+                        that shares a pod's lifetime
                       properties:
-                        clientIP:
-                          description: clientIP contains the configurations of Client
-                            IP based session affinity.
-                          properties:
-                            timeoutSeconds:
-                              description: timeoutSeconds specifies the seconds of
-                                ClientIP type session sticky time. The value must
-                                be >0 && <=86400(for 1 day) if ServiceAffinity ==
-                                "ClientIP". Default value is 10800(for 3 hours).
-                              format: int32
-                              type: integer
-                          type: object
+                        group:
+                          description: Group to map volume access to Default is no
+                            group
+                          type: string
+                        readOnly:
+                          description: ReadOnly here will force the Quobyte volume
+                            to be mounted with read-only permissions. Defaults to
+                            false.
+                          type: boolean
+                        registry:
+                          description: Registry represents a single or multiple Quobyte
+                            Registry services specified as a string as host:port pair
+                            (multiple entries are separated with commas) which acts
+                            as the central registry for volumes
+                          type: string
+                        tenant:
+                          description: Tenant owning the given Quobyte volume in the
+                            Backend Used with dynamically provisioned Quobyte volumes,
+                            value is set by the plugin
+                          type: string
+                        user:
+                          description: User to map volume access to Defaults to serivceaccount
+                            user
+                          type: string
+                        volume:
+                          description: Volume is a string that references an already
+                            created Quobyte volume by name.
+                          type: string
+                      required:
+                      - registry
+                      - volume
                       type: object
-                    type:
-                      description: 'type determines how the Service is exposed. Defaults
-                        to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort,
-                        and LoadBalancer. "ExternalName" maps to the specified externalName.
-                        "ClusterIP" allocates a cluster-internal IP address for load-balancing
-                        to endpoints. Endpoints are determined by the selector or
-                        if that is not specified, by manual construction of an Endpoints
-                        object. If clusterIP is "None", no virtual IP is allocated
-                        and the endpoints are published as a set of endpoints rather
-                        than a stable IP. "NodePort" builds on ClusterIP and allocates
-                        a port on every node which routes to the clusterIP. "LoadBalancer"
-                        builds on NodePort and creates an external load-balancer (if
-                        supported in the current cloud) which routes to the clusterIP.
-                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
-                      type: string
-                  type: object
-                status:
-                  description: 'Most recently observed status of the service. Populated
-                    by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-                  properties:
-                    loadBalancer:
-                      description: LoadBalancer contains the current status of the
-                        load-balancer, if one is present.
+                    rbd:
+                      description: 'RBD represents a Rados Block Device mount on the
+                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                       properties:
-                        ingress:
-                          description: Ingress is a list containing ingress points
-                            for the load-balancer. Traffic intended for the service
-                            should be sent to these ingress points.
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        image:
+                          description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        keyring:
+                          description: 'Keyring is the path to key ring for RBDUser.
+                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        monitors:
+                          description: 'A collection of Ceph monitors. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           items:
-                            description: 'LoadBalancerIngress represents the status
-                              of a load-balancer ingress point: traffic intended for
-                              the service should be sent to an ingress point.'
+                            type: string
+                          type: array
+                        pool:
+                          description: 'The rados pool name. Default is rbd. More
+                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: boolean
+                        secretRef:
+                          description: 'SecretRef is name of the authentication secret
+                            for RBDUser. If provided overrides keyring. Default is
+                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        user:
+                          description: 'The rados user name. Default is admin. More
+                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                      required:
+                      - image
+                      - monitors
+                      type: object
+                    scaleIO:
+                      description: ScaleIO represents a ScaleIO persistent volume
+                        attached and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Default is "xfs".
+                          type: string
+                        gateway:
+                          description: The host address of the ScaleIO API Gateway.
+                          type: string
+                        protectionDomain:
+                          description: The name of the ScaleIO Protection Domain for
+                            the configured storage.
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: SecretRef references to the secret for ScaleIO
+                            user and other sensitive information. If this is not provided,
+                            Login operation will fail.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        sslEnabled:
+                          description: Flag to enable/disable SSL communication with
+                            Gateway, default false
+                          type: boolean
+                        storageMode:
+                          description: Indicates whether the storage for a volume
+                            should be ThickProvisioned or ThinProvisioned. Default
+                            is ThinProvisioned.
+                          type: string
+                        storagePool:
+                          description: The ScaleIO Storage Pool associated with the
+                            protection domain.
+                          type: string
+                        system:
+                          description: The name of the storage system as configured
+                            in ScaleIO.
+                          type: string
+                        volumeName:
+                          description: The name of a volume already created in the
+                            ScaleIO system that is associated with this volume source.
+                          type: string
+                      required:
+                      - gateway
+                      - secretRef
+                      - system
+                      type: object
+                    secret:
+                      description: 'Secret represents a secret that should populate
+                        this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                      properties:
+                        defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default. Must be a value between 0 and 0777. Defaults
+                            to 0644. Directories within the path are not affected
+                            by this setting. This might be in conflict with other
+                            options that affect the file mode, like fsGroup, and the
+                            result can be other mode bits set.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: If unspecified, each key-value pair in the
+                            Data field of the referenced Secret will be projected
+                            into the volume as a file whose name is the key and content
+                            is the value. If specified, the listed keys will be projected
+                            into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in
+                            the Secret, the volume setup will error unless it is marked
+                            optional. Paths must be relative and may not contain the
+                            '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
                             properties:
-                              hostname:
-                                description: Hostname is set for load-balancer ingress
-                                  points that are DNS based (typically AWS load-balancers)
+                              key:
+                                description: The key to project.
                                 type: string
-                              ip:
-                                description: IP is set for load-balancer ingress points
-                                  that are IP based (typically GCE or OpenStack load-balancers)
+                              mode:
+                                description: 'Optional: mode bits to use on this file,
+                                  must be a value between 0 and 0777. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: The relative path of the file to map
+                                  the key to. May not be an absolute path. May not
+                                  contain the path element '..'. May not start with
+                                  the string '..'.
                                 type: string
+                            required:
+                            - key
+                            - path
                             type: object
                           type: array
+                        optional:
+                          description: Specify whether the Secret or its keys must
+                            be defined
+                          type: boolean
+                        secretName:
+                          description: 'Name of the secret in the pod''s namespace
+                            to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                          type: string
                       type: object
+                    storageos:
+                      description: StorageOS represents a StorageOS volume attached
+                        and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: SecretRef specifies the secret to use for obtaining
+                            the StorageOS API credentials.  If not specified, default
+                            values will be attempted.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        volumeName:
+                          description: VolumeName is the human-readable name of the
+                            StorageOS volume.  Volume names are only unique within
+                            a namespace.
+                          type: string
+                        volumeNamespace:
+                          description: VolumeNamespace specifies the scope of the
+                            volume within StorageOS.  If no namespace is specified
+                            then the Pod's namespace will be used.  This allows the
+                            Kubernetes name scoping to be mirrored within StorageOS
+                            for tighter integration. Set VolumeName to any name to
+                            override the default behaviour. Set to "default" if you
+                            are not using namespaces within StorageOS. Namespaces
+                            that do not pre-exist within StorageOS will be created.
+                          type: string
+                      type: object
+                    vsphereVolume:
+                      description: VsphereVolume represents a vSphere volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        storagePolicyID:
+                          description: Storage Policy Based Management (SPBM) profile
+                            ID associated with the StoragePolicyName.
+                          type: string
+                        storagePolicyName:
+                          description: Storage Policy Based Management (SPBM) profile
+                            name.
+                          type: string
+                        volumePath:
+                          description: Path that identifies vSphere volume vmdk
+                          type: string
+                      required:
+                      - volumePath
+                      type: object
+                  required:
+                  - name
                   type: object
-              type: object
-            storageClassName:
-              description: Name of StorageClass to use for persistent volume claims
-              type: string
-            tolerations:
-              description: Pod's tolerations for Kubernetes node's taint
-              items:
-                description: The pod this Toleration is attached to tolerates any
-                  taint that matches the triple <key,value,effect> using the matching
-                  operator <operator>.
-                properties:
-                  effect:
-                    description: Effect indicates the taint effect to match. Empty
-                      means match all taint effects. When specified, allowed values
-                      are NoSchedule, PreferNoSchedule and NoExecute.
-                    type: string
-                  key:
-                    description: Key is the taint key that the toleration applies
-                      to. Empty means match all taint keys. If the key is empty, operator
-                      must be Exists; this combination means to match all values and
-                      all keys.
-                    type: string
-                  operator:
-                    description: Operator represents a key's relationship to the value.
-                      Valid operators are Exists and Equal. Defaults to Equal. Exists
-                      is equivalent to wildcard for value, so that a pod can tolerate
-                      all taints of a particular category.
-                    type: string
-                  tolerationSeconds:
-                    description: TolerationSeconds represents the period of time the
-                      toleration (which must be of effect NoExecute, otherwise this
-                      field is ignored) tolerates the taint. By default, it is not
-                      set, which means tolerate the taint forever (do not evict).
-                      Zero and negative values will be treated as 0 (evict immediately)
-                      by the system.
-                    format: int64
-                    type: integer
-                  value:
-                    description: Value is the taint value the toleration matches to.
-                      If the operator is Exists, the value should be empty, otherwise
-                      just a regular string.
-                    type: string
-                type: object
-              type: array
-            varStorage:
-              description: Storage capacity to request for /opt/splunk/var persistent
-                volume claims (default=”50Gi”)
-              type: string
-            volumes:
-              description: List of one or more Kubernetes volumes. These will be mounted
-                in all pod containers as as /mnt/<name>
-              items:
-                description: Volume represents a named volume in a pod that may be
-                  accessed by any container in the pod.
-                properties:
-                  awsElasticBlockStore:
-                    description: 'AWSElasticBlockStore represents an AWS Disk resource
-                      that is attached to a kubelet''s host machine and then exposed
-                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      partition:
-                        description: 'The partition in the volume that you want to
-                          mount. If omitted, the default is to mount by volume name.
-                          Examples: For volume /dev/sda1, you specify the partition
-                          as "1". Similarly, the volume partition for /dev/sda is
-                          "0" (or you can leave the property empty).'
-                        format: int32
-                        type: integer
-                      readOnly:
-                        description: 'Specify "true" to force and set the ReadOnly
-                          property in VolumeMounts to "true". If omitted, the default
-                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                        type: boolean
-                      volumeID:
-                        description: 'Unique ID of the persistent disk resource in
-                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  azureDisk:
-                    description: AzureDisk represents an Azure Data Disk mount on
-                      the host and bind mount to the pod.
-                    properties:
-                      cachingMode:
-                        description: 'Host Caching mode: None, Read Only, Read Write.'
-                        type: string
-                      diskName:
-                        description: The Name of the data disk in the blob storage
-                        type: string
-                      diskURI:
-                        description: The URI the data disk in the blob storage
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      kind:
-                        description: 'Expected values Shared: multiple blob disks
-                          per storage account  Dedicated: single blob disk per storage
-                          account  Managed: azure managed data disk (only in managed
-                          availability set). defaults to shared'
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                    required:
-                    - diskName
-                    - diskURI
-                    type: object
-                  azureFile:
-                    description: AzureFile represents an Azure File Service mount
-                      on the host and bind mount to the pod.
-                    properties:
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretName:
-                        description: the name of secret that contains Azure Storage
-                          Account Name and Key
-                        type: string
-                      shareName:
-                        description: Share Name
-                        type: string
-                    required:
-                    - secretName
-                    - shareName
-                    type: object
-                  cephfs:
-                    description: CephFS represents a Ceph FS mount on the host that
-                      shares a pod's lifetime
-                    properties:
-                      monitors:
-                        description: 'Required: Monitors is a collection of Ceph monitors
-                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        items:
-                          type: string
-                        type: array
-                      path:
-                        description: 'Optional: Used as the mounted root, rather than
-                          the full Ceph tree, default is /'
-                        type: string
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts. More
-                          info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: boolean
-                      secretFile:
-                        description: 'Optional: SecretFile is the path to key ring
-                          for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: string
-                      secretRef:
-                        description: 'Optional: SecretRef is reference to the authentication
-                          secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      user:
-                        description: 'Optional: User is the rados user name, default
-                          is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: string
-                    required:
-                    - monitors
-                    type: object
-                  cinder:
-                    description: 'Cinder represents a cinder volume attached and mounted
-                      on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Examples: "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: string
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts. More
-                          info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: boolean
-                      secretRef:
-                        description: 'Optional: points to a secret object containing
-                          parameters used to connect to OpenStack.'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      volumeID:
-                        description: 'volume id used to identify the volume in cinder.
-                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  configMap:
-                    description: ConfigMap represents a configMap that should populate
-                      this volume
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: If unspecified, each key-value pair in the Data
-                          field of the referenced ConfigMap will be projected into
-                          the volume as a file whose name is the key and content is
-                          the value. If specified, the listed keys will be projected
-                          into the specified paths, and unlisted keys will not be
-                          present. If a key is specified which is not present in the
-                          ConfigMap, the volume setup will error unless it is marked
-                          optional. Paths must be relative and may not contain the
-                          '..' path or start with '..'.
-                        items:
-                          description: Maps a string key to a path within a volume.
-                          properties:
-                            key:
-                              description: The key to project.
-                              type: string
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: The relative path of the file to map the
-                                key to. May not be an absolute path. May not contain
-                                the path element '..'. May not start with the string
-                                '..'.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          type: object
-                        type: array
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
-                        type: string
-                      optional:
-                        description: Specify whether the ConfigMap or its keys must
-                          be defined
-                        type: boolean
-                    type: object
-                  csi:
-                    description: CSI (Container Storage Interface) represents storage
-                      that is handled by an external CSI driver (Alpha feature).
-                    properties:
-                      driver:
-                        description: Driver is the name of the CSI driver that handles
-                          this volume. Consult with your admin for the correct name
-                          as registered in the cluster.
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Ex. "ext4", "xfs",
-                          "ntfs". If not provided, the empty value is passed to the
-                          associated CSI driver which will determine the default filesystem
-                          to apply.
-                        type: string
-                      nodePublishSecretRef:
-                        description: NodePublishSecretRef is a reference to the secret
-                          object containing sensitive information to pass to the CSI
-                          driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
-                          calls. This field is optional, and  may be empty if no secret
-                          is required. If the secret object contains more than one
-                          secret, all secret references are passed.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      readOnly:
-                        description: Specifies a read-only configuration for the volume.
-                          Defaults to false (read/write).
-                        type: boolean
-                      volumeAttributes:
-                        additionalProperties:
-                          type: string
-                        description: VolumeAttributes stores driver-specific properties
-                          that are passed to the CSI driver. Consult your driver's
-                          documentation for supported values.
-                        type: object
-                    required:
-                    - driver
-                    type: object
-                  downwardAPI:
-                    description: DownwardAPI represents downward API about the pod
-                      that should populate this volume
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: Items is a list of downward API volume file
-                        items:
-                          description: DownwardAPIVolumeFile represents information
-                            to create the file containing the pod field
-                          properties:
-                            fieldRef:
-                              description: 'Required: Selects a field of the pod:
-                                only annotations, labels, name and namespace are supported.'
-                              properties:
-                                apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
-                                  type: string
-                                fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
-                                  type: string
-                              required:
-                              - fieldPath
-                              type: object
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: 'Required: Path is  the relative path name
-                                of the file to be created. Must not be absolute or
-                                contain the ''..'' path. Must be utf-8 encoded. The
-                                first item of the relative path must not start with
-                                ''..'''
-                              type: string
-                            resourceFieldRef:
-                              description: 'Selects a resource of the container: only
-                                resources limits and requests (limits.cpu, limits.memory,
-                                requests.cpu and requests.memory) are currently supported.'
-                              properties:
-                                containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
-                                  type: string
-                                divisor:
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
-                                  type: string
-                                resource:
-                                  description: 'Required: resource to select'
-                                  type: string
-                              required:
-                              - resource
-                              type: object
-                          required:
-                          - path
-                          type: object
-                        type: array
-                    type: object
-                  emptyDir:
-                    description: 'EmptyDir represents a temporary directory that shares
-                      a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                    properties:
-                      medium:
-                        description: 'What type of storage medium should back this
-                          directory. The default is "" which means to use the node''s
-                          default medium. Must be an empty string (default) or Memory.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                        type: string
-                      sizeLimit:
-                        description: 'Total amount of local storage required for this
-                          EmptyDir volume. The size limit is also applicable for memory
-                          medium. The maximum usage on memory medium EmptyDir would
-                          be the minimum value between the SizeLimit specified here
-                          and the sum of memory limits of all containers in a pod.
-                          The default is nil which means that the limit is undefined.
-                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                        type: string
-                    type: object
-                  fc:
-                    description: FC represents a Fibre Channel resource that is attached
-                      to a kubelet's host machine and then exposed to the pod.
-                    properties:
-                      fsType:
-                        description: 'Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      lun:
-                        description: 'Optional: FC target lun number'
-                        format: int32
-                        type: integer
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts.'
-                        type: boolean
-                      targetWWNs:
-                        description: 'Optional: FC target worldwide names (WWNs)'
-                        items:
-                          type: string
-                        type: array
-                      wwids:
-                        description: 'Optional: FC volume world wide identifiers (wwids)
-                          Either wwids or combination of targetWWNs and lun must be
-                          set, but not both simultaneously.'
-                        items:
-                          type: string
-                        type: array
-                    type: object
-                  flexVolume:
-                    description: FlexVolume represents a generic volume resource that
-                      is provisioned/attached using an exec based plugin.
-                    properties:
-                      driver:
-                        description: Driver is the name of the driver to use for this
-                          volume.
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". The default filesystem depends on FlexVolume
-                          script.
-                        type: string
-                      options:
-                        additionalProperties:
-                          type: string
-                        description: 'Optional: Extra command options if any.'
-                        type: object
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts.'
-                        type: boolean
-                      secretRef:
-                        description: 'Optional: SecretRef is reference to the secret
-                          object containing sensitive information to pass to the plugin
-                          scripts. This may be empty if no secret object is specified.
-                          If the secret object contains more than one secret, all
-                          secrets are passed to the plugin scripts.'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                    required:
-                    - driver
-                    type: object
-                  flocker:
-                    description: Flocker represents a Flocker volume attached to a
-                      kubelet's host machine. This depends on the Flocker control
-                      service being running
-                    properties:
-                      datasetName:
-                        description: Name of the dataset stored as metadata -> name
-                          on the dataset for Flocker should be considered as deprecated
-                        type: string
-                      datasetUUID:
-                        description: UUID of the dataset. This is unique identifier
-                          of a Flocker dataset
-                        type: string
-                    type: object
-                  gcePersistentDisk:
-                    description: 'GCEPersistentDisk represents a GCE Disk resource
-                      that is attached to a kubelet''s host machine and then exposed
-                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      partition:
-                        description: 'The partition in the volume that you want to
-                          mount. If omitted, the default is to mount by volume name.
-                          Examples: For volume /dev/sda1, you specify the partition
-                          as "1". Similarly, the volume partition for /dev/sda is
-                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        format: int32
-                        type: integer
-                      pdName:
-                        description: 'Unique name of the PD resource in GCE. Used
-                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        type: boolean
-                    required:
-                    - pdName
-                    type: object
-                  gitRepo:
-                    description: 'GitRepo represents a git repository at a particular
-                      revision. DEPRECATED: GitRepo is deprecated. To provision a
-                      container with a git repo, mount an EmptyDir into an InitContainer
-                      that clones the repo using git, then mount the EmptyDir into
-                      the Pod''s container.'
-                    properties:
-                      directory:
-                        description: Target directory name. Must not contain or start
-                          with '..'.  If '.' is supplied, the volume directory will
-                          be the git repository.  Otherwise, if specified, the volume
-                          will contain the git repository in the subdirectory with
-                          the given name.
-                        type: string
-                      repository:
-                        description: Repository URL
-                        type: string
-                      revision:
-                        description: Commit hash for the specified revision.
-                        type: string
-                    required:
-                    - repository
-                    type: object
-                  glusterfs:
-                    description: 'Glusterfs represents a Glusterfs mount on the host
-                      that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
-                    properties:
-                      endpoints:
-                        description: 'EndpointsName is the endpoint name that details
-                          Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: string
-                      path:
-                        description: 'Path is the Glusterfs volume path. More info:
-                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the Glusterfs volume
-                          to be mounted with read-only permissions. Defaults to false.
-                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: boolean
-                    required:
-                    - endpoints
-                    - path
-                    type: object
-                  hostPath:
-                    description: 'HostPath represents a pre-existing file or directory
-                      on the host machine that is directly exposed to the container.
-                      This is generally used for system agents or other privileged
-                      things that are allowed to see the host machine. Most containers
-                      will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                      --- TODO(jonesdl) We need to restrict who can use host directory
-                      mounts and who can/can not mount host directories as read/write.'
-                    properties:
-                      path:
-                        description: 'Path of the directory on the host. If the path
-                          is a symlink, it will follow the link to the real path.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                        type: string
-                      type:
-                        description: 'Type for HostPath Volume Defaults to "" More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                        type: string
-                    required:
-                    - path
-                    type: object
-                  iscsi:
-                    description: 'ISCSI represents an ISCSI Disk resource that is
-                      attached to a kubelet''s host machine and then exposed to the
-                      pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
-                    properties:
-                      chapAuthDiscovery:
-                        description: whether support iSCSI Discovery CHAP authentication
-                        type: boolean
-                      chapAuthSession:
-                        description: whether support iSCSI Session CHAP authentication
-                        type: boolean
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      initiatorName:
-                        description: Custom iSCSI Initiator Name. If initiatorName
-                          is specified with iscsiInterface simultaneously, new iSCSI
-                          interface <target portal>:<volume name> will be created
-                          for the connection.
-                        type: string
-                      iqn:
-                        description: Target iSCSI Qualified Name.
-                        type: string
-                      iscsiInterface:
-                        description: iSCSI Interface Name that uses an iSCSI transport.
-                          Defaults to 'default' (tcp).
-                        type: string
-                      lun:
-                        description: iSCSI Target Lun number.
-                        format: int32
-                        type: integer
-                      portals:
-                        description: iSCSI Target Portal List. The portal is either
-                          an IP or ip_addr:port if the port is other than default
-                          (typically TCP ports 860 and 3260).
-                        items:
-                          type: string
-                        type: array
-                      readOnly:
-                        description: ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false.
-                        type: boolean
-                      secretRef:
-                        description: CHAP Secret for iSCSI target and initiator authentication
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      targetPortal:
-                        description: iSCSI Target Portal. The Portal is either an
-                          IP or ip_addr:port if the port is other than default (typically
-                          TCP ports 860 and 3260).
-                        type: string
-                    required:
-                    - iqn
-                    - lun
-                    - targetPortal
-                    type: object
-                  name:
-                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
-                      the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  nfs:
-                    description: 'NFS represents an NFS mount on the host that shares
-                      a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                    properties:
-                      path:
-                        description: 'Path that is exported by the NFS server. More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the NFS export to be
-                          mounted with read-only permissions. Defaults to false. More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: boolean
-                      server:
-                        description: 'Server is the hostname or IP address of the
-                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: string
-                    required:
-                    - path
-                    - server
-                    type: object
-                  persistentVolumeClaim:
-                    description: 'PersistentVolumeClaimVolumeSource represents a reference
-                      to a PersistentVolumeClaim in the same namespace. More info:
-                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                    properties:
-                      claimName:
-                        description: 'ClaimName is the name of a PersistentVolumeClaim
-                          in the same namespace as the pod using this volume. More
-                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                        type: string
-                      readOnly:
-                        description: Will force the ReadOnly setting in VolumeMounts.
-                          Default false.
-                        type: boolean
-                    required:
-                    - claimName
-                    type: object
-                  photonPersistentDisk:
-                    description: PhotonPersistentDisk represents a PhotonController
-                      persistent disk attached and mounted on kubelets host machine
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      pdID:
-                        description: ID that identifies Photon Controller persistent
-                          disk
-                        type: string
-                    required:
-                    - pdID
-                    type: object
-                  portworxVolume:
-                    description: PortworxVolume represents a portworx volume attached
-                      and mounted on kubelets host machine
-                    properties:
-                      fsType:
-                        description: FSType represents the filesystem type to mount
-                          Must be a filesystem type supported by the host operating
-                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                          if unspecified.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      volumeID:
-                        description: VolumeID uniquely identifies a Portworx volume
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  projected:
-                    description: Items for all in one resources secrets, configmaps,
-                      and downward API
-                    properties:
-                      defaultMode:
-                        description: Mode bits to use on created files by default.
-                          Must be a value between 0 and 0777. Directories within the
-                          path are not affected by this setting. This might be in
-                          conflict with other options that affect the file mode, like
-                          fsGroup, and the result can be other mode bits set.
-                        format: int32
-                        type: integer
-                      sources:
-                        description: list of volume projections
-                        items:
-                          description: Projection that may be projected along with
-                            other supported volume types
-                          properties:
-                            configMap:
-                              description: information about the configMap data to
-                                project
-                              properties:
-                                items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced ConfigMap
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the ConfigMap, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
-                                  items:
-                                    description: Maps a string key to a path within
-                                      a volume.
-                                    properties:
-                                      key:
-                                        description: The key to project.
-                                        type: string
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap or its
-                                    keys must be defined
-                                  type: boolean
-                              type: object
-                            downwardAPI:
-                              description: information about the downwardAPI data
-                                to project
-                              properties:
-                                items:
-                                  description: Items is a list of DownwardAPIVolume
-                                    file
-                                  items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
-                                    properties:
-                                      fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
-                                        properties:
-                                          apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
-                                            type: string
-                                          fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
-                                        type: string
-                                      resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, requests.cpu and requests.memory)
-                                          are currently supported.'
-                                        properties:
-                                          containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
-                                            type: string
-                                          divisor:
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
-                                            type: string
-                                          resource:
-                                            description: 'Required: resource to select'
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                    required:
-                                    - path
-                                    type: object
-                                  type: array
-                              type: object
-                            secret:
-                              description: information about the secret data to project
-                              properties:
-                                items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced Secret will
-                                    be projected into the volume as a file whose name
-                                    is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the Secret, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
-                                  items:
-                                    description: Maps a string key to a path within
-                                      a volume.
-                                    properties:
-                                      key:
-                                        description: The key to project.
-                                        type: string
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
-                                  type: boolean
-                              type: object
-                            serviceAccountToken:
-                              description: information about the serviceAccountToken
-                                data to project
-                              properties:
-                                audience:
-                                  description: Audience is the intended audience of
-                                    the token. A recipient of a token must identify
-                                    itself with an identifier specified in the audience
-                                    of the token, and otherwise should reject the
-                                    token. The audience defaults to the identifier
-                                    of the apiserver.
-                                  type: string
-                                expirationSeconds:
-                                  description: ExpirationSeconds is the requested
-                                    duration of validity of the service account token.
-                                    As the token approaches expiration, the kubelet
-                                    volume plugin will proactively rotate the service
-                                    account token. The kubelet will start trying to
-                                    rotate the token if the token is older than 80
-                                    percent of its time to live or if the token is
-                                    older than 24 hours.Defaults to 1 hour and must
-                                    be at least 10 minutes.
-                                  format: int64
-                                  type: integer
-                                path:
-                                  description: Path is the path relative to the mount
-                                    point of the file to project the token into.
-                                  type: string
-                              required:
-                              - path
-                              type: object
-                          type: object
-                        type: array
-                    required:
-                    - sources
-                    type: object
-                  quobyte:
-                    description: Quobyte represents a Quobyte mount on the host that
-                      shares a pod's lifetime
-                    properties:
-                      group:
-                        description: Group to map volume access to Default is no group
-                        type: string
-                      readOnly:
-                        description: ReadOnly here will force the Quobyte volume to
-                          be mounted with read-only permissions. Defaults to false.
-                        type: boolean
-                      registry:
-                        description: Registry represents a single or multiple Quobyte
-                          Registry services specified as a string as host:port pair
-                          (multiple entries are separated with commas) which acts
-                          as the central registry for volumes
-                        type: string
-                      tenant:
-                        description: Tenant owning the given Quobyte volume in the
-                          Backend Used with dynamically provisioned Quobyte volumes,
-                          value is set by the plugin
-                        type: string
-                      user:
-                        description: User to map volume access to Defaults to serivceaccount
-                          user
-                        type: string
-                      volume:
-                        description: Volume is a string that references an already
-                          created Quobyte volume by name.
-                        type: string
-                    required:
-                    - registry
-                    - volume
-                    type: object
-                  rbd:
-                    description: 'RBD represents a Rados Block Device mount on the
-                      host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      image:
-                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      keyring:
-                        description: 'Keyring is the path to key ring for RBDUser.
-                          Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      monitors:
-                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        items:
-                          type: string
-                        type: array
-                      pool:
-                        description: 'The rados pool name. Default is rbd. More info:
-                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: boolean
-                      secretRef:
-                        description: 'SecretRef is name of the authentication secret
-                          for RBDUser. If provided overrides keyring. Default is nil.
-                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      user:
-                        description: 'The rados user name. Default is admin. More
-                          info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                    required:
-                    - image
-                    - monitors
-                    type: object
-                  scaleIO:
-                    description: ScaleIO represents a ScaleIO persistent volume attached
-                      and mounted on Kubernetes nodes.
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Default is "xfs".
-                        type: string
-                      gateway:
-                        description: The host address of the ScaleIO API Gateway.
-                        type: string
-                      protectionDomain:
-                        description: The name of the ScaleIO Protection Domain for
-                          the configured storage.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretRef:
-                        description: SecretRef references to the secret for ScaleIO
-                          user and other sensitive information. If this is not provided,
-                          Login operation will fail.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      sslEnabled:
-                        description: Flag to enable/disable SSL communication with
-                          Gateway, default false
-                        type: boolean
-                      storageMode:
-                        description: Indicates whether the storage for a volume should
-                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
-                        type: string
-                      storagePool:
-                        description: The ScaleIO Storage Pool associated with the
-                          protection domain.
-                        type: string
-                      system:
-                        description: The name of the storage system as configured
-                          in ScaleIO.
-                        type: string
-                      volumeName:
-                        description: The name of a volume already created in the ScaleIO
-                          system that is associated with this volume source.
-                        type: string
-                    required:
-                    - gateway
-                    - secretRef
-                    - system
-                    type: object
-                  secret:
-                    description: 'Secret represents a secret that should populate
-                      this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: If unspecified, each key-value pair in the Data
-                          field of the referenced Secret will be projected into the
-                          volume as a file whose name is the key and content is the
-                          value. If specified, the listed keys will be projected into
-                          the specified paths, and unlisted keys will not be present.
-                          If a key is specified which is not present in the Secret,
-                          the volume setup will error unless it is marked optional.
-                          Paths must be relative and may not contain the '..' path
-                          or start with '..'.
-                        items:
-                          description: Maps a string key to a path within a volume.
-                          properties:
-                            key:
-                              description: The key to project.
-                              type: string
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: The relative path of the file to map the
-                                key to. May not be an absolute path. May not contain
-                                the path element '..'. May not start with the string
-                                '..'.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          type: object
-                        type: array
-                      optional:
-                        description: Specify whether the Secret or its keys must be
-                          defined
-                        type: boolean
-                      secretName:
-                        description: 'Name of the secret in the pod''s namespace to
-                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                        type: string
-                    type: object
-                  storageos:
-                    description: StorageOS represents a StorageOS volume attached
-                      and mounted on Kubernetes nodes.
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretRef:
-                        description: SecretRef specifies the secret to use for obtaining
-                          the StorageOS API credentials.  If not specified, default
-                          values will be attempted.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      volumeName:
-                        description: VolumeName is the human-readable name of the
-                          StorageOS volume.  Volume names are only unique within a
-                          namespace.
-                        type: string
-                      volumeNamespace:
-                        description: VolumeNamespace specifies the scope of the volume
-                          within StorageOS.  If no namespace is specified then the
-                          Pod's namespace will be used.  This allows the Kubernetes
-                          name scoping to be mirrored within StorageOS for tighter
-                          integration. Set VolumeName to any name to override the
-                          default behaviour. Set to "default" if you are not using
-                          namespaces within StorageOS. Namespaces that do not pre-exist
-                          within StorageOS will be created.
-                        type: string
-                    type: object
-                  vsphereVolume:
-                    description: VsphereVolume represents a vSphere volume attached
-                      and mounted on kubelets host machine
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      storagePolicyID:
-                        description: Storage Policy Based Management (SPBM) profile
-                          ID associated with the StoragePolicyName.
-                        type: string
-                      storagePolicyName:
-                        description: Storage Policy Based Management (SPBM) profile
-                          name.
-                        type: string
-                      volumePath:
-                        description: Path that identifies vSphere volume vmdk
-                        type: string
-                    required:
-                    - volumePath
-                    type: object
-                required:
-                - name
-                type: object
-              type: array
-          type: object
-        status:
-          description: LicenseMasterStatus defines the observed state of a Splunk
-            Enterprise license master.
-          properties:
-            phase:
-              description: current phase of the license master
-              enum:
-              - Pending
-              - Ready
-              - Updating
-              - ScalingUp
-              - ScalingDown
-              - Terminating
-              - Error
-              type: string
-          type: object
-      type: object
-  version: v1alpha3
-  versions:
-  - name: v1alpha3
+                type: array
+            type: object
+          status:
+            description: LicenseMasterStatus defines the observed state of a Splunk
+              Enterprise license master.
+            properties:
+              phase:
+                description: current phase of the license master
+                enum:
+                - Pending
+                - Ready
+                - Updating
+                - ScalingUp
+                - ScalingDown
+                - Terminating
+                - Error
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
-  - name: v1alpha2
-    served: true
-    storage: false
+    subresources:
+      status: {}

--- a/deploy/crds/enterprise.splunk.com_licensemasters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_licensemasters_crd.yaml
@@ -1,8 +1,17 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: licensemasters.enterprise.splunk.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: Status of license master
+    name: Phase
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of license master
+    name: Age
+    type: date
   group: enterprise.splunk.com
   names:
     kind: LicenseMaster
@@ -12,2284 +21,2217 @@ spec:
     - lm
     singular: licensemaster
   scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: Status of license master
-      jsonPath: .status.phase
-      name: Phase
-      type: string
-    - description: Age of license master
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        description: LicenseMaster is the Schema for a Splunk Enterprise license master.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: LicenseMasterSpec defines the desired state of a Splunk Enterprise
-              license master.
-            properties:
-              Mock:
-                description: Mock to differentiate between UTs and actual reconcile
-                type: boolean
-              affinity:
-                description: Kubernetes Affinity rules that control how pods are assigned
-                  to particular nodes.
-                properties:
-                  nodeAffinity:
-                    description: Describes node affinity scheduling rules for the
-                      pod.
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node matches
-                          the corresponding matchExpressions; the node(s) with the
-                          highest sum are the most preferred.
-                        items:
-                          description: An empty preferred scheduling term matches
-                            all objects with implicit weight 0 (i.e. it's a no-op).
-                            A null preferred scheduling term matches no objects (i.e.
-                            is also a no-op).
-                          properties:
-                            preference:
-                              description: A node selector term, associated with the
-                                corresponding weight.
-                              properties:
-                                matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            weight:
-                              description: Weight associated with matching the corresponding
-                                nodeSelectorTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - preference
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to an update), the system may or may not try to
-                          eventually evict the pod from its node.
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: LicenseMaster is the Schema for a Splunk Enterprise license master.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: LicenseMasterSpec defines the desired state of a Splunk Enterprise
+            license master.
+          properties:
+            Mock:
+              description: Mock to differentiate between UTs and actual reconcile
+              type: boolean
+            affinity:
+              description: Kubernetes Affinity rules that control how pods are assigned
+                to particular nodes.
+              properties:
+                nodeAffinity:
+                  description: Describes node affinity scheduling rules for the pod.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node matches the corresponding matchExpressions; the
+                        node(s) with the highest sum are the most preferred.
+                      items:
+                        description: An empty preferred scheduling term matches all
+                          objects with implicit weight 0 (i.e. it's a no-op). A null
+                          preferred scheduling term matches no objects (i.e. is also
+                          a no-op).
                         properties:
-                          nodeSelectorTerms:
-                            description: Required. A list of node selector terms.
-                              The terms are ORed.
-                            items:
-                              description: A null or empty node selector term matches
-                                no objects. The requirements of them are ANDed. The
-                                TopologySelectorTerm type implements a subset of the
-                                NodeSelectorTerm.
-                              properties:
-                                matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
+                          preference:
+                            description: A node selector term, associated with the
+                              corresponding weight.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
                                         type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
                                         type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            type: array
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          weight:
+                            description: Weight associated with matching the corresponding
+                              nodeSelectorTerm, in the range 1-100.
+                            format: int32
+                            type: integer
                         required:
-                        - nodeSelectorTerms
+                        - preference
+                        - weight
                         type: object
-                    type: object
-                  podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate
-                      this pod in the same node, zone, etc. as some other pod(s)).
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
-                        items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
-                          properties:
-                            podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to an update), the system may or may not try to
+                        eventually evict the pod from its node.
+                      properties:
+                        nodeSelectorTerms:
+                          description: Required. A list of node selector terms. The
+                            terms are ORed.
+                          items:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
                                   type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                      required:
+                      - nodeSelectorTerms
+                      type: object
+                  type: object
+                podAffinity:
+                  description: Describes pod affinity scheduling rules (e.g. co-locate
+                    this pod in the same node, zone, etc. as some other pod(s)).
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node has pods which matches the corresponding podAffinityTerm;
+                        the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Required. A pod affinity term, associated
+                              with the corresponding weight.
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
                                   type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to a pod label update), the system may or may not
+                        try to eventually evict the pod from its node. When there
+                        are multiple elements, the lists of nodes corresponding to
+                        each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources, in
+                              this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+                podAntiAffinity:
+                  description: Describes pod anti-affinity scheduling rules (e.g.
+                    avoid putting this pod in the same node, zone, etc. as some other
+                    pod(s)).
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the anti-affinity expressions specified by this
+                        field, but it may choose a node that violates one or more
+                        of the expressions. The node that is most preferred is the
+                        one with the greatest sum of weights, i.e. for each node that
+                        meets all of the scheduling requirements (resource request,
+                        requiredDuringScheduling anti-affinity expressions, etc.),
+                        compute a sum by iterating through the elements of this field
+                        and adding "weight" to the sum if the node has pods which
+                        matches the corresponding podAffinityTerm; the node(s) with
+                        the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Required. A pod affinity term, associated
+                              with the corresponding weight.
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the anti-affinity requirements specified by
+                        this field are not met at scheduling time, the pod will not
+                        be scheduled onto the node. If the anti-affinity requirements
+                        specified by this field cease to be met at some point during
+                        pod execution (e.g. due to a pod label update), the system
+                        may or may not try to eventually evict the pod from its node.
+                        When there are multiple elements, the lists of nodes corresponding
+                        to each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources, in
+                              this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            clusterMasterRef:
+              description: ClusterMasterRef refers to a Splunk Enterprise indexer
+                cluster managed by the operator within Kubernetes
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            defaults:
+              description: Inline map of default.yml overrides used to initialize
+                the environment
+              type: string
+            defaultsUrl:
+              description: Full path or URL for one or more default.yml files, separated
+                by commas
+              type: string
+            ephemeralStorage:
+              description: If true, ephemeral (emptyDir) storage will be used for
+                /opt/splunk/etc and /opt/splunk/var volumes
+              type: boolean
+            etcStorage:
+              description: Storage capacity to request for /opt/splunk/etc persistent
+                volume claims (default=”1Gi”)
+              type: string
+            image:
+              description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
+                environment variables)
+              type: string
+            imagePullPolicy:
+              description: 'Sets pull policy for all images (either “Always” or the
+                default: “IfNotPresent”)'
+              enum:
+              - Always
+              - IfNotPresent
+              type: string
+            licenseMasterRef:
+              description: LicenseMasterRef refers to a Splunk Enterprise license
+                master managed by the operator within Kubernetes
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            licenseUrl:
+              description: Full path or URL for a Splunk Enterprise license file
+              type: string
+            resources:
+              description: resource requirements for the pod containers
+              properties:
+                limits:
+                  additionalProperties:
+                    type: string
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    type: string
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
+            schedulerName:
+              description: Name of Scheduler to use for pod placement (defaults to
+                “default-scheduler”)
+              type: string
+            serviceTemplate:
+              description: ServiceTemplate is a template used to create Kubernetes
+                services
+              properties:
+                apiVersion:
+                  description: 'APIVersion defines the versioned schema of this representation
+                    of an object. Servers should convert recognized schemas to the
+                    latest internal value, and may reject unrecognized values. More
+                    info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                  type: string
+                kind:
+                  description: 'Kind is a string value representing the REST resource
+                    this object represents. Servers may infer this from the endpoint
+                    the client submits requests to. Cannot be updated. In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                metadata:
+                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                  type: object
+                spec:
+                  description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                  properties:
+                    clusterIP:
+                      description: 'clusterIP is the IP address of the service and
+                        is usually assigned randomly by the master. If an address
+                        is specified manually and is not in use by others, it will
+                        be allocated to the service; otherwise, creation of the service
+                        will fail. This field can not be changed through updates.
+                        Valid values are "None", empty string (""), or a valid IP
+                        address. "None" can be specified for headless services when
+                        proxying is not required. Only applies to types ClusterIP,
+                        NodePort, and LoadBalancer. Ignored if type is ExternalName.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    externalIPs:
+                      description: externalIPs is a list of IP addresses for which
+                        nodes in the cluster will also accept traffic for this service.  These
+                        IPs are not managed by Kubernetes.  The user is responsible
+                        for ensuring that traffic arrives at a node with this IP.  A
+                        common example is external load-balancers that are not part
+                        of the Kubernetes system.
+                      items:
+                        type: string
+                      type: array
+                    externalName:
+                      description: externalName is the external reference that kubedns
+                        or equivalent will return as a CNAME record for this service.
+                        No proxying will be involved. Must be a valid RFC-1123 hostname
+                        (https://tools.ietf.org/html/rfc1123) and requires Type to
+                        be ExternalName.
+                      type: string
+                    externalTrafficPolicy:
+                      description: externalTrafficPolicy denotes if this Service desires
+                        to route external traffic to node-local or cluster-wide endpoints.
+                        "Local" preserves the client source IP and avoids a second
+                        hop for LoadBalancer and Nodeport type services, but risks
+                        potentially imbalanced traffic spreading. "Cluster" obscures
+                        the client source IP and may cause a second hop to another
+                        node, but should have good overall load-spreading.
+                      type: string
+                    healthCheckNodePort:
+                      description: healthCheckNodePort specifies the healthcheck nodePort
+                        for the service. If not specified, HealthCheckNodePort is
+                        created by the service api backend with the allocated nodePort.
+                        Will use user-specified nodePort value if specified by the
+                        client. Only effects when Type is set to LoadBalancer and
+                        ExternalTrafficPolicy is set to Local.
+                      format: int32
+                      type: integer
+                    ipFamily:
+                      description: ipFamily specifies whether this Service has a preference
+                        for a particular IP family (e.g. IPv4 vs. IPv6).  If a specific
+                        IP family is requested, the clusterIP field will be allocated
+                        from that family, if it is available in the cluster.  If no
+                        IP family is requested, the cluster's primary IP family will
+                        be used. Other IP fields (loadBalancerIP, loadBalancerSourceRanges,
+                        externalIPs) and controllers which allocate external load-balancers
+                        should use the same IP family.  Endpoints for this Service
+                        will be of this family.  This field is immutable after creation.
+                        Assigning a ServiceIPFamily not available in the cluster (e.g.
+                        IPv6 in IPv4 only cluster) is an error condition and will
+                        fail during clusterIP assignment.
+                      type: string
+                    loadBalancerIP:
+                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                        will get created with the IP specified in this field. This
+                        feature depends on whether the underlying cloud-provider supports
+                        specifying the loadBalancerIP when a load balancer is created.
+                        This field will be ignored if the cloud-provider does not
+                        support the feature.'
+                      type: string
+                    loadBalancerSourceRanges:
+                      description: 'If specified and supported by the platform, this
+                        will restrict traffic through the cloud-provider load-balancer
+                        will be restricted to the specified client IPs. This field
+                        will be ignored if the cloud-provider does not support the
+                        feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: 'The list of ports that are exposed by this service.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      items:
+                        description: ServicePort contains information on service's
+                          port.
+                        properties:
+                          name:
+                            description: The name of this port within the service.
+                              This must be a DNS_LABEL. All ports within a ServiceSpec
+                              must have unique names. When considering the endpoints
+                              for a Service, this must match the 'name' field in the
+                              EndpointPort. Optional if only one ServicePort is defined
+                              on this service.
+                            type: string
+                          nodePort:
+                            description: 'The port on each node on which this service
+                              is exposed when type=NodePort or LoadBalancer. Usually
+                              assigned by the system. If specified, it will be allocated
+                              to the service if unused or else creation of the service
+                              will fail. Default is to auto-allocate a port if the
+                              ServiceType of this Service requires one. More info:
+                              https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                            format: int32
+                            type: integer
+                          port:
+                            description: The port that will be exposed by this service.
+                            format: int32
+                            type: integer
+                          protocol:
+                            description: The IP protocol for this port. Supports "TCP",
+                              "UDP", and "SCTP". Default is TCP.
+                            type: string
+                          targetPort:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: 'Number or name of the port to access on
+                              the pods targeted by the service. Number must be in
+                              the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              If this is a string, it will be looked up as a named
+                              port in the target Pod''s container ports. If this is
+                              not specified, the value of the ''port'' field is used
+                              (an identity map). This field is ignored for services
+                              with clusterIP=None, and should be omitted or set equal
+                              to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      type: array
+                    publishNotReadyAddresses:
+                      description: publishNotReadyAddresses, when set to true, indicates
+                        that DNS implementations must publish the notReadyAddresses
+                        of subsets for the Endpoints associated with the Service.
+                        The default value is false. The primary use case for setting
+                        this field is to use a StatefulSet's Headless Service to propagate
+                        SRV records for its Pods without respect to their readiness
+                        for purpose of peer discovery.
+                      type: boolean
+                    selector:
+                      additionalProperties:
+                        type: string
+                      description: 'Route service traffic to pods with label keys
+                        and values matching this selector. If empty or not present,
+                        the service is assumed to have an external process managing
+                        its endpoints, which Kubernetes will not modify. Only applies
+                        to types ClusterIP, NodePort, and LoadBalancer. Ignored if
+                        type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                      type: object
+                    sessionAffinity:
+                      description: 'Supports "ClientIP" and "None". Used to maintain
+                        session affinity. Enable client IP based session affinity.
+                        Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    sessionAffinityConfig:
+                      description: sessionAffinityConfig contains the configurations
+                        of session affinity.
+                      properties:
+                        clientIP:
+                          description: clientIP contains the configurations of Client
+                            IP based session affinity.
+                          properties:
+                            timeoutSeconds:
+                              description: timeoutSeconds specifies the seconds of
+                                ClientIP type session sticky time. The value must
+                                be >0 && <=86400(for 1 day) if ServiceAffinity ==
+                                "ClientIP". Default value is 10800(for 3 hours).
                               format: int32
                               type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
                           type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to a pod label update), the system may or may
-                          not try to eventually evict the pod from its node. When
-                          there are multiple elements, the lists of nodes corresponding
-                          to each podAffinityTerm are intersected, i.e. all terms
-                          must be satisfied.
-                        items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
-                          properties:
-                            labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            namespaces:
-                              description: namespaces specifies which namespaces the
-                                labelSelector applies to (matches against); null or
-                                empty list means "this pod's namespace"
-                              items:
+                      type: object
+                    type:
+                      description: 'type determines how the Service is exposed. Defaults
+                        to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort,
+                        and LoadBalancer. "ExternalName" maps to the specified externalName.
+                        "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                        to endpoints. Endpoints are determined by the selector or
+                        if that is not specified, by manual construction of an Endpoints
+                        object. If clusterIP is "None", no virtual IP is allocated
+                        and the endpoints are published as a set of endpoints rather
+                        than a stable IP. "NodePort" builds on ClusterIP and allocates
+                        a port on every node which routes to the clusterIP. "LoadBalancer"
+                        builds on NodePort and creates an external load-balancer (if
+                        supported in the current cloud) which routes to the clusterIP.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                      type: string
+                  type: object
+                status:
+                  description: 'Most recently observed status of the service. Populated
+                    by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                  properties:
+                    loadBalancer:
+                      description: LoadBalancer contains the current status of the
+                        load-balancer, if one is present.
+                      properties:
+                        ingress:
+                          description: Ingress is a list containing ingress points
+                            for the load-balancer. Traffic intended for the service
+                            should be sent to these ingress points.
+                          items:
+                            description: 'LoadBalancerIngress represents the status
+                              of a load-balancer ingress point: traffic intended for
+                              the service should be sent to an ingress point.'
+                            properties:
+                              hostname:
+                                description: Hostname is set for load-balancer ingress
+                                  points that are DNS based (typically AWS load-balancers)
                                 type: string
-                              type: array
-                            topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                  podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g.
-                      avoid putting this pod in the same node, zone, etc. as some
-                      other pod(s)).
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the anti-affinity expressions specified
-                          by this field, but it may choose a node that violates one
-                          or more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling anti-affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
-                        items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
-                          properties:
-                            podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the anti-affinity requirements specified by
-                          this field are not met at scheduling time, the pod will
-                          not be scheduled onto the node. If the anti-affinity requirements
-                          specified by this field cease to be met at some point during
-                          pod execution (e.g. due to a pod label update), the system
-                          may or may not try to eventually evict the pod from its
-                          node. When there are multiple elements, the lists of nodes
-                          corresponding to each podAffinityTerm are intersected, i.e.
-                          all terms must be satisfied.
-                        items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
-                          properties:
-                            labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            namespaces:
-                              description: namespaces specifies which namespaces the
-                                labelSelector applies to (matches against); null or
-                                empty list means "this pod's namespace"
-                              items:
+                              ip:
+                                description: IP is set for load-balancer ingress points
+                                  that are IP based (typically GCE or OpenStack load-balancers)
                                 type: string
-                              type: array
-                            topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                type: object
-              clusterMasterRef:
-                description: ClusterMasterRef refers to a Splunk Enterprise indexer
-                  cluster managed by the operator within Kubernetes
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+              type: object
+            storageClassName:
+              description: Name of StorageClass to use for persistent volume claims
+              type: string
+            tolerations:
+              description: Pod's tolerations for Kubernetes node's taint
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
                 properties:
-                  apiVersion:
-                    description: API version of the referent.
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
                     type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
                     type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
                     type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
                     type: string
                 type: object
-              defaults:
-                description: Inline map of default.yml overrides used to initialize
-                  the environment
-                type: string
-              defaultsUrl:
-                description: Full path or URL for one or more default.yml files, separated
-                  by commas
-                type: string
-              ephemeralStorage:
-                description: If true, ephemeral (emptyDir) storage will be used for
-                  /opt/splunk/etc and /opt/splunk/var volumes
-                type: boolean
-              etcStorage:
-                description: Storage capacity to request for /opt/splunk/etc persistent
-                  volume claims (default=”1Gi”)
-                type: string
-              image:
-                description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
-                  environment variables)
-                type: string
-              imagePullPolicy:
-                description: 'Sets pull policy for all images (either “Always” or
-                  the default: “IfNotPresent”)'
-                enum:
-                - Always
-                - IfNotPresent
-                type: string
-              licenseMasterRef:
-                description: LicenseMasterRef refers to a Splunk Enterprise license
-                  master managed by the operator within Kubernetes
+              type: array
+            varStorage:
+              description: Storage capacity to request for /opt/splunk/var persistent
+                volume claims (default=”50Gi”)
+              type: string
+            volumes:
+              description: List of one or more Kubernetes volumes. These will be mounted
+                in all pod containers as as /mnt/<name>
+              items:
+                description: Volume represents a named volume in a pod that may be
+                  accessed by any container in the pod.
                 properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              licenseUrl:
-                description: Full path or URL for a Splunk Enterprise license file
-                type: string
-              resources:
-                description: resource requirements for the pod containers
-                properties:
-                  limits:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                    type: object
-                  requests:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                    type: object
-                type: object
-              schedulerName:
-                description: Name of Scheduler to use for pod placement (defaults
-                  to “default-scheduler”)
-                type: string
-              serviceTemplate:
-                description: ServiceTemplate is a template used to create Kubernetes
-                  services
-                properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  metadata:
-                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                    type: object
-                  spec:
-                    description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                  awsElasticBlockStore:
+                    description: 'AWSElasticBlockStore represents an AWS Disk resource
+                      that is attached to a kubelet''s host machine and then exposed
+                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                     properties:
-                      clusterIP:
-                        description: 'clusterIP is the IP address of the service and
-                          is usually assigned randomly by the master. If an address
-                          is specified manually and is not in use by others, it will
-                          be allocated to the service; otherwise, creation of the
-                          service will fail. This field can not be changed through
-                          updates. Valid values are "None", empty string (""), or
-                          a valid IP address. "None" can be specified for headless
-                          services when proxying is not required. Only applies to
-                          types ClusterIP, NodePort, and LoadBalancer. Ignored if
-                          type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
                         type: string
-                      externalIPs:
-                        description: externalIPs is a list of IP addresses for which
-                          nodes in the cluster will also accept traffic for this service.  These
-                          IPs are not managed by Kubernetes.  The user is responsible
-                          for ensuring that traffic arrives at a node with this IP.  A
-                          common example is external load-balancers that are not part
-                          of the Kubernetes system.
-                        items:
-                          type: string
-                        type: array
-                      externalName:
-                        description: externalName is the external reference that kubedns
-                          or equivalent will return as a CNAME record for this service.
-                          No proxying will be involved. Must be a valid RFC-1123 hostname
-                          (https://tools.ietf.org/html/rfc1123) and requires Type
-                          to be ExternalName.
-                        type: string
-                      externalTrafficPolicy:
-                        description: externalTrafficPolicy denotes if this Service
-                          desires to route external traffic to node-local or cluster-wide
-                          endpoints. "Local" preserves the client source IP and avoids
-                          a second hop for LoadBalancer and Nodeport type services,
-                          but risks potentially imbalanced traffic spreading. "Cluster"
-                          obscures the client source IP and may cause a second hop
-                          to another node, but should have good overall load-spreading.
-                        type: string
-                      healthCheckNodePort:
-                        description: healthCheckNodePort specifies the healthcheck
-                          nodePort for the service. If not specified, HealthCheckNodePort
-                          is created by the service api backend with the allocated
-                          nodePort. Will use user-specified nodePort value if specified
-                          by the client. Only effects when Type is set to LoadBalancer
-                          and ExternalTrafficPolicy is set to Local.
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty).'
                         format: int32
                         type: integer
-                      ipFamily:
-                        description: ipFamily specifies whether this Service has a
-                          preference for a particular IP family (e.g. IPv4 vs. IPv6).  If
-                          a specific IP family is requested, the clusterIP field will
-                          be allocated from that family, if it is available in the
-                          cluster.  If no IP family is requested, the cluster's primary
-                          IP family will be used. Other IP fields (loadBalancerIP,
-                          loadBalancerSourceRanges, externalIPs) and controllers which
-                          allocate external load-balancers should use the same IP
-                          family.  Endpoints for this Service will be of this family.  This
-                          field is immutable after creation. Assigning a ServiceIPFamily
-                          not available in the cluster (e.g. IPv6 in IPv4 only cluster)
-                          is an error condition and will fail during clusterIP assignment.
+                      readOnly:
+                        description: 'Specify "true" to force and set the ReadOnly
+                          property in VolumeMounts to "true". If omitted, the default
+                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: boolean
+                      volumeID:
+                        description: 'Unique ID of the persistent disk resource in
+                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                         type: string
-                      loadBalancerIP:
-                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                          will get created with the IP specified in this field. This
-                          feature depends on whether the underlying cloud-provider
-                          supports specifying the loadBalancerIP when a load balancer
-                          is created. This field will be ignored if the cloud-provider
-                          does not support the feature.'
+                    required:
+                    - volumeID
+                    type: object
+                  azureDisk:
+                    description: AzureDisk represents an Azure Data Disk mount on
+                      the host and bind mount to the pod.
+                    properties:
+                      cachingMode:
+                        description: 'Host Caching mode: None, Read Only, Read Write.'
                         type: string
-                      loadBalancerSourceRanges:
-                        description: 'If specified and supported by the platform,
-                          this will restrict traffic through the cloud-provider load-balancer
-                          will be restricted to the specified client IPs. This field
-                          will be ignored if the cloud-provider does not support the
-                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                      diskName:
+                        description: The Name of the data disk in the blob storage
+                        type: string
+                      diskURI:
+                        description: The URI the data disk in the blob storage
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      kind:
+                        description: 'Expected values Shared: multiple blob disks
+                          per storage account  Dedicated: single blob disk per storage
+                          account  Managed: azure managed data disk (only in managed
+                          availability set). defaults to shared'
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                    required:
+                    - diskName
+                    - diskURI
+                    type: object
+                  azureFile:
+                    description: AzureFile represents an Azure File Service mount
+                      on the host and bind mount to the pod.
+                    properties:
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretName:
+                        description: the name of secret that contains Azure Storage
+                          Account Name and Key
+                        type: string
+                      shareName:
+                        description: Share Name
+                        type: string
+                    required:
+                    - secretName
+                    - shareName
+                    type: object
+                  cephfs:
+                    description: CephFS represents a Ceph FS mount on the host that
+                      shares a pod's lifetime
+                    properties:
+                      monitors:
+                        description: 'Required: Monitors is a collection of Ceph monitors
+                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                         items:
                           type: string
                         type: array
-                      ports:
-                        description: 'The list of ports that are exposed by this service.
-                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      path:
+                        description: 'Optional: Used as the mounted root, rather than
+                          the full Ceph tree, default is /'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: boolean
+                      secretFile:
+                        description: 'Optional: SecretFile is the path to key ring
+                          for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                      secretRef:
+                        description: 'Optional: SecretRef is reference to the authentication
+                          secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      user:
+                        description: 'Optional: User is the rados user name, default
+                          is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                    required:
+                    - monitors
+                    type: object
+                  cinder:
+                    description: 'Cinder represents a cinder volume attached and mounted
+                      on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Examples: "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: boolean
+                      secretRef:
+                        description: 'Optional: points to a secret object containing
+                          parameters used to connect to OpenStack.'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      volumeID:
+                        description: 'volume id used to identify the volume in cinder.
+                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  configMap:
+                    description: ConfigMap represents a configMap that should populate
+                      this volume
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced ConfigMap will be projected into
+                          the volume as a file whose name is the key and content is
+                          the value. If specified, the listed keys will be projected
+                          into the specified paths, and unlisted keys will not be
+                          present. If a key is specified which is not present in the
+                          ConfigMap, the volume setup will error unless it is marked
+                          optional. Paths must be relative and may not contain the
+                          '..' path or start with '..'.
                         items:
-                          description: ServicePort contains information on service's
-                            port.
+                          description: Maps a string key to a path within a volume.
                           properties:
-                            name:
-                              description: The name of this port within the service.
-                                This must be a DNS_LABEL. All ports within a ServiceSpec
-                                must have unique names. When considering the endpoints
-                                for a Service, this must match the 'name' field in
-                                the EndpointPort. Optional if only one ServicePort
-                                is defined on this service.
+                            key:
+                              description: The key to project.
                               type: string
-                            nodePort:
-                              description: 'The port on each node on which this service
-                                is exposed when type=NodePort or LoadBalancer. Usually
-                                assigned by the system. If specified, it will be allocated
-                                to the service if unused or else creation of the service
-                                will fail. Default is to auto-allocate a port if the
-                                ServiceType of this Service requires one. More info:
-                                https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
                               format: int32
                               type: integer
-                            port:
-                              description: The port that will be exposed by this service.
-                              format: int32
-                              type: integer
-                            protocol:
-                              description: The IP protocol for this port. Supports
-                                "TCP", "UDP", and "SCTP". Default is TCP.
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
                               type: string
-                            targetPort:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              description: 'Number or name of the port to access on
-                                the pods targeted by the service. Number must be in
-                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                                If this is a string, it will be looked up as a named
-                                port in the target Pod''s container ports. If this
-                                is not specified, the value of the ''port'' field
-                                is used (an identity map). This field is ignored for
-                                services with clusterIP=None, and should be omitted
-                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
-                              x-kubernetes-int-or-string: true
                           required:
-                          - port
+                          - key
+                          - path
                           type: object
                         type: array
-                        x-kubernetes-list-map-keys:
-                        - port
-                        - protocol
-                        x-kubernetes-list-type: map
-                      publishNotReadyAddresses:
-                        description: publishNotReadyAddresses, when set to true, indicates
-                          that DNS implementations must publish the notReadyAddresses
-                          of subsets for the Endpoints associated with the Service.
-                          The default value is false. The primary use case for setting
-                          this field is to use a StatefulSet's Headless Service to
-                          propagate SRV records for its Pods without respect to their
-                          readiness for purpose of peer discovery.
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the ConfigMap or its keys must
+                          be defined
                         type: boolean
-                      selector:
+                    type: object
+                  csi:
+                    description: CSI (Container Storage Interface) represents storage
+                      that is handled by an external CSI driver (Alpha feature).
+                    properties:
+                      driver:
+                        description: Driver is the name of the CSI driver that handles
+                          this volume. Consult with your admin for the correct name
+                          as registered in the cluster.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Ex. "ext4", "xfs",
+                          "ntfs". If not provided, the empty value is passed to the
+                          associated CSI driver which will determine the default filesystem
+                          to apply.
+                        type: string
+                      nodePublishSecretRef:
+                        description: NodePublishSecretRef is a reference to the secret
+                          object containing sensitive information to pass to the CSI
+                          driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
+                          calls. This field is optional, and  may be empty if no secret
+                          is required. If the secret object contains more than one
+                          secret, all secret references are passed.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      readOnly:
+                        description: Specifies a read-only configuration for the volume.
+                          Defaults to false (read/write).
+                        type: boolean
+                      volumeAttributes:
                         additionalProperties:
                           type: string
-                        description: 'Route service traffic to pods with label keys
-                          and values matching this selector. If empty or not present,
-                          the service is assumed to have an external process managing
-                          its endpoints, which Kubernetes will not modify. Only applies
-                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
-                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                        description: VolumeAttributes stores driver-specific properties
+                          that are passed to the CSI driver. Consult your driver's
+                          documentation for supported values.
                         type: object
-                      sessionAffinity:
-                        description: 'Supports "ClientIP" and "None". Used to maintain
-                          session affinity. Enable client IP based session affinity.
-                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                        type: string
-                      sessionAffinityConfig:
-                        description: sessionAffinityConfig contains the configurations
-                          of session affinity.
-                        properties:
-                          clientIP:
-                            description: clientIP contains the configurations of Client
-                              IP based session affinity.
-                            properties:
-                              timeoutSeconds:
-                                description: timeoutSeconds specifies the seconds
-                                  of ClientIP type session sticky time. The value
-                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
-                                  == "ClientIP". Default value is 10800(for 3 hours).
-                                format: int32
-                                type: integer
-                            type: object
-                        type: object
-                      type:
-                        description: 'type determines how the Service is exposed.
-                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
-                          NodePort, and LoadBalancer. "ExternalName" maps to the specified
-                          externalName. "ClusterIP" allocates a cluster-internal IP
-                          address for load-balancing to endpoints. Endpoints are determined
-                          by the selector or if that is not specified, by manual construction
-                          of an Endpoints object. If clusterIP is "None", no virtual
-                          IP is allocated and the endpoints are published as a set
-                          of endpoints rather than a stable IP. "NodePort" builds
-                          on ClusterIP and allocates a port on every node which routes
-                          to the clusterIP. "LoadBalancer" builds on NodePort and
-                          creates an external load-balancer (if supported in the current
-                          cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
-                        type: string
+                    required:
+                    - driver
                     type: object
-                  status:
-                    description: 'Most recently observed status of the service. Populated
-                      by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                  downwardAPI:
+                    description: DownwardAPI represents downward API about the pod
+                      that should populate this volume
                     properties:
-                      loadBalancer:
-                        description: LoadBalancer contains the current status of the
-                          load-balancer, if one is present.
-                        properties:
-                          ingress:
-                            description: Ingress is a list containing ingress points
-                              for the load-balancer. Traffic intended for the service
-                              should be sent to these ingress points.
-                            items:
-                              description: 'LoadBalancerIngress represents the status
-                                of a load-balancer ingress point: traffic intended
-                                for the service should be sent to an ingress point.'
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: Items is a list of downward API volume file
+                        items:
+                          description: DownwardAPIVolumeFile represents information
+                            to create the file containing the pod field
+                          properties:
+                            fieldRef:
+                              description: 'Required: Selects a field of the pod:
+                                only annotations, labels, name and namespace are supported.'
                               properties:
-                                hostname:
-                                  description: Hostname is set for load-balancer ingress
-                                    points that are DNS based (typically AWS load-balancers)
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
                                   type: string
-                                ip:
-                                  description: IP is set for load-balancer ingress
-                                    points that are IP based (typically GCE or OpenStack
-                                    load-balancers)
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
                                   type: string
+                              required:
+                              - fieldPath
                               type: object
-                            type: array
-                        type: object
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: 'Required: Path is  the relative path name
+                                of the file to be created. Must not be absolute or
+                                contain the ''..'' path. Must be utf-8 encoded. The
+                                first item of the relative path must not start with
+                                ''..'''
+                              type: string
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                requests.cpu and requests.memory) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  type: string
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                          required:
+                          - path
+                          type: object
+                        type: array
                     type: object
+                  emptyDir:
+                    description: 'EmptyDir represents a temporary directory that shares
+                      a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                    properties:
+                      medium:
+                        description: 'What type of storage medium should back this
+                          directory. The default is "" which means to use the node''s
+                          default medium. Must be an empty string (default) or Memory.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        type: string
+                      sizeLimit:
+                        description: 'Total amount of local storage required for this
+                          EmptyDir volume. The size limit is also applicable for memory
+                          medium. The maximum usage on memory medium EmptyDir would
+                          be the minimum value between the SizeLimit specified here
+                          and the sum of memory limits of all containers in a pod.
+                          The default is nil which means that the limit is undefined.
+                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                        type: string
+                    type: object
+                  fc:
+                    description: FC represents a Fibre Channel resource that is attached
+                      to a kubelet's host machine and then exposed to the pod.
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      lun:
+                        description: 'Optional: FC target lun number'
+                        format: int32
+                        type: integer
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      targetWWNs:
+                        description: 'Optional: FC target worldwide names (WWNs)'
+                        items:
+                          type: string
+                        type: array
+                      wwids:
+                        description: 'Optional: FC volume world wide identifiers (wwids)
+                          Either wwids or combination of targetWWNs and lun must be
+                          set, but not both simultaneously.'
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  flexVolume:
+                    description: FlexVolume represents a generic volume resource that
+                      is provisioned/attached using an exec based plugin.
+                    properties:
+                      driver:
+                        description: Driver is the name of the driver to use for this
+                          volume.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". The default filesystem depends on FlexVolume
+                          script.
+                        type: string
+                      options:
+                        additionalProperties:
+                          type: string
+                        description: 'Optional: Extra command options if any.'
+                        type: object
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      secretRef:
+                        description: 'Optional: SecretRef is reference to the secret
+                          object containing sensitive information to pass to the plugin
+                          scripts. This may be empty if no secret object is specified.
+                          If the secret object contains more than one secret, all
+                          secrets are passed to the plugin scripts.'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                    required:
+                    - driver
+                    type: object
+                  flocker:
+                    description: Flocker represents a Flocker volume attached to a
+                      kubelet's host machine. This depends on the Flocker control
+                      service being running
+                    properties:
+                      datasetName:
+                        description: Name of the dataset stored as metadata -> name
+                          on the dataset for Flocker should be considered as deprecated
+                        type: string
+                      datasetUUID:
+                        description: UUID of the dataset. This is unique identifier
+                          of a Flocker dataset
+                        type: string
+                    type: object
+                  gcePersistentDisk:
+                    description: 'GCEPersistentDisk represents a GCE Disk resource
+                      that is attached to a kubelet''s host machine and then exposed
+                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        format: int32
+                        type: integer
+                      pdName:
+                        description: 'Unique name of the PD resource in GCE. Used
+                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: boolean
+                    required:
+                    - pdName
+                    type: object
+                  gitRepo:
+                    description: 'GitRepo represents a git repository at a particular
+                      revision. DEPRECATED: GitRepo is deprecated. To provision a
+                      container with a git repo, mount an EmptyDir into an InitContainer
+                      that clones the repo using git, then mount the EmptyDir into
+                      the Pod''s container.'
+                    properties:
+                      directory:
+                        description: Target directory name. Must not contain or start
+                          with '..'.  If '.' is supplied, the volume directory will
+                          be the git repository.  Otherwise, if specified, the volume
+                          will contain the git repository in the subdirectory with
+                          the given name.
+                        type: string
+                      repository:
+                        description: Repository URL
+                        type: string
+                      revision:
+                        description: Commit hash for the specified revision.
+                        type: string
+                    required:
+                    - repository
+                    type: object
+                  glusterfs:
+                    description: 'Glusterfs represents a Glusterfs mount on the host
+                      that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                    properties:
+                      endpoints:
+                        description: 'EndpointsName is the endpoint name that details
+                          Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      path:
+                        description: 'Path is the Glusterfs volume path. More info:
+                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the Glusterfs volume
+                          to be mounted with read-only permissions. Defaults to false.
+                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: boolean
+                    required:
+                    - endpoints
+                    - path
+                    type: object
+                  hostPath:
+                    description: 'HostPath represents a pre-existing file or directory
+                      on the host machine that is directly exposed to the container.
+                      This is generally used for system agents or other privileged
+                      things that are allowed to see the host machine. Most containers
+                      will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                      --- TODO(jonesdl) We need to restrict who can use host directory
+                      mounts and who can/can not mount host directories as read/write.'
+                    properties:
+                      path:
+                        description: 'Path of the directory on the host. If the path
+                          is a symlink, it will follow the link to the real path.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                      type:
+                        description: 'Type for HostPath Volume Defaults to "" More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                    required:
+                    - path
+                    type: object
+                  iscsi:
+                    description: 'ISCSI represents an ISCSI Disk resource that is
+                      attached to a kubelet''s host machine and then exposed to the
+                      pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                    properties:
+                      chapAuthDiscovery:
+                        description: whether support iSCSI Discovery CHAP authentication
+                        type: boolean
+                      chapAuthSession:
+                        description: whether support iSCSI Session CHAP authentication
+                        type: boolean
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      initiatorName:
+                        description: Custom iSCSI Initiator Name. If initiatorName
+                          is specified with iscsiInterface simultaneously, new iSCSI
+                          interface <target portal>:<volume name> will be created
+                          for the connection.
+                        type: string
+                      iqn:
+                        description: Target iSCSI Qualified Name.
+                        type: string
+                      iscsiInterface:
+                        description: iSCSI Interface Name that uses an iSCSI transport.
+                          Defaults to 'default' (tcp).
+                        type: string
+                      lun:
+                        description: iSCSI Target Lun number.
+                        format: int32
+                        type: integer
+                      portals:
+                        description: iSCSI Target Portal List. The portal is either
+                          an IP or ip_addr:port if the port is other than default
+                          (typically TCP ports 860 and 3260).
+                        items:
+                          type: string
+                        type: array
+                      readOnly:
+                        description: ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false.
+                        type: boolean
+                      secretRef:
+                        description: CHAP Secret for iSCSI target and initiator authentication
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      targetPortal:
+                        description: iSCSI Target Portal. The Portal is either an
+                          IP or ip_addr:port if the port is other than default (typically
+                          TCP ports 860 and 3260).
+                        type: string
+                    required:
+                    - iqn
+                    - lun
+                    - targetPortal
+                    type: object
+                  name:
+                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
+                      the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  nfs:
+                    description: 'NFS represents an NFS mount on the host that shares
+                      a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                    properties:
+                      path:
+                        description: 'Path that is exported by the NFS server. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the NFS export to be
+                          mounted with read-only permissions. Defaults to false. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: boolean
+                      server:
+                        description: 'Server is the hostname or IP address of the
+                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                    required:
+                    - path
+                    - server
+                    type: object
+                  persistentVolumeClaim:
+                    description: 'PersistentVolumeClaimVolumeSource represents a reference
+                      to a PersistentVolumeClaim in the same namespace. More info:
+                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                    properties:
+                      claimName:
+                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                          in the same namespace as the pod using this volume. More
+                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        type: string
+                      readOnly:
+                        description: Will force the ReadOnly setting in VolumeMounts.
+                          Default false.
+                        type: boolean
+                    required:
+                    - claimName
+                    type: object
+                  photonPersistentDisk:
+                    description: PhotonPersistentDisk represents a PhotonController
+                      persistent disk attached and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      pdID:
+                        description: ID that identifies Photon Controller persistent
+                          disk
+                        type: string
+                    required:
+                    - pdID
+                    type: object
+                  portworxVolume:
+                    description: PortworxVolume represents a portworx volume attached
+                      and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: FSType represents the filesystem type to mount
+                          Must be a filesystem type supported by the host operating
+                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                          if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      volumeID:
+                        description: VolumeID uniquely identifies a Portworx volume
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  projected:
+                    description: Items for all in one resources secrets, configmaps,
+                      and downward API
+                    properties:
+                      defaultMode:
+                        description: Mode bits to use on created files by default.
+                          Must be a value between 0 and 0777. Directories within the
+                          path are not affected by this setting. This might be in
+                          conflict with other options that affect the file mode, like
+                          fsGroup, and the result can be other mode bits set.
+                        format: int32
+                        type: integer
+                      sources:
+                        description: list of volume projections
+                        items:
+                          description: Projection that may be projected along with
+                            other supported volume types
+                          properties:
+                            configMap:
+                              description: information about the configMap data to
+                                project
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    keys must be defined
+                                  type: boolean
+                              type: object
+                            downwardAPI:
+                              description: information about the downwardAPI data
+                                to project
+                              properties:
+                                items:
+                                  description: Items is a list of DownwardAPIVolume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, requests.cpu and requests.memory)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            secret:
+                              description: information about the secret data to project
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced Secret will
+                                    be projected into the volume as a file whose name
+                                    is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              type: object
+                            serviceAccountToken:
+                              description: information about the serviceAccountToken
+                                data to project
+                              properties:
+                                audience:
+                                  description: Audience is the intended audience of
+                                    the token. A recipient of a token must identify
+                                    itself with an identifier specified in the audience
+                                    of the token, and otherwise should reject the
+                                    token. The audience defaults to the identifier
+                                    of the apiserver.
+                                  type: string
+                                expirationSeconds:
+                                  description: ExpirationSeconds is the requested
+                                    duration of validity of the service account token.
+                                    As the token approaches expiration, the kubelet
+                                    volume plugin will proactively rotate the service
+                                    account token. The kubelet will start trying to
+                                    rotate the token if the token is older than 80
+                                    percent of its time to live or if the token is
+                                    older than 24 hours.Defaults to 1 hour and must
+                                    be at least 10 minutes.
+                                  format: int64
+                                  type: integer
+                                path:
+                                  description: Path is the path relative to the mount
+                                    point of the file to project the token into.
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                          type: object
+                        type: array
+                    required:
+                    - sources
+                    type: object
+                  quobyte:
+                    description: Quobyte represents a Quobyte mount on the host that
+                      shares a pod's lifetime
+                    properties:
+                      group:
+                        description: Group to map volume access to Default is no group
+                        type: string
+                      readOnly:
+                        description: ReadOnly here will force the Quobyte volume to
+                          be mounted with read-only permissions. Defaults to false.
+                        type: boolean
+                      registry:
+                        description: Registry represents a single or multiple Quobyte
+                          Registry services specified as a string as host:port pair
+                          (multiple entries are separated with commas) which acts
+                          as the central registry for volumes
+                        type: string
+                      tenant:
+                        description: Tenant owning the given Quobyte volume in the
+                          Backend Used with dynamically provisioned Quobyte volumes,
+                          value is set by the plugin
+                        type: string
+                      user:
+                        description: User to map volume access to Defaults to serivceaccount
+                          user
+                        type: string
+                      volume:
+                        description: Volume is a string that references an already
+                          created Quobyte volume by name.
+                        type: string
+                    required:
+                    - registry
+                    - volume
+                    type: object
+                  rbd:
+                    description: 'RBD represents a Rados Block Device mount on the
+                      host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      image:
+                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      keyring:
+                        description: 'Keyring is the path to key ring for RBDUser.
+                          Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      monitors:
+                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        items:
+                          type: string
+                        type: array
+                      pool:
+                        description: 'The rados pool name. Default is rbd. More info:
+                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: boolean
+                      secretRef:
+                        description: 'SecretRef is name of the authentication secret
+                          for RBDUser. If provided overrides keyring. Default is nil.
+                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      user:
+                        description: 'The rados user name. Default is admin. More
+                          info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                    required:
+                    - image
+                    - monitors
+                    type: object
+                  scaleIO:
+                    description: ScaleIO represents a ScaleIO persistent volume attached
+                      and mounted on Kubernetes nodes.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Default is "xfs".
+                        type: string
+                      gateway:
+                        description: The host address of the ScaleIO API Gateway.
+                        type: string
+                      protectionDomain:
+                        description: The name of the ScaleIO Protection Domain for
+                          the configured storage.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: SecretRef references to the secret for ScaleIO
+                          user and other sensitive information. If this is not provided,
+                          Login operation will fail.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      sslEnabled:
+                        description: Flag to enable/disable SSL communication with
+                          Gateway, default false
+                        type: boolean
+                      storageMode:
+                        description: Indicates whether the storage for a volume should
+                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                        type: string
+                      storagePool:
+                        description: The ScaleIO Storage Pool associated with the
+                          protection domain.
+                        type: string
+                      system:
+                        description: The name of the storage system as configured
+                          in ScaleIO.
+                        type: string
+                      volumeName:
+                        description: The name of a volume already created in the ScaleIO
+                          system that is associated with this volume source.
+                        type: string
+                    required:
+                    - gateway
+                    - secretRef
+                    - system
+                    type: object
+                  secret:
+                    description: 'Secret represents a secret that should populate
+                      this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced Secret will be projected into the
+                          volume as a file whose name is the key and content is the
+                          value. If specified, the listed keys will be projected into
+                          the specified paths, and unlisted keys will not be present.
+                          If a key is specified which is not present in the Secret,
+                          the volume setup will error unless it is marked optional.
+                          Paths must be relative and may not contain the '..' path
+                          or start with '..'.
+                        items:
+                          description: Maps a string key to a path within a volume.
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          type: object
+                        type: array
+                      optional:
+                        description: Specify whether the Secret or its keys must be
+                          defined
+                        type: boolean
+                      secretName:
+                        description: 'Name of the secret in the pod''s namespace to
+                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        type: string
+                    type: object
+                  storageos:
+                    description: StorageOS represents a StorageOS volume attached
+                      and mounted on Kubernetes nodes.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: SecretRef specifies the secret to use for obtaining
+                          the StorageOS API credentials.  If not specified, default
+                          values will be attempted.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      volumeName:
+                        description: VolumeName is the human-readable name of the
+                          StorageOS volume.  Volume names are only unique within a
+                          namespace.
+                        type: string
+                      volumeNamespace:
+                        description: VolumeNamespace specifies the scope of the volume
+                          within StorageOS.  If no namespace is specified then the
+                          Pod's namespace will be used.  This allows the Kubernetes
+                          name scoping to be mirrored within StorageOS for tighter
+                          integration. Set VolumeName to any name to override the
+                          default behaviour. Set to "default" if you are not using
+                          namespaces within StorageOS. Namespaces that do not pre-exist
+                          within StorageOS will be created.
+                        type: string
+                    type: object
+                  vsphereVolume:
+                    description: VsphereVolume represents a vSphere volume attached
+                      and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      storagePolicyID:
+                        description: Storage Policy Based Management (SPBM) profile
+                          ID associated with the StoragePolicyName.
+                        type: string
+                      storagePolicyName:
+                        description: Storage Policy Based Management (SPBM) profile
+                          name.
+                        type: string
+                      volumePath:
+                        description: Path that identifies vSphere volume vmdk
+                        type: string
+                    required:
+                    - volumePath
+                    type: object
+                required:
+                - name
                 type: object
-              storageClassName:
-                description: Name of StorageClass to use for persistent volume claims
-                type: string
-              tolerations:
-                description: Pod's tolerations for Kubernetes node's taint
-                items:
-                  description: The pod this Toleration is attached to tolerates any
-                    taint that matches the triple <key,value,effect> using the matching
-                    operator <operator>.
-                  properties:
-                    effect:
-                      description: Effect indicates the taint effect to match. Empty
-                        means match all taint effects. When specified, allowed values
-                        are NoSchedule, PreferNoSchedule and NoExecute.
-                      type: string
-                    key:
-                      description: Key is the taint key that the toleration applies
-                        to. Empty means match all taint keys. If the key is empty,
-                        operator must be Exists; this combination means to match all
-                        values and all keys.
-                      type: string
-                    operator:
-                      description: Operator represents a key's relationship to the
-                        value. Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod
-                        can tolerate all taints of a particular category.
-                      type: string
-                    tolerationSeconds:
-                      description: TolerationSeconds represents the period of time
-                        the toleration (which must be of effect NoExecute, otherwise
-                        this field is ignored) tolerates the taint. By default, it
-                        is not set, which means tolerate the taint forever (do not
-                        evict). Zero and negative values will be treated as 0 (evict
-                        immediately) by the system.
-                      format: int64
-                      type: integer
-                    value:
-                      description: Value is the taint value the toleration matches
-                        to. If the operator is Exists, the value should be empty,
-                        otherwise just a regular string.
-                      type: string
-                  type: object
-                type: array
-              varStorage:
-                description: Storage capacity to request for /opt/splunk/var persistent
-                  volume claims (default=”50Gi”)
-                type: string
-              volumes:
-                description: List of one or more Kubernetes volumes. These will be
-                  mounted in all pod containers as as /mnt/<name>
-                items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
-                  properties:
-                    awsElasticBlockStore:
-                      description: 'AWSElasticBlockStore represents an AWS Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        partition:
-                          description: 'The partition in the volume that you want
-                            to mount. If omitted, the default is to mount by volume
-                            name. Examples: For volume /dev/sda1, you specify the
-                            partition as "1". Similarly, the volume partition for
-                            /dev/sda is "0" (or you can leave the property empty).'
-                          format: int32
-                          type: integer
-                        readOnly:
-                          description: 'Specify "true" to force and set the ReadOnly
-                            property in VolumeMounts to "true". If omitted, the default
-                            is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                          type: boolean
-                        volumeID:
-                          description: 'Unique ID of the persistent disk resource
-                            in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    azureDisk:
-                      description: AzureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
-                      properties:
-                        cachingMode:
-                          description: 'Host Caching mode: None, Read Only, Read Write.'
-                          type: string
-                        diskName:
-                          description: The Name of the data disk in the blob storage
-                          type: string
-                        diskURI:
-                          description: The URI the data disk in the blob storage
-                          type: string
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        kind:
-                          description: 'Expected values Shared: multiple blob disks
-                            per storage account  Dedicated: single blob disk per storage
-                            account  Managed: azure managed data disk (only in managed
-                            availability set). defaults to shared'
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                      required:
-                      - diskName
-                      - diskURI
-                      type: object
-                    azureFile:
-                      description: AzureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
-                      properties:
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretName:
-                          description: the name of secret that contains Azure Storage
-                            Account Name and Key
-                          type: string
-                        shareName:
-                          description: Share Name
-                          type: string
-                      required:
-                      - secretName
-                      - shareName
-                      type: object
-                    cephfs:
-                      description: CephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
-                      properties:
-                        monitors:
-                          description: 'Required: Monitors is a collection of Ceph
-                            monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          items:
-                            type: string
-                          type: array
-                        path:
-                          description: 'Optional: Used as the mounted root, rather
-                            than the full Ceph tree, default is /'
-                          type: string
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: boolean
-                        secretFile:
-                          description: 'Optional: SecretFile is the path to key ring
-                            for User, default is /etc/ceph/user.secret More info:
-                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: string
-                        secretRef:
-                          description: 'Optional: SecretRef is reference to the authentication
-                            secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        user:
-                          description: 'Optional: User is the rados user name, default
-                            is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: string
-                      required:
-                      - monitors
-                      type: object
-                    cinder:
-                      description: 'Cinder represents a cinder volume attached and
-                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: string
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: boolean
-                        secretRef:
-                          description: 'Optional: points to a secret object containing
-                            parameters used to connect to OpenStack.'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        volumeID:
-                          description: 'volume id used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    configMap:
-                      description: ConfigMap represents a configMap that should populate
-                        this volume
-                      properties:
-                        defaultMode:
-                          description: 'Optional: mode bits to use on created files
-                            by default. Must be a value between 0 and 0777. Defaults
-                            to 0644. Directories within the path are not affected
-                            by this setting. This might be in conflict with other
-                            options that affect the file mode, like fsGroup, and the
-                            result can be other mode bits set.'
-                          format: int32
-                          type: integer
-                        items:
-                          description: If unspecified, each key-value pair in the
-                            Data field of the referenced ConfigMap will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the ConfigMap, the volume setup will error unless it is
-                            marked optional. Paths must be relative and may not contain
-                            the '..' path or start with '..'.
-                          items:
-                            description: Maps a string key to a path within a volume.
-                            properties:
-                              key:
-                                description: The key to project.
-                                type: string
-                              mode:
-                                description: 'Optional: mode bits to use on this file,
-                                  must be a value between 0 and 0777. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: The relative path of the file to map
-                                  the key to. May not be an absolute path. May not
-                                  contain the path element '..'. May not start with
-                                  the string '..'.
-                                type: string
-                            required:
-                            - key
-                            - path
-                            type: object
-                          type: array
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                        optional:
-                          description: Specify whether the ConfigMap or its keys must
-                            be defined
-                          type: boolean
-                      type: object
-                    csi:
-                      description: CSI (Container Storage Interface) represents storage
-                        that is handled by an external CSI driver (Alpha feature).
-                      properties:
-                        driver:
-                          description: Driver is the name of the CSI driver that handles
-                            this volume. Consult with your admin for the correct name
-                            as registered in the cluster.
-                          type: string
-                        fsType:
-                          description: Filesystem type to mount. Ex. "ext4", "xfs",
-                            "ntfs". If not provided, the empty value is passed to
-                            the associated CSI driver which will determine the default
-                            filesystem to apply.
-                          type: string
-                        nodePublishSecretRef:
-                          description: NodePublishSecretRef is a reference to the
-                            secret object containing sensitive information to pass
-                            to the CSI driver to complete the CSI NodePublishVolume
-                            and NodeUnpublishVolume calls. This field is optional,
-                            and  may be empty if no secret is required. If the secret
-                            object contains more than one secret, all secret references
-                            are passed.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        readOnly:
-                          description: Specifies a read-only configuration for the
-                            volume. Defaults to false (read/write).
-                          type: boolean
-                        volumeAttributes:
-                          additionalProperties:
-                            type: string
-                          description: VolumeAttributes stores driver-specific properties
-                            that are passed to the CSI driver. Consult your driver's
-                            documentation for supported values.
-                          type: object
-                      required:
-                      - driver
-                      type: object
-                    downwardAPI:
-                      description: DownwardAPI represents downward API about the pod
-                        that should populate this volume
-                      properties:
-                        defaultMode:
-                          description: 'Optional: mode bits to use on created files
-                            by default. Must be a value between 0 and 0777. Defaults
-                            to 0644. Directories within the path are not affected
-                            by this setting. This might be in conflict with other
-                            options that affect the file mode, like fsGroup, and the
-                            result can be other mode bits set.'
-                          format: int32
-                          type: integer
-                        items:
-                          description: Items is a list of downward API volume file
-                          items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
-                            properties:
-                              fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
-                                properties:
-                                  apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
-                                    type: string
-                                required:
-                                - fieldPath
-                                type: object
-                              mode:
-                                description: 'Optional: mode bits to use on this file,
-                                  must be a value between 0 and 0777. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
-                                type: string
-                              resourceFieldRef:
-                                description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, requests.cpu and requests.memory)
-                                  are currently supported.'
-                                properties:
-                                  containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: 'Required: resource to select'
-                                    type: string
-                                required:
-                                - resource
-                                type: object
-                            required:
-                            - path
-                            type: object
-                          type: array
-                      type: object
-                    emptyDir:
-                      description: 'EmptyDir represents a temporary directory that
-                        shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                      properties:
-                        medium:
-                          description: 'What type of storage medium should back this
-                            directory. The default is "" which means to use the node''s
-                            default medium. Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                          type: string
-                        sizeLimit:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          description: 'Total amount of local storage required for
-                            this EmptyDir volume. The size limit is also applicable
-                            for memory medium. The maximum usage on memory medium
-                            EmptyDir would be the minimum value between the SizeLimit
-                            specified here and the sum of memory limits of all containers
-                            in a pod. The default is nil which means that the limit
-                            is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                      type: object
-                    fc:
-                      description: FC represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
-                      properties:
-                        fsType:
-                          description: 'Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        lun:
-                          description: 'Optional: FC target lun number'
-                          format: int32
-                          type: integer
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
-                          type: boolean
-                        targetWWNs:
-                          description: 'Optional: FC target worldwide names (WWNs)'
-                          items:
-                            type: string
-                          type: array
-                        wwids:
-                          description: 'Optional: FC volume world wide identifiers
-                            (wwids) Either wwids or combination of targetWWNs and
-                            lun must be set, but not both simultaneously.'
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    flexVolume:
-                      description: FlexVolume represents a generic volume resource
-                        that is provisioned/attached using an exec based plugin.
-                      properties:
-                        driver:
-                          description: Driver is the name of the driver to use for
-                            this volume.
-                          type: string
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". The default filesystem depends on FlexVolume
-                            script.
-                          type: string
-                        options:
-                          additionalProperties:
-                            type: string
-                          description: 'Optional: Extra command options if any.'
-                          type: object
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
-                          type: boolean
-                        secretRef:
-                          description: 'Optional: SecretRef is reference to the secret
-                            object containing sensitive information to pass to the
-                            plugin scripts. This may be empty if no secret object
-                            is specified. If the secret object contains more than
-                            one secret, all secrets are passed to the plugin scripts.'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                      required:
-                      - driver
-                      type: object
-                    flocker:
-                      description: Flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
-                      properties:
-                        datasetName:
-                          description: Name of the dataset stored as metadata -> name
-                            on the dataset for Flocker should be considered as deprecated
-                          type: string
-                        datasetUUID:
-                          description: UUID of the dataset. This is unique identifier
-                            of a Flocker dataset
-                          type: string
-                      type: object
-                    gcePersistentDisk:
-                      description: 'GCEPersistentDisk represents a GCE Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        partition:
-                          description: 'The partition in the volume that you want
-                            to mount. If omitted, the default is to mount by volume
-                            name. Examples: For volume /dev/sda1, you specify the
-                            partition as "1". Similarly, the volume partition for
-                            /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          format: int32
-                          type: integer
-                        pdName:
-                          description: 'Unique name of the PD resource in GCE. Used
-                            to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          type: boolean
-                      required:
-                      - pdName
-                      type: object
-                    gitRepo:
-                      description: 'GitRepo represents a git repository at a particular
-                        revision. DEPRECATED: GitRepo is deprecated. To provision
-                        a container with a git repo, mount an EmptyDir into an InitContainer
-                        that clones the repo using git, then mount the EmptyDir into
-                        the Pod''s container.'
-                      properties:
-                        directory:
-                          description: Target directory name. Must not contain or
-                            start with '..'.  If '.' is supplied, the volume directory
-                            will be the git repository.  Otherwise, if specified,
-                            the volume will contain the git repository in the subdirectory
-                            with the given name.
-                          type: string
-                        repository:
-                          description: Repository URL
-                          type: string
-                        revision:
-                          description: Commit hash for the specified revision.
-                          type: string
-                      required:
-                      - repository
-                      type: object
-                    glusterfs:
-                      description: 'Glusterfs represents a Glusterfs mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
-                      properties:
-                        endpoints:
-                          description: 'EndpointsName is the endpoint name that details
-                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: string
-                        path:
-                          description: 'Path is the Glusterfs volume path. More info:
-                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the Glusterfs volume
-                            to be mounted with read-only permissions. Defaults to
-                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: boolean
-                      required:
-                      - endpoints
-                      - path
-                      type: object
-                    hostPath:
-                      description: 'HostPath represents a pre-existing file or directory
-                        on the host machine that is directly exposed to the container.
-                        This is generally used for system agents or other privileged
-                        things that are allowed to see the host machine. Most containers
-                        will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        --- TODO(jonesdl) We need to restrict who can use host directory
-                        mounts and who can/can not mount host directories as read/write.'
-                      properties:
-                        path:
-                          description: 'Path of the directory on the host. If the
-                            path is a symlink, it will follow the link to the real
-                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                          type: string
-                        type:
-                          description: 'Type for HostPath Volume Defaults to "" More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                          type: string
-                      required:
-                      - path
-                      type: object
-                    iscsi:
-                      description: 'ISCSI represents an ISCSI Disk resource that is
-                        attached to a kubelet''s host machine and then exposed to
-                        the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
-                      properties:
-                        chapAuthDiscovery:
-                          description: whether support iSCSI Discovery CHAP authentication
-                          type: boolean
-                        chapAuthSession:
-                          description: whether support iSCSI Session CHAP authentication
-                          type: boolean
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        initiatorName:
-                          description: Custom iSCSI Initiator Name. If initiatorName
-                            is specified with iscsiInterface simultaneously, new iSCSI
-                            interface <target portal>:<volume name> will be created
-                            for the connection.
-                          type: string
-                        iqn:
-                          description: Target iSCSI Qualified Name.
-                          type: string
-                        iscsiInterface:
-                          description: iSCSI Interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
-                          type: string
-                        lun:
-                          description: iSCSI Target Lun number.
-                          format: int32
-                          type: integer
-                        portals:
-                          description: iSCSI Target Portal List. The portal is either
-                            an IP or ip_addr:port if the port is other than default
-                            (typically TCP ports 860 and 3260).
-                          items:
-                            type: string
-                          type: array
-                        readOnly:
-                          description: ReadOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false.
-                          type: boolean
-                        secretRef:
-                          description: CHAP Secret for iSCSI target and initiator
-                            authentication
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        targetPortal:
-                          description: iSCSI Target Portal. The Portal is either an
-                            IP or ip_addr:port if the port is other than default (typically
-                            TCP ports 860 and 3260).
-                          type: string
-                      required:
-                      - iqn
-                      - lun
-                      - targetPortal
-                      type: object
-                    name:
-                      description: 'Volume''s name. Must be a DNS_LABEL and unique
-                        within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                      type: string
-                    nfs:
-                      description: 'NFS represents an NFS mount on the host that shares
-                        a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                      properties:
-                        path:
-                          description: 'Path that is exported by the NFS server. More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the NFS export to
-                            be mounted with read-only permissions. Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: boolean
-                        server:
-                          description: 'Server is the hostname or IP address of the
-                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: string
-                      required:
-                      - path
-                      - server
-                      type: object
-                    persistentVolumeClaim:
-                      description: 'PersistentVolumeClaimVolumeSource represents a
-                        reference to a PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                      properties:
-                        claimName:
-                          description: 'ClaimName is the name of a PersistentVolumeClaim
-                            in the same namespace as the pod using this volume. More
-                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                          type: string
-                        readOnly:
-                          description: Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
-                          type: boolean
-                      required:
-                      - claimName
-                      type: object
-                    photonPersistentDisk:
-                      description: PhotonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        pdID:
-                          description: ID that identifies Photon Controller persistent
-                            disk
-                          type: string
-                      required:
-                      - pdID
-                      type: object
-                    portworxVolume:
-                      description: PortworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: FSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating
-                            system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                            if unspecified.
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        volumeID:
-                          description: VolumeID uniquely identifies a Portworx volume
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    projected:
-                      description: Items for all in one resources secrets, configmaps,
-                        and downward API
-                      properties:
-                        defaultMode:
-                          description: Mode bits to use on created files by default.
-                            Must be a value between 0 and 0777. Directories within
-                            the path are not affected by this setting. This might
-                            be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits
-                            set.
-                          format: int32
-                          type: integer
-                        sources:
-                          description: list of volume projections
-                          items:
-                            description: Projection that may be projected along with
-                              other supported volume types
-                            properties:
-                              configMap:
-                                description: information about the configMap data
-                                  to project
-                                properties:
-                                  items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced ConfigMap
-                                      will be projected into the volume as a file
-                                      whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the ConfigMap, the volume
-                                      setup will error unless it is marked optional.
-                                      Paths must be relative and may not contain the
-                                      '..' path or start with '..'.
-                                    items:
-                                      description: Maps a string key to a path within
-                                        a volume.
-                                      properties:
-                                        key:
-                                          description: The key to project.
-                                          type: string
-                                        mode:
-                                          description: 'Optional: mode bits to use
-                                            on this file, must be a value between
-                                            0 and 0777. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element
-                                            '..'. May not start with the string '..'.
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or
-                                      its keys must be defined
-                                    type: boolean
-                                type: object
-                              downwardAPI:
-                                description: information about the downwardAPI data
-                                  to project
-                                properties:
-                                  items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
-                                    items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
-                                      properties:
-                                        fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
-                                          properties:
-                                            apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
-                                              type: string
-                                            fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
-                                              type: string
-                                          required:
-                                          - fieldPath
-                                          type: object
-                                        mode:
-                                          description: 'Optional: mode bits to use
-                                            on this file, must be a value between
-                                            0 and 0777. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
-                                          type: string
-                                        resourceFieldRef:
-                                          description: 'Selects a resource of the
-                                            container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu
-                                            and requests.memory) are currently supported.'
-                                          properties:
-                                            containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
-                                              type: string
-                                            divisor:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            resource:
-                                              description: 'Required: resource to
-                                                select'
-                                              type: string
-                                          required:
-                                          - resource
-                                          type: object
-                                      required:
-                                      - path
-                                      type: object
-                                    type: array
-                                type: object
-                              secret:
-                                description: information about the secret data to
-                                  project
-                                properties:
-                                  items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced Secret will
-                                      be projected into the volume as a file whose
-                                      name is the key and content is the value. If
-                                      specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the Secret, the volume setup
-                                      will error unless it is marked optional. Paths
-                                      must be relative and may not contain the '..'
-                                      path or start with '..'.
-                                    items:
-                                      description: Maps a string key to a path within
-                                        a volume.
-                                      properties:
-                                        key:
-                                          description: The key to project.
-                                          type: string
-                                        mode:
-                                          description: 'Optional: mode bits to use
-                                            on this file, must be a value between
-                                            0 and 0777. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element
-                                            '..'. May not start with the string '..'.
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
-                                    type: boolean
-                                type: object
-                              serviceAccountToken:
-                                description: information about the serviceAccountToken
-                                  data to project
-                                properties:
-                                  audience:
-                                    description: Audience is the intended audience
-                                      of the token. A recipient of a token must identify
-                                      itself with an identifier specified in the audience
-                                      of the token, and otherwise should reject the
-                                      token. The audience defaults to the identifier
-                                      of the apiserver.
-                                    type: string
-                                  expirationSeconds:
-                                    description: ExpirationSeconds is the requested
-                                      duration of validity of the service account
-                                      token. As the token approaches expiration, the
-                                      kubelet volume plugin will proactively rotate
-                                      the service account token. The kubelet will
-                                      start trying to rotate the token if the token
-                                      is older than 80 percent of its time to live
-                                      or if the token is older than 24 hours.Defaults
-                                      to 1 hour and must be at least 10 minutes.
-                                    format: int64
-                                    type: integer
-                                  path:
-                                    description: Path is the path relative to the
-                                      mount point of the file to project the token
-                                      into.
-                                    type: string
-                                required:
-                                - path
-                                type: object
-                            type: object
-                          type: array
-                      required:
-                      - sources
-                      type: object
-                    quobyte:
-                      description: Quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
-                      properties:
-                        group:
-                          description: Group to map volume access to Default is no
-                            group
-                          type: string
-                        readOnly:
-                          description: ReadOnly here will force the Quobyte volume
-                            to be mounted with read-only permissions. Defaults to
-                            false.
-                          type: boolean
-                        registry:
-                          description: Registry represents a single or multiple Quobyte
-                            Registry services specified as a string as host:port pair
-                            (multiple entries are separated with commas) which acts
-                            as the central registry for volumes
-                          type: string
-                        tenant:
-                          description: Tenant owning the given Quobyte volume in the
-                            Backend Used with dynamically provisioned Quobyte volumes,
-                            value is set by the plugin
-                          type: string
-                        user:
-                          description: User to map volume access to Defaults to serivceaccount
-                            user
-                          type: string
-                        volume:
-                          description: Volume is a string that references an already
-                            created Quobyte volume by name.
-                          type: string
-                      required:
-                      - registry
-                      - volume
-                      type: object
-                    rbd:
-                      description: 'RBD represents a Rados Block Device mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        image:
-                          description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        keyring:
-                          description: 'Keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        monitors:
-                          description: 'A collection of Ceph monitors. More info:
-                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          items:
-                            type: string
-                          type: array
-                        pool:
-                          description: 'The rados pool name. Default is rbd. More
-                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: boolean
-                        secretRef:
-                          description: 'SecretRef is name of the authentication secret
-                            for RBDUser. If provided overrides keyring. Default is
-                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        user:
-                          description: 'The rados user name. Default is admin. More
-                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                      required:
-                      - image
-                      - monitors
-                      type: object
-                    scaleIO:
-                      description: ScaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Default is "xfs".
-                          type: string
-                        gateway:
-                          description: The host address of the ScaleIO API Gateway.
-                          type: string
-                        protectionDomain:
-                          description: The name of the ScaleIO Protection Domain for
-                            the configured storage.
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretRef:
-                          description: SecretRef references to the secret for ScaleIO
-                            user and other sensitive information. If this is not provided,
-                            Login operation will fail.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        sslEnabled:
-                          description: Flag to enable/disable SSL communication with
-                            Gateway, default false
-                          type: boolean
-                        storageMode:
-                          description: Indicates whether the storage for a volume
-                            should be ThickProvisioned or ThinProvisioned. Default
-                            is ThinProvisioned.
-                          type: string
-                        storagePool:
-                          description: The ScaleIO Storage Pool associated with the
-                            protection domain.
-                          type: string
-                        system:
-                          description: The name of the storage system as configured
-                            in ScaleIO.
-                          type: string
-                        volumeName:
-                          description: The name of a volume already created in the
-                            ScaleIO system that is associated with this volume source.
-                          type: string
-                      required:
-                      - gateway
-                      - secretRef
-                      - system
-                      type: object
-                    secret:
-                      description: 'Secret represents a secret that should populate
-                        this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                      properties:
-                        defaultMode:
-                          description: 'Optional: mode bits to use on created files
-                            by default. Must be a value between 0 and 0777. Defaults
-                            to 0644. Directories within the path are not affected
-                            by this setting. This might be in conflict with other
-                            options that affect the file mode, like fsGroup, and the
-                            result can be other mode bits set.'
-                          format: int32
-                          type: integer
-                        items:
-                          description: If unspecified, each key-value pair in the
-                            Data field of the referenced Secret will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the Secret, the volume setup will error unless it is marked
-                            optional. Paths must be relative and may not contain the
-                            '..' path or start with '..'.
-                          items:
-                            description: Maps a string key to a path within a volume.
-                            properties:
-                              key:
-                                description: The key to project.
-                                type: string
-                              mode:
-                                description: 'Optional: mode bits to use on this file,
-                                  must be a value between 0 and 0777. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: The relative path of the file to map
-                                  the key to. May not be an absolute path. May not
-                                  contain the path element '..'. May not start with
-                                  the string '..'.
-                                type: string
-                            required:
-                            - key
-                            - path
-                            type: object
-                          type: array
-                        optional:
-                          description: Specify whether the Secret or its keys must
-                            be defined
-                          type: boolean
-                        secretName:
-                          description: 'Name of the secret in the pod''s namespace
-                            to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                          type: string
-                      type: object
-                    storageos:
-                      description: StorageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretRef:
-                          description: SecretRef specifies the secret to use for obtaining
-                            the StorageOS API credentials.  If not specified, default
-                            values will be attempted.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        volumeName:
-                          description: VolumeName is the human-readable name of the
-                            StorageOS volume.  Volume names are only unique within
-                            a namespace.
-                          type: string
-                        volumeNamespace:
-                          description: VolumeNamespace specifies the scope of the
-                            volume within StorageOS.  If no namespace is specified
-                            then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS
-                            for tighter integration. Set VolumeName to any name to
-                            override the default behaviour. Set to "default" if you
-                            are not using namespaces within StorageOS. Namespaces
-                            that do not pre-exist within StorageOS will be created.
-                          type: string
-                      type: object
-                    vsphereVolume:
-                      description: VsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        storagePolicyID:
-                          description: Storage Policy Based Management (SPBM) profile
-                            ID associated with the StoragePolicyName.
-                          type: string
-                        storagePolicyName:
-                          description: Storage Policy Based Management (SPBM) profile
-                            name.
-                          type: string
-                        volumePath:
-                          description: Path that identifies vSphere volume vmdk
-                          type: string
-                      required:
-                      - volumePath
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
-            type: object
-          status:
-            description: LicenseMasterStatus defines the observed state of a Splunk
-              Enterprise license master.
-            properties:
-              phase:
-                description: current phase of the license master
-                enum:
-                - Pending
-                - Ready
-                - Updating
-                - ScalingUp
-                - ScalingDown
-                - Terminating
-                - Error
-                type: string
-            type: object
-        type: object
+              type: array
+          type: object
+        status:
+          description: LicenseMasterStatus defines the observed state of a Splunk
+            Enterprise license master.
+          properties:
+            phase:
+              description: current phase of the license master
+              enum:
+              - Pending
+              - Ready
+              - Updating
+              - ScalingUp
+              - ScalingDown
+              - Terminating
+              - Error
+              type: string
+          type: object
+      type: object
+  version: v1alpha3
+  versions:
+  - name: v1alpha3
     served: true
     storage: true
-    subresources:
-      status: {}
+  - name: v1alpha2
+    served: true
+    storage: false

--- a/deploy/crds/enterprise.splunk.com_searchheadclusters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_searchheadclusters_crd.yaml
@@ -1,8 +1,29 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: searchheadclusters.enterprise.splunk.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: Status of search head cluster
+    name: Phase
+    type: string
+  - JSONPath: .status.deployerPhase
+    description: Status of the deployer
+    name: Deployer
+    type: string
+  - JSONPath: .status.replicas
+    description: Desired number of search head cluster members
+    name: Desired
+    type: integer
+  - JSONPath: .status.readyReplicas
+    description: Current number of ready search head cluster members
+    name: Ready
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of search head cluster
+    name: Age
+    type: date
   group: enterprise.splunk.com
   names:
     kind: SearchHeadCluster
@@ -12,2424 +33,2344 @@ spec:
     - shc
     singular: searchheadcluster
   scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: Status of search head cluster
-      jsonPath: .status.phase
-      name: Phase
-      type: string
-    - description: Status of the deployer
-      jsonPath: .status.deployerPhase
-      name: Deployer
-      type: string
-    - description: Desired number of search head cluster members
-      jsonPath: .status.replicas
-      name: Desired
-      type: integer
-    - description: Current number of ready search head cluster members
-      jsonPath: .status.readyReplicas
-      name: Ready
-      type: integer
-    - description: Age of search head cluster
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        description: SearchHeadCluster is the Schema for a Splunk Enterprise search
-          head cluster
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: SearchHeadClusterSpec defines the desired state of a Splunk
-              Enterprise search head cluster
-            properties:
-              Mock:
-                description: Mock to differentiate between UTs and actual reconcile
-                type: boolean
-              affinity:
-                description: Kubernetes Affinity rules that control how pods are assigned
-                  to particular nodes.
-                properties:
-                  nodeAffinity:
-                    description: Describes node affinity scheduling rules for the
-                      pod.
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node matches
-                          the corresponding matchExpressions; the node(s) with the
-                          highest sum are the most preferred.
-                        items:
-                          description: An empty preferred scheduling term matches
-                            all objects with implicit weight 0 (i.e. it's a no-op).
-                            A null preferred scheduling term matches no objects (i.e.
-                            is also a no-op).
-                          properties:
-                            preference:
-                              description: A node selector term, associated with the
-                                corresponding weight.
-                              properties:
-                                matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            weight:
-                              description: Weight associated with matching the corresponding
-                                nodeSelectorTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - preference
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to an update), the system may or may not try to
-                          eventually evict the pod from its node.
+  subresources:
+    scale:
+      labelSelectorPath: .status.selector
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: SearchHeadCluster is the Schema for a Splunk Enterprise search
+        head cluster
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SearchHeadClusterSpec defines the desired state of a Splunk
+            Enterprise search head cluster
+          properties:
+            Mock:
+              description: Mock to differentiate between UTs and actual reconcile
+              type: boolean
+            affinity:
+              description: Kubernetes Affinity rules that control how pods are assigned
+                to particular nodes.
+              properties:
+                nodeAffinity:
+                  description: Describes node affinity scheduling rules for the pod.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node matches the corresponding matchExpressions; the
+                        node(s) with the highest sum are the most preferred.
+                      items:
+                        description: An empty preferred scheduling term matches all
+                          objects with implicit weight 0 (i.e. it's a no-op). A null
+                          preferred scheduling term matches no objects (i.e. is also
+                          a no-op).
                         properties:
-                          nodeSelectorTerms:
-                            description: Required. A list of node selector terms.
-                              The terms are ORed.
-                            items:
-                              description: A null or empty node selector term matches
-                                no objects. The requirements of them are ANDed. The
-                                TopologySelectorTerm type implements a subset of the
-                                NodeSelectorTerm.
-                              properties:
-                                matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
+                          preference:
+                            description: A node selector term, associated with the
+                              corresponding weight.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
                                         type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
                                         type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            type: array
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          weight:
+                            description: Weight associated with matching the corresponding
+                              nodeSelectorTerm, in the range 1-100.
+                            format: int32
+                            type: integer
                         required:
-                        - nodeSelectorTerms
+                        - preference
+                        - weight
                         type: object
-                    type: object
-                  podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate
-                      this pod in the same node, zone, etc. as some other pod(s)).
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
-                        items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
-                          properties:
-                            podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to an update), the system may or may not try to
+                        eventually evict the pod from its node.
+                      properties:
+                        nodeSelectorTerms:
+                          description: Required. A list of node selector terms. The
+                            terms are ORed.
+                          items:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
                                   type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                      required:
+                      - nodeSelectorTerms
+                      type: object
+                  type: object
+                podAffinity:
+                  description: Describes pod affinity scheduling rules (e.g. co-locate
+                    this pod in the same node, zone, etc. as some other pod(s)).
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node has pods which matches the corresponding podAffinityTerm;
+                        the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Required. A pod affinity term, associated
+                              with the corresponding weight.
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
                                   type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to a pod label update), the system may or may not
+                        try to eventually evict the pod from its node. When there
+                        are multiple elements, the lists of nodes corresponding to
+                        each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources, in
+                              this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+                podAntiAffinity:
+                  description: Describes pod anti-affinity scheduling rules (e.g.
+                    avoid putting this pod in the same node, zone, etc. as some other
+                    pod(s)).
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the anti-affinity expressions specified by this
+                        field, but it may choose a node that violates one or more
+                        of the expressions. The node that is most preferred is the
+                        one with the greatest sum of weights, i.e. for each node that
+                        meets all of the scheduling requirements (resource request,
+                        requiredDuringScheduling anti-affinity expressions, etc.),
+                        compute a sum by iterating through the elements of this field
+                        and adding "weight" to the sum if the node has pods which
+                        matches the corresponding podAffinityTerm; the node(s) with
+                        the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Required. A pod affinity term, associated
+                              with the corresponding weight.
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the anti-affinity requirements specified by
+                        this field are not met at scheduling time, the pod will not
+                        be scheduled onto the node. If the anti-affinity requirements
+                        specified by this field cease to be met at some point during
+                        pod execution (e.g. due to a pod label update), the system
+                        may or may not try to eventually evict the pod from its node.
+                        When there are multiple elements, the lists of nodes corresponding
+                        to each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources, in
+                              this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            clusterMasterRef:
+              description: ClusterMasterRef refers to a Splunk Enterprise indexer
+                cluster managed by the operator within Kubernetes
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            defaults:
+              description: Inline map of default.yml overrides used to initialize
+                the environment
+              type: string
+            defaultsUrl:
+              description: Full path or URL for one or more default.yml files, separated
+                by commas
+              type: string
+            ephemeralStorage:
+              description: If true, ephemeral (emptyDir) storage will be used for
+                /opt/splunk/etc and /opt/splunk/var volumes
+              type: boolean
+            etcStorage:
+              description: Storage capacity to request for /opt/splunk/etc persistent
+                volume claims (default=”1Gi”)
+              type: string
+            image:
+              description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
+                environment variables)
+              type: string
+            imagePullPolicy:
+              description: 'Sets pull policy for all images (either “Always” or the
+                default: “IfNotPresent”)'
+              enum:
+              - Always
+              - IfNotPresent
+              type: string
+            licenseMasterRef:
+              description: LicenseMasterRef refers to a Splunk Enterprise license
+                master managed by the operator within Kubernetes
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            licenseUrl:
+              description: Full path or URL for a Splunk Enterprise license file
+              type: string
+            replicas:
+              description: Number of search head pods; a search head cluster will
+                be created if > 1
+              format: int32
+              type: integer
+            resources:
+              description: resource requirements for the pod containers
+              properties:
+                limits:
+                  additionalProperties:
+                    type: string
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    type: string
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
+            schedulerName:
+              description: Name of Scheduler to use for pod placement (defaults to
+                “default-scheduler”)
+              type: string
+            serviceTemplate:
+              description: ServiceTemplate is a template used to create Kubernetes
+                services
+              properties:
+                apiVersion:
+                  description: 'APIVersion defines the versioned schema of this representation
+                    of an object. Servers should convert recognized schemas to the
+                    latest internal value, and may reject unrecognized values. More
+                    info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                  type: string
+                kind:
+                  description: 'Kind is a string value representing the REST resource
+                    this object represents. Servers may infer this from the endpoint
+                    the client submits requests to. Cannot be updated. In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                metadata:
+                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                  type: object
+                spec:
+                  description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                  properties:
+                    clusterIP:
+                      description: 'clusterIP is the IP address of the service and
+                        is usually assigned randomly by the master. If an address
+                        is specified manually and is not in use by others, it will
+                        be allocated to the service; otherwise, creation of the service
+                        will fail. This field can not be changed through updates.
+                        Valid values are "None", empty string (""), or a valid IP
+                        address. "None" can be specified for headless services when
+                        proxying is not required. Only applies to types ClusterIP,
+                        NodePort, and LoadBalancer. Ignored if type is ExternalName.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    externalIPs:
+                      description: externalIPs is a list of IP addresses for which
+                        nodes in the cluster will also accept traffic for this service.  These
+                        IPs are not managed by Kubernetes.  The user is responsible
+                        for ensuring that traffic arrives at a node with this IP.  A
+                        common example is external load-balancers that are not part
+                        of the Kubernetes system.
+                      items:
+                        type: string
+                      type: array
+                    externalName:
+                      description: externalName is the external reference that kubedns
+                        or equivalent will return as a CNAME record for this service.
+                        No proxying will be involved. Must be a valid RFC-1123 hostname
+                        (https://tools.ietf.org/html/rfc1123) and requires Type to
+                        be ExternalName.
+                      type: string
+                    externalTrafficPolicy:
+                      description: externalTrafficPolicy denotes if this Service desires
+                        to route external traffic to node-local or cluster-wide endpoints.
+                        "Local" preserves the client source IP and avoids a second
+                        hop for LoadBalancer and Nodeport type services, but risks
+                        potentially imbalanced traffic spreading. "Cluster" obscures
+                        the client source IP and may cause a second hop to another
+                        node, but should have good overall load-spreading.
+                      type: string
+                    healthCheckNodePort:
+                      description: healthCheckNodePort specifies the healthcheck nodePort
+                        for the service. If not specified, HealthCheckNodePort is
+                        created by the service api backend with the allocated nodePort.
+                        Will use user-specified nodePort value if specified by the
+                        client. Only effects when Type is set to LoadBalancer and
+                        ExternalTrafficPolicy is set to Local.
+                      format: int32
+                      type: integer
+                    ipFamily:
+                      description: ipFamily specifies whether this Service has a preference
+                        for a particular IP family (e.g. IPv4 vs. IPv6).  If a specific
+                        IP family is requested, the clusterIP field will be allocated
+                        from that family, if it is available in the cluster.  If no
+                        IP family is requested, the cluster's primary IP family will
+                        be used. Other IP fields (loadBalancerIP, loadBalancerSourceRanges,
+                        externalIPs) and controllers which allocate external load-balancers
+                        should use the same IP family.  Endpoints for this Service
+                        will be of this family.  This field is immutable after creation.
+                        Assigning a ServiceIPFamily not available in the cluster (e.g.
+                        IPv6 in IPv4 only cluster) is an error condition and will
+                        fail during clusterIP assignment.
+                      type: string
+                    loadBalancerIP:
+                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                        will get created with the IP specified in this field. This
+                        feature depends on whether the underlying cloud-provider supports
+                        specifying the loadBalancerIP when a load balancer is created.
+                        This field will be ignored if the cloud-provider does not
+                        support the feature.'
+                      type: string
+                    loadBalancerSourceRanges:
+                      description: 'If specified and supported by the platform, this
+                        will restrict traffic through the cloud-provider load-balancer
+                        will be restricted to the specified client IPs. This field
+                        will be ignored if the cloud-provider does not support the
+                        feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: 'The list of ports that are exposed by this service.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      items:
+                        description: ServicePort contains information on service's
+                          port.
+                        properties:
+                          name:
+                            description: The name of this port within the service.
+                              This must be a DNS_LABEL. All ports within a ServiceSpec
+                              must have unique names. When considering the endpoints
+                              for a Service, this must match the 'name' field in the
+                              EndpointPort. Optional if only one ServicePort is defined
+                              on this service.
+                            type: string
+                          nodePort:
+                            description: 'The port on each node on which this service
+                              is exposed when type=NodePort or LoadBalancer. Usually
+                              assigned by the system. If specified, it will be allocated
+                              to the service if unused or else creation of the service
+                              will fail. Default is to auto-allocate a port if the
+                              ServiceType of this Service requires one. More info:
+                              https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                            format: int32
+                            type: integer
+                          port:
+                            description: The port that will be exposed by this service.
+                            format: int32
+                            type: integer
+                          protocol:
+                            description: The IP protocol for this port. Supports "TCP",
+                              "UDP", and "SCTP". Default is TCP.
+                            type: string
+                          targetPort:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: 'Number or name of the port to access on
+                              the pods targeted by the service. Number must be in
+                              the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              If this is a string, it will be looked up as a named
+                              port in the target Pod''s container ports. If this is
+                              not specified, the value of the ''port'' field is used
+                              (an identity map). This field is ignored for services
+                              with clusterIP=None, and should be omitted or set equal
+                              to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      type: array
+                    publishNotReadyAddresses:
+                      description: publishNotReadyAddresses, when set to true, indicates
+                        that DNS implementations must publish the notReadyAddresses
+                        of subsets for the Endpoints associated with the Service.
+                        The default value is false. The primary use case for setting
+                        this field is to use a StatefulSet's Headless Service to propagate
+                        SRV records for its Pods without respect to their readiness
+                        for purpose of peer discovery.
+                      type: boolean
+                    selector:
+                      additionalProperties:
+                        type: string
+                      description: 'Route service traffic to pods with label keys
+                        and values matching this selector. If empty or not present,
+                        the service is assumed to have an external process managing
+                        its endpoints, which Kubernetes will not modify. Only applies
+                        to types ClusterIP, NodePort, and LoadBalancer. Ignored if
+                        type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                      type: object
+                    sessionAffinity:
+                      description: 'Supports "ClientIP" and "None". Used to maintain
+                        session affinity. Enable client IP based session affinity.
+                        Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    sessionAffinityConfig:
+                      description: sessionAffinityConfig contains the configurations
+                        of session affinity.
+                      properties:
+                        clientIP:
+                          description: clientIP contains the configurations of Client
+                            IP based session affinity.
+                          properties:
+                            timeoutSeconds:
+                              description: timeoutSeconds specifies the seconds of
+                                ClientIP type session sticky time. The value must
+                                be >0 && <=86400(for 1 day) if ServiceAffinity ==
+                                "ClientIP". Default value is 10800(for 3 hours).
                               format: int32
                               type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
                           type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to a pod label update), the system may or may
-                          not try to eventually evict the pod from its node. When
-                          there are multiple elements, the lists of nodes corresponding
-                          to each podAffinityTerm are intersected, i.e. all terms
-                          must be satisfied.
-                        items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
-                          properties:
-                            labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            namespaces:
-                              description: namespaces specifies which namespaces the
-                                labelSelector applies to (matches against); null or
-                                empty list means "this pod's namespace"
-                              items:
+                      type: object
+                    type:
+                      description: 'type determines how the Service is exposed. Defaults
+                        to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort,
+                        and LoadBalancer. "ExternalName" maps to the specified externalName.
+                        "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                        to endpoints. Endpoints are determined by the selector or
+                        if that is not specified, by manual construction of an Endpoints
+                        object. If clusterIP is "None", no virtual IP is allocated
+                        and the endpoints are published as a set of endpoints rather
+                        than a stable IP. "NodePort" builds on ClusterIP and allocates
+                        a port on every node which routes to the clusterIP. "LoadBalancer"
+                        builds on NodePort and creates an external load-balancer (if
+                        supported in the current cloud) which routes to the clusterIP.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                      type: string
+                  type: object
+                status:
+                  description: 'Most recently observed status of the service. Populated
+                    by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                  properties:
+                    loadBalancer:
+                      description: LoadBalancer contains the current status of the
+                        load-balancer, if one is present.
+                      properties:
+                        ingress:
+                          description: Ingress is a list containing ingress points
+                            for the load-balancer. Traffic intended for the service
+                            should be sent to these ingress points.
+                          items:
+                            description: 'LoadBalancerIngress represents the status
+                              of a load-balancer ingress point: traffic intended for
+                              the service should be sent to an ingress point.'
+                            properties:
+                              hostname:
+                                description: Hostname is set for load-balancer ingress
+                                  points that are DNS based (typically AWS load-balancers)
                                 type: string
-                              type: array
-                            topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                  podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g.
-                      avoid putting this pod in the same node, zone, etc. as some
-                      other pod(s)).
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the anti-affinity expressions specified
-                          by this field, but it may choose a node that violates one
-                          or more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling anti-affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
-                        items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
-                          properties:
-                            podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the anti-affinity requirements specified by
-                          this field are not met at scheduling time, the pod will
-                          not be scheduled onto the node. If the anti-affinity requirements
-                          specified by this field cease to be met at some point during
-                          pod execution (e.g. due to a pod label update), the system
-                          may or may not try to eventually evict the pod from its
-                          node. When there are multiple elements, the lists of nodes
-                          corresponding to each podAffinityTerm are intersected, i.e.
-                          all terms must be satisfied.
-                        items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
-                          properties:
-                            labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            namespaces:
-                              description: namespaces specifies which namespaces the
-                                labelSelector applies to (matches against); null or
-                                empty list means "this pod's namespace"
-                              items:
+                              ip:
+                                description: IP is set for load-balancer ingress points
+                                  that are IP based (typically GCE or OpenStack load-balancers)
                                 type: string
-                              type: array
-                            topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                type: object
-              clusterMasterRef:
-                description: ClusterMasterRef refers to a Splunk Enterprise indexer
-                  cluster managed by the operator within Kubernetes
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+              type: object
+            sparkImage:
+              description: Image to use for Spark pod containers (overrides RELATED_IMAGE_SPLUNK_SPARK
+                environment variables)
+              type: string
+            sparkRef:
+              description: SparkRef refers to a Spark cluster managed by the operator
+                within Kubernetes When defined, Data Fabric Search (DFS) will be enabled
+                and configured to use the Spark cluster.
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            storageClassName:
+              description: Name of StorageClass to use for persistent volume claims
+              type: string
+            tolerations:
+              description: Pod's tolerations for Kubernetes node's taint
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
                 properties:
-                  apiVersion:
-                    description: API version of the referent.
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
                     type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
                     type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
                     type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              defaults:
-                description: Inline map of default.yml overrides used to initialize
-                  the environment
-                type: string
-              defaultsUrl:
-                description: Full path or URL for one or more default.yml files, separated
-                  by commas
-                type: string
-              ephemeralStorage:
-                description: If true, ephemeral (emptyDir) storage will be used for
-                  /opt/splunk/etc and /opt/splunk/var volumes
-                type: boolean
-              etcStorage:
-                description: Storage capacity to request for /opt/splunk/etc persistent
-                  volume claims (default=”1Gi”)
-                type: string
-              image:
-                description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
-                  environment variables)
-                type: string
-              imagePullPolicy:
-                description: 'Sets pull policy for all images (either “Always” or
-                  the default: “IfNotPresent”)'
-                enum:
-                - Always
-                - IfNotPresent
-                type: string
-              licenseMasterRef:
-                description: LicenseMasterRef refers to a Splunk Enterprise license
-                  master managed by the operator within Kubernetes
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
                     type: string
                 type: object
-              licenseUrl:
-                description: Full path or URL for a Splunk Enterprise license file
-                type: string
-              replicas:
-                description: Number of search head pods; a search head cluster will
-                  be created if > 1
-                format: int32
-                type: integer
-              resources:
-                description: resource requirements for the pod containers
+              type: array
+            varStorage:
+              description: Storage capacity to request for /opt/splunk/var persistent
+                volume claims (default=”50Gi”)
+              type: string
+            volumes:
+              description: List of one or more Kubernetes volumes. These will be mounted
+                in all pod containers as as /mnt/<name>
+              items:
+                description: Volume represents a named volume in a pod that may be
+                  accessed by any container in the pod.
                 properties:
-                  limits:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                    type: object
-                  requests:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                    type: object
-                type: object
-              schedulerName:
-                description: Name of Scheduler to use for pod placement (defaults
-                  to “default-scheduler”)
-                type: string
-              serviceTemplate:
-                description: ServiceTemplate is a template used to create Kubernetes
-                  services
-                properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  metadata:
-                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                    type: object
-                  spec:
-                    description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                  awsElasticBlockStore:
+                    description: 'AWSElasticBlockStore represents an AWS Disk resource
+                      that is attached to a kubelet''s host machine and then exposed
+                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                     properties:
-                      clusterIP:
-                        description: 'clusterIP is the IP address of the service and
-                          is usually assigned randomly by the master. If an address
-                          is specified manually and is not in use by others, it will
-                          be allocated to the service; otherwise, creation of the
-                          service will fail. This field can not be changed through
-                          updates. Valid values are "None", empty string (""), or
-                          a valid IP address. "None" can be specified for headless
-                          services when proxying is not required. Only applies to
-                          types ClusterIP, NodePort, and LoadBalancer. Ignored if
-                          type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
                         type: string
-                      externalIPs:
-                        description: externalIPs is a list of IP addresses for which
-                          nodes in the cluster will also accept traffic for this service.  These
-                          IPs are not managed by Kubernetes.  The user is responsible
-                          for ensuring that traffic arrives at a node with this IP.  A
-                          common example is external load-balancers that are not part
-                          of the Kubernetes system.
-                        items:
-                          type: string
-                        type: array
-                      externalName:
-                        description: externalName is the external reference that kubedns
-                          or equivalent will return as a CNAME record for this service.
-                          No proxying will be involved. Must be a valid RFC-1123 hostname
-                          (https://tools.ietf.org/html/rfc1123) and requires Type
-                          to be ExternalName.
-                        type: string
-                      externalTrafficPolicy:
-                        description: externalTrafficPolicy denotes if this Service
-                          desires to route external traffic to node-local or cluster-wide
-                          endpoints. "Local" preserves the client source IP and avoids
-                          a second hop for LoadBalancer and Nodeport type services,
-                          but risks potentially imbalanced traffic spreading. "Cluster"
-                          obscures the client source IP and may cause a second hop
-                          to another node, but should have good overall load-spreading.
-                        type: string
-                      healthCheckNodePort:
-                        description: healthCheckNodePort specifies the healthcheck
-                          nodePort for the service. If not specified, HealthCheckNodePort
-                          is created by the service api backend with the allocated
-                          nodePort. Will use user-specified nodePort value if specified
-                          by the client. Only effects when Type is set to LoadBalancer
-                          and ExternalTrafficPolicy is set to Local.
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty).'
                         format: int32
                         type: integer
-                      ipFamily:
-                        description: ipFamily specifies whether this Service has a
-                          preference for a particular IP family (e.g. IPv4 vs. IPv6).  If
-                          a specific IP family is requested, the clusterIP field will
-                          be allocated from that family, if it is available in the
-                          cluster.  If no IP family is requested, the cluster's primary
-                          IP family will be used. Other IP fields (loadBalancerIP,
-                          loadBalancerSourceRanges, externalIPs) and controllers which
-                          allocate external load-balancers should use the same IP
-                          family.  Endpoints for this Service will be of this family.  This
-                          field is immutable after creation. Assigning a ServiceIPFamily
-                          not available in the cluster (e.g. IPv6 in IPv4 only cluster)
-                          is an error condition and will fail during clusterIP assignment.
+                      readOnly:
+                        description: 'Specify "true" to force and set the ReadOnly
+                          property in VolumeMounts to "true". If omitted, the default
+                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: boolean
+                      volumeID:
+                        description: 'Unique ID of the persistent disk resource in
+                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                         type: string
-                      loadBalancerIP:
-                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                          will get created with the IP specified in this field. This
-                          feature depends on whether the underlying cloud-provider
-                          supports specifying the loadBalancerIP when a load balancer
-                          is created. This field will be ignored if the cloud-provider
-                          does not support the feature.'
+                    required:
+                    - volumeID
+                    type: object
+                  azureDisk:
+                    description: AzureDisk represents an Azure Data Disk mount on
+                      the host and bind mount to the pod.
+                    properties:
+                      cachingMode:
+                        description: 'Host Caching mode: None, Read Only, Read Write.'
                         type: string
-                      loadBalancerSourceRanges:
-                        description: 'If specified and supported by the platform,
-                          this will restrict traffic through the cloud-provider load-balancer
-                          will be restricted to the specified client IPs. This field
-                          will be ignored if the cloud-provider does not support the
-                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                      diskName:
+                        description: The Name of the data disk in the blob storage
+                        type: string
+                      diskURI:
+                        description: The URI the data disk in the blob storage
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      kind:
+                        description: 'Expected values Shared: multiple blob disks
+                          per storage account  Dedicated: single blob disk per storage
+                          account  Managed: azure managed data disk (only in managed
+                          availability set). defaults to shared'
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                    required:
+                    - diskName
+                    - diskURI
+                    type: object
+                  azureFile:
+                    description: AzureFile represents an Azure File Service mount
+                      on the host and bind mount to the pod.
+                    properties:
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretName:
+                        description: the name of secret that contains Azure Storage
+                          Account Name and Key
+                        type: string
+                      shareName:
+                        description: Share Name
+                        type: string
+                    required:
+                    - secretName
+                    - shareName
+                    type: object
+                  cephfs:
+                    description: CephFS represents a Ceph FS mount on the host that
+                      shares a pod's lifetime
+                    properties:
+                      monitors:
+                        description: 'Required: Monitors is a collection of Ceph monitors
+                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                         items:
                           type: string
                         type: array
-                      ports:
-                        description: 'The list of ports that are exposed by this service.
-                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      path:
+                        description: 'Optional: Used as the mounted root, rather than
+                          the full Ceph tree, default is /'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: boolean
+                      secretFile:
+                        description: 'Optional: SecretFile is the path to key ring
+                          for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                      secretRef:
+                        description: 'Optional: SecretRef is reference to the authentication
+                          secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      user:
+                        description: 'Optional: User is the rados user name, default
+                          is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                    required:
+                    - monitors
+                    type: object
+                  cinder:
+                    description: 'Cinder represents a cinder volume attached and mounted
+                      on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Examples: "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: boolean
+                      secretRef:
+                        description: 'Optional: points to a secret object containing
+                          parameters used to connect to OpenStack.'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      volumeID:
+                        description: 'volume id used to identify the volume in cinder.
+                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  configMap:
+                    description: ConfigMap represents a configMap that should populate
+                      this volume
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced ConfigMap will be projected into
+                          the volume as a file whose name is the key and content is
+                          the value. If specified, the listed keys will be projected
+                          into the specified paths, and unlisted keys will not be
+                          present. If a key is specified which is not present in the
+                          ConfigMap, the volume setup will error unless it is marked
+                          optional. Paths must be relative and may not contain the
+                          '..' path or start with '..'.
                         items:
-                          description: ServicePort contains information on service's
-                            port.
+                          description: Maps a string key to a path within a volume.
                           properties:
-                            name:
-                              description: The name of this port within the service.
-                                This must be a DNS_LABEL. All ports within a ServiceSpec
-                                must have unique names. When considering the endpoints
-                                for a Service, this must match the 'name' field in
-                                the EndpointPort. Optional if only one ServicePort
-                                is defined on this service.
+                            key:
+                              description: The key to project.
                               type: string
-                            nodePort:
-                              description: 'The port on each node on which this service
-                                is exposed when type=NodePort or LoadBalancer. Usually
-                                assigned by the system. If specified, it will be allocated
-                                to the service if unused or else creation of the service
-                                will fail. Default is to auto-allocate a port if the
-                                ServiceType of this Service requires one. More info:
-                                https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
                               format: int32
                               type: integer
-                            port:
-                              description: The port that will be exposed by this service.
-                              format: int32
-                              type: integer
-                            protocol:
-                              description: The IP protocol for this port. Supports
-                                "TCP", "UDP", and "SCTP". Default is TCP.
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
                               type: string
-                            targetPort:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              description: 'Number or name of the port to access on
-                                the pods targeted by the service. Number must be in
-                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                                If this is a string, it will be looked up as a named
-                                port in the target Pod''s container ports. If this
-                                is not specified, the value of the ''port'' field
-                                is used (an identity map). This field is ignored for
-                                services with clusterIP=None, and should be omitted
-                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
-                              x-kubernetes-int-or-string: true
                           required:
-                          - port
+                          - key
+                          - path
                           type: object
                         type: array
-                        x-kubernetes-list-map-keys:
-                        - port
-                        - protocol
-                        x-kubernetes-list-type: map
-                      publishNotReadyAddresses:
-                        description: publishNotReadyAddresses, when set to true, indicates
-                          that DNS implementations must publish the notReadyAddresses
-                          of subsets for the Endpoints associated with the Service.
-                          The default value is false. The primary use case for setting
-                          this field is to use a StatefulSet's Headless Service to
-                          propagate SRV records for its Pods without respect to their
-                          readiness for purpose of peer discovery.
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the ConfigMap or its keys must
+                          be defined
                         type: boolean
-                      selector:
+                    type: object
+                  csi:
+                    description: CSI (Container Storage Interface) represents storage
+                      that is handled by an external CSI driver (Alpha feature).
+                    properties:
+                      driver:
+                        description: Driver is the name of the CSI driver that handles
+                          this volume. Consult with your admin for the correct name
+                          as registered in the cluster.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Ex. "ext4", "xfs",
+                          "ntfs". If not provided, the empty value is passed to the
+                          associated CSI driver which will determine the default filesystem
+                          to apply.
+                        type: string
+                      nodePublishSecretRef:
+                        description: NodePublishSecretRef is a reference to the secret
+                          object containing sensitive information to pass to the CSI
+                          driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
+                          calls. This field is optional, and  may be empty if no secret
+                          is required. If the secret object contains more than one
+                          secret, all secret references are passed.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      readOnly:
+                        description: Specifies a read-only configuration for the volume.
+                          Defaults to false (read/write).
+                        type: boolean
+                      volumeAttributes:
                         additionalProperties:
                           type: string
-                        description: 'Route service traffic to pods with label keys
-                          and values matching this selector. If empty or not present,
-                          the service is assumed to have an external process managing
-                          its endpoints, which Kubernetes will not modify. Only applies
-                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
-                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                        description: VolumeAttributes stores driver-specific properties
+                          that are passed to the CSI driver. Consult your driver's
+                          documentation for supported values.
                         type: object
-                      sessionAffinity:
-                        description: 'Supports "ClientIP" and "None". Used to maintain
-                          session affinity. Enable client IP based session affinity.
-                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                        type: string
-                      sessionAffinityConfig:
-                        description: sessionAffinityConfig contains the configurations
-                          of session affinity.
-                        properties:
-                          clientIP:
-                            description: clientIP contains the configurations of Client
-                              IP based session affinity.
-                            properties:
-                              timeoutSeconds:
-                                description: timeoutSeconds specifies the seconds
-                                  of ClientIP type session sticky time. The value
-                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
-                                  == "ClientIP". Default value is 10800(for 3 hours).
-                                format: int32
-                                type: integer
-                            type: object
-                        type: object
-                      type:
-                        description: 'type determines how the Service is exposed.
-                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
-                          NodePort, and LoadBalancer. "ExternalName" maps to the specified
-                          externalName. "ClusterIP" allocates a cluster-internal IP
-                          address for load-balancing to endpoints. Endpoints are determined
-                          by the selector or if that is not specified, by manual construction
-                          of an Endpoints object. If clusterIP is "None", no virtual
-                          IP is allocated and the endpoints are published as a set
-                          of endpoints rather than a stable IP. "NodePort" builds
-                          on ClusterIP and allocates a port on every node which routes
-                          to the clusterIP. "LoadBalancer" builds on NodePort and
-                          creates an external load-balancer (if supported in the current
-                          cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
-                        type: string
+                    required:
+                    - driver
                     type: object
-                  status:
-                    description: 'Most recently observed status of the service. Populated
-                      by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                  downwardAPI:
+                    description: DownwardAPI represents downward API about the pod
+                      that should populate this volume
                     properties:
-                      loadBalancer:
-                        description: LoadBalancer contains the current status of the
-                          load-balancer, if one is present.
-                        properties:
-                          ingress:
-                            description: Ingress is a list containing ingress points
-                              for the load-balancer. Traffic intended for the service
-                              should be sent to these ingress points.
-                            items:
-                              description: 'LoadBalancerIngress represents the status
-                                of a load-balancer ingress point: traffic intended
-                                for the service should be sent to an ingress point.'
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: Items is a list of downward API volume file
+                        items:
+                          description: DownwardAPIVolumeFile represents information
+                            to create the file containing the pod field
+                          properties:
+                            fieldRef:
+                              description: 'Required: Selects a field of the pod:
+                                only annotations, labels, name and namespace are supported.'
                               properties:
-                                hostname:
-                                  description: Hostname is set for load-balancer ingress
-                                    points that are DNS based (typically AWS load-balancers)
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
                                   type: string
-                                ip:
-                                  description: IP is set for load-balancer ingress
-                                    points that are IP based (typically GCE or OpenStack
-                                    load-balancers)
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
                                   type: string
+                              required:
+                              - fieldPath
                               type: object
-                            type: array
-                        type: object
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: 'Required: Path is  the relative path name
+                                of the file to be created. Must not be absolute or
+                                contain the ''..'' path. Must be utf-8 encoded. The
+                                first item of the relative path must not start with
+                                ''..'''
+                              type: string
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                requests.cpu and requests.memory) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  type: string
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                          required:
+                          - path
+                          type: object
+                        type: array
                     type: object
-                type: object
-              sparkImage:
-                description: Image to use for Spark pod containers (overrides RELATED_IMAGE_SPLUNK_SPARK
-                  environment variables)
-                type: string
-              sparkRef:
-                description: SparkRef refers to a Spark cluster managed by the operator
-                  within Kubernetes When defined, Data Fabric Search (DFS) will be
-                  enabled and configured to use the Spark cluster.
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
+                  emptyDir:
+                    description: 'EmptyDir represents a temporary directory that shares
+                      a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                    properties:
+                      medium:
+                        description: 'What type of storage medium should back this
+                          directory. The default is "" which means to use the node''s
+                          default medium. Must be an empty string (default) or Memory.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        type: string
+                      sizeLimit:
+                        description: 'Total amount of local storage required for this
+                          EmptyDir volume. The size limit is also applicable for memory
+                          medium. The maximum usage on memory medium EmptyDir would
+                          be the minimum value between the SizeLimit specified here
+                          and the sum of memory limits of all containers in a pod.
+                          The default is nil which means that the limit is undefined.
+                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                        type: string
+                    type: object
+                  fc:
+                    description: FC represents a Fibre Channel resource that is attached
+                      to a kubelet's host machine and then exposed to the pod.
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      lun:
+                        description: 'Optional: FC target lun number'
+                        format: int32
+                        type: integer
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      targetWWNs:
+                        description: 'Optional: FC target worldwide names (WWNs)'
+                        items:
+                          type: string
+                        type: array
+                      wwids:
+                        description: 'Optional: FC volume world wide identifiers (wwids)
+                          Either wwids or combination of targetWWNs and lun must be
+                          set, but not both simultaneously.'
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  flexVolume:
+                    description: FlexVolume represents a generic volume resource that
+                      is provisioned/attached using an exec based plugin.
+                    properties:
+                      driver:
+                        description: Driver is the name of the driver to use for this
+                          volume.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". The default filesystem depends on FlexVolume
+                          script.
+                        type: string
+                      options:
+                        additionalProperties:
+                          type: string
+                        description: 'Optional: Extra command options if any.'
+                        type: object
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      secretRef:
+                        description: 'Optional: SecretRef is reference to the secret
+                          object containing sensitive information to pass to the plugin
+                          scripts. This may be empty if no secret object is specified.
+                          If the secret object contains more than one secret, all
+                          secrets are passed to the plugin scripts.'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                    required:
+                    - driver
+                    type: object
+                  flocker:
+                    description: Flocker represents a Flocker volume attached to a
+                      kubelet's host machine. This depends on the Flocker control
+                      service being running
+                    properties:
+                      datasetName:
+                        description: Name of the dataset stored as metadata -> name
+                          on the dataset for Flocker should be considered as deprecated
+                        type: string
+                      datasetUUID:
+                        description: UUID of the dataset. This is unique identifier
+                          of a Flocker dataset
+                        type: string
+                    type: object
+                  gcePersistentDisk:
+                    description: 'GCEPersistentDisk represents a GCE Disk resource
+                      that is attached to a kubelet''s host machine and then exposed
+                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        format: int32
+                        type: integer
+                      pdName:
+                        description: 'Unique name of the PD resource in GCE. Used
+                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: boolean
+                    required:
+                    - pdName
+                    type: object
+                  gitRepo:
+                    description: 'GitRepo represents a git repository at a particular
+                      revision. DEPRECATED: GitRepo is deprecated. To provision a
+                      container with a git repo, mount an EmptyDir into an InitContainer
+                      that clones the repo using git, then mount the EmptyDir into
+                      the Pod''s container.'
+                    properties:
+                      directory:
+                        description: Target directory name. Must not contain or start
+                          with '..'.  If '.' is supplied, the volume directory will
+                          be the git repository.  Otherwise, if specified, the volume
+                          will contain the git repository in the subdirectory with
+                          the given name.
+                        type: string
+                      repository:
+                        description: Repository URL
+                        type: string
+                      revision:
+                        description: Commit hash for the specified revision.
+                        type: string
+                    required:
+                    - repository
+                    type: object
+                  glusterfs:
+                    description: 'Glusterfs represents a Glusterfs mount on the host
+                      that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                    properties:
+                      endpoints:
+                        description: 'EndpointsName is the endpoint name that details
+                          Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      path:
+                        description: 'Path is the Glusterfs volume path. More info:
+                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the Glusterfs volume
+                          to be mounted with read-only permissions. Defaults to false.
+                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: boolean
+                    required:
+                    - endpoints
+                    - path
+                    type: object
+                  hostPath:
+                    description: 'HostPath represents a pre-existing file or directory
+                      on the host machine that is directly exposed to the container.
+                      This is generally used for system agents or other privileged
+                      things that are allowed to see the host machine. Most containers
+                      will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                      --- TODO(jonesdl) We need to restrict who can use host directory
+                      mounts and who can/can not mount host directories as read/write.'
+                    properties:
+                      path:
+                        description: 'Path of the directory on the host. If the path
+                          is a symlink, it will follow the link to the real path.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                      type:
+                        description: 'Type for HostPath Volume Defaults to "" More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                    required:
+                    - path
+                    type: object
+                  iscsi:
+                    description: 'ISCSI represents an ISCSI Disk resource that is
+                      attached to a kubelet''s host machine and then exposed to the
+                      pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                    properties:
+                      chapAuthDiscovery:
+                        description: whether support iSCSI Discovery CHAP authentication
+                        type: boolean
+                      chapAuthSession:
+                        description: whether support iSCSI Session CHAP authentication
+                        type: boolean
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      initiatorName:
+                        description: Custom iSCSI Initiator Name. If initiatorName
+                          is specified with iscsiInterface simultaneously, new iSCSI
+                          interface <target portal>:<volume name> will be created
+                          for the connection.
+                        type: string
+                      iqn:
+                        description: Target iSCSI Qualified Name.
+                        type: string
+                      iscsiInterface:
+                        description: iSCSI Interface Name that uses an iSCSI transport.
+                          Defaults to 'default' (tcp).
+                        type: string
+                      lun:
+                        description: iSCSI Target Lun number.
+                        format: int32
+                        type: integer
+                      portals:
+                        description: iSCSI Target Portal List. The portal is either
+                          an IP or ip_addr:port if the port is other than default
+                          (typically TCP ports 860 and 3260).
+                        items:
+                          type: string
+                        type: array
+                      readOnly:
+                        description: ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false.
+                        type: boolean
+                      secretRef:
+                        description: CHAP Secret for iSCSI target and initiator authentication
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      targetPortal:
+                        description: iSCSI Target Portal. The Portal is either an
+                          IP or ip_addr:port if the port is other than default (typically
+                          TCP ports 860 and 3260).
+                        type: string
+                    required:
+                    - iqn
+                    - lun
+                    - targetPortal
+                    type: object
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
+                      the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  nfs:
+                    description: 'NFS represents an NFS mount on the host that shares
+                      a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                    properties:
+                      path:
+                        description: 'Path that is exported by the NFS server. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the NFS export to be
+                          mounted with read-only permissions. Defaults to false. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: boolean
+                      server:
+                        description: 'Server is the hostname or IP address of the
+                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                    required:
+                    - path
+                    - server
+                    type: object
+                  persistentVolumeClaim:
+                    description: 'PersistentVolumeClaimVolumeSource represents a reference
+                      to a PersistentVolumeClaim in the same namespace. More info:
+                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                    properties:
+                      claimName:
+                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                          in the same namespace as the pod using this volume. More
+                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        type: string
+                      readOnly:
+                        description: Will force the ReadOnly setting in VolumeMounts.
+                          Default false.
+                        type: boolean
+                    required:
+                    - claimName
+                    type: object
+                  photonPersistentDisk:
+                    description: PhotonPersistentDisk represents a PhotonController
+                      persistent disk attached and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      pdID:
+                        description: ID that identifies Photon Controller persistent
+                          disk
+                        type: string
+                    required:
+                    - pdID
+                    type: object
+                  portworxVolume:
+                    description: PortworxVolume represents a portworx volume attached
+                      and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: FSType represents the filesystem type to mount
+                          Must be a filesystem type supported by the host operating
+                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                          if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      volumeID:
+                        description: VolumeID uniquely identifies a Portworx volume
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  projected:
+                    description: Items for all in one resources secrets, configmaps,
+                      and downward API
+                    properties:
+                      defaultMode:
+                        description: Mode bits to use on created files by default.
+                          Must be a value between 0 and 0777. Directories within the
+                          path are not affected by this setting. This might be in
+                          conflict with other options that affect the file mode, like
+                          fsGroup, and the result can be other mode bits set.
+                        format: int32
+                        type: integer
+                      sources:
+                        description: list of volume projections
+                        items:
+                          description: Projection that may be projected along with
+                            other supported volume types
+                          properties:
+                            configMap:
+                              description: information about the configMap data to
+                                project
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    keys must be defined
+                                  type: boolean
+                              type: object
+                            downwardAPI:
+                              description: information about the downwardAPI data
+                                to project
+                              properties:
+                                items:
+                                  description: Items is a list of DownwardAPIVolume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, requests.cpu and requests.memory)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            secret:
+                              description: information about the secret data to project
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced Secret will
+                                    be projected into the volume as a file whose name
+                                    is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              type: object
+                            serviceAccountToken:
+                              description: information about the serviceAccountToken
+                                data to project
+                              properties:
+                                audience:
+                                  description: Audience is the intended audience of
+                                    the token. A recipient of a token must identify
+                                    itself with an identifier specified in the audience
+                                    of the token, and otherwise should reject the
+                                    token. The audience defaults to the identifier
+                                    of the apiserver.
+                                  type: string
+                                expirationSeconds:
+                                  description: ExpirationSeconds is the requested
+                                    duration of validity of the service account token.
+                                    As the token approaches expiration, the kubelet
+                                    volume plugin will proactively rotate the service
+                                    account token. The kubelet will start trying to
+                                    rotate the token if the token is older than 80
+                                    percent of its time to live or if the token is
+                                    older than 24 hours.Defaults to 1 hour and must
+                                    be at least 10 minutes.
+                                  format: int64
+                                  type: integer
+                                path:
+                                  description: Path is the path relative to the mount
+                                    point of the file to project the token into.
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                          type: object
+                        type: array
+                    required:
+                    - sources
+                    type: object
+                  quobyte:
+                    description: Quobyte represents a Quobyte mount on the host that
+                      shares a pod's lifetime
+                    properties:
+                      group:
+                        description: Group to map volume access to Default is no group
+                        type: string
+                      readOnly:
+                        description: ReadOnly here will force the Quobyte volume to
+                          be mounted with read-only permissions. Defaults to false.
+                        type: boolean
+                      registry:
+                        description: Registry represents a single or multiple Quobyte
+                          Registry services specified as a string as host:port pair
+                          (multiple entries are separated with commas) which acts
+                          as the central registry for volumes
+                        type: string
+                      tenant:
+                        description: Tenant owning the given Quobyte volume in the
+                          Backend Used with dynamically provisioned Quobyte volumes,
+                          value is set by the plugin
+                        type: string
+                      user:
+                        description: User to map volume access to Defaults to serivceaccount
+                          user
+                        type: string
+                      volume:
+                        description: Volume is a string that references an already
+                          created Quobyte volume by name.
+                        type: string
+                    required:
+                    - registry
+                    - volume
+                    type: object
+                  rbd:
+                    description: 'RBD represents a Rados Block Device mount on the
+                      host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      image:
+                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      keyring:
+                        description: 'Keyring is the path to key ring for RBDUser.
+                          Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      monitors:
+                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        items:
+                          type: string
+                        type: array
+                      pool:
+                        description: 'The rados pool name. Default is rbd. More info:
+                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: boolean
+                      secretRef:
+                        description: 'SecretRef is name of the authentication secret
+                          for RBDUser. If provided overrides keyring. Default is nil.
+                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      user:
+                        description: 'The rados user name. Default is admin. More
+                          info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                    required:
+                    - image
+                    - monitors
+                    type: object
+                  scaleIO:
+                    description: ScaleIO represents a ScaleIO persistent volume attached
+                      and mounted on Kubernetes nodes.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Default is "xfs".
+                        type: string
+                      gateway:
+                        description: The host address of the ScaleIO API Gateway.
+                        type: string
+                      protectionDomain:
+                        description: The name of the ScaleIO Protection Domain for
+                          the configured storage.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: SecretRef references to the secret for ScaleIO
+                          user and other sensitive information. If this is not provided,
+                          Login operation will fail.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      sslEnabled:
+                        description: Flag to enable/disable SSL communication with
+                          Gateway, default false
+                        type: boolean
+                      storageMode:
+                        description: Indicates whether the storage for a volume should
+                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                        type: string
+                      storagePool:
+                        description: The ScaleIO Storage Pool associated with the
+                          protection domain.
+                        type: string
+                      system:
+                        description: The name of the storage system as configured
+                          in ScaleIO.
+                        type: string
+                      volumeName:
+                        description: The name of a volume already created in the ScaleIO
+                          system that is associated with this volume source.
+                        type: string
+                    required:
+                    - gateway
+                    - secretRef
+                    - system
+                    type: object
+                  secret:
+                    description: 'Secret represents a secret that should populate
+                      this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced Secret will be projected into the
+                          volume as a file whose name is the key and content is the
+                          value. If specified, the listed keys will be projected into
+                          the specified paths, and unlisted keys will not be present.
+                          If a key is specified which is not present in the Secret,
+                          the volume setup will error unless it is marked optional.
+                          Paths must be relative and may not contain the '..' path
+                          or start with '..'.
+                        items:
+                          description: Maps a string key to a path within a volume.
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          type: object
+                        type: array
+                      optional:
+                        description: Specify whether the Secret or its keys must be
+                          defined
+                        type: boolean
+                      secretName:
+                        description: 'Name of the secret in the pod''s namespace to
+                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        type: string
+                    type: object
+                  storageos:
+                    description: StorageOS represents a StorageOS volume attached
+                      and mounted on Kubernetes nodes.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: SecretRef specifies the secret to use for obtaining
+                          the StorageOS API credentials.  If not specified, default
+                          values will be attempted.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      volumeName:
+                        description: VolumeName is the human-readable name of the
+                          StorageOS volume.  Volume names are only unique within a
+                          namespace.
+                        type: string
+                      volumeNamespace:
+                        description: VolumeNamespace specifies the scope of the volume
+                          within StorageOS.  If no namespace is specified then the
+                          Pod's namespace will be used.  This allows the Kubernetes
+                          name scoping to be mirrored within StorageOS for tighter
+                          integration. Set VolumeName to any name to override the
+                          default behaviour. Set to "default" if you are not using
+                          namespaces within StorageOS. Namespaces that do not pre-exist
+                          within StorageOS will be created.
+                        type: string
+                    type: object
+                  vsphereVolume:
+                    description: VsphereVolume represents a vSphere volume attached
+                      and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      storagePolicyID:
+                        description: Storage Policy Based Management (SPBM) profile
+                          ID associated with the StoragePolicyName.
+                        type: string
+                      storagePolicyName:
+                        description: Storage Policy Based Management (SPBM) profile
+                          name.
+                        type: string
+                      volumePath:
+                        description: Path that identifies vSphere volume vmdk
+                        type: string
+                    required:
+                    - volumePath
+                    type: object
+                required:
+                - name
+                type: object
+              type: array
+          type: object
+        status:
+          description: SearchHeadClusterStatus defines the observed state of a Splunk
+            Enterprise search head cluster
+          properties:
+            captain:
+              description: name or label of the search head captain
+              type: string
+            captainReady:
+              description: true if the search head cluster's captain is ready to service
+                requests
+              type: boolean
+            deployerPhase:
+              description: current phase of the deployer
+              enum:
+              - Pending
+              - Ready
+              - Updating
+              - ScalingUp
+              - ScalingDown
+              - Terminating
+              - Error
+              type: string
+            initialized:
+              description: true if the search head cluster has finished initialization
+              type: boolean
+            maintenanceMode:
+              description: true if the search head cluster is in maintenance mode
+              type: boolean
+            members:
+              description: status of each search head cluster member
+              items:
+                description: SearchHeadClusterMemberStatus is used to track the status
+                  of each search head cluster member
+                properties:
+                  active_historical_search_count:
+                    description: Number of currently running historical searches.
+                    type: integer
+                  active_realtime_search_count:
+                    description: Number of currently running realtime searches.
+                    type: integer
+                  adhoc_searchhead:
+                    description: Flag that indicates if this member can run scheduled
+                      searches.
+                    type: boolean
+                  is_registered:
+                    description: Indicates if this member is registered with the searchhead
+                      cluster captain.
+                    type: boolean
+                  name:
+                    description: Name of the search head cluster member
                     type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  status:
+                    description: Indicates the status of the member.
                     type: string
                 type: object
-              storageClassName:
-                description: Name of StorageClass to use for persistent volume claims
-                type: string
-              tolerations:
-                description: Pod's tolerations for Kubernetes node's taint
-                items:
-                  description: The pod this Toleration is attached to tolerates any
-                    taint that matches the triple <key,value,effect> using the matching
-                    operator <operator>.
-                  properties:
-                    effect:
-                      description: Effect indicates the taint effect to match. Empty
-                        means match all taint effects. When specified, allowed values
-                        are NoSchedule, PreferNoSchedule and NoExecute.
-                      type: string
-                    key:
-                      description: Key is the taint key that the toleration applies
-                        to. Empty means match all taint keys. If the key is empty,
-                        operator must be Exists; this combination means to match all
-                        values and all keys.
-                      type: string
-                    operator:
-                      description: Operator represents a key's relationship to the
-                        value. Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod
-                        can tolerate all taints of a particular category.
-                      type: string
-                    tolerationSeconds:
-                      description: TolerationSeconds represents the period of time
-                        the toleration (which must be of effect NoExecute, otherwise
-                        this field is ignored) tolerates the taint. By default, it
-                        is not set, which means tolerate the taint forever (do not
-                        evict). Zero and negative values will be treated as 0 (evict
-                        immediately) by the system.
-                      format: int64
-                      type: integer
-                    value:
-                      description: Value is the taint value the toleration matches
-                        to. If the operator is Exists, the value should be empty,
-                        otherwise just a regular string.
-                      type: string
-                  type: object
-                type: array
-              varStorage:
-                description: Storage capacity to request for /opt/splunk/var persistent
-                  volume claims (default=”50Gi”)
-                type: string
-              volumes:
-                description: List of one or more Kubernetes volumes. These will be
-                  mounted in all pod containers as as /mnt/<name>
-                items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
-                  properties:
-                    awsElasticBlockStore:
-                      description: 'AWSElasticBlockStore represents an AWS Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        partition:
-                          description: 'The partition in the volume that you want
-                            to mount. If omitted, the default is to mount by volume
-                            name. Examples: For volume /dev/sda1, you specify the
-                            partition as "1". Similarly, the volume partition for
-                            /dev/sda is "0" (or you can leave the property empty).'
-                          format: int32
-                          type: integer
-                        readOnly:
-                          description: 'Specify "true" to force and set the ReadOnly
-                            property in VolumeMounts to "true". If omitted, the default
-                            is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                          type: boolean
-                        volumeID:
-                          description: 'Unique ID of the persistent disk resource
-                            in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    azureDisk:
-                      description: AzureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
-                      properties:
-                        cachingMode:
-                          description: 'Host Caching mode: None, Read Only, Read Write.'
-                          type: string
-                        diskName:
-                          description: The Name of the data disk in the blob storage
-                          type: string
-                        diskURI:
-                          description: The URI the data disk in the blob storage
-                          type: string
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        kind:
-                          description: 'Expected values Shared: multiple blob disks
-                            per storage account  Dedicated: single blob disk per storage
-                            account  Managed: azure managed data disk (only in managed
-                            availability set). defaults to shared'
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                      required:
-                      - diskName
-                      - diskURI
-                      type: object
-                    azureFile:
-                      description: AzureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
-                      properties:
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretName:
-                          description: the name of secret that contains Azure Storage
-                            Account Name and Key
-                          type: string
-                        shareName:
-                          description: Share Name
-                          type: string
-                      required:
-                      - secretName
-                      - shareName
-                      type: object
-                    cephfs:
-                      description: CephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
-                      properties:
-                        monitors:
-                          description: 'Required: Monitors is a collection of Ceph
-                            monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          items:
-                            type: string
-                          type: array
-                        path:
-                          description: 'Optional: Used as the mounted root, rather
-                            than the full Ceph tree, default is /'
-                          type: string
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: boolean
-                        secretFile:
-                          description: 'Optional: SecretFile is the path to key ring
-                            for User, default is /etc/ceph/user.secret More info:
-                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: string
-                        secretRef:
-                          description: 'Optional: SecretRef is reference to the authentication
-                            secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        user:
-                          description: 'Optional: User is the rados user name, default
-                            is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: string
-                      required:
-                      - monitors
-                      type: object
-                    cinder:
-                      description: 'Cinder represents a cinder volume attached and
-                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: string
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: boolean
-                        secretRef:
-                          description: 'Optional: points to a secret object containing
-                            parameters used to connect to OpenStack.'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        volumeID:
-                          description: 'volume id used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    configMap:
-                      description: ConfigMap represents a configMap that should populate
-                        this volume
-                      properties:
-                        defaultMode:
-                          description: 'Optional: mode bits to use on created files
-                            by default. Must be a value between 0 and 0777. Defaults
-                            to 0644. Directories within the path are not affected
-                            by this setting. This might be in conflict with other
-                            options that affect the file mode, like fsGroup, and the
-                            result can be other mode bits set.'
-                          format: int32
-                          type: integer
-                        items:
-                          description: If unspecified, each key-value pair in the
-                            Data field of the referenced ConfigMap will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the ConfigMap, the volume setup will error unless it is
-                            marked optional. Paths must be relative and may not contain
-                            the '..' path or start with '..'.
-                          items:
-                            description: Maps a string key to a path within a volume.
-                            properties:
-                              key:
-                                description: The key to project.
-                                type: string
-                              mode:
-                                description: 'Optional: mode bits to use on this file,
-                                  must be a value between 0 and 0777. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: The relative path of the file to map
-                                  the key to. May not be an absolute path. May not
-                                  contain the path element '..'. May not start with
-                                  the string '..'.
-                                type: string
-                            required:
-                            - key
-                            - path
-                            type: object
-                          type: array
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                        optional:
-                          description: Specify whether the ConfigMap or its keys must
-                            be defined
-                          type: boolean
-                      type: object
-                    csi:
-                      description: CSI (Container Storage Interface) represents storage
-                        that is handled by an external CSI driver (Alpha feature).
-                      properties:
-                        driver:
-                          description: Driver is the name of the CSI driver that handles
-                            this volume. Consult with your admin for the correct name
-                            as registered in the cluster.
-                          type: string
-                        fsType:
-                          description: Filesystem type to mount. Ex. "ext4", "xfs",
-                            "ntfs". If not provided, the empty value is passed to
-                            the associated CSI driver which will determine the default
-                            filesystem to apply.
-                          type: string
-                        nodePublishSecretRef:
-                          description: NodePublishSecretRef is a reference to the
-                            secret object containing sensitive information to pass
-                            to the CSI driver to complete the CSI NodePublishVolume
-                            and NodeUnpublishVolume calls. This field is optional,
-                            and  may be empty if no secret is required. If the secret
-                            object contains more than one secret, all secret references
-                            are passed.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        readOnly:
-                          description: Specifies a read-only configuration for the
-                            volume. Defaults to false (read/write).
-                          type: boolean
-                        volumeAttributes:
-                          additionalProperties:
-                            type: string
-                          description: VolumeAttributes stores driver-specific properties
-                            that are passed to the CSI driver. Consult your driver's
-                            documentation for supported values.
-                          type: object
-                      required:
-                      - driver
-                      type: object
-                    downwardAPI:
-                      description: DownwardAPI represents downward API about the pod
-                        that should populate this volume
-                      properties:
-                        defaultMode:
-                          description: 'Optional: mode bits to use on created files
-                            by default. Must be a value between 0 and 0777. Defaults
-                            to 0644. Directories within the path are not affected
-                            by this setting. This might be in conflict with other
-                            options that affect the file mode, like fsGroup, and the
-                            result can be other mode bits set.'
-                          format: int32
-                          type: integer
-                        items:
-                          description: Items is a list of downward API volume file
-                          items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
-                            properties:
-                              fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
-                                properties:
-                                  apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
-                                    type: string
-                                required:
-                                - fieldPath
-                                type: object
-                              mode:
-                                description: 'Optional: mode bits to use on this file,
-                                  must be a value between 0 and 0777. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
-                                type: string
-                              resourceFieldRef:
-                                description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, requests.cpu and requests.memory)
-                                  are currently supported.'
-                                properties:
-                                  containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: 'Required: resource to select'
-                                    type: string
-                                required:
-                                - resource
-                                type: object
-                            required:
-                            - path
-                            type: object
-                          type: array
-                      type: object
-                    emptyDir:
-                      description: 'EmptyDir represents a temporary directory that
-                        shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                      properties:
-                        medium:
-                          description: 'What type of storage medium should back this
-                            directory. The default is "" which means to use the node''s
-                            default medium. Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                          type: string
-                        sizeLimit:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          description: 'Total amount of local storage required for
-                            this EmptyDir volume. The size limit is also applicable
-                            for memory medium. The maximum usage on memory medium
-                            EmptyDir would be the minimum value between the SizeLimit
-                            specified here and the sum of memory limits of all containers
-                            in a pod. The default is nil which means that the limit
-                            is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                      type: object
-                    fc:
-                      description: FC represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
-                      properties:
-                        fsType:
-                          description: 'Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        lun:
-                          description: 'Optional: FC target lun number'
-                          format: int32
-                          type: integer
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
-                          type: boolean
-                        targetWWNs:
-                          description: 'Optional: FC target worldwide names (WWNs)'
-                          items:
-                            type: string
-                          type: array
-                        wwids:
-                          description: 'Optional: FC volume world wide identifiers
-                            (wwids) Either wwids or combination of targetWWNs and
-                            lun must be set, but not both simultaneously.'
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    flexVolume:
-                      description: FlexVolume represents a generic volume resource
-                        that is provisioned/attached using an exec based plugin.
-                      properties:
-                        driver:
-                          description: Driver is the name of the driver to use for
-                            this volume.
-                          type: string
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". The default filesystem depends on FlexVolume
-                            script.
-                          type: string
-                        options:
-                          additionalProperties:
-                            type: string
-                          description: 'Optional: Extra command options if any.'
-                          type: object
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
-                          type: boolean
-                        secretRef:
-                          description: 'Optional: SecretRef is reference to the secret
-                            object containing sensitive information to pass to the
-                            plugin scripts. This may be empty if no secret object
-                            is specified. If the secret object contains more than
-                            one secret, all secrets are passed to the plugin scripts.'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                      required:
-                      - driver
-                      type: object
-                    flocker:
-                      description: Flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
-                      properties:
-                        datasetName:
-                          description: Name of the dataset stored as metadata -> name
-                            on the dataset for Flocker should be considered as deprecated
-                          type: string
-                        datasetUUID:
-                          description: UUID of the dataset. This is unique identifier
-                            of a Flocker dataset
-                          type: string
-                      type: object
-                    gcePersistentDisk:
-                      description: 'GCEPersistentDisk represents a GCE Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        partition:
-                          description: 'The partition in the volume that you want
-                            to mount. If omitted, the default is to mount by volume
-                            name. Examples: For volume /dev/sda1, you specify the
-                            partition as "1". Similarly, the volume partition for
-                            /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          format: int32
-                          type: integer
-                        pdName:
-                          description: 'Unique name of the PD resource in GCE. Used
-                            to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          type: boolean
-                      required:
-                      - pdName
-                      type: object
-                    gitRepo:
-                      description: 'GitRepo represents a git repository at a particular
-                        revision. DEPRECATED: GitRepo is deprecated. To provision
-                        a container with a git repo, mount an EmptyDir into an InitContainer
-                        that clones the repo using git, then mount the EmptyDir into
-                        the Pod''s container.'
-                      properties:
-                        directory:
-                          description: Target directory name. Must not contain or
-                            start with '..'.  If '.' is supplied, the volume directory
-                            will be the git repository.  Otherwise, if specified,
-                            the volume will contain the git repository in the subdirectory
-                            with the given name.
-                          type: string
-                        repository:
-                          description: Repository URL
-                          type: string
-                        revision:
-                          description: Commit hash for the specified revision.
-                          type: string
-                      required:
-                      - repository
-                      type: object
-                    glusterfs:
-                      description: 'Glusterfs represents a Glusterfs mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
-                      properties:
-                        endpoints:
-                          description: 'EndpointsName is the endpoint name that details
-                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: string
-                        path:
-                          description: 'Path is the Glusterfs volume path. More info:
-                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the Glusterfs volume
-                            to be mounted with read-only permissions. Defaults to
-                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: boolean
-                      required:
-                      - endpoints
-                      - path
-                      type: object
-                    hostPath:
-                      description: 'HostPath represents a pre-existing file or directory
-                        on the host machine that is directly exposed to the container.
-                        This is generally used for system agents or other privileged
-                        things that are allowed to see the host machine. Most containers
-                        will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        --- TODO(jonesdl) We need to restrict who can use host directory
-                        mounts and who can/can not mount host directories as read/write.'
-                      properties:
-                        path:
-                          description: 'Path of the directory on the host. If the
-                            path is a symlink, it will follow the link to the real
-                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                          type: string
-                        type:
-                          description: 'Type for HostPath Volume Defaults to "" More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                          type: string
-                      required:
-                      - path
-                      type: object
-                    iscsi:
-                      description: 'ISCSI represents an ISCSI Disk resource that is
-                        attached to a kubelet''s host machine and then exposed to
-                        the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
-                      properties:
-                        chapAuthDiscovery:
-                          description: whether support iSCSI Discovery CHAP authentication
-                          type: boolean
-                        chapAuthSession:
-                          description: whether support iSCSI Session CHAP authentication
-                          type: boolean
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        initiatorName:
-                          description: Custom iSCSI Initiator Name. If initiatorName
-                            is specified with iscsiInterface simultaneously, new iSCSI
-                            interface <target portal>:<volume name> will be created
-                            for the connection.
-                          type: string
-                        iqn:
-                          description: Target iSCSI Qualified Name.
-                          type: string
-                        iscsiInterface:
-                          description: iSCSI Interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
-                          type: string
-                        lun:
-                          description: iSCSI Target Lun number.
-                          format: int32
-                          type: integer
-                        portals:
-                          description: iSCSI Target Portal List. The portal is either
-                            an IP or ip_addr:port if the port is other than default
-                            (typically TCP ports 860 and 3260).
-                          items:
-                            type: string
-                          type: array
-                        readOnly:
-                          description: ReadOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false.
-                          type: boolean
-                        secretRef:
-                          description: CHAP Secret for iSCSI target and initiator
-                            authentication
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        targetPortal:
-                          description: iSCSI Target Portal. The Portal is either an
-                            IP or ip_addr:port if the port is other than default (typically
-                            TCP ports 860 and 3260).
-                          type: string
-                      required:
-                      - iqn
-                      - lun
-                      - targetPortal
-                      type: object
-                    name:
-                      description: 'Volume''s name. Must be a DNS_LABEL and unique
-                        within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                      type: string
-                    nfs:
-                      description: 'NFS represents an NFS mount on the host that shares
-                        a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                      properties:
-                        path:
-                          description: 'Path that is exported by the NFS server. More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the NFS export to
-                            be mounted with read-only permissions. Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: boolean
-                        server:
-                          description: 'Server is the hostname or IP address of the
-                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: string
-                      required:
-                      - path
-                      - server
-                      type: object
-                    persistentVolumeClaim:
-                      description: 'PersistentVolumeClaimVolumeSource represents a
-                        reference to a PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                      properties:
-                        claimName:
-                          description: 'ClaimName is the name of a PersistentVolumeClaim
-                            in the same namespace as the pod using this volume. More
-                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                          type: string
-                        readOnly:
-                          description: Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
-                          type: boolean
-                      required:
-                      - claimName
-                      type: object
-                    photonPersistentDisk:
-                      description: PhotonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        pdID:
-                          description: ID that identifies Photon Controller persistent
-                            disk
-                          type: string
-                      required:
-                      - pdID
-                      type: object
-                    portworxVolume:
-                      description: PortworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: FSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating
-                            system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                            if unspecified.
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        volumeID:
-                          description: VolumeID uniquely identifies a Portworx volume
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    projected:
-                      description: Items for all in one resources secrets, configmaps,
-                        and downward API
-                      properties:
-                        defaultMode:
-                          description: Mode bits to use on created files by default.
-                            Must be a value between 0 and 0777. Directories within
-                            the path are not affected by this setting. This might
-                            be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits
-                            set.
-                          format: int32
-                          type: integer
-                        sources:
-                          description: list of volume projections
-                          items:
-                            description: Projection that may be projected along with
-                              other supported volume types
-                            properties:
-                              configMap:
-                                description: information about the configMap data
-                                  to project
-                                properties:
-                                  items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced ConfigMap
-                                      will be projected into the volume as a file
-                                      whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the ConfigMap, the volume
-                                      setup will error unless it is marked optional.
-                                      Paths must be relative and may not contain the
-                                      '..' path or start with '..'.
-                                    items:
-                                      description: Maps a string key to a path within
-                                        a volume.
-                                      properties:
-                                        key:
-                                          description: The key to project.
-                                          type: string
-                                        mode:
-                                          description: 'Optional: mode bits to use
-                                            on this file, must be a value between
-                                            0 and 0777. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element
-                                            '..'. May not start with the string '..'.
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or
-                                      its keys must be defined
-                                    type: boolean
-                                type: object
-                              downwardAPI:
-                                description: information about the downwardAPI data
-                                  to project
-                                properties:
-                                  items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
-                                    items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
-                                      properties:
-                                        fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
-                                          properties:
-                                            apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
-                                              type: string
-                                            fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
-                                              type: string
-                                          required:
-                                          - fieldPath
-                                          type: object
-                                        mode:
-                                          description: 'Optional: mode bits to use
-                                            on this file, must be a value between
-                                            0 and 0777. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
-                                          type: string
-                                        resourceFieldRef:
-                                          description: 'Selects a resource of the
-                                            container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu
-                                            and requests.memory) are currently supported.'
-                                          properties:
-                                            containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
-                                              type: string
-                                            divisor:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            resource:
-                                              description: 'Required: resource to
-                                                select'
-                                              type: string
-                                          required:
-                                          - resource
-                                          type: object
-                                      required:
-                                      - path
-                                      type: object
-                                    type: array
-                                type: object
-                              secret:
-                                description: information about the secret data to
-                                  project
-                                properties:
-                                  items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced Secret will
-                                      be projected into the volume as a file whose
-                                      name is the key and content is the value. If
-                                      specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the Secret, the volume setup
-                                      will error unless it is marked optional. Paths
-                                      must be relative and may not contain the '..'
-                                      path or start with '..'.
-                                    items:
-                                      description: Maps a string key to a path within
-                                        a volume.
-                                      properties:
-                                        key:
-                                          description: The key to project.
-                                          type: string
-                                        mode:
-                                          description: 'Optional: mode bits to use
-                                            on this file, must be a value between
-                                            0 and 0777. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element
-                                            '..'. May not start with the string '..'.
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
-                                    type: boolean
-                                type: object
-                              serviceAccountToken:
-                                description: information about the serviceAccountToken
-                                  data to project
-                                properties:
-                                  audience:
-                                    description: Audience is the intended audience
-                                      of the token. A recipient of a token must identify
-                                      itself with an identifier specified in the audience
-                                      of the token, and otherwise should reject the
-                                      token. The audience defaults to the identifier
-                                      of the apiserver.
-                                    type: string
-                                  expirationSeconds:
-                                    description: ExpirationSeconds is the requested
-                                      duration of validity of the service account
-                                      token. As the token approaches expiration, the
-                                      kubelet volume plugin will proactively rotate
-                                      the service account token. The kubelet will
-                                      start trying to rotate the token if the token
-                                      is older than 80 percent of its time to live
-                                      or if the token is older than 24 hours.Defaults
-                                      to 1 hour and must be at least 10 minutes.
-                                    format: int64
-                                    type: integer
-                                  path:
-                                    description: Path is the path relative to the
-                                      mount point of the file to project the token
-                                      into.
-                                    type: string
-                                required:
-                                - path
-                                type: object
-                            type: object
-                          type: array
-                      required:
-                      - sources
-                      type: object
-                    quobyte:
-                      description: Quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
-                      properties:
-                        group:
-                          description: Group to map volume access to Default is no
-                            group
-                          type: string
-                        readOnly:
-                          description: ReadOnly here will force the Quobyte volume
-                            to be mounted with read-only permissions. Defaults to
-                            false.
-                          type: boolean
-                        registry:
-                          description: Registry represents a single or multiple Quobyte
-                            Registry services specified as a string as host:port pair
-                            (multiple entries are separated with commas) which acts
-                            as the central registry for volumes
-                          type: string
-                        tenant:
-                          description: Tenant owning the given Quobyte volume in the
-                            Backend Used with dynamically provisioned Quobyte volumes,
-                            value is set by the plugin
-                          type: string
-                        user:
-                          description: User to map volume access to Defaults to serivceaccount
-                            user
-                          type: string
-                        volume:
-                          description: Volume is a string that references an already
-                            created Quobyte volume by name.
-                          type: string
-                      required:
-                      - registry
-                      - volume
-                      type: object
-                    rbd:
-                      description: 'RBD represents a Rados Block Device mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        image:
-                          description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        keyring:
-                          description: 'Keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        monitors:
-                          description: 'A collection of Ceph monitors. More info:
-                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          items:
-                            type: string
-                          type: array
-                        pool:
-                          description: 'The rados pool name. Default is rbd. More
-                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: boolean
-                        secretRef:
-                          description: 'SecretRef is name of the authentication secret
-                            for RBDUser. If provided overrides keyring. Default is
-                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        user:
-                          description: 'The rados user name. Default is admin. More
-                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                      required:
-                      - image
-                      - monitors
-                      type: object
-                    scaleIO:
-                      description: ScaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Default is "xfs".
-                          type: string
-                        gateway:
-                          description: The host address of the ScaleIO API Gateway.
-                          type: string
-                        protectionDomain:
-                          description: The name of the ScaleIO Protection Domain for
-                            the configured storage.
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretRef:
-                          description: SecretRef references to the secret for ScaleIO
-                            user and other sensitive information. If this is not provided,
-                            Login operation will fail.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        sslEnabled:
-                          description: Flag to enable/disable SSL communication with
-                            Gateway, default false
-                          type: boolean
-                        storageMode:
-                          description: Indicates whether the storage for a volume
-                            should be ThickProvisioned or ThinProvisioned. Default
-                            is ThinProvisioned.
-                          type: string
-                        storagePool:
-                          description: The ScaleIO Storage Pool associated with the
-                            protection domain.
-                          type: string
-                        system:
-                          description: The name of the storage system as configured
-                            in ScaleIO.
-                          type: string
-                        volumeName:
-                          description: The name of a volume already created in the
-                            ScaleIO system that is associated with this volume source.
-                          type: string
-                      required:
-                      - gateway
-                      - secretRef
-                      - system
-                      type: object
-                    secret:
-                      description: 'Secret represents a secret that should populate
-                        this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                      properties:
-                        defaultMode:
-                          description: 'Optional: mode bits to use on created files
-                            by default. Must be a value between 0 and 0777. Defaults
-                            to 0644. Directories within the path are not affected
-                            by this setting. This might be in conflict with other
-                            options that affect the file mode, like fsGroup, and the
-                            result can be other mode bits set.'
-                          format: int32
-                          type: integer
-                        items:
-                          description: If unspecified, each key-value pair in the
-                            Data field of the referenced Secret will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the Secret, the volume setup will error unless it is marked
-                            optional. Paths must be relative and may not contain the
-                            '..' path or start with '..'.
-                          items:
-                            description: Maps a string key to a path within a volume.
-                            properties:
-                              key:
-                                description: The key to project.
-                                type: string
-                              mode:
-                                description: 'Optional: mode bits to use on this file,
-                                  must be a value between 0 and 0777. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: The relative path of the file to map
-                                  the key to. May not be an absolute path. May not
-                                  contain the path element '..'. May not start with
-                                  the string '..'.
-                                type: string
-                            required:
-                            - key
-                            - path
-                            type: object
-                          type: array
-                        optional:
-                          description: Specify whether the Secret or its keys must
-                            be defined
-                          type: boolean
-                        secretName:
-                          description: 'Name of the secret in the pod''s namespace
-                            to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                          type: string
-                      type: object
-                    storageos:
-                      description: StorageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretRef:
-                          description: SecretRef specifies the secret to use for obtaining
-                            the StorageOS API credentials.  If not specified, default
-                            values will be attempted.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        volumeName:
-                          description: VolumeName is the human-readable name of the
-                            StorageOS volume.  Volume names are only unique within
-                            a namespace.
-                          type: string
-                        volumeNamespace:
-                          description: VolumeNamespace specifies the scope of the
-                            volume within StorageOS.  If no namespace is specified
-                            then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS
-                            for tighter integration. Set VolumeName to any name to
-                            override the default behaviour. Set to "default" if you
-                            are not using namespaces within StorageOS. Namespaces
-                            that do not pre-exist within StorageOS will be created.
-                          type: string
-                      type: object
-                    vsphereVolume:
-                      description: VsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        storagePolicyID:
-                          description: Storage Policy Based Management (SPBM) profile
-                            ID associated with the StoragePolicyName.
-                          type: string
-                        storagePolicyName:
-                          description: Storage Policy Based Management (SPBM) profile
-                            name.
-                          type: string
-                        volumePath:
-                          description: Path that identifies vSphere volume vmdk
-                          type: string
-                      required:
-                      - volumePath
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
-            type: object
-          status:
-            description: SearchHeadClusterStatus defines the observed state of a Splunk
-              Enterprise search head cluster
-            properties:
-              captain:
-                description: name or label of the search head captain
-                type: string
-              captainReady:
-                description: true if the search head cluster's captain is ready to
-                  service requests
+              type: array
+            minPeersJoined:
+              description: true if the minimum number of search head cluster members
+                have joined
+              type: boolean
+            namespace_scoped_secret_resource_version:
+              description: Indicates resource version of namespace scoped secret
+              type: string
+            phase:
+              description: current phase of the search head cluster
+              enum:
+              - Pending
+              - Ready
+              - Updating
+              - ScalingUp
+              - ScalingDown
+              - Terminating
+              - Error
+              type: string
+            readyReplicas:
+              description: current number of ready search head cluster members
+              format: int32
+              type: integer
+            replicas:
+              description: desired number of search head cluster members
+              format: int32
+              type: integer
+            selector:
+              description: selector for pods, used by HorizontalPodAutoscaler
+              type: string
+            shcSecretChangedFlag:
+              description: Indicates when the shc_secret has been changed for a peer
+              items:
                 type: boolean
-              deployerPhase:
-                description: current phase of the deployer
-                enum:
-                - Pending
-                - Ready
-                - Updating
-                - ScalingUp
-                - ScalingDown
-                - Terminating
-                - Error
-                type: string
-              initialized:
-                description: true if the search head cluster has finished initialization
-                type: boolean
-              maintenanceMode:
-                description: true if the search head cluster is in maintenance mode
-                type: boolean
-              members:
-                description: status of each search head cluster member
-                items:
-                  description: SearchHeadClusterMemberStatus is used to track the
-                    status of each search head cluster member
-                  properties:
-                    active_historical_search_count:
-                      description: Number of currently running historical searches.
-                      type: integer
-                    active_realtime_search_count:
-                      description: Number of currently running realtime searches.
-                      type: integer
-                    adhoc_searchhead:
-                      description: Flag that indicates if this member can run scheduled
-                        searches.
-                      type: boolean
-                    is_registered:
-                      description: Indicates if this member is registered with the
-                        searchhead cluster captain.
-                      type: boolean
-                    name:
-                      description: Name of the search head cluster member
-                      type: string
-                    status:
-                      description: Indicates the status of the member.
-                      type: string
-                  type: object
-                type: array
-              minPeersJoined:
-                description: true if the minimum number of search head cluster members
-                  have joined
-                type: boolean
-              namespace_scoped_secret_resource_version:
-                description: Indicates resource version of namespace scoped secret
-                type: string
-              phase:
-                description: current phase of the search head cluster
-                enum:
-                - Pending
-                - Ready
-                - Updating
-                - ScalingUp
-                - ScalingDown
-                - Terminating
-                - Error
-                type: string
-              readyReplicas:
-                description: current number of ready search head cluster members
-                format: int32
-                type: integer
-              replicas:
-                description: desired number of search head cluster members
-                format: int32
-                type: integer
-              selector:
-                description: selector for pods, used by HorizontalPodAutoscaler
-                type: string
-              shcSecretChangedFlag:
-                description: Indicates when the shc_secret has been changed for a
-                  peer
-                items:
-                  type: boolean
-                type: array
-            type: object
-        type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha3
+  versions:
+  - name: v1alpha3
     served: true
     storage: true
-    subresources:
-      scale:
-        labelSelectorPath: .status.selector
-        specReplicasPath: .spec.replicas
-        statusReplicasPath: .status.replicas
-      status: {}
+  - name: v1alpha2
+    served: true
+    storage: false

--- a/deploy/crds/enterprise.splunk.com_searchheadclusters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_searchheadclusters_crd.yaml
@@ -1,29 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: searchheadclusters.enterprise.splunk.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: Status of search head cluster
-    name: Phase
-    type: string
-  - JSONPath: .status.deployerPhase
-    description: Status of the deployer
-    name: Deployer
-    type: string
-  - JSONPath: .status.replicas
-    description: Desired number of search head cluster members
-    name: Desired
-    type: integer
-  - JSONPath: .status.readyReplicas
-    description: Current number of ready search head cluster members
-    name: Ready
-    type: integer
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of search head cluster
-    name: Age
-    type: date
   group: enterprise.splunk.com
   names:
     kind: SearchHeadCluster
@@ -33,2341 +12,2424 @@ spec:
     - shc
     singular: searchheadcluster
   scope: Namespaced
-  subresources:
-    scale:
-      labelSelectorPath: .status.selector
-      specReplicasPath: .spec.replicas
-      statusReplicasPath: .status.replicas
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: SearchHeadCluster is the Schema for a Splunk Enterprise search
-        head cluster
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: SearchHeadClusterSpec defines the desired state of a Splunk
-            Enterprise search head cluster
-          properties:
-            affinity:
-              description: Kubernetes Affinity rules that control how pods are assigned
-                to particular nodes.
-              properties:
-                nodeAffinity:
-                  description: Describes node affinity scheduling rules for the pod.
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node matches the corresponding matchExpressions; the
-                        node(s) with the highest sum are the most preferred.
-                      items:
-                        description: An empty preferred scheduling term matches all
-                          objects with implicit weight 0 (i.e. it's a no-op). A null
-                          preferred scheduling term matches no objects (i.e. is also
-                          a no-op).
+  versions:
+  - additionalPrinterColumns:
+    - description: Status of search head cluster
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Status of the deployer
+      jsonPath: .status.deployerPhase
+      name: Deployer
+      type: string
+    - description: Desired number of search head cluster members
+      jsonPath: .status.replicas
+      name: Desired
+      type: integer
+    - description: Current number of ready search head cluster members
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Age of search head cluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: SearchHeadCluster is the Schema for a Splunk Enterprise search
+          head cluster
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SearchHeadClusterSpec defines the desired state of a Splunk
+              Enterprise search head cluster
+            properties:
+              Mock:
+                description: Mock to differentiate between UTs and actual reconcile
+                type: boolean
+              affinity:
+                description: Kubernetes Affinity rules that control how pods are assigned
+                  to particular nodes.
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
                         properties:
-                          preference:
-                            description: A node selector term, associated with the
-                              corresponding weight.
-                            properties:
-                              matchExpressions:
-                                description: A list of node selector requirements
-                                  by node's labels.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchFields:
-                                description: A list of node selector requirements
-                                  by node's fields.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
                                         type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                            type: object
-                          weight:
-                            description: Weight associated with matching the corresponding
-                              nodeSelectorTerm, in the range 1-100.
-                            format: int32
-                            type: integer
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
                         required:
-                        - preference
-                        - weight
+                        - nodeSelectorTerms
                         type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to an update), the system may or may not try to
-                        eventually evict the pod from its node.
-                      properties:
-                        nodeSelectorTerms:
-                          description: Required. A list of node selector terms. The
-                            terms are ORed.
-                          items:
-                            description: A null or empty node selector term matches
-                              no objects. The requirements of them are ANDed. The
-                              TopologySelectorTerm type implements a subset of the
-                              NodeSelectorTerm.
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              clusterMasterRef:
+                description: ClusterMasterRef refers to a Splunk Enterprise indexer
+                  cluster managed by the operator within Kubernetes
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              defaults:
+                description: Inline map of default.yml overrides used to initialize
+                  the environment
+                type: string
+              defaultsUrl:
+                description: Full path or URL for one or more default.yml files, separated
+                  by commas
+                type: string
+              ephemeralStorage:
+                description: If true, ephemeral (emptyDir) storage will be used for
+                  /opt/splunk/etc and /opt/splunk/var volumes
+                type: boolean
+              etcStorage:
+                description: Storage capacity to request for /opt/splunk/etc persistent
+                  volume claims (default=”1Gi”)
+                type: string
+              image:
+                description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
+                  environment variables)
+                type: string
+              imagePullPolicy:
+                description: 'Sets pull policy for all images (either “Always” or
+                  the default: “IfNotPresent”)'
+                enum:
+                - Always
+                - IfNotPresent
+                type: string
+              licenseMasterRef:
+                description: LicenseMasterRef refers to a Splunk Enterprise license
+                  master managed by the operator within Kubernetes
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              licenseUrl:
+                description: Full path or URL for a Splunk Enterprise license file
+                type: string
+              replicas:
+                description: Number of search head pods; a search head cluster will
+                  be created if > 1
+                format: int32
+                type: integer
+              resources:
+                description: resource requirements for the pod containers
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+              schedulerName:
+                description: Name of Scheduler to use for pod placement (defaults
+                  to “default-scheduler”)
+                type: string
+              serviceTemplate:
+                description: ServiceTemplate is a template used to create Kubernetes
+                  services
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      clusterIP:
+                        description: 'clusterIP is the IP address of the service and
+                          is usually assigned randomly by the master. If an address
+                          is specified manually and is not in use by others, it will
+                          be allocated to the service; otherwise, creation of the
+                          service will fail. This field can not be changed through
+                          updates. Valid values are "None", empty string (""), or
+                          a valid IP address. "None" can be specified for headless
+                          services when proxying is not required. Only applies to
+                          types ClusterIP, NodePort, and LoadBalancer. Ignored if
+                          type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      externalIPs:
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for this service.  These
+                          IPs are not managed by Kubernetes.  The user is responsible
+                          for ensuring that traffic arrives at a node with this IP.  A
+                          common example is external load-balancers that are not part
+                          of the Kubernetes system.
+                        items:
+                          type: string
+                        type: array
+                      externalName:
+                        description: externalName is the external reference that kubedns
+                          or equivalent will return as a CNAME record for this service.
+                          No proxying will be involved. Must be a valid RFC-1123 hostname
+                          (https://tools.ietf.org/html/rfc1123) and requires Type
+                          to be ExternalName.
+                        type: string
+                      externalTrafficPolicy:
+                        description: externalTrafficPolicy denotes if this Service
+                          desires to route external traffic to node-local or cluster-wide
+                          endpoints. "Local" preserves the client source IP and avoids
+                          a second hop for LoadBalancer and Nodeport type services,
+                          but risks potentially imbalanced traffic spreading. "Cluster"
+                          obscures the client source IP and may cause a second hop
+                          to another node, but should have good overall load-spreading.
+                        type: string
+                      healthCheckNodePort:
+                        description: healthCheckNodePort specifies the healthcheck
+                          nodePort for the service. If not specified, HealthCheckNodePort
+                          is created by the service api backend with the allocated
+                          nodePort. Will use user-specified nodePort value if specified
+                          by the client. Only effects when Type is set to LoadBalancer
+                          and ExternalTrafficPolicy is set to Local.
+                        format: int32
+                        type: integer
+                      ipFamily:
+                        description: ipFamily specifies whether this Service has a
+                          preference for a particular IP family (e.g. IPv4 vs. IPv6).  If
+                          a specific IP family is requested, the clusterIP field will
+                          be allocated from that family, if it is available in the
+                          cluster.  If no IP family is requested, the cluster's primary
+                          IP family will be used. Other IP fields (loadBalancerIP,
+                          loadBalancerSourceRanges, externalIPs) and controllers which
+                          allocate external load-balancers should use the same IP
+                          family.  Endpoints for this Service will be of this family.  This
+                          field is immutable after creation. Assigning a ServiceIPFamily
+                          not available in the cluster (e.g. IPv6 in IPv4 only cluster)
+                          is an error condition and will fail during clusterIP assignment.
+                        type: string
+                      loadBalancerIP:
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in this field. This
+                          feature depends on whether the underlying cloud-provider
+                          supports specifying the loadBalancerIP when a load balancer
+                          is created. This field will be ignored if the cloud-provider
+                          does not support the feature.'
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: 'If specified and supported by the platform,
+                          this will restrict traffic through the cloud-provider load-balancer
+                          will be restricted to the specified client IPs. This field
+                          will be ignored if the cloud-provider does not support the
+                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        description: 'The list of ports that are exposed by this service.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            name:
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names. When considering the endpoints
+                                for a Service, this must match the 'name' field in
+                                the EndpointPort. Optional if only one ServicePort
+                                is defined on this service.
+                              type: string
+                            nodePort:
+                              description: 'The port on each node on which this service
+                                is exposed when type=NodePort or LoadBalancer. Usually
+                                assigned by the system. If specified, it will be allocated
+                                to the service if unused or else creation of the service
+                                will fail. Default is to auto-allocate a port if the
+                                ServiceType of this Service requires one. More info:
+                                https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'Number or name of the port to access on
+                                the pods targeted by the service. Number must be in
+                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                If this is a string, it will be looked up as a named
+                                port in the target Pod''s container ports. If this
+                                is not specified, the value of the ''port'' field
+                                is used (an identity map). This field is ignored for
+                                services with clusterIP=None, and should be omitted
+                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        description: publishNotReadyAddresses, when set to true, indicates
+                          that DNS implementations must publish the notReadyAddresses
+                          of subsets for the Endpoints associated with the Service.
+                          The default value is false. The primary use case for setting
+                          this field is to use a StatefulSet's Headless Service to
+                          propagate SRV records for its Pods without respect to their
+                          readiness for purpose of peer discovery.
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: 'Route service traffic to pods with label keys
+                          and values matching this selector. If empty or not present,
+                          the service is assumed to have an external process managing
+                          its endpoints, which Kubernetes will not modify. Only applies
+                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
+                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                        type: object
+                      sessionAffinity:
+                        description: 'Supports "ClientIP" and "None". Used to maintain
+                          session affinity. Enable client IP based session affinity.
+                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
                             properties:
-                              matchExpressions:
-                                description: A list of node selector requirements
-                                  by node's labels.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchFields:
-                                description: A list of node selector requirements
-                                  by node's fields.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
+                              timeoutSeconds:
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time. The value
+                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                  == "ClientIP". Default value is 10800(for 3 hours).
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      type:
+                        description: 'type determines how the Service is exposed.
+                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
+                          NodePort, and LoadBalancer. "ExternalName" maps to the specified
+                          externalName. "ClusterIP" allocates a cluster-internal IP
+                          address for load-balancing to endpoints. Endpoints are determined
+                          by the selector or if that is not specified, by manual construction
+                          of an Endpoints object. If clusterIP is "None", no virtual
+                          IP is allocated and the endpoints are published as a set
+                          of endpoints rather than a stable IP. "NodePort" builds
+                          on ClusterIP and allocates a port on every node which routes
+                          to the clusterIP. "LoadBalancer" builds on NodePort and
+                          creates an external load-balancer (if supported in the current
+                          cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                        type: string
+                    type: object
+                  status:
+                    description: 'Most recently observed status of the service. Populated
+                      by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      loadBalancer:
+                        description: LoadBalancer contains the current status of the
+                          load-balancer, if one is present.
+                        properties:
+                          ingress:
+                            description: Ingress is a list containing ingress points
+                              for the load-balancer. Traffic intended for the service
+                              should be sent to these ingress points.
+                            items:
+                              description: 'LoadBalancerIngress represents the status
+                                of a load-balancer ingress point: traffic intended
+                                for the service should be sent to an ingress point.'
+                              properties:
+                                hostname:
+                                  description: Hostname is set for load-balancer ingress
+                                    points that are DNS based (typically AWS load-balancers)
+                                  type: string
+                                ip:
+                                  description: IP is set for load-balancer ingress
+                                    points that are IP based (typically GCE or OpenStack
+                                    load-balancers)
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                type: object
+              sparkImage:
+                description: Image to use for Spark pod containers (overrides RELATED_IMAGE_SPLUNK_SPARK
+                  environment variables)
+                type: string
+              sparkRef:
+                description: SparkRef refers to a Spark cluster managed by the operator
+                  within Kubernetes When defined, Data Fabric Search (DFS) will be
+                  enabled and configured to use the Spark cluster.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              storageClassName:
+                description: Name of StorageClass to use for persistent volume claims
+                type: string
+              tolerations:
+                description: Pod's tolerations for Kubernetes node's taint
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              varStorage:
+                description: Storage capacity to request for /opt/splunk/var persistent
+                  volume claims (default=”50Gi”)
+                type: string
+              volumes:
+                description: List of one or more Kubernetes volumes. These will be
+                  mounted in all pod containers as as /mnt/<name>
+                items:
+                  description: Volume represents a named volume in a pod that may
+                    be accessed by any container in the pod.
+                  properties:
+                    awsElasticBlockStore:
+                      description: 'AWSElasticBlockStore represents an AWS Disk resource
+                        that is attached to a kubelet''s host machine and then exposed
+                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      properties:
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        partition:
+                          description: 'The partition in the volume that you want
+                            to mount. If omitted, the default is to mount by volume
+                            name. Examples: For volume /dev/sda1, you specify the
+                            partition as "1". Similarly, the volume partition for
+                            /dev/sda is "0" (or you can leave the property empty).'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: 'Specify "true" to force and set the ReadOnly
+                            property in VolumeMounts to "true". If omitted, the default
+                            is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          type: boolean
+                        volumeID:
+                          description: 'Unique ID of the persistent disk resource
+                            in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    azureDisk:
+                      description: AzureDisk represents an Azure Data Disk mount on
+                        the host and bind mount to the pod.
+                      properties:
+                        cachingMode:
+                          description: 'Host Caching mode: None, Read Only, Read Write.'
+                          type: string
+                        diskName:
+                          description: The Name of the data disk in the blob storage
+                          type: string
+                        diskURI:
+                          description: The URI the data disk in the blob storage
+                          type: string
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        kind:
+                          description: 'Expected values Shared: multiple blob disks
+                            per storage account  Dedicated: single blob disk per storage
+                            account  Managed: azure managed data disk (only in managed
+                            availability set). defaults to shared'
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                      required:
+                      - diskName
+                      - diskURI
+                      type: object
+                    azureFile:
+                      description: AzureFile represents an Azure File Service mount
+                        on the host and bind mount to the pod.
+                      properties:
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretName:
+                          description: the name of secret that contains Azure Storage
+                            Account Name and Key
+                          type: string
+                        shareName:
+                          description: Share Name
+                          type: string
+                      required:
+                      - secretName
+                      - shareName
+                      type: object
+                    cephfs:
+                      description: CephFS represents a Ceph FS mount on the host that
+                        shares a pod's lifetime
+                      properties:
+                        monitors:
+                          description: 'Required: Monitors is a collection of Ceph
+                            monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          items:
+                            type: string
+                          type: array
+                        path:
+                          description: 'Optional: Used as the mounted root, rather
+                            than the full Ceph tree, default is /'
+                          type: string
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: boolean
+                        secretFile:
+                          description: 'Optional: SecretFile is the path to key ring
+                            for User, default is /etc/ceph/user.secret More info:
+                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: string
+                        secretRef:
+                          description: 'Optional: SecretRef is reference to the authentication
+                            secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        user:
+                          description: 'Optional: User is the rados user name, default
+                            is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: string
+                      required:
+                      - monitors
+                      type: object
+                    cinder:
+                      description: 'Cinder represents a cinder volume attached and
+                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      properties:
+                        fsType:
+                          description: 'Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: string
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: boolean
+                        secretRef:
+                          description: 'Optional: points to a secret object containing
+                            parameters used to connect to OpenStack.'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        volumeID:
+                          description: 'volume id used to identify the volume in cinder.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    configMap:
+                      description: ConfigMap represents a configMap that should populate
+                        this volume
+                      properties:
+                        defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default. Must be a value between 0 and 0777. Defaults
+                            to 0644. Directories within the path are not affected
+                            by this setting. This might be in conflict with other
+                            options that affect the file mode, like fsGroup, and the
+                            result can be other mode bits set.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: If unspecified, each key-value pair in the
+                            Data field of the referenced ConfigMap will be projected
+                            into the volume as a file whose name is the key and content
+                            is the value. If specified, the listed keys will be projected
+                            into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in
+                            the ConfigMap, the volume setup will error unless it is
+                            marked optional. Paths must be relative and may not contain
+                            the '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
+                            properties:
+                              key:
+                                description: The key to project.
+                                type: string
+                              mode:
+                                description: 'Optional: mode bits to use on this file,
+                                  must be a value between 0 and 0777. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: The relative path of the file to map
+                                  the key to. May not be an absolute path. May not
+                                  contain the path element '..'. May not start with
+                                  the string '..'.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap or its keys must
+                            be defined
+                          type: boolean
+                      type: object
+                    csi:
+                      description: CSI (Container Storage Interface) represents storage
+                        that is handled by an external CSI driver (Alpha feature).
+                      properties:
+                        driver:
+                          description: Driver is the name of the CSI driver that handles
+                            this volume. Consult with your admin for the correct name
+                            as registered in the cluster.
+                          type: string
+                        fsType:
+                          description: Filesystem type to mount. Ex. "ext4", "xfs",
+                            "ntfs". If not provided, the empty value is passed to
+                            the associated CSI driver which will determine the default
+                            filesystem to apply.
+                          type: string
+                        nodePublishSecretRef:
+                          description: NodePublishSecretRef is a reference to the
+                            secret object containing sensitive information to pass
+                            to the CSI driver to complete the CSI NodePublishVolume
+                            and NodeUnpublishVolume calls. This field is optional,
+                            and  may be empty if no secret is required. If the secret
+                            object contains more than one secret, all secret references
+                            are passed.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        readOnly:
+                          description: Specifies a read-only configuration for the
+                            volume. Defaults to false (read/write).
+                          type: boolean
+                        volumeAttributes:
+                          additionalProperties:
+                            type: string
+                          description: VolumeAttributes stores driver-specific properties
+                            that are passed to the CSI driver. Consult your driver's
+                            documentation for supported values.
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    downwardAPI:
+                      description: DownwardAPI represents downward API about the pod
+                        that should populate this volume
+                      properties:
+                        defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default. Must be a value between 0 and 0777. Defaults
+                            to 0644. Directories within the path are not affected
+                            by this setting. This might be in conflict with other
+                            options that affect the file mode, like fsGroup, and the
+                            result can be other mode bits set.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: Items is a list of downward API volume file
+                          items:
+                            description: DownwardAPIVolumeFile represents information
+                              to create the file containing the pod field
+                            properties:
+                              fieldRef:
+                                description: 'Required: Selects a field of the pod:
+                                  only annotations, labels, name and namespace are
+                                  supported.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                              mode:
+                                description: 'Optional: mode bits to use on this file,
+                                  must be a value between 0 and 0777. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: 'Required: Path is  the relative path
+                                  name of the file to be created. Must not be absolute
+                                  or contain the ''..'' path. Must be utf-8 encoded.
+                                  The first item of the relative path must not start
+                                  with ''..'''
+                                type: string
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, requests.cpu and requests.memory)
+                                  are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                            required:
+                            - path
+                            type: object
+                          type: array
+                      type: object
+                    emptyDir:
+                      description: 'EmptyDir represents a temporary directory that
+                        shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      properties:
+                        medium:
+                          description: 'What type of storage medium should back this
+                            directory. The default is "" which means to use the node''s
+                            default medium. Must be an empty string (default) or Memory.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          type: string
+                        sizeLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'Total amount of local storage required for
+                            this EmptyDir volume. The size limit is also applicable
+                            for memory medium. The maximum usage on memory medium
+                            EmptyDir would be the minimum value between the SizeLimit
+                            specified here and the sum of memory limits of all containers
+                            in a pod. The default is nil which means that the limit
+                            is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    fc:
+                      description: FC represents a Fibre Channel resource that is
+                        attached to a kubelet's host machine and then exposed to the
+                        pod.
+                      properties:
+                        fsType:
+                          description: 'Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        lun:
+                          description: 'Optional: FC target lun number'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                          type: boolean
+                        targetWWNs:
+                          description: 'Optional: FC target worldwide names (WWNs)'
+                          items:
+                            type: string
+                          type: array
+                        wwids:
+                          description: 'Optional: FC volume world wide identifiers
+                            (wwids) Either wwids or combination of targetWWNs and
+                            lun must be set, but not both simultaneously.'
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    flexVolume:
+                      description: FlexVolume represents a generic volume resource
+                        that is provisioned/attached using an exec based plugin.
+                      properties:
+                        driver:
+                          description: Driver is the name of the driver to use for
+                            this volume.
+                          type: string
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". The default filesystem depends on FlexVolume
+                            script.
+                          type: string
+                        options:
+                          additionalProperties:
+                            type: string
+                          description: 'Optional: Extra command options if any.'
+                          type: object
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                          type: boolean
+                        secretRef:
+                          description: 'Optional: SecretRef is reference to the secret
+                            object containing sensitive information to pass to the
+                            plugin scripts. This may be empty if no secret object
+                            is specified. If the secret object contains more than
+                            one secret, all secrets are passed to the plugin scripts.'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    flocker:
+                      description: Flocker represents a Flocker volume attached to
+                        a kubelet's host machine. This depends on the Flocker control
+                        service being running
+                      properties:
+                        datasetName:
+                          description: Name of the dataset stored as metadata -> name
+                            on the dataset for Flocker should be considered as deprecated
+                          type: string
+                        datasetUUID:
+                          description: UUID of the dataset. This is unique identifier
+                            of a Flocker dataset
+                          type: string
+                      type: object
+                    gcePersistentDisk:
+                      description: 'GCEPersistentDisk represents a GCE Disk resource
+                        that is attached to a kubelet''s host machine and then exposed
+                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      properties:
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        partition:
+                          description: 'The partition in the volume that you want
+                            to mount. If omitted, the default is to mount by volume
+                            name. Examples: For volume /dev/sda1, you specify the
+                            partition as "1". Similarly, the volume partition for
+                            /dev/sda is "0" (or you can leave the property empty).
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          format: int32
+                          type: integer
+                        pdName:
+                          description: 'Unique name of the PD resource in GCE. Used
+                            to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          type: boolean
+                      required:
+                      - pdName
+                      type: object
+                    gitRepo:
+                      description: 'GitRepo represents a git repository at a particular
+                        revision. DEPRECATED: GitRepo is deprecated. To provision
+                        a container with a git repo, mount an EmptyDir into an InitContainer
+                        that clones the repo using git, then mount the EmptyDir into
+                        the Pod''s container.'
+                      properties:
+                        directory:
+                          description: Target directory name. Must not contain or
+                            start with '..'.  If '.' is supplied, the volume directory
+                            will be the git repository.  Otherwise, if specified,
+                            the volume will contain the git repository in the subdirectory
+                            with the given name.
+                          type: string
+                        repository:
+                          description: Repository URL
+                          type: string
+                        revision:
+                          description: Commit hash for the specified revision.
+                          type: string
+                      required:
+                      - repository
+                      type: object
+                    glusterfs:
+                      description: 'Glusterfs represents a Glusterfs mount on the
+                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                      properties:
+                        endpoints:
+                          description: 'EndpointsName is the endpoint name that details
+                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: string
+                        path:
+                          description: 'Path is the Glusterfs volume path. More info:
+                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the Glusterfs volume
+                            to be mounted with read-only permissions. Defaults to
+                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: boolean
+                      required:
+                      - endpoints
+                      - path
+                      type: object
+                    hostPath:
+                      description: 'HostPath represents a pre-existing file or directory
+                        on the host machine that is directly exposed to the container.
+                        This is generally used for system agents or other privileged
+                        things that are allowed to see the host machine. Most containers
+                        will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                        --- TODO(jonesdl) We need to restrict who can use host directory
+                        mounts and who can/can not mount host directories as read/write.'
+                      properties:
+                        path:
+                          description: 'Path of the directory on the host. If the
+                            path is a symlink, it will follow the link to the real
+                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          type: string
+                        type:
+                          description: 'Type for HostPath Volume Defaults to "" More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    iscsi:
+                      description: 'ISCSI represents an ISCSI Disk resource that is
+                        attached to a kubelet''s host machine and then exposed to
+                        the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                      properties:
+                        chapAuthDiscovery:
+                          description: whether support iSCSI Discovery CHAP authentication
+                          type: boolean
+                        chapAuthSession:
+                          description: whether support iSCSI Session CHAP authentication
+                          type: boolean
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        initiatorName:
+                          description: Custom iSCSI Initiator Name. If initiatorName
+                            is specified with iscsiInterface simultaneously, new iSCSI
+                            interface <target portal>:<volume name> will be created
+                            for the connection.
+                          type: string
+                        iqn:
+                          description: Target iSCSI Qualified Name.
+                          type: string
+                        iscsiInterface:
+                          description: iSCSI Interface Name that uses an iSCSI transport.
+                            Defaults to 'default' (tcp).
+                          type: string
+                        lun:
+                          description: iSCSI Target Lun number.
+                          format: int32
+                          type: integer
+                        portals:
+                          description: iSCSI Target Portal List. The portal is either
+                            an IP or ip_addr:port if the port is other than default
+                            (typically TCP ports 860 and 3260).
+                          items:
+                            type: string
+                          type: array
+                        readOnly:
+                          description: ReadOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false.
+                          type: boolean
+                        secretRef:
+                          description: CHAP Secret for iSCSI target and initiator
+                            authentication
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        targetPortal:
+                          description: iSCSI Target Portal. The Portal is either an
+                            IP or ip_addr:port if the port is other than default (typically
+                            TCP ports 860 and 3260).
+                          type: string
+                      required:
+                      - iqn
+                      - lun
+                      - targetPortal
+                      type: object
+                    name:
+                      description: 'Volume''s name. Must be a DNS_LABEL and unique
+                        within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    nfs:
+                      description: 'NFS represents an NFS mount on the host that shares
+                        a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      properties:
+                        path:
+                          description: 'Path that is exported by the NFS server. More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the NFS export to
+                            be mounted with read-only permissions. Defaults to false.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: boolean
+                        server:
+                          description: 'Server is the hostname or IP address of the
+                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: string
+                      required:
+                      - path
+                      - server
+                      type: object
+                    persistentVolumeClaim:
+                      description: 'PersistentVolumeClaimVolumeSource represents a
+                        reference to a PersistentVolumeClaim in the same namespace.
+                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                      properties:
+                        claimName:
+                          description: 'ClaimName is the name of a PersistentVolumeClaim
+                            in the same namespace as the pod using this volume. More
+                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          type: string
+                        readOnly:
+                          description: Will force the ReadOnly setting in VolumeMounts.
+                            Default false.
+                          type: boolean
+                      required:
+                      - claimName
+                      type: object
+                    photonPersistentDisk:
+                      description: PhotonPersistentDisk represents a PhotonController
+                        persistent disk attached and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        pdID:
+                          description: ID that identifies Photon Controller persistent
+                            disk
+                          type: string
+                      required:
+                      - pdID
+                      type: object
+                    portworxVolume:
+                      description: PortworxVolume represents a portworx volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: FSType represents the filesystem type to mount
+                            Must be a filesystem type supported by the host operating
+                            system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        volumeID:
+                          description: VolumeID uniquely identifies a Portworx volume
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    projected:
+                      description: Items for all in one resources secrets, configmaps,
+                        and downward API
+                      properties:
+                        defaultMode:
+                          description: Mode bits to use on created files by default.
+                            Must be a value between 0 and 0777. Directories within
+                            the path are not affected by this setting. This might
+                            be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits
+                            set.
+                          format: int32
+                          type: integer
+                        sources:
+                          description: list of volume projections
+                          items:
+                            description: Projection that may be projected along with
+                              other supported volume types
+                            properties:
+                              configMap:
+                                description: information about the configMap data
+                                  to project
+                                properties:
+                                  items:
+                                    description: If unspecified, each key-value pair
+                                      in the Data field of the referenced ConfigMap
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the ConfigMap, the volume
+                                      setup will error unless it is marked optional.
+                                      Paths must be relative and may not contain the
+                                      '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: The key to project.
+                                          type: string
+                                        mode:
+                                          description: 'Optional: mode bits to use
+                                            on this file, must be a value between
+                                            0 and 0777. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: The relative path of the file
+                                            to map the key to. May not be an absolute
+                                            path. May not contain the path element
+                                            '..'. May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its keys must be defined
+                                    type: boolean
+                                type: object
+                              downwardAPI:
+                                description: information about the downwardAPI data
+                                  to project
+                                properties:
+                                  items:
+                                    description: Items is a list of DownwardAPIVolume
+                                      file
+                                    items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
+                                      properties:
+                                        fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name and namespace are supported.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                        mode:
+                                          description: 'Optional: mode bits to use
+                                            on this file, must be a value between
+                                            0 and 0777. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path. Must be utf-8 encoded. The first
+                                            item of the relative path must not start
+                                            with ''..'''
+                                          type: string
+                                        resourceFieldRef:
+                                          description: 'Selects a resource of the
+                                            container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu
+                                            and requests.memory) are currently supported.'
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                type: object
+                              secret:
+                                description: information about the secret data to
+                                  project
+                                properties:
+                                  items:
+                                    description: If unspecified, each key-value pair
+                                      in the Data field of the referenced Secret will
+                                      be projected into the volume as a file whose
+                                      name is the key and content is the value. If
+                                      specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the Secret, the volume setup
+                                      will error unless it is marked optional. Paths
+                                      must be relative and may not contain the '..'
+                                      path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: The key to project.
+                                          type: string
+                                        mode:
+                                          description: 'Optional: mode bits to use
+                                            on this file, must be a value between
+                                            0 and 0777. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: The relative path of the file
+                                            to map the key to. May not be an absolute
+                                            path. May not contain the path element
+                                            '..'. May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                type: object
+                              serviceAccountToken:
+                                description: information about the serviceAccountToken
+                                  data to project
+                                properties:
+                                  audience:
+                                    description: Audience is the intended audience
+                                      of the token. A recipient of a token must identify
+                                      itself with an identifier specified in the audience
+                                      of the token, and otherwise should reject the
+                                      token. The audience defaults to the identifier
+                                      of the apiserver.
+                                    type: string
+                                  expirationSeconds:
+                                    description: ExpirationSeconds is the requested
+                                      duration of validity of the service account
+                                      token. As the token approaches expiration, the
+                                      kubelet volume plugin will proactively rotate
+                                      the service account token. The kubelet will
+                                      start trying to rotate the token if the token
+                                      is older than 80 percent of its time to live
+                                      or if the token is older than 24 hours.Defaults
+                                      to 1 hour and must be at least 10 minutes.
+                                    format: int64
+                                    type: integer
+                                  path:
+                                    description: Path is the path relative to the
+                                      mount point of the file to project the token
+                                      into.
+                                    type: string
+                                required:
+                                - path
+                                type: object
                             type: object
                           type: array
                       required:
-                      - nodeSelectorTerms
+                      - sources
                       type: object
-                  type: object
-                podAffinity:
-                  description: Describes pod affinity scheduling rules (e.g. co-locate
-                    this pod in the same node, zone, etc. as some other pod(s)).
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node has pods which matches the corresponding podAffinityTerm;
-                        the node(s) with the highest sum are the most preferred.
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            format: int32
-                            type: integer
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to a pod label update), the system may or may not
-                        try to eventually evict the pod from its node. When there
-                        are multiple elements, the lists of nodes corresponding to
-                        each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            items:
-                              type: string
-                            type: array
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-                        required:
-                        - topologyKey
-                        type: object
-                      type: array
-                  type: object
-                podAntiAffinity:
-                  description: Describes pod anti-affinity scheduling rules (e.g.
-                    avoid putting this pod in the same node, zone, etc. as some other
-                    pod(s)).
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the anti-affinity expressions specified by this
-                        field, but it may choose a node that violates one or more
-                        of the expressions. The node that is most preferred is the
-                        one with the greatest sum of weights, i.e. for each node that
-                        meets all of the scheduling requirements (resource request,
-                        requiredDuringScheduling anti-affinity expressions, etc.),
-                        compute a sum by iterating through the elements of this field
-                        and adding "weight" to the sum if the node has pods which
-                        matches the corresponding podAffinityTerm; the node(s) with
-                        the highest sum are the most preferred.
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            format: int32
-                            type: integer
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the anti-affinity requirements specified by
-                        this field are not met at scheduling time, the pod will not
-                        be scheduled onto the node. If the anti-affinity requirements
-                        specified by this field cease to be met at some point during
-                        pod execution (e.g. due to a pod label update), the system
-                        may or may not try to eventually evict the pod from its node.
-                        When there are multiple elements, the lists of nodes corresponding
-                        to each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            items:
-                              type: string
-                            type: array
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-                        required:
-                        - topologyKey
-                        type: object
-                      type: array
-                  type: object
-              type: object
-            clusterMasterRef:
-              description: ClusterMasterRef refers to a Splunk Enterprise indexer
-                cluster managed by the operator within Kubernetes
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            defaults:
-              description: Inline map of default.yml overrides used to initialize
-                the environment
-              type: string
-            defaultsUrl:
-              description: Full path or URL for one or more default.yml files, separated
-                by commas
-              type: string
-            ephemeralStorage:
-              description: If true, ephemeral (emptyDir) storage will be used for
-                /opt/splunk/etc and /opt/splunk/var volumes
-              type: boolean
-            etcStorage:
-              description: Storage capacity to request for /opt/splunk/etc persistent
-                volume claims (default=”1Gi”)
-              type: string
-            image:
-              description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
-                environment variables)
-              type: string
-            imagePullPolicy:
-              description: 'Sets pull policy for all images (either “Always” or the
-                default: “IfNotPresent”)'
-              enum:
-              - Always
-              - IfNotPresent
-              type: string
-            licenseMasterRef:
-              description: LicenseMasterRef refers to a Splunk Enterprise license
-                master managed by the operator within Kubernetes
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            licenseUrl:
-              description: Full path or URL for a Splunk Enterprise license file
-              type: string
-            replicas:
-              description: Number of search head pods; a search head cluster will
-                be created if > 1
-              format: int32
-              type: integer
-            resources:
-              description: resource requirements for the pod containers
-              properties:
-                limits:
-                  additionalProperties:
-                    type: string
-                  description: 'Limits describes the maximum amount of compute resources
-                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                requests:
-                  additionalProperties:
-                    type: string
-                  description: 'Requests describes the minimum amount of compute resources
-                    required. If Requests is omitted for a container, it defaults
-                    to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-              type: object
-            schedulerName:
-              description: Name of Scheduler to use for pod placement (defaults to
-                “default-scheduler”)
-              type: string
-            serviceTemplate:
-              description: ServiceTemplate is a template used to create Kubernetes
-                services
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                    of an object. Servers should convert recognized schemas to the
-                    latest internal value, and may reject unrecognized values. More
-                    info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource
-                    this object represents. Servers may infer this from the endpoint
-                    the client submits requests to. Cannot be updated. In CamelCase.
-                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                  type: object
-                spec:
-                  description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                  properties:
-                    clusterIP:
-                      description: 'clusterIP is the IP address of the service and
-                        is usually assigned randomly by the master. If an address
-                        is specified manually and is not in use by others, it will
-                        be allocated to the service; otherwise, creation of the service
-                        will fail. This field can not be changed through updates.
-                        Valid values are "None", empty string (""), or a valid IP
-                        address. "None" can be specified for headless services when
-                        proxying is not required. Only applies to types ClusterIP,
-                        NodePort, and LoadBalancer. Ignored if type is ExternalName.
-                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                      type: string
-                    externalIPs:
-                      description: externalIPs is a list of IP addresses for which
-                        nodes in the cluster will also accept traffic for this service.  These
-                        IPs are not managed by Kubernetes.  The user is responsible
-                        for ensuring that traffic arrives at a node with this IP.  A
-                        common example is external load-balancers that are not part
-                        of the Kubernetes system.
-                      items:
-                        type: string
-                      type: array
-                    externalName:
-                      description: externalName is the external reference that kubedns
-                        or equivalent will return as a CNAME record for this service.
-                        No proxying will be involved. Must be a valid RFC-1123 hostname
-                        (https://tools.ietf.org/html/rfc1123) and requires Type to
-                        be ExternalName.
-                      type: string
-                    externalTrafficPolicy:
-                      description: externalTrafficPolicy denotes if this Service desires
-                        to route external traffic to node-local or cluster-wide endpoints.
-                        "Local" preserves the client source IP and avoids a second
-                        hop for LoadBalancer and Nodeport type services, but risks
-                        potentially imbalanced traffic spreading. "Cluster" obscures
-                        the client source IP and may cause a second hop to another
-                        node, but should have good overall load-spreading.
-                      type: string
-                    healthCheckNodePort:
-                      description: healthCheckNodePort specifies the healthcheck nodePort
-                        for the service. If not specified, HealthCheckNodePort is
-                        created by the service api backend with the allocated nodePort.
-                        Will use user-specified nodePort value if specified by the
-                        client. Only effects when Type is set to LoadBalancer and
-                        ExternalTrafficPolicy is set to Local.
-                      format: int32
-                      type: integer
-                    ipFamily:
-                      description: ipFamily specifies whether this Service has a preference
-                        for a particular IP family (e.g. IPv4 vs. IPv6).  If a specific
-                        IP family is requested, the clusterIP field will be allocated
-                        from that family, if it is available in the cluster.  If no
-                        IP family is requested, the cluster's primary IP family will
-                        be used. Other IP fields (loadBalancerIP, loadBalancerSourceRanges,
-                        externalIPs) and controllers which allocate external load-balancers
-                        should use the same IP family.  Endpoints for this Service
-                        will be of this family.  This field is immutable after creation.
-                        Assigning a ServiceIPFamily not available in the cluster (e.g.
-                        IPv6 in IPv4 only cluster) is an error condition and will
-                        fail during clusterIP assignment.
-                      type: string
-                    loadBalancerIP:
-                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                        will get created with the IP specified in this field. This
-                        feature depends on whether the underlying cloud-provider supports
-                        specifying the loadBalancerIP when a load balancer is created.
-                        This field will be ignored if the cloud-provider does not
-                        support the feature.'
-                      type: string
-                    loadBalancerSourceRanges:
-                      description: 'If specified and supported by the platform, this
-                        will restrict traffic through the cloud-provider load-balancer
-                        will be restricted to the specified client IPs. This field
-                        will be ignored if the cloud-provider does not support the
-                        feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
-                      items:
-                        type: string
-                      type: array
-                    ports:
-                      description: 'The list of ports that are exposed by this service.
-                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                      items:
-                        description: ServicePort contains information on service's
-                          port.
-                        properties:
-                          name:
-                            description: The name of this port within the service.
-                              This must be a DNS_LABEL. All ports within a ServiceSpec
-                              must have unique names. When considering the endpoints
-                              for a Service, this must match the 'name' field in the
-                              EndpointPort. Optional if only one ServicePort is defined
-                              on this service.
-                            type: string
-                          nodePort:
-                            description: 'The port on each node on which this service
-                              is exposed when type=NodePort or LoadBalancer. Usually
-                              assigned by the system. If specified, it will be allocated
-                              to the service if unused or else creation of the service
-                              will fail. Default is to auto-allocate a port if the
-                              ServiceType of this Service requires one. More info:
-                              https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
-                            format: int32
-                            type: integer
-                          port:
-                            description: The port that will be exposed by this service.
-                            format: int32
-                            type: integer
-                          protocol:
-                            description: The IP protocol for this port. Supports "TCP",
-                              "UDP", and "SCTP". Default is TCP.
-                            type: string
-                          targetPort:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: 'Number or name of the port to access on
-                              the pods targeted by the service. Number must be in
-                              the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                              If this is a string, it will be looked up as a named
-                              port in the target Pod''s container ports. If this is
-                              not specified, the value of the ''port'' field is used
-                              (an identity map). This field is ignored for services
-                              with clusterIP=None, and should be omitted or set equal
-                              to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
-                            x-kubernetes-int-or-string: true
-                        required:
-                        - port
-                        type: object
-                      type: array
-                    publishNotReadyAddresses:
-                      description: publishNotReadyAddresses, when set to true, indicates
-                        that DNS implementations must publish the notReadyAddresses
-                        of subsets for the Endpoints associated with the Service.
-                        The default value is false. The primary use case for setting
-                        this field is to use a StatefulSet's Headless Service to propagate
-                        SRV records for its Pods without respect to their readiness
-                        for purpose of peer discovery.
-                      type: boolean
-                    selector:
-                      additionalProperties:
-                        type: string
-                      description: 'Route service traffic to pods with label keys
-                        and values matching this selector. If empty or not present,
-                        the service is assumed to have an external process managing
-                        its endpoints, which Kubernetes will not modify. Only applies
-                        to types ClusterIP, NodePort, and LoadBalancer. Ignored if
-                        type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
-                      type: object
-                    sessionAffinity:
-                      description: 'Supports "ClientIP" and "None". Used to maintain
-                        session affinity. Enable client IP based session affinity.
-                        Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                      type: string
-                    sessionAffinityConfig:
-                      description: sessionAffinityConfig contains the configurations
-                        of session affinity.
+                    quobyte:
+                      description: Quobyte represents a Quobyte mount on the host
+                        that shares a pod's lifetime
                       properties:
-                        clientIP:
-                          description: clientIP contains the configurations of Client
-                            IP based session affinity.
-                          properties:
-                            timeoutSeconds:
-                              description: timeoutSeconds specifies the seconds of
-                                ClientIP type session sticky time. The value must
-                                be >0 && <=86400(for 1 day) if ServiceAffinity ==
-                                "ClientIP". Default value is 10800(for 3 hours).
-                              format: int32
-                              type: integer
-                          type: object
+                        group:
+                          description: Group to map volume access to Default is no
+                            group
+                          type: string
+                        readOnly:
+                          description: ReadOnly here will force the Quobyte volume
+                            to be mounted with read-only permissions. Defaults to
+                            false.
+                          type: boolean
+                        registry:
+                          description: Registry represents a single or multiple Quobyte
+                            Registry services specified as a string as host:port pair
+                            (multiple entries are separated with commas) which acts
+                            as the central registry for volumes
+                          type: string
+                        tenant:
+                          description: Tenant owning the given Quobyte volume in the
+                            Backend Used with dynamically provisioned Quobyte volumes,
+                            value is set by the plugin
+                          type: string
+                        user:
+                          description: User to map volume access to Defaults to serivceaccount
+                            user
+                          type: string
+                        volume:
+                          description: Volume is a string that references an already
+                            created Quobyte volume by name.
+                          type: string
+                      required:
+                      - registry
+                      - volume
                       type: object
-                    type:
-                      description: 'type determines how the Service is exposed. Defaults
-                        to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort,
-                        and LoadBalancer. "ExternalName" maps to the specified externalName.
-                        "ClusterIP" allocates a cluster-internal IP address for load-balancing
-                        to endpoints. Endpoints are determined by the selector or
-                        if that is not specified, by manual construction of an Endpoints
-                        object. If clusterIP is "None", no virtual IP is allocated
-                        and the endpoints are published as a set of endpoints rather
-                        than a stable IP. "NodePort" builds on ClusterIP and allocates
-                        a port on every node which routes to the clusterIP. "LoadBalancer"
-                        builds on NodePort and creates an external load-balancer (if
-                        supported in the current cloud) which routes to the clusterIP.
-                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
-                      type: string
-                  type: object
-                status:
-                  description: 'Most recently observed status of the service. Populated
-                    by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-                  properties:
-                    loadBalancer:
-                      description: LoadBalancer contains the current status of the
-                        load-balancer, if one is present.
+                    rbd:
+                      description: 'RBD represents a Rados Block Device mount on the
+                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                       properties:
-                        ingress:
-                          description: Ingress is a list containing ingress points
-                            for the load-balancer. Traffic intended for the service
-                            should be sent to these ingress points.
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        image:
+                          description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        keyring:
+                          description: 'Keyring is the path to key ring for RBDUser.
+                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        monitors:
+                          description: 'A collection of Ceph monitors. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           items:
-                            description: 'LoadBalancerIngress represents the status
-                              of a load-balancer ingress point: traffic intended for
-                              the service should be sent to an ingress point.'
+                            type: string
+                          type: array
+                        pool:
+                          description: 'The rados pool name. Default is rbd. More
+                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: boolean
+                        secretRef:
+                          description: 'SecretRef is name of the authentication secret
+                            for RBDUser. If provided overrides keyring. Default is
+                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        user:
+                          description: 'The rados user name. Default is admin. More
+                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                      required:
+                      - image
+                      - monitors
+                      type: object
+                    scaleIO:
+                      description: ScaleIO represents a ScaleIO persistent volume
+                        attached and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Default is "xfs".
+                          type: string
+                        gateway:
+                          description: The host address of the ScaleIO API Gateway.
+                          type: string
+                        protectionDomain:
+                          description: The name of the ScaleIO Protection Domain for
+                            the configured storage.
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: SecretRef references to the secret for ScaleIO
+                            user and other sensitive information. If this is not provided,
+                            Login operation will fail.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        sslEnabled:
+                          description: Flag to enable/disable SSL communication with
+                            Gateway, default false
+                          type: boolean
+                        storageMode:
+                          description: Indicates whether the storage for a volume
+                            should be ThickProvisioned or ThinProvisioned. Default
+                            is ThinProvisioned.
+                          type: string
+                        storagePool:
+                          description: The ScaleIO Storage Pool associated with the
+                            protection domain.
+                          type: string
+                        system:
+                          description: The name of the storage system as configured
+                            in ScaleIO.
+                          type: string
+                        volumeName:
+                          description: The name of a volume already created in the
+                            ScaleIO system that is associated with this volume source.
+                          type: string
+                      required:
+                      - gateway
+                      - secretRef
+                      - system
+                      type: object
+                    secret:
+                      description: 'Secret represents a secret that should populate
+                        this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                      properties:
+                        defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default. Must be a value between 0 and 0777. Defaults
+                            to 0644. Directories within the path are not affected
+                            by this setting. This might be in conflict with other
+                            options that affect the file mode, like fsGroup, and the
+                            result can be other mode bits set.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: If unspecified, each key-value pair in the
+                            Data field of the referenced Secret will be projected
+                            into the volume as a file whose name is the key and content
+                            is the value. If specified, the listed keys will be projected
+                            into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in
+                            the Secret, the volume setup will error unless it is marked
+                            optional. Paths must be relative and may not contain the
+                            '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
                             properties:
-                              hostname:
-                                description: Hostname is set for load-balancer ingress
-                                  points that are DNS based (typically AWS load-balancers)
+                              key:
+                                description: The key to project.
                                 type: string
-                              ip:
-                                description: IP is set for load-balancer ingress points
-                                  that are IP based (typically GCE or OpenStack load-balancers)
+                              mode:
+                                description: 'Optional: mode bits to use on this file,
+                                  must be a value between 0 and 0777. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: The relative path of the file to map
+                                  the key to. May not be an absolute path. May not
+                                  contain the path element '..'. May not start with
+                                  the string '..'.
                                 type: string
+                            required:
+                            - key
+                            - path
                             type: object
                           type: array
+                        optional:
+                          description: Specify whether the Secret or its keys must
+                            be defined
+                          type: boolean
+                        secretName:
+                          description: 'Name of the secret in the pod''s namespace
+                            to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                          type: string
                       type: object
+                    storageos:
+                      description: StorageOS represents a StorageOS volume attached
+                        and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: SecretRef specifies the secret to use for obtaining
+                            the StorageOS API credentials.  If not specified, default
+                            values will be attempted.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        volumeName:
+                          description: VolumeName is the human-readable name of the
+                            StorageOS volume.  Volume names are only unique within
+                            a namespace.
+                          type: string
+                        volumeNamespace:
+                          description: VolumeNamespace specifies the scope of the
+                            volume within StorageOS.  If no namespace is specified
+                            then the Pod's namespace will be used.  This allows the
+                            Kubernetes name scoping to be mirrored within StorageOS
+                            for tighter integration. Set VolumeName to any name to
+                            override the default behaviour. Set to "default" if you
+                            are not using namespaces within StorageOS. Namespaces
+                            that do not pre-exist within StorageOS will be created.
+                          type: string
+                      type: object
+                    vsphereVolume:
+                      description: VsphereVolume represents a vSphere volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        storagePolicyID:
+                          description: Storage Policy Based Management (SPBM) profile
+                            ID associated with the StoragePolicyName.
+                          type: string
+                        storagePolicyName:
+                          description: Storage Policy Based Management (SPBM) profile
+                            name.
+                          type: string
+                        volumePath:
+                          description: Path that identifies vSphere volume vmdk
+                          type: string
+                      required:
+                      - volumePath
+                      type: object
+                  required:
+                  - name
                   type: object
-              type: object
-            sparkImage:
-              description: Image to use for Spark pod containers (overrides RELATED_IMAGE_SPLUNK_SPARK
-                environment variables)
-              type: string
-            sparkRef:
-              description: SparkRef refers to a Spark cluster managed by the operator
-                within Kubernetes When defined, Data Fabric Search (DFS) will be enabled
-                and configured to use the Spark cluster.
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            storageClassName:
-              description: Name of StorageClass to use for persistent volume claims
-              type: string
-            tolerations:
-              description: Pod's tolerations for Kubernetes node's taint
-              items:
-                description: The pod this Toleration is attached to tolerates any
-                  taint that matches the triple <key,value,effect> using the matching
-                  operator <operator>.
-                properties:
-                  effect:
-                    description: Effect indicates the taint effect to match. Empty
-                      means match all taint effects. When specified, allowed values
-                      are NoSchedule, PreferNoSchedule and NoExecute.
-                    type: string
-                  key:
-                    description: Key is the taint key that the toleration applies
-                      to. Empty means match all taint keys. If the key is empty, operator
-                      must be Exists; this combination means to match all values and
-                      all keys.
-                    type: string
-                  operator:
-                    description: Operator represents a key's relationship to the value.
-                      Valid operators are Exists and Equal. Defaults to Equal. Exists
-                      is equivalent to wildcard for value, so that a pod can tolerate
-                      all taints of a particular category.
-                    type: string
-                  tolerationSeconds:
-                    description: TolerationSeconds represents the period of time the
-                      toleration (which must be of effect NoExecute, otherwise this
-                      field is ignored) tolerates the taint. By default, it is not
-                      set, which means tolerate the taint forever (do not evict).
-                      Zero and negative values will be treated as 0 (evict immediately)
-                      by the system.
-                    format: int64
-                    type: integer
-                  value:
-                    description: Value is the taint value the toleration matches to.
-                      If the operator is Exists, the value should be empty, otherwise
-                      just a regular string.
-                    type: string
-                type: object
-              type: array
-            varStorage:
-              description: Storage capacity to request for /opt/splunk/var persistent
-                volume claims (default=”50Gi”)
-              type: string
-            volumes:
-              description: List of one or more Kubernetes volumes. These will be mounted
-                in all pod containers as as /mnt/<name>
-              items:
-                description: Volume represents a named volume in a pod that may be
-                  accessed by any container in the pod.
-                properties:
-                  awsElasticBlockStore:
-                    description: 'AWSElasticBlockStore represents an AWS Disk resource
-                      that is attached to a kubelet''s host machine and then exposed
-                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      partition:
-                        description: 'The partition in the volume that you want to
-                          mount. If omitted, the default is to mount by volume name.
-                          Examples: For volume /dev/sda1, you specify the partition
-                          as "1". Similarly, the volume partition for /dev/sda is
-                          "0" (or you can leave the property empty).'
-                        format: int32
-                        type: integer
-                      readOnly:
-                        description: 'Specify "true" to force and set the ReadOnly
-                          property in VolumeMounts to "true". If omitted, the default
-                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                        type: boolean
-                      volumeID:
-                        description: 'Unique ID of the persistent disk resource in
-                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  azureDisk:
-                    description: AzureDisk represents an Azure Data Disk mount on
-                      the host and bind mount to the pod.
-                    properties:
-                      cachingMode:
-                        description: 'Host Caching mode: None, Read Only, Read Write.'
-                        type: string
-                      diskName:
-                        description: The Name of the data disk in the blob storage
-                        type: string
-                      diskURI:
-                        description: The URI the data disk in the blob storage
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      kind:
-                        description: 'Expected values Shared: multiple blob disks
-                          per storage account  Dedicated: single blob disk per storage
-                          account  Managed: azure managed data disk (only in managed
-                          availability set). defaults to shared'
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                    required:
-                    - diskName
-                    - diskURI
-                    type: object
-                  azureFile:
-                    description: AzureFile represents an Azure File Service mount
-                      on the host and bind mount to the pod.
-                    properties:
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretName:
-                        description: the name of secret that contains Azure Storage
-                          Account Name and Key
-                        type: string
-                      shareName:
-                        description: Share Name
-                        type: string
-                    required:
-                    - secretName
-                    - shareName
-                    type: object
-                  cephfs:
-                    description: CephFS represents a Ceph FS mount on the host that
-                      shares a pod's lifetime
-                    properties:
-                      monitors:
-                        description: 'Required: Monitors is a collection of Ceph monitors
-                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        items:
-                          type: string
-                        type: array
-                      path:
-                        description: 'Optional: Used as the mounted root, rather than
-                          the full Ceph tree, default is /'
-                        type: string
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts. More
-                          info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: boolean
-                      secretFile:
-                        description: 'Optional: SecretFile is the path to key ring
-                          for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: string
-                      secretRef:
-                        description: 'Optional: SecretRef is reference to the authentication
-                          secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      user:
-                        description: 'Optional: User is the rados user name, default
-                          is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: string
-                    required:
-                    - monitors
-                    type: object
-                  cinder:
-                    description: 'Cinder represents a cinder volume attached and mounted
-                      on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Examples: "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: string
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts. More
-                          info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: boolean
-                      secretRef:
-                        description: 'Optional: points to a secret object containing
-                          parameters used to connect to OpenStack.'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      volumeID:
-                        description: 'volume id used to identify the volume in cinder.
-                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  configMap:
-                    description: ConfigMap represents a configMap that should populate
-                      this volume
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: If unspecified, each key-value pair in the Data
-                          field of the referenced ConfigMap will be projected into
-                          the volume as a file whose name is the key and content is
-                          the value. If specified, the listed keys will be projected
-                          into the specified paths, and unlisted keys will not be
-                          present. If a key is specified which is not present in the
-                          ConfigMap, the volume setup will error unless it is marked
-                          optional. Paths must be relative and may not contain the
-                          '..' path or start with '..'.
-                        items:
-                          description: Maps a string key to a path within a volume.
-                          properties:
-                            key:
-                              description: The key to project.
-                              type: string
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: The relative path of the file to map the
-                                key to. May not be an absolute path. May not contain
-                                the path element '..'. May not start with the string
-                                '..'.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          type: object
-                        type: array
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
-                        type: string
-                      optional:
-                        description: Specify whether the ConfigMap or its keys must
-                          be defined
-                        type: boolean
-                    type: object
-                  csi:
-                    description: CSI (Container Storage Interface) represents storage
-                      that is handled by an external CSI driver (Alpha feature).
-                    properties:
-                      driver:
-                        description: Driver is the name of the CSI driver that handles
-                          this volume. Consult with your admin for the correct name
-                          as registered in the cluster.
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Ex. "ext4", "xfs",
-                          "ntfs". If not provided, the empty value is passed to the
-                          associated CSI driver which will determine the default filesystem
-                          to apply.
-                        type: string
-                      nodePublishSecretRef:
-                        description: NodePublishSecretRef is a reference to the secret
-                          object containing sensitive information to pass to the CSI
-                          driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
-                          calls. This field is optional, and  may be empty if no secret
-                          is required. If the secret object contains more than one
-                          secret, all secret references are passed.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      readOnly:
-                        description: Specifies a read-only configuration for the volume.
-                          Defaults to false (read/write).
-                        type: boolean
-                      volumeAttributes:
-                        additionalProperties:
-                          type: string
-                        description: VolumeAttributes stores driver-specific properties
-                          that are passed to the CSI driver. Consult your driver's
-                          documentation for supported values.
-                        type: object
-                    required:
-                    - driver
-                    type: object
-                  downwardAPI:
-                    description: DownwardAPI represents downward API about the pod
-                      that should populate this volume
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: Items is a list of downward API volume file
-                        items:
-                          description: DownwardAPIVolumeFile represents information
-                            to create the file containing the pod field
-                          properties:
-                            fieldRef:
-                              description: 'Required: Selects a field of the pod:
-                                only annotations, labels, name and namespace are supported.'
-                              properties:
-                                apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
-                                  type: string
-                                fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
-                                  type: string
-                              required:
-                              - fieldPath
-                              type: object
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: 'Required: Path is  the relative path name
-                                of the file to be created. Must not be absolute or
-                                contain the ''..'' path. Must be utf-8 encoded. The
-                                first item of the relative path must not start with
-                                ''..'''
-                              type: string
-                            resourceFieldRef:
-                              description: 'Selects a resource of the container: only
-                                resources limits and requests (limits.cpu, limits.memory,
-                                requests.cpu and requests.memory) are currently supported.'
-                              properties:
-                                containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
-                                  type: string
-                                divisor:
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
-                                  type: string
-                                resource:
-                                  description: 'Required: resource to select'
-                                  type: string
-                              required:
-                              - resource
-                              type: object
-                          required:
-                          - path
-                          type: object
-                        type: array
-                    type: object
-                  emptyDir:
-                    description: 'EmptyDir represents a temporary directory that shares
-                      a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                    properties:
-                      medium:
-                        description: 'What type of storage medium should back this
-                          directory. The default is "" which means to use the node''s
-                          default medium. Must be an empty string (default) or Memory.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                        type: string
-                      sizeLimit:
-                        description: 'Total amount of local storage required for this
-                          EmptyDir volume. The size limit is also applicable for memory
-                          medium. The maximum usage on memory medium EmptyDir would
-                          be the minimum value between the SizeLimit specified here
-                          and the sum of memory limits of all containers in a pod.
-                          The default is nil which means that the limit is undefined.
-                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                        type: string
-                    type: object
-                  fc:
-                    description: FC represents a Fibre Channel resource that is attached
-                      to a kubelet's host machine and then exposed to the pod.
-                    properties:
-                      fsType:
-                        description: 'Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      lun:
-                        description: 'Optional: FC target lun number'
-                        format: int32
-                        type: integer
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts.'
-                        type: boolean
-                      targetWWNs:
-                        description: 'Optional: FC target worldwide names (WWNs)'
-                        items:
-                          type: string
-                        type: array
-                      wwids:
-                        description: 'Optional: FC volume world wide identifiers (wwids)
-                          Either wwids or combination of targetWWNs and lun must be
-                          set, but not both simultaneously.'
-                        items:
-                          type: string
-                        type: array
-                    type: object
-                  flexVolume:
-                    description: FlexVolume represents a generic volume resource that
-                      is provisioned/attached using an exec based plugin.
-                    properties:
-                      driver:
-                        description: Driver is the name of the driver to use for this
-                          volume.
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". The default filesystem depends on FlexVolume
-                          script.
-                        type: string
-                      options:
-                        additionalProperties:
-                          type: string
-                        description: 'Optional: Extra command options if any.'
-                        type: object
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts.'
-                        type: boolean
-                      secretRef:
-                        description: 'Optional: SecretRef is reference to the secret
-                          object containing sensitive information to pass to the plugin
-                          scripts. This may be empty if no secret object is specified.
-                          If the secret object contains more than one secret, all
-                          secrets are passed to the plugin scripts.'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                    required:
-                    - driver
-                    type: object
-                  flocker:
-                    description: Flocker represents a Flocker volume attached to a
-                      kubelet's host machine. This depends on the Flocker control
-                      service being running
-                    properties:
-                      datasetName:
-                        description: Name of the dataset stored as metadata -> name
-                          on the dataset for Flocker should be considered as deprecated
-                        type: string
-                      datasetUUID:
-                        description: UUID of the dataset. This is unique identifier
-                          of a Flocker dataset
-                        type: string
-                    type: object
-                  gcePersistentDisk:
-                    description: 'GCEPersistentDisk represents a GCE Disk resource
-                      that is attached to a kubelet''s host machine and then exposed
-                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      partition:
-                        description: 'The partition in the volume that you want to
-                          mount. If omitted, the default is to mount by volume name.
-                          Examples: For volume /dev/sda1, you specify the partition
-                          as "1". Similarly, the volume partition for /dev/sda is
-                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        format: int32
-                        type: integer
-                      pdName:
-                        description: 'Unique name of the PD resource in GCE. Used
-                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        type: boolean
-                    required:
-                    - pdName
-                    type: object
-                  gitRepo:
-                    description: 'GitRepo represents a git repository at a particular
-                      revision. DEPRECATED: GitRepo is deprecated. To provision a
-                      container with a git repo, mount an EmptyDir into an InitContainer
-                      that clones the repo using git, then mount the EmptyDir into
-                      the Pod''s container.'
-                    properties:
-                      directory:
-                        description: Target directory name. Must not contain or start
-                          with '..'.  If '.' is supplied, the volume directory will
-                          be the git repository.  Otherwise, if specified, the volume
-                          will contain the git repository in the subdirectory with
-                          the given name.
-                        type: string
-                      repository:
-                        description: Repository URL
-                        type: string
-                      revision:
-                        description: Commit hash for the specified revision.
-                        type: string
-                    required:
-                    - repository
-                    type: object
-                  glusterfs:
-                    description: 'Glusterfs represents a Glusterfs mount on the host
-                      that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
-                    properties:
-                      endpoints:
-                        description: 'EndpointsName is the endpoint name that details
-                          Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: string
-                      path:
-                        description: 'Path is the Glusterfs volume path. More info:
-                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the Glusterfs volume
-                          to be mounted with read-only permissions. Defaults to false.
-                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: boolean
-                    required:
-                    - endpoints
-                    - path
-                    type: object
-                  hostPath:
-                    description: 'HostPath represents a pre-existing file or directory
-                      on the host machine that is directly exposed to the container.
-                      This is generally used for system agents or other privileged
-                      things that are allowed to see the host machine. Most containers
-                      will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                      --- TODO(jonesdl) We need to restrict who can use host directory
-                      mounts and who can/can not mount host directories as read/write.'
-                    properties:
-                      path:
-                        description: 'Path of the directory on the host. If the path
-                          is a symlink, it will follow the link to the real path.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                        type: string
-                      type:
-                        description: 'Type for HostPath Volume Defaults to "" More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                        type: string
-                    required:
-                    - path
-                    type: object
-                  iscsi:
-                    description: 'ISCSI represents an ISCSI Disk resource that is
-                      attached to a kubelet''s host machine and then exposed to the
-                      pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
-                    properties:
-                      chapAuthDiscovery:
-                        description: whether support iSCSI Discovery CHAP authentication
-                        type: boolean
-                      chapAuthSession:
-                        description: whether support iSCSI Session CHAP authentication
-                        type: boolean
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      initiatorName:
-                        description: Custom iSCSI Initiator Name. If initiatorName
-                          is specified with iscsiInterface simultaneously, new iSCSI
-                          interface <target portal>:<volume name> will be created
-                          for the connection.
-                        type: string
-                      iqn:
-                        description: Target iSCSI Qualified Name.
-                        type: string
-                      iscsiInterface:
-                        description: iSCSI Interface Name that uses an iSCSI transport.
-                          Defaults to 'default' (tcp).
-                        type: string
-                      lun:
-                        description: iSCSI Target Lun number.
-                        format: int32
-                        type: integer
-                      portals:
-                        description: iSCSI Target Portal List. The portal is either
-                          an IP or ip_addr:port if the port is other than default
-                          (typically TCP ports 860 and 3260).
-                        items:
-                          type: string
-                        type: array
-                      readOnly:
-                        description: ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false.
-                        type: boolean
-                      secretRef:
-                        description: CHAP Secret for iSCSI target and initiator authentication
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      targetPortal:
-                        description: iSCSI Target Portal. The Portal is either an
-                          IP or ip_addr:port if the port is other than default (typically
-                          TCP ports 860 and 3260).
-                        type: string
-                    required:
-                    - iqn
-                    - lun
-                    - targetPortal
-                    type: object
-                  name:
-                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
-                      the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  nfs:
-                    description: 'NFS represents an NFS mount on the host that shares
-                      a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                    properties:
-                      path:
-                        description: 'Path that is exported by the NFS server. More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the NFS export to be
-                          mounted with read-only permissions. Defaults to false. More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: boolean
-                      server:
-                        description: 'Server is the hostname or IP address of the
-                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: string
-                    required:
-                    - path
-                    - server
-                    type: object
-                  persistentVolumeClaim:
-                    description: 'PersistentVolumeClaimVolumeSource represents a reference
-                      to a PersistentVolumeClaim in the same namespace. More info:
-                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                    properties:
-                      claimName:
-                        description: 'ClaimName is the name of a PersistentVolumeClaim
-                          in the same namespace as the pod using this volume. More
-                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                        type: string
-                      readOnly:
-                        description: Will force the ReadOnly setting in VolumeMounts.
-                          Default false.
-                        type: boolean
-                    required:
-                    - claimName
-                    type: object
-                  photonPersistentDisk:
-                    description: PhotonPersistentDisk represents a PhotonController
-                      persistent disk attached and mounted on kubelets host machine
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      pdID:
-                        description: ID that identifies Photon Controller persistent
-                          disk
-                        type: string
-                    required:
-                    - pdID
-                    type: object
-                  portworxVolume:
-                    description: PortworxVolume represents a portworx volume attached
-                      and mounted on kubelets host machine
-                    properties:
-                      fsType:
-                        description: FSType represents the filesystem type to mount
-                          Must be a filesystem type supported by the host operating
-                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                          if unspecified.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      volumeID:
-                        description: VolumeID uniquely identifies a Portworx volume
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  projected:
-                    description: Items for all in one resources secrets, configmaps,
-                      and downward API
-                    properties:
-                      defaultMode:
-                        description: Mode bits to use on created files by default.
-                          Must be a value between 0 and 0777. Directories within the
-                          path are not affected by this setting. This might be in
-                          conflict with other options that affect the file mode, like
-                          fsGroup, and the result can be other mode bits set.
-                        format: int32
-                        type: integer
-                      sources:
-                        description: list of volume projections
-                        items:
-                          description: Projection that may be projected along with
-                            other supported volume types
-                          properties:
-                            configMap:
-                              description: information about the configMap data to
-                                project
-                              properties:
-                                items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced ConfigMap
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the ConfigMap, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
-                                  items:
-                                    description: Maps a string key to a path within
-                                      a volume.
-                                    properties:
-                                      key:
-                                        description: The key to project.
-                                        type: string
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap or its
-                                    keys must be defined
-                                  type: boolean
-                              type: object
-                            downwardAPI:
-                              description: information about the downwardAPI data
-                                to project
-                              properties:
-                                items:
-                                  description: Items is a list of DownwardAPIVolume
-                                    file
-                                  items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
-                                    properties:
-                                      fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
-                                        properties:
-                                          apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
-                                            type: string
-                                          fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
-                                        type: string
-                                      resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, requests.cpu and requests.memory)
-                                          are currently supported.'
-                                        properties:
-                                          containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
-                                            type: string
-                                          divisor:
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
-                                            type: string
-                                          resource:
-                                            description: 'Required: resource to select'
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                    required:
-                                    - path
-                                    type: object
-                                  type: array
-                              type: object
-                            secret:
-                              description: information about the secret data to project
-                              properties:
-                                items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced Secret will
-                                    be projected into the volume as a file whose name
-                                    is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the Secret, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
-                                  items:
-                                    description: Maps a string key to a path within
-                                      a volume.
-                                    properties:
-                                      key:
-                                        description: The key to project.
-                                        type: string
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
-                                  type: boolean
-                              type: object
-                            serviceAccountToken:
-                              description: information about the serviceAccountToken
-                                data to project
-                              properties:
-                                audience:
-                                  description: Audience is the intended audience of
-                                    the token. A recipient of a token must identify
-                                    itself with an identifier specified in the audience
-                                    of the token, and otherwise should reject the
-                                    token. The audience defaults to the identifier
-                                    of the apiserver.
-                                  type: string
-                                expirationSeconds:
-                                  description: ExpirationSeconds is the requested
-                                    duration of validity of the service account token.
-                                    As the token approaches expiration, the kubelet
-                                    volume plugin will proactively rotate the service
-                                    account token. The kubelet will start trying to
-                                    rotate the token if the token is older than 80
-                                    percent of its time to live or if the token is
-                                    older than 24 hours.Defaults to 1 hour and must
-                                    be at least 10 minutes.
-                                  format: int64
-                                  type: integer
-                                path:
-                                  description: Path is the path relative to the mount
-                                    point of the file to project the token into.
-                                  type: string
-                              required:
-                              - path
-                              type: object
-                          type: object
-                        type: array
-                    required:
-                    - sources
-                    type: object
-                  quobyte:
-                    description: Quobyte represents a Quobyte mount on the host that
-                      shares a pod's lifetime
-                    properties:
-                      group:
-                        description: Group to map volume access to Default is no group
-                        type: string
-                      readOnly:
-                        description: ReadOnly here will force the Quobyte volume to
-                          be mounted with read-only permissions. Defaults to false.
-                        type: boolean
-                      registry:
-                        description: Registry represents a single or multiple Quobyte
-                          Registry services specified as a string as host:port pair
-                          (multiple entries are separated with commas) which acts
-                          as the central registry for volumes
-                        type: string
-                      tenant:
-                        description: Tenant owning the given Quobyte volume in the
-                          Backend Used with dynamically provisioned Quobyte volumes,
-                          value is set by the plugin
-                        type: string
-                      user:
-                        description: User to map volume access to Defaults to serivceaccount
-                          user
-                        type: string
-                      volume:
-                        description: Volume is a string that references an already
-                          created Quobyte volume by name.
-                        type: string
-                    required:
-                    - registry
-                    - volume
-                    type: object
-                  rbd:
-                    description: 'RBD represents a Rados Block Device mount on the
-                      host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      image:
-                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      keyring:
-                        description: 'Keyring is the path to key ring for RBDUser.
-                          Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      monitors:
-                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        items:
-                          type: string
-                        type: array
-                      pool:
-                        description: 'The rados pool name. Default is rbd. More info:
-                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: boolean
-                      secretRef:
-                        description: 'SecretRef is name of the authentication secret
-                          for RBDUser. If provided overrides keyring. Default is nil.
-                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      user:
-                        description: 'The rados user name. Default is admin. More
-                          info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                    required:
-                    - image
-                    - monitors
-                    type: object
-                  scaleIO:
-                    description: ScaleIO represents a ScaleIO persistent volume attached
-                      and mounted on Kubernetes nodes.
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Default is "xfs".
-                        type: string
-                      gateway:
-                        description: The host address of the ScaleIO API Gateway.
-                        type: string
-                      protectionDomain:
-                        description: The name of the ScaleIO Protection Domain for
-                          the configured storage.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretRef:
-                        description: SecretRef references to the secret for ScaleIO
-                          user and other sensitive information. If this is not provided,
-                          Login operation will fail.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      sslEnabled:
-                        description: Flag to enable/disable SSL communication with
-                          Gateway, default false
-                        type: boolean
-                      storageMode:
-                        description: Indicates whether the storage for a volume should
-                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
-                        type: string
-                      storagePool:
-                        description: The ScaleIO Storage Pool associated with the
-                          protection domain.
-                        type: string
-                      system:
-                        description: The name of the storage system as configured
-                          in ScaleIO.
-                        type: string
-                      volumeName:
-                        description: The name of a volume already created in the ScaleIO
-                          system that is associated with this volume source.
-                        type: string
-                    required:
-                    - gateway
-                    - secretRef
-                    - system
-                    type: object
-                  secret:
-                    description: 'Secret represents a secret that should populate
-                      this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: If unspecified, each key-value pair in the Data
-                          field of the referenced Secret will be projected into the
-                          volume as a file whose name is the key and content is the
-                          value. If specified, the listed keys will be projected into
-                          the specified paths, and unlisted keys will not be present.
-                          If a key is specified which is not present in the Secret,
-                          the volume setup will error unless it is marked optional.
-                          Paths must be relative and may not contain the '..' path
-                          or start with '..'.
-                        items:
-                          description: Maps a string key to a path within a volume.
-                          properties:
-                            key:
-                              description: The key to project.
-                              type: string
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: The relative path of the file to map the
-                                key to. May not be an absolute path. May not contain
-                                the path element '..'. May not start with the string
-                                '..'.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          type: object
-                        type: array
-                      optional:
-                        description: Specify whether the Secret or its keys must be
-                          defined
-                        type: boolean
-                      secretName:
-                        description: 'Name of the secret in the pod''s namespace to
-                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                        type: string
-                    type: object
-                  storageos:
-                    description: StorageOS represents a StorageOS volume attached
-                      and mounted on Kubernetes nodes.
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretRef:
-                        description: SecretRef specifies the secret to use for obtaining
-                          the StorageOS API credentials.  If not specified, default
-                          values will be attempted.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      volumeName:
-                        description: VolumeName is the human-readable name of the
-                          StorageOS volume.  Volume names are only unique within a
-                          namespace.
-                        type: string
-                      volumeNamespace:
-                        description: VolumeNamespace specifies the scope of the volume
-                          within StorageOS.  If no namespace is specified then the
-                          Pod's namespace will be used.  This allows the Kubernetes
-                          name scoping to be mirrored within StorageOS for tighter
-                          integration. Set VolumeName to any name to override the
-                          default behaviour. Set to "default" if you are not using
-                          namespaces within StorageOS. Namespaces that do not pre-exist
-                          within StorageOS will be created.
-                        type: string
-                    type: object
-                  vsphereVolume:
-                    description: VsphereVolume represents a vSphere volume attached
-                      and mounted on kubelets host machine
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      storagePolicyID:
-                        description: Storage Policy Based Management (SPBM) profile
-                          ID associated with the StoragePolicyName.
-                        type: string
-                      storagePolicyName:
-                        description: Storage Policy Based Management (SPBM) profile
-                          name.
-                        type: string
-                      volumePath:
-                        description: Path that identifies vSphere volume vmdk
-                        type: string
-                    required:
-                    - volumePath
-                    type: object
-                required:
-                - name
-                type: object
-              type: array
-          type: object
-        status:
-          description: SearchHeadClusterStatus defines the observed state of a Splunk
-            Enterprise search head cluster
-          properties:
-            captain:
-              description: name or label of the search head captain
-              type: string
-            captainReady:
-              description: true if the search head cluster's captain is ready to service
-                requests
-              type: boolean
-            deployerPhase:
-              description: current phase of the deployer
-              enum:
-              - Pending
-              - Ready
-              - Updating
-              - ScalingUp
-              - ScalingDown
-              - Terminating
-              - Error
-              type: string
-            initialized:
-              description: true if the search head cluster has finished initialization
-              type: boolean
-            maintenanceMode:
-              description: true if the search head cluster is in maintenance mode
-              type: boolean
-            members:
-              description: status of each search head cluster member
-              items:
-                description: SearchHeadClusterMemberStatus is used to track the status
-                  of each search head cluster member
-                properties:
-                  active_historical_search_count:
-                    description: Number of currently running historical searches.
-                    type: integer
-                  active_realtime_search_count:
-                    description: Number of currently running realtime searches.
-                    type: integer
-                  adhoc_searchhead:
-                    description: Flag that indicates if this member can run scheduled
-                      searches.
-                    type: boolean
-                  is_registered:
-                    description: Indicates if this member is registered with the searchhead
-                      cluster captain.
-                    type: boolean
-                  name:
-                    description: Name of the search head cluster member
-                    type: string
-                  status:
-                    description: Indicates the status of the member.
-                    type: string
-                type: object
-              type: array
-            minPeersJoined:
-              description: true if the minimum number of search head cluster members
-                have joined
-              type: boolean
-            namespace_scoped_secret_resource_version:
-              description: Indicates resource version of namespace scoped secret
-              type: string
-            phase:
-              description: current phase of the search head cluster
-              enum:
-              - Pending
-              - Ready
-              - Updating
-              - ScalingUp
-              - ScalingDown
-              - Terminating
-              - Error
-              type: string
-            readyReplicas:
-              description: current number of ready search head cluster members
-              format: int32
-              type: integer
-            replicas:
-              description: desired number of search head cluster members
-              format: int32
-              type: integer
-            selector:
-              description: selector for pods, used by HorizontalPodAutoscaler
-              type: string
-            shcSecretChangedFlag:
-              description: Indicates when the shc_secret has been changed for a peer
-              items:
+                type: array
+            type: object
+          status:
+            description: SearchHeadClusterStatus defines the observed state of a Splunk
+              Enterprise search head cluster
+            properties:
+              captain:
+                description: name or label of the search head captain
+                type: string
+              captainReady:
+                description: true if the search head cluster's captain is ready to
+                  service requests
                 type: boolean
-              type: array
-          type: object
-      type: object
-  version: v1alpha3
-  versions:
-  - name: v1alpha3
+              deployerPhase:
+                description: current phase of the deployer
+                enum:
+                - Pending
+                - Ready
+                - Updating
+                - ScalingUp
+                - ScalingDown
+                - Terminating
+                - Error
+                type: string
+              initialized:
+                description: true if the search head cluster has finished initialization
+                type: boolean
+              maintenanceMode:
+                description: true if the search head cluster is in maintenance mode
+                type: boolean
+              members:
+                description: status of each search head cluster member
+                items:
+                  description: SearchHeadClusterMemberStatus is used to track the
+                    status of each search head cluster member
+                  properties:
+                    active_historical_search_count:
+                      description: Number of currently running historical searches.
+                      type: integer
+                    active_realtime_search_count:
+                      description: Number of currently running realtime searches.
+                      type: integer
+                    adhoc_searchhead:
+                      description: Flag that indicates if this member can run scheduled
+                        searches.
+                      type: boolean
+                    is_registered:
+                      description: Indicates if this member is registered with the
+                        searchhead cluster captain.
+                      type: boolean
+                    name:
+                      description: Name of the search head cluster member
+                      type: string
+                    status:
+                      description: Indicates the status of the member.
+                      type: string
+                  type: object
+                type: array
+              minPeersJoined:
+                description: true if the minimum number of search head cluster members
+                  have joined
+                type: boolean
+              namespace_scoped_secret_resource_version:
+                description: Indicates resource version of namespace scoped secret
+                type: string
+              phase:
+                description: current phase of the search head cluster
+                enum:
+                - Pending
+                - Ready
+                - Updating
+                - ScalingUp
+                - ScalingDown
+                - Terminating
+                - Error
+                type: string
+              readyReplicas:
+                description: current number of ready search head cluster members
+                format: int32
+                type: integer
+              replicas:
+                description: desired number of search head cluster members
+                format: int32
+                type: integer
+              selector:
+                description: selector for pods, used by HorizontalPodAutoscaler
+                type: string
+              shcSecretChangedFlag:
+                description: Indicates when the shc_secret has been changed for a
+                  peer
+                items:
+                  type: boolean
+                type: array
+            type: object
+        type: object
     served: true
     storage: true
-  - name: v1alpha2
-    served: true
-    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/deploy/crds/enterprise.splunk.com_sparks_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_sparks_crd.yaml
@@ -1,8 +1,29 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: sparks.enterprise.splunk.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: Status of Spark workers
+    name: Phase
+    type: string
+  - JSONPath: .status.masterPhase
+    description: Status of Spark master
+    name: Master
+    type: string
+  - JSONPath: .status.replicas
+    description: Number of desired Spark workers
+    name: Desired
+    type: integer
+  - JSONPath: .status.readyReplicas
+    description: Current number of ready Spark workers
+    name: Ready
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of Spark cluster
+    name: Age
+    type: date
   group: enterprise.splunk.com
   names:
     kind: Spark
@@ -10,1012 +31,963 @@ spec:
     plural: sparks
     singular: spark
   scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: Status of Spark workers
-      jsonPath: .status.phase
-      name: Phase
-      type: string
-    - description: Status of Spark master
-      jsonPath: .status.masterPhase
-      name: Master
-      type: string
-    - description: Number of desired Spark workers
-      jsonPath: .status.replicas
-      name: Desired
-      type: integer
-    - description: Current number of ready Spark workers
-      jsonPath: .status.readyReplicas
-      name: Ready
-      type: integer
-    - description: Age of Spark cluster
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        description: Spark is the Schema for a Spark cluster
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: SparkSpec defines the desired state of a Spark cluster
-            properties:
-              affinity:
-                description: Kubernetes Affinity rules that control how pods are assigned
-                  to particular nodes.
-                properties:
-                  nodeAffinity:
-                    description: Describes node affinity scheduling rules for the
-                      pod.
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node matches
-                          the corresponding matchExpressions; the node(s) with the
-                          highest sum are the most preferred.
-                        items:
-                          description: An empty preferred scheduling term matches
-                            all objects with implicit weight 0 (i.e. it's a no-op).
-                            A null preferred scheduling term matches no objects (i.e.
-                            is also a no-op).
-                          properties:
-                            preference:
-                              description: A node selector term, associated with the
-                                corresponding weight.
-                              properties:
-                                matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            weight:
-                              description: Weight associated with matching the corresponding
-                                nodeSelectorTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - preference
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to an update), the system may or may not try to
-                          eventually evict the pod from its node.
-                        properties:
-                          nodeSelectorTerms:
-                            description: Required. A list of node selector terms.
-                              The terms are ORed.
-                            items:
-                              description: A null or empty node selector term matches
-                                no objects. The requirements of them are ANDed. The
-                                TopologySelectorTerm type implements a subset of the
-                                NodeSelectorTerm.
-                              properties:
-                                matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            type: array
-                        required:
-                        - nodeSelectorTerms
-                        type: object
-                    type: object
-                  podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate
-                      this pod in the same node, zone, etc. as some other pod(s)).
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
-                        items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
-                          properties:
-                            podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to a pod label update), the system may or may
-                          not try to eventually evict the pod from its node. When
-                          there are multiple elements, the lists of nodes corresponding
-                          to each podAffinityTerm are intersected, i.e. all terms
-                          must be satisfied.
-                        items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
-                          properties:
-                            labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            namespaces:
-                              description: namespaces specifies which namespaces the
-                                labelSelector applies to (matches against); null or
-                                empty list means "this pod's namespace"
-                              items:
-                                type: string
-                              type: array
-                            topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                  podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g.
-                      avoid putting this pod in the same node, zone, etc. as some
-                      other pod(s)).
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the anti-affinity expressions specified
-                          by this field, but it may choose a node that violates one
-                          or more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling anti-affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
-                        items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
-                          properties:
-                            podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the anti-affinity requirements specified by
-                          this field are not met at scheduling time, the pod will
-                          not be scheduled onto the node. If the anti-affinity requirements
-                          specified by this field cease to be met at some point during
-                          pod execution (e.g. due to a pod label update), the system
-                          may or may not try to eventually evict the pod from its
-                          node. When there are multiple elements, the lists of nodes
-                          corresponding to each podAffinityTerm are intersected, i.e.
-                          all terms must be satisfied.
-                        items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
-                          properties:
-                            labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            namespaces:
-                              description: namespaces specifies which namespaces the
-                                labelSelector applies to (matches against); null or
-                                empty list means "this pod's namespace"
-                              items:
-                                type: string
-                              type: array
-                            topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                type: object
-              image:
-                description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
-                  environment variables)
-                type: string
-              imagePullPolicy:
-                description: 'Sets pull policy for all images (either “Always” or
-                  the default: “IfNotPresent”)'
-                enum:
-                - Always
-                - IfNotPresent
-                type: string
-              replicas:
-                description: Number of spark worker pods
-                format: int32
-                type: integer
-              resources:
-                description: resource requirements for the pod containers
-                properties:
-                  limits:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                    type: object
-                  requests:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                    type: object
-                type: object
-              schedulerName:
-                description: Name of Scheduler to use for pod placement (defaults
-                  to “default-scheduler”)
-                type: string
-              serviceTemplate:
-                description: ServiceTemplate is a template used to create Kubernetes
-                  services
-                properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  metadata:
-                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                    type: object
-                  spec:
-                    description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                    properties:
-                      clusterIP:
-                        description: 'clusterIP is the IP address of the service and
-                          is usually assigned randomly by the master. If an address
-                          is specified manually and is not in use by others, it will
-                          be allocated to the service; otherwise, creation of the
-                          service will fail. This field can not be changed through
-                          updates. Valid values are "None", empty string (""), or
-                          a valid IP address. "None" can be specified for headless
-                          services when proxying is not required. Only applies to
-                          types ClusterIP, NodePort, and LoadBalancer. Ignored if
-                          type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                        type: string
-                      externalIPs:
-                        description: externalIPs is a list of IP addresses for which
-                          nodes in the cluster will also accept traffic for this service.  These
-                          IPs are not managed by Kubernetes.  The user is responsible
-                          for ensuring that traffic arrives at a node with this IP.  A
-                          common example is external load-balancers that are not part
-                          of the Kubernetes system.
-                        items:
-                          type: string
-                        type: array
-                      externalName:
-                        description: externalName is the external reference that kubedns
-                          or equivalent will return as a CNAME record for this service.
-                          No proxying will be involved. Must be a valid RFC-1123 hostname
-                          (https://tools.ietf.org/html/rfc1123) and requires Type
-                          to be ExternalName.
-                        type: string
-                      externalTrafficPolicy:
-                        description: externalTrafficPolicy denotes if this Service
-                          desires to route external traffic to node-local or cluster-wide
-                          endpoints. "Local" preserves the client source IP and avoids
-                          a second hop for LoadBalancer and Nodeport type services,
-                          but risks potentially imbalanced traffic spreading. "Cluster"
-                          obscures the client source IP and may cause a second hop
-                          to another node, but should have good overall load-spreading.
-                        type: string
-                      healthCheckNodePort:
-                        description: healthCheckNodePort specifies the healthcheck
-                          nodePort for the service. If not specified, HealthCheckNodePort
-                          is created by the service api backend with the allocated
-                          nodePort. Will use user-specified nodePort value if specified
-                          by the client. Only effects when Type is set to LoadBalancer
-                          and ExternalTrafficPolicy is set to Local.
-                        format: int32
-                        type: integer
-                      ipFamily:
-                        description: ipFamily specifies whether this Service has a
-                          preference for a particular IP family (e.g. IPv4 vs. IPv6).  If
-                          a specific IP family is requested, the clusterIP field will
-                          be allocated from that family, if it is available in the
-                          cluster.  If no IP family is requested, the cluster's primary
-                          IP family will be used. Other IP fields (loadBalancerIP,
-                          loadBalancerSourceRanges, externalIPs) and controllers which
-                          allocate external load-balancers should use the same IP
-                          family.  Endpoints for this Service will be of this family.  This
-                          field is immutable after creation. Assigning a ServiceIPFamily
-                          not available in the cluster (e.g. IPv6 in IPv4 only cluster)
-                          is an error condition and will fail during clusterIP assignment.
-                        type: string
-                      loadBalancerIP:
-                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                          will get created with the IP specified in this field. This
-                          feature depends on whether the underlying cloud-provider
-                          supports specifying the loadBalancerIP when a load balancer
-                          is created. This field will be ignored if the cloud-provider
-                          does not support the feature.'
-                        type: string
-                      loadBalancerSourceRanges:
-                        description: 'If specified and supported by the platform,
-                          this will restrict traffic through the cloud-provider load-balancer
-                          will be restricted to the specified client IPs. This field
-                          will be ignored if the cloud-provider does not support the
-                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
-                        items:
-                          type: string
-                        type: array
-                      ports:
-                        description: 'The list of ports that are exposed by this service.
-                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                        items:
-                          description: ServicePort contains information on service's
-                            port.
-                          properties:
-                            name:
-                              description: The name of this port within the service.
-                                This must be a DNS_LABEL. All ports within a ServiceSpec
-                                must have unique names. When considering the endpoints
-                                for a Service, this must match the 'name' field in
-                                the EndpointPort. Optional if only one ServicePort
-                                is defined on this service.
-                              type: string
-                            nodePort:
-                              description: 'The port on each node on which this service
-                                is exposed when type=NodePort or LoadBalancer. Usually
-                                assigned by the system. If specified, it will be allocated
-                                to the service if unused or else creation of the service
-                                will fail. Default is to auto-allocate a port if the
-                                ServiceType of this Service requires one. More info:
-                                https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
-                              format: int32
-                              type: integer
-                            port:
-                              description: The port that will be exposed by this service.
-                              format: int32
-                              type: integer
-                            protocol:
-                              description: The IP protocol for this port. Supports
-                                "TCP", "UDP", and "SCTP". Default is TCP.
-                              type: string
-                            targetPort:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              description: 'Number or name of the port to access on
-                                the pods targeted by the service. Number must be in
-                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                                If this is a string, it will be looked up as a named
-                                port in the target Pod''s container ports. If this
-                                is not specified, the value of the ''port'' field
-                                is used (an identity map). This field is ignored for
-                                services with clusterIP=None, and should be omitted
-                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
-                              x-kubernetes-int-or-string: true
-                          required:
-                          - port
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                        - port
-                        - protocol
-                        x-kubernetes-list-type: map
-                      publishNotReadyAddresses:
-                        description: publishNotReadyAddresses, when set to true, indicates
-                          that DNS implementations must publish the notReadyAddresses
-                          of subsets for the Endpoints associated with the Service.
-                          The default value is false. The primary use case for setting
-                          this field is to use a StatefulSet's Headless Service to
-                          propagate SRV records for its Pods without respect to their
-                          readiness for purpose of peer discovery.
-                        type: boolean
-                      selector:
-                        additionalProperties:
-                          type: string
-                        description: 'Route service traffic to pods with label keys
-                          and values matching this selector. If empty or not present,
-                          the service is assumed to have an external process managing
-                          its endpoints, which Kubernetes will not modify. Only applies
-                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
-                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
-                        type: object
-                      sessionAffinity:
-                        description: 'Supports "ClientIP" and "None". Used to maintain
-                          session affinity. Enable client IP based session affinity.
-                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                        type: string
-                      sessionAffinityConfig:
-                        description: sessionAffinityConfig contains the configurations
-                          of session affinity.
-                        properties:
-                          clientIP:
-                            description: clientIP contains the configurations of Client
-                              IP based session affinity.
-                            properties:
-                              timeoutSeconds:
-                                description: timeoutSeconds specifies the seconds
-                                  of ClientIP type session sticky time. The value
-                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
-                                  == "ClientIP". Default value is 10800(for 3 hours).
-                                format: int32
-                                type: integer
-                            type: object
-                        type: object
-                      type:
-                        description: 'type determines how the Service is exposed.
-                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
-                          NodePort, and LoadBalancer. "ExternalName" maps to the specified
-                          externalName. "ClusterIP" allocates a cluster-internal IP
-                          address for load-balancing to endpoints. Endpoints are determined
-                          by the selector or if that is not specified, by manual construction
-                          of an Endpoints object. If clusterIP is "None", no virtual
-                          IP is allocated and the endpoints are published as a set
-                          of endpoints rather than a stable IP. "NodePort" builds
-                          on ClusterIP and allocates a port on every node which routes
-                          to the clusterIP. "LoadBalancer" builds on NodePort and
-                          creates an external load-balancer (if supported in the current
-                          cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
-                        type: string
-                    type: object
-                  status:
-                    description: 'Most recently observed status of the service. Populated
-                      by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-                    properties:
-                      loadBalancer:
-                        description: LoadBalancer contains the current status of the
-                          load-balancer, if one is present.
-                        properties:
-                          ingress:
-                            description: Ingress is a list containing ingress points
-                              for the load-balancer. Traffic intended for the service
-                              should be sent to these ingress points.
-                            items:
-                              description: 'LoadBalancerIngress represents the status
-                                of a load-balancer ingress point: traffic intended
-                                for the service should be sent to an ingress point.'
-                              properties:
-                                hostname:
-                                  description: Hostname is set for load-balancer ingress
-                                    points that are DNS based (typically AWS load-balancers)
-                                  type: string
-                                ip:
-                                  description: IP is set for load-balancer ingress
-                                    points that are IP based (typically GCE or OpenStack
-                                    load-balancers)
-                                  type: string
-                              type: object
-                            type: array
-                        type: object
-                    type: object
-                type: object
-              tolerations:
-                description: Pod's tolerations for Kubernetes node's taint
-                items:
-                  description: The pod this Toleration is attached to tolerates any
-                    taint that matches the triple <key,value,effect> using the matching
-                    operator <operator>.
+  subresources:
+    scale:
+      labelSelectorPath: .status.selector
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Spark is the Schema for a Spark cluster
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SparkSpec defines the desired state of a Spark cluster
+          properties:
+            affinity:
+              description: Kubernetes Affinity rules that control how pods are assigned
+                to particular nodes.
+              properties:
+                nodeAffinity:
+                  description: Describes node affinity scheduling rules for the pod.
                   properties:
-                    effect:
-                      description: Effect indicates the taint effect to match. Empty
-                        means match all taint effects. When specified, allowed values
-                        are NoSchedule, PreferNoSchedule and NoExecute.
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node matches the corresponding matchExpressions; the
+                        node(s) with the highest sum are the most preferred.
+                      items:
+                        description: An empty preferred scheduling term matches all
+                          objects with implicit weight 0 (i.e. it's a no-op). A null
+                          preferred scheduling term matches no objects (i.e. is also
+                          a no-op).
+                        properties:
+                          preference:
+                            description: A node selector term, associated with the
+                              corresponding weight.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          weight:
+                            description: Weight associated with matching the corresponding
+                              nodeSelectorTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - preference
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to an update), the system may or may not try to
+                        eventually evict the pod from its node.
+                      properties:
+                        nodeSelectorTerms:
+                          description: Required. A list of node selector terms. The
+                            terms are ORed.
+                          items:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                      required:
+                      - nodeSelectorTerms
+                      type: object
+                  type: object
+                podAffinity:
+                  description: Describes pod affinity scheduling rules (e.g. co-locate
+                    this pod in the same node, zone, etc. as some other pod(s)).
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node has pods which matches the corresponding podAffinityTerm;
+                        the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Required. A pod affinity term, associated
+                              with the corresponding weight.
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to a pod label update), the system may or may not
+                        try to eventually evict the pod from its node. When there
+                        are multiple elements, the lists of nodes corresponding to
+                        each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources, in
+                              this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+                podAntiAffinity:
+                  description: Describes pod anti-affinity scheduling rules (e.g.
+                    avoid putting this pod in the same node, zone, etc. as some other
+                    pod(s)).
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the anti-affinity expressions specified by this
+                        field, but it may choose a node that violates one or more
+                        of the expressions. The node that is most preferred is the
+                        one with the greatest sum of weights, i.e. for each node that
+                        meets all of the scheduling requirements (resource request,
+                        requiredDuringScheduling anti-affinity expressions, etc.),
+                        compute a sum by iterating through the elements of this field
+                        and adding "weight" to the sum if the node has pods which
+                        matches the corresponding podAffinityTerm; the node(s) with
+                        the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Required. A pod affinity term, associated
+                              with the corresponding weight.
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the anti-affinity requirements specified by
+                        this field are not met at scheduling time, the pod will not
+                        be scheduled onto the node. If the anti-affinity requirements
+                        specified by this field cease to be met at some point during
+                        pod execution (e.g. due to a pod label update), the system
+                        may or may not try to eventually evict the pod from its node.
+                        When there are multiple elements, the lists of nodes corresponding
+                        to each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources, in
+                              this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            image:
+              description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
+                environment variables)
+              type: string
+            imagePullPolicy:
+              description: 'Sets pull policy for all images (either “Always” or the
+                default: “IfNotPresent”)'
+              enum:
+              - Always
+              - IfNotPresent
+              type: string
+            replicas:
+              description: Number of spark worker pods
+              format: int32
+              type: integer
+            resources:
+              description: resource requirements for the pod containers
+              properties:
+                limits:
+                  additionalProperties:
+                    type: string
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    type: string
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
+            schedulerName:
+              description: Name of Scheduler to use for pod placement (defaults to
+                “default-scheduler”)
+              type: string
+            serviceTemplate:
+              description: ServiceTemplate is a template used to create Kubernetes
+                services
+              properties:
+                apiVersion:
+                  description: 'APIVersion defines the versioned schema of this representation
+                    of an object. Servers should convert recognized schemas to the
+                    latest internal value, and may reject unrecognized values. More
+                    info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                  type: string
+                kind:
+                  description: 'Kind is a string value representing the REST resource
+                    this object represents. Servers may infer this from the endpoint
+                    the client submits requests to. Cannot be updated. In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                metadata:
+                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                  type: object
+                spec:
+                  description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                  properties:
+                    clusterIP:
+                      description: 'clusterIP is the IP address of the service and
+                        is usually assigned randomly by the master. If an address
+                        is specified manually and is not in use by others, it will
+                        be allocated to the service; otherwise, creation of the service
+                        will fail. This field can not be changed through updates.
+                        Valid values are "None", empty string (""), or a valid IP
+                        address. "None" can be specified for headless services when
+                        proxying is not required. Only applies to types ClusterIP,
+                        NodePort, and LoadBalancer. Ignored if type is ExternalName.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                       type: string
-                    key:
-                      description: Key is the taint key that the toleration applies
-                        to. Empty means match all taint keys. If the key is empty,
-                        operator must be Exists; this combination means to match all
-                        values and all keys.
+                    externalIPs:
+                      description: externalIPs is a list of IP addresses for which
+                        nodes in the cluster will also accept traffic for this service.  These
+                        IPs are not managed by Kubernetes.  The user is responsible
+                        for ensuring that traffic arrives at a node with this IP.  A
+                        common example is external load-balancers that are not part
+                        of the Kubernetes system.
+                      items:
+                        type: string
+                      type: array
+                    externalName:
+                      description: externalName is the external reference that kubedns
+                        or equivalent will return as a CNAME record for this service.
+                        No proxying will be involved. Must be a valid RFC-1123 hostname
+                        (https://tools.ietf.org/html/rfc1123) and requires Type to
+                        be ExternalName.
                       type: string
-                    operator:
-                      description: Operator represents a key's relationship to the
-                        value. Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod
-                        can tolerate all taints of a particular category.
+                    externalTrafficPolicy:
+                      description: externalTrafficPolicy denotes if this Service desires
+                        to route external traffic to node-local or cluster-wide endpoints.
+                        "Local" preserves the client source IP and avoids a second
+                        hop for LoadBalancer and Nodeport type services, but risks
+                        potentially imbalanced traffic spreading. "Cluster" obscures
+                        the client source IP and may cause a second hop to another
+                        node, but should have good overall load-spreading.
                       type: string
-                    tolerationSeconds:
-                      description: TolerationSeconds represents the period of time
-                        the toleration (which must be of effect NoExecute, otherwise
-                        this field is ignored) tolerates the taint. By default, it
-                        is not set, which means tolerate the taint forever (do not
-                        evict). Zero and negative values will be treated as 0 (evict
-                        immediately) by the system.
-                      format: int64
+                    healthCheckNodePort:
+                      description: healthCheckNodePort specifies the healthcheck nodePort
+                        for the service. If not specified, HealthCheckNodePort is
+                        created by the service api backend with the allocated nodePort.
+                        Will use user-specified nodePort value if specified by the
+                        client. Only effects when Type is set to LoadBalancer and
+                        ExternalTrafficPolicy is set to Local.
+                      format: int32
                       type: integer
-                    value:
-                      description: Value is the taint value the toleration matches
-                        to. If the operator is Exists, the value should be empty,
-                        otherwise just a regular string.
+                    ipFamily:
+                      description: ipFamily specifies whether this Service has a preference
+                        for a particular IP family (e.g. IPv4 vs. IPv6).  If a specific
+                        IP family is requested, the clusterIP field will be allocated
+                        from that family, if it is available in the cluster.  If no
+                        IP family is requested, the cluster's primary IP family will
+                        be used. Other IP fields (loadBalancerIP, loadBalancerSourceRanges,
+                        externalIPs) and controllers which allocate external load-balancers
+                        should use the same IP family.  Endpoints for this Service
+                        will be of this family.  This field is immutable after creation.
+                        Assigning a ServiceIPFamily not available in the cluster (e.g.
+                        IPv6 in IPv4 only cluster) is an error condition and will
+                        fail during clusterIP assignment.
+                      type: string
+                    loadBalancerIP:
+                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                        will get created with the IP specified in this field. This
+                        feature depends on whether the underlying cloud-provider supports
+                        specifying the loadBalancerIP when a load balancer is created.
+                        This field will be ignored if the cloud-provider does not
+                        support the feature.'
+                      type: string
+                    loadBalancerSourceRanges:
+                      description: 'If specified and supported by the platform, this
+                        will restrict traffic through the cloud-provider load-balancer
+                        will be restricted to the specified client IPs. This field
+                        will be ignored if the cloud-provider does not support the
+                        feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: 'The list of ports that are exposed by this service.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      items:
+                        description: ServicePort contains information on service's
+                          port.
+                        properties:
+                          name:
+                            description: The name of this port within the service.
+                              This must be a DNS_LABEL. All ports within a ServiceSpec
+                              must have unique names. When considering the endpoints
+                              for a Service, this must match the 'name' field in the
+                              EndpointPort. Optional if only one ServicePort is defined
+                              on this service.
+                            type: string
+                          nodePort:
+                            description: 'The port on each node on which this service
+                              is exposed when type=NodePort or LoadBalancer. Usually
+                              assigned by the system. If specified, it will be allocated
+                              to the service if unused or else creation of the service
+                              will fail. Default is to auto-allocate a port if the
+                              ServiceType of this Service requires one. More info:
+                              https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                            format: int32
+                            type: integer
+                          port:
+                            description: The port that will be exposed by this service.
+                            format: int32
+                            type: integer
+                          protocol:
+                            description: The IP protocol for this port. Supports "TCP",
+                              "UDP", and "SCTP". Default is TCP.
+                            type: string
+                          targetPort:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: 'Number or name of the port to access on
+                              the pods targeted by the service. Number must be in
+                              the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              If this is a string, it will be looked up as a named
+                              port in the target Pod''s container ports. If this is
+                              not specified, the value of the ''port'' field is used
+                              (an identity map). This field is ignored for services
+                              with clusterIP=None, and should be omitted or set equal
+                              to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      type: array
+                    publishNotReadyAddresses:
+                      description: publishNotReadyAddresses, when set to true, indicates
+                        that DNS implementations must publish the notReadyAddresses
+                        of subsets for the Endpoints associated with the Service.
+                        The default value is false. The primary use case for setting
+                        this field is to use a StatefulSet's Headless Service to propagate
+                        SRV records for its Pods without respect to their readiness
+                        for purpose of peer discovery.
+                      type: boolean
+                    selector:
+                      additionalProperties:
+                        type: string
+                      description: 'Route service traffic to pods with label keys
+                        and values matching this selector. If empty or not present,
+                        the service is assumed to have an external process managing
+                        its endpoints, which Kubernetes will not modify. Only applies
+                        to types ClusterIP, NodePort, and LoadBalancer. Ignored if
+                        type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                      type: object
+                    sessionAffinity:
+                      description: 'Supports "ClientIP" and "None". Used to maintain
+                        session affinity. Enable client IP based session affinity.
+                        Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    sessionAffinityConfig:
+                      description: sessionAffinityConfig contains the configurations
+                        of session affinity.
+                      properties:
+                        clientIP:
+                          description: clientIP contains the configurations of Client
+                            IP based session affinity.
+                          properties:
+                            timeoutSeconds:
+                              description: timeoutSeconds specifies the seconds of
+                                ClientIP type session sticky time. The value must
+                                be >0 && <=86400(for 1 day) if ServiceAffinity ==
+                                "ClientIP". Default value is 10800(for 3 hours).
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    type:
+                      description: 'type determines how the Service is exposed. Defaults
+                        to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort,
+                        and LoadBalancer. "ExternalName" maps to the specified externalName.
+                        "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                        to endpoints. Endpoints are determined by the selector or
+                        if that is not specified, by manual construction of an Endpoints
+                        object. If clusterIP is "None", no virtual IP is allocated
+                        and the endpoints are published as a set of endpoints rather
+                        than a stable IP. "NodePort" builds on ClusterIP and allocates
+                        a port on every node which routes to the clusterIP. "LoadBalancer"
+                        builds on NodePort and creates an external load-balancer (if
+                        supported in the current cloud) which routes to the clusterIP.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
                       type: string
                   type: object
-                type: array
-            type: object
-          status:
-            description: SparkStatus defines the observed state of a Spark cluster
-            properties:
-              masterPhase:
-                description: current phase of the spark master
-                enum:
-                - Pending
-                - Ready
-                - Updating
-                - ScalingUp
-                - ScalingDown
-                - Terminating
-                - Error
-                type: string
-              phase:
-                description: current phase of the spark workers
-                enum:
-                - Pending
-                - Ready
-                - Updating
-                - ScalingUp
-                - ScalingDown
-                - Terminating
-                - Error
-                type: string
-              readyReplicas:
-                description: current number of ready spark workers
-                format: int32
-                type: integer
-              replicas:
-                description: number of desired spark workers
-                format: int32
-                type: integer
-              selector:
-                description: selector for pods, used by HorizontalPodAutoscaler
-                type: string
-            type: object
-        type: object
+                status:
+                  description: 'Most recently observed status of the service. Populated
+                    by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                  properties:
+                    loadBalancer:
+                      description: LoadBalancer contains the current status of the
+                        load-balancer, if one is present.
+                      properties:
+                        ingress:
+                          description: Ingress is a list containing ingress points
+                            for the load-balancer. Traffic intended for the service
+                            should be sent to these ingress points.
+                          items:
+                            description: 'LoadBalancerIngress represents the status
+                              of a load-balancer ingress point: traffic intended for
+                              the service should be sent to an ingress point.'
+                            properties:
+                              hostname:
+                                description: Hostname is set for load-balancer ingress
+                                  points that are DNS based (typically AWS load-balancers)
+                                type: string
+                              ip:
+                                description: IP is set for load-balancer ingress points
+                                  that are IP based (typically GCE or OpenStack load-balancers)
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+              type: object
+            tolerations:
+              description: Pod's tolerations for Kubernetes node's taint
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+                type: object
+              type: array
+          type: object
+        status:
+          description: SparkStatus defines the observed state of a Spark cluster
+          properties:
+            masterPhase:
+              description: current phase of the spark master
+              enum:
+              - Pending
+              - Ready
+              - Updating
+              - ScalingUp
+              - ScalingDown
+              - Terminating
+              - Error
+              type: string
+            phase:
+              description: current phase of the spark workers
+              enum:
+              - Pending
+              - Ready
+              - Updating
+              - ScalingUp
+              - ScalingDown
+              - Terminating
+              - Error
+              type: string
+            readyReplicas:
+              description: current number of ready spark workers
+              format: int32
+              type: integer
+            replicas:
+              description: number of desired spark workers
+              format: int32
+              type: integer
+            selector:
+              description: selector for pods, used by HorizontalPodAutoscaler
+              type: string
+          type: object
+      type: object
+  version: v1alpha3
+  versions:
+  - name: v1alpha3
     served: true
     storage: true
-    subresources:
-      scale:
-        labelSelectorPath: .status.selector
-        specReplicasPath: .spec.replicas
-        statusReplicasPath: .status.replicas
-      status: {}
+  - name: v1alpha2
+    served: true
+    storage: false

--- a/deploy/crds/enterprise.splunk.com_sparks_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_sparks_crd.yaml
@@ -1,29 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: sparks.enterprise.splunk.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: Status of Spark workers
-    name: Phase
-    type: string
-  - JSONPath: .status.masterPhase
-    description: Status of Spark master
-    name: Master
-    type: string
-  - JSONPath: .status.replicas
-    description: Number of desired Spark workers
-    name: Desired
-    type: integer
-  - JSONPath: .status.readyReplicas
-    description: Current number of ready Spark workers
-    name: Ready
-    type: integer
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of Spark cluster
-    name: Age
-    type: date
   group: enterprise.splunk.com
   names:
     kind: Spark
@@ -31,963 +10,1012 @@ spec:
     plural: sparks
     singular: spark
   scope: Namespaced
-  subresources:
-    scale:
-      labelSelectorPath: .status.selector
-      specReplicasPath: .spec.replicas
-      statusReplicasPath: .status.replicas
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Spark is the Schema for a Spark cluster
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: SparkSpec defines the desired state of a Spark cluster
-          properties:
-            affinity:
-              description: Kubernetes Affinity rules that control how pods are assigned
-                to particular nodes.
-              properties:
-                nodeAffinity:
-                  description: Describes node affinity scheduling rules for the pod.
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node matches the corresponding matchExpressions; the
-                        node(s) with the highest sum are the most preferred.
-                      items:
-                        description: An empty preferred scheduling term matches all
-                          objects with implicit weight 0 (i.e. it's a no-op). A null
-                          preferred scheduling term matches no objects (i.e. is also
-                          a no-op).
-                        properties:
-                          preference:
-                            description: A node selector term, associated with the
-                              corresponding weight.
-                            properties:
-                              matchExpressions:
-                                description: A list of node selector requirements
-                                  by node's labels.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchFields:
-                                description: A list of node selector requirements
-                                  by node's fields.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                            type: object
-                          weight:
-                            description: Weight associated with matching the corresponding
-                              nodeSelectorTerm, in the range 1-100.
-                            format: int32
-                            type: integer
-                        required:
-                        - preference
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to an update), the system may or may not try to
-                        eventually evict the pod from its node.
-                      properties:
-                        nodeSelectorTerms:
-                          description: Required. A list of node selector terms. The
-                            terms are ORed.
-                          items:
-                            description: A null or empty node selector term matches
-                              no objects. The requirements of them are ANDed. The
-                              TopologySelectorTerm type implements a subset of the
-                              NodeSelectorTerm.
-                            properties:
-                              matchExpressions:
-                                description: A list of node selector requirements
-                                  by node's labels.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchFields:
-                                description: A list of node selector requirements
-                                  by node's fields.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                            type: object
-                          type: array
-                      required:
-                      - nodeSelectorTerms
-                      type: object
-                  type: object
-                podAffinity:
-                  description: Describes pod affinity scheduling rules (e.g. co-locate
-                    this pod in the same node, zone, etc. as some other pod(s)).
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node has pods which matches the corresponding podAffinityTerm;
-                        the node(s) with the highest sum are the most preferred.
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            format: int32
-                            type: integer
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to a pod label update), the system may or may not
-                        try to eventually evict the pod from its node. When there
-                        are multiple elements, the lists of nodes corresponding to
-                        each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            items:
-                              type: string
-                            type: array
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-                        required:
-                        - topologyKey
-                        type: object
-                      type: array
-                  type: object
-                podAntiAffinity:
-                  description: Describes pod anti-affinity scheduling rules (e.g.
-                    avoid putting this pod in the same node, zone, etc. as some other
-                    pod(s)).
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the anti-affinity expressions specified by this
-                        field, but it may choose a node that violates one or more
-                        of the expressions. The node that is most preferred is the
-                        one with the greatest sum of weights, i.e. for each node that
-                        meets all of the scheduling requirements (resource request,
-                        requiredDuringScheduling anti-affinity expressions, etc.),
-                        compute a sum by iterating through the elements of this field
-                        and adding "weight" to the sum if the node has pods which
-                        matches the corresponding podAffinityTerm; the node(s) with
-                        the highest sum are the most preferred.
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            format: int32
-                            type: integer
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the anti-affinity requirements specified by
-                        this field are not met at scheduling time, the pod will not
-                        be scheduled onto the node. If the anti-affinity requirements
-                        specified by this field cease to be met at some point during
-                        pod execution (e.g. due to a pod label update), the system
-                        may or may not try to eventually evict the pod from its node.
-                        When there are multiple elements, the lists of nodes corresponding
-                        to each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            items:
-                              type: string
-                            type: array
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-                        required:
-                        - topologyKey
-                        type: object
-                      type: array
-                  type: object
-              type: object
-            image:
-              description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
-                environment variables)
-              type: string
-            imagePullPolicy:
-              description: 'Sets pull policy for all images (either “Always” or the
-                default: “IfNotPresent”)'
-              enum:
-              - Always
-              - IfNotPresent
-              type: string
-            replicas:
-              description: Number of spark worker pods
-              format: int32
-              type: integer
-            resources:
-              description: resource requirements for the pod containers
-              properties:
-                limits:
-                  additionalProperties:
-                    type: string
-                  description: 'Limits describes the maximum amount of compute resources
-                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                requests:
-                  additionalProperties:
-                    type: string
-                  description: 'Requests describes the minimum amount of compute resources
-                    required. If Requests is omitted for a container, it defaults
-                    to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-              type: object
-            schedulerName:
-              description: Name of Scheduler to use for pod placement (defaults to
-                “default-scheduler”)
-              type: string
-            serviceTemplate:
-              description: ServiceTemplate is a template used to create Kubernetes
-                services
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                    of an object. Servers should convert recognized schemas to the
-                    latest internal value, and may reject unrecognized values. More
-                    info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource
-                    this object represents. Servers may infer this from the endpoint
-                    the client submits requests to. Cannot be updated. In CamelCase.
-                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                  type: object
-                spec:
-                  description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                  properties:
-                    clusterIP:
-                      description: 'clusterIP is the IP address of the service and
-                        is usually assigned randomly by the master. If an address
-                        is specified manually and is not in use by others, it will
-                        be allocated to the service; otherwise, creation of the service
-                        will fail. This field can not be changed through updates.
-                        Valid values are "None", empty string (""), or a valid IP
-                        address. "None" can be specified for headless services when
-                        proxying is not required. Only applies to types ClusterIP,
-                        NodePort, and LoadBalancer. Ignored if type is ExternalName.
-                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                      type: string
-                    externalIPs:
-                      description: externalIPs is a list of IP addresses for which
-                        nodes in the cluster will also accept traffic for this service.  These
-                        IPs are not managed by Kubernetes.  The user is responsible
-                        for ensuring that traffic arrives at a node with this IP.  A
-                        common example is external load-balancers that are not part
-                        of the Kubernetes system.
-                      items:
-                        type: string
-                      type: array
-                    externalName:
-                      description: externalName is the external reference that kubedns
-                        or equivalent will return as a CNAME record for this service.
-                        No proxying will be involved. Must be a valid RFC-1123 hostname
-                        (https://tools.ietf.org/html/rfc1123) and requires Type to
-                        be ExternalName.
-                      type: string
-                    externalTrafficPolicy:
-                      description: externalTrafficPolicy denotes if this Service desires
-                        to route external traffic to node-local or cluster-wide endpoints.
-                        "Local" preserves the client source IP and avoids a second
-                        hop for LoadBalancer and Nodeport type services, but risks
-                        potentially imbalanced traffic spreading. "Cluster" obscures
-                        the client source IP and may cause a second hop to another
-                        node, but should have good overall load-spreading.
-                      type: string
-                    healthCheckNodePort:
-                      description: healthCheckNodePort specifies the healthcheck nodePort
-                        for the service. If not specified, HealthCheckNodePort is
-                        created by the service api backend with the allocated nodePort.
-                        Will use user-specified nodePort value if specified by the
-                        client. Only effects when Type is set to LoadBalancer and
-                        ExternalTrafficPolicy is set to Local.
-                      format: int32
-                      type: integer
-                    ipFamily:
-                      description: ipFamily specifies whether this Service has a preference
-                        for a particular IP family (e.g. IPv4 vs. IPv6).  If a specific
-                        IP family is requested, the clusterIP field will be allocated
-                        from that family, if it is available in the cluster.  If no
-                        IP family is requested, the cluster's primary IP family will
-                        be used. Other IP fields (loadBalancerIP, loadBalancerSourceRanges,
-                        externalIPs) and controllers which allocate external load-balancers
-                        should use the same IP family.  Endpoints for this Service
-                        will be of this family.  This field is immutable after creation.
-                        Assigning a ServiceIPFamily not available in the cluster (e.g.
-                        IPv6 in IPv4 only cluster) is an error condition and will
-                        fail during clusterIP assignment.
-                      type: string
-                    loadBalancerIP:
-                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                        will get created with the IP specified in this field. This
-                        feature depends on whether the underlying cloud-provider supports
-                        specifying the loadBalancerIP when a load balancer is created.
-                        This field will be ignored if the cloud-provider does not
-                        support the feature.'
-                      type: string
-                    loadBalancerSourceRanges:
-                      description: 'If specified and supported by the platform, this
-                        will restrict traffic through the cloud-provider load-balancer
-                        will be restricted to the specified client IPs. This field
-                        will be ignored if the cloud-provider does not support the
-                        feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
-                      items:
-                        type: string
-                      type: array
-                    ports:
-                      description: 'The list of ports that are exposed by this service.
-                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                      items:
-                        description: ServicePort contains information on service's
-                          port.
-                        properties:
-                          name:
-                            description: The name of this port within the service.
-                              This must be a DNS_LABEL. All ports within a ServiceSpec
-                              must have unique names. When considering the endpoints
-                              for a Service, this must match the 'name' field in the
-                              EndpointPort. Optional if only one ServicePort is defined
-                              on this service.
-                            type: string
-                          nodePort:
-                            description: 'The port on each node on which this service
-                              is exposed when type=NodePort or LoadBalancer. Usually
-                              assigned by the system. If specified, it will be allocated
-                              to the service if unused or else creation of the service
-                              will fail. Default is to auto-allocate a port if the
-                              ServiceType of this Service requires one. More info:
-                              https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
-                            format: int32
-                            type: integer
-                          port:
-                            description: The port that will be exposed by this service.
-                            format: int32
-                            type: integer
-                          protocol:
-                            description: The IP protocol for this port. Supports "TCP",
-                              "UDP", and "SCTP". Default is TCP.
-                            type: string
-                          targetPort:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: 'Number or name of the port to access on
-                              the pods targeted by the service. Number must be in
-                              the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                              If this is a string, it will be looked up as a named
-                              port in the target Pod''s container ports. If this is
-                              not specified, the value of the ''port'' field is used
-                              (an identity map). This field is ignored for services
-                              with clusterIP=None, and should be omitted or set equal
-                              to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
-                            x-kubernetes-int-or-string: true
-                        required:
-                        - port
-                        type: object
-                      type: array
-                    publishNotReadyAddresses:
-                      description: publishNotReadyAddresses, when set to true, indicates
-                        that DNS implementations must publish the notReadyAddresses
-                        of subsets for the Endpoints associated with the Service.
-                        The default value is false. The primary use case for setting
-                        this field is to use a StatefulSet's Headless Service to propagate
-                        SRV records for its Pods without respect to their readiness
-                        for purpose of peer discovery.
-                      type: boolean
-                    selector:
-                      additionalProperties:
-                        type: string
-                      description: 'Route service traffic to pods with label keys
-                        and values matching this selector. If empty or not present,
-                        the service is assumed to have an external process managing
-                        its endpoints, which Kubernetes will not modify. Only applies
-                        to types ClusterIP, NodePort, and LoadBalancer. Ignored if
-                        type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
-                      type: object
-                    sessionAffinity:
-                      description: 'Supports "ClientIP" and "None". Used to maintain
-                        session affinity. Enable client IP based session affinity.
-                        Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                      type: string
-                    sessionAffinityConfig:
-                      description: sessionAffinityConfig contains the configurations
-                        of session affinity.
-                      properties:
-                        clientIP:
-                          description: clientIP contains the configurations of Client
-                            IP based session affinity.
+  versions:
+  - additionalPrinterColumns:
+    - description: Status of Spark workers
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Status of Spark master
+      jsonPath: .status.masterPhase
+      name: Master
+      type: string
+    - description: Number of desired Spark workers
+      jsonPath: .status.replicas
+      name: Desired
+      type: integer
+    - description: Current number of ready Spark workers
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Age of Spark cluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: Spark is the Schema for a Spark cluster
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SparkSpec defines the desired state of a Spark cluster
+            properties:
+              affinity:
+                description: Kubernetes Affinity rules that control how pods are assigned
+                  to particular nodes.
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
                           properties:
-                            timeoutSeconds:
-                              description: timeoutSeconds specifies the seconds of
-                                ClientIP type session sticky time. The value must
-                                be >0 && <=86400(for 1 day) if ServiceAffinity ==
-                                "ClientIP". Default value is 10800(for 3 hours).
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
                               format: int32
                               type: integer
+                          required:
+                          - preference
+                          - weight
                           type: object
-                      type: object
-                    type:
-                      description: 'type determines how the Service is exposed. Defaults
-                        to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort,
-                        and LoadBalancer. "ExternalName" maps to the specified externalName.
-                        "ClusterIP" allocates a cluster-internal IP address for load-balancing
-                        to endpoints. Endpoints are determined by the selector or
-                        if that is not specified, by manual construction of an Endpoints
-                        object. If clusterIP is "None", no virtual IP is allocated
-                        and the endpoints are published as a set of endpoints rather
-                        than a stable IP. "NodePort" builds on ClusterIP and allocates
-                        a port on every node which routes to the clusterIP. "LoadBalancer"
-                        builds on NodePort and creates an external load-balancer (if
-                        supported in the current cloud) which routes to the clusterIP.
-                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              image:
+                description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
+                  environment variables)
+                type: string
+              imagePullPolicy:
+                description: 'Sets pull policy for all images (either “Always” or
+                  the default: “IfNotPresent”)'
+                enum:
+                - Always
+                - IfNotPresent
+                type: string
+              replicas:
+                description: Number of spark worker pods
+                format: int32
+                type: integer
+              resources:
+                description: resource requirements for the pod containers
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+              schedulerName:
+                description: Name of Scheduler to use for pod placement (defaults
+                  to “default-scheduler”)
+                type: string
+              serviceTemplate:
+                description: ServiceTemplate is a template used to create Kubernetes
+                  services
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      clusterIP:
+                        description: 'clusterIP is the IP address of the service and
+                          is usually assigned randomly by the master. If an address
+                          is specified manually and is not in use by others, it will
+                          be allocated to the service; otherwise, creation of the
+                          service will fail. This field can not be changed through
+                          updates. Valid values are "None", empty string (""), or
+                          a valid IP address. "None" can be specified for headless
+                          services when proxying is not required. Only applies to
+                          types ClusterIP, NodePort, and LoadBalancer. Ignored if
+                          type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      externalIPs:
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for this service.  These
+                          IPs are not managed by Kubernetes.  The user is responsible
+                          for ensuring that traffic arrives at a node with this IP.  A
+                          common example is external load-balancers that are not part
+                          of the Kubernetes system.
+                        items:
+                          type: string
+                        type: array
+                      externalName:
+                        description: externalName is the external reference that kubedns
+                          or equivalent will return as a CNAME record for this service.
+                          No proxying will be involved. Must be a valid RFC-1123 hostname
+                          (https://tools.ietf.org/html/rfc1123) and requires Type
+                          to be ExternalName.
+                        type: string
+                      externalTrafficPolicy:
+                        description: externalTrafficPolicy denotes if this Service
+                          desires to route external traffic to node-local or cluster-wide
+                          endpoints. "Local" preserves the client source IP and avoids
+                          a second hop for LoadBalancer and Nodeport type services,
+                          but risks potentially imbalanced traffic spreading. "Cluster"
+                          obscures the client source IP and may cause a second hop
+                          to another node, but should have good overall load-spreading.
+                        type: string
+                      healthCheckNodePort:
+                        description: healthCheckNodePort specifies the healthcheck
+                          nodePort for the service. If not specified, HealthCheckNodePort
+                          is created by the service api backend with the allocated
+                          nodePort. Will use user-specified nodePort value if specified
+                          by the client. Only effects when Type is set to LoadBalancer
+                          and ExternalTrafficPolicy is set to Local.
+                        format: int32
+                        type: integer
+                      ipFamily:
+                        description: ipFamily specifies whether this Service has a
+                          preference for a particular IP family (e.g. IPv4 vs. IPv6).  If
+                          a specific IP family is requested, the clusterIP field will
+                          be allocated from that family, if it is available in the
+                          cluster.  If no IP family is requested, the cluster's primary
+                          IP family will be used. Other IP fields (loadBalancerIP,
+                          loadBalancerSourceRanges, externalIPs) and controllers which
+                          allocate external load-balancers should use the same IP
+                          family.  Endpoints for this Service will be of this family.  This
+                          field is immutable after creation. Assigning a ServiceIPFamily
+                          not available in the cluster (e.g. IPv6 in IPv4 only cluster)
+                          is an error condition and will fail during clusterIP assignment.
+                        type: string
+                      loadBalancerIP:
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in this field. This
+                          feature depends on whether the underlying cloud-provider
+                          supports specifying the loadBalancerIP when a load balancer
+                          is created. This field will be ignored if the cloud-provider
+                          does not support the feature.'
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: 'If specified and supported by the platform,
+                          this will restrict traffic through the cloud-provider load-balancer
+                          will be restricted to the specified client IPs. This field
+                          will be ignored if the cloud-provider does not support the
+                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        description: 'The list of ports that are exposed by this service.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            name:
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names. When considering the endpoints
+                                for a Service, this must match the 'name' field in
+                                the EndpointPort. Optional if only one ServicePort
+                                is defined on this service.
+                              type: string
+                            nodePort:
+                              description: 'The port on each node on which this service
+                                is exposed when type=NodePort or LoadBalancer. Usually
+                                assigned by the system. If specified, it will be allocated
+                                to the service if unused or else creation of the service
+                                will fail. Default is to auto-allocate a port if the
+                                ServiceType of this Service requires one. More info:
+                                https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'Number or name of the port to access on
+                                the pods targeted by the service. Number must be in
+                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                If this is a string, it will be looked up as a named
+                                port in the target Pod''s container ports. If this
+                                is not specified, the value of the ''port'' field
+                                is used (an identity map). This field is ignored for
+                                services with clusterIP=None, and should be omitted
+                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        description: publishNotReadyAddresses, when set to true, indicates
+                          that DNS implementations must publish the notReadyAddresses
+                          of subsets for the Endpoints associated with the Service.
+                          The default value is false. The primary use case for setting
+                          this field is to use a StatefulSet's Headless Service to
+                          propagate SRV records for its Pods without respect to their
+                          readiness for purpose of peer discovery.
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: 'Route service traffic to pods with label keys
+                          and values matching this selector. If empty or not present,
+                          the service is assumed to have an external process managing
+                          its endpoints, which Kubernetes will not modify. Only applies
+                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
+                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                        type: object
+                      sessionAffinity:
+                        description: 'Supports "ClientIP" and "None". Used to maintain
+                          session affinity. Enable client IP based session affinity.
+                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
+                            properties:
+                              timeoutSeconds:
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time. The value
+                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                  == "ClientIP". Default value is 10800(for 3 hours).
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      type:
+                        description: 'type determines how the Service is exposed.
+                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
+                          NodePort, and LoadBalancer. "ExternalName" maps to the specified
+                          externalName. "ClusterIP" allocates a cluster-internal IP
+                          address for load-balancing to endpoints. Endpoints are determined
+                          by the selector or if that is not specified, by manual construction
+                          of an Endpoints object. If clusterIP is "None", no virtual
+                          IP is allocated and the endpoints are published as a set
+                          of endpoints rather than a stable IP. "NodePort" builds
+                          on ClusterIP and allocates a port on every node which routes
+                          to the clusterIP. "LoadBalancer" builds on NodePort and
+                          creates an external load-balancer (if supported in the current
+                          cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                        type: string
+                    type: object
+                  status:
+                    description: 'Most recently observed status of the service. Populated
+                      by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      loadBalancer:
+                        description: LoadBalancer contains the current status of the
+                          load-balancer, if one is present.
+                        properties:
+                          ingress:
+                            description: Ingress is a list containing ingress points
+                              for the load-balancer. Traffic intended for the service
+                              should be sent to these ingress points.
+                            items:
+                              description: 'LoadBalancerIngress represents the status
+                                of a load-balancer ingress point: traffic intended
+                                for the service should be sent to an ingress point.'
+                              properties:
+                                hostname:
+                                  description: Hostname is set for load-balancer ingress
+                                    points that are DNS based (typically AWS load-balancers)
+                                  type: string
+                                ip:
+                                  description: IP is set for load-balancer ingress
+                                    points that are IP based (typically GCE or OpenStack
+                                    load-balancers)
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                type: object
+              tolerations:
+                description: Pod's tolerations for Kubernetes node's taint
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
                       type: string
                   type: object
-                status:
-                  description: 'Most recently observed status of the service. Populated
-                    by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-                  properties:
-                    loadBalancer:
-                      description: LoadBalancer contains the current status of the
-                        load-balancer, if one is present.
-                      properties:
-                        ingress:
-                          description: Ingress is a list containing ingress points
-                            for the load-balancer. Traffic intended for the service
-                            should be sent to these ingress points.
-                          items:
-                            description: 'LoadBalancerIngress represents the status
-                              of a load-balancer ingress point: traffic intended for
-                              the service should be sent to an ingress point.'
-                            properties:
-                              hostname:
-                                description: Hostname is set for load-balancer ingress
-                                  points that are DNS based (typically AWS load-balancers)
-                                type: string
-                              ip:
-                                description: IP is set for load-balancer ingress points
-                                  that are IP based (typically GCE or OpenStack load-balancers)
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                  type: object
-              type: object
-            tolerations:
-              description: Pod's tolerations for Kubernetes node's taint
-              items:
-                description: The pod this Toleration is attached to tolerates any
-                  taint that matches the triple <key,value,effect> using the matching
-                  operator <operator>.
-                properties:
-                  effect:
-                    description: Effect indicates the taint effect to match. Empty
-                      means match all taint effects. When specified, allowed values
-                      are NoSchedule, PreferNoSchedule and NoExecute.
-                    type: string
-                  key:
-                    description: Key is the taint key that the toleration applies
-                      to. Empty means match all taint keys. If the key is empty, operator
-                      must be Exists; this combination means to match all values and
-                      all keys.
-                    type: string
-                  operator:
-                    description: Operator represents a key's relationship to the value.
-                      Valid operators are Exists and Equal. Defaults to Equal. Exists
-                      is equivalent to wildcard for value, so that a pod can tolerate
-                      all taints of a particular category.
-                    type: string
-                  tolerationSeconds:
-                    description: TolerationSeconds represents the period of time the
-                      toleration (which must be of effect NoExecute, otherwise this
-                      field is ignored) tolerates the taint. By default, it is not
-                      set, which means tolerate the taint forever (do not evict).
-                      Zero and negative values will be treated as 0 (evict immediately)
-                      by the system.
-                    format: int64
-                    type: integer
-                  value:
-                    description: Value is the taint value the toleration matches to.
-                      If the operator is Exists, the value should be empty, otherwise
-                      just a regular string.
-                    type: string
-                type: object
-              type: array
-          type: object
-        status:
-          description: SparkStatus defines the observed state of a Spark cluster
-          properties:
-            masterPhase:
-              description: current phase of the spark master
-              enum:
-              - Pending
-              - Ready
-              - Updating
-              - ScalingUp
-              - ScalingDown
-              - Terminating
-              - Error
-              type: string
-            phase:
-              description: current phase of the spark workers
-              enum:
-              - Pending
-              - Ready
-              - Updating
-              - ScalingUp
-              - ScalingDown
-              - Terminating
-              - Error
-              type: string
-            readyReplicas:
-              description: current number of ready spark workers
-              format: int32
-              type: integer
-            replicas:
-              description: number of desired spark workers
-              format: int32
-              type: integer
-            selector:
-              description: selector for pods, used by HorizontalPodAutoscaler
-              type: string
-          type: object
-      type: object
-  version: v1alpha3
-  versions:
-  - name: v1alpha3
+                type: array
+            type: object
+          status:
+            description: SparkStatus defines the observed state of a Spark cluster
+            properties:
+              masterPhase:
+                description: current phase of the spark master
+                enum:
+                - Pending
+                - Ready
+                - Updating
+                - ScalingUp
+                - ScalingDown
+                - Terminating
+                - Error
+                type: string
+              phase:
+                description: current phase of the spark workers
+                enum:
+                - Pending
+                - Ready
+                - Updating
+                - ScalingUp
+                - ScalingDown
+                - Terminating
+                - Error
+                type: string
+              readyReplicas:
+                description: current number of ready spark workers
+                format: int32
+                type: integer
+              replicas:
+                description: number of desired spark workers
+                format: int32
+                type: integer
+              selector:
+                description: selector for pods, used by HorizontalPodAutoscaler
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
-  - name: v1alpha2
-    served: true
-    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
@@ -1,8 +1,25 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: standalones.enterprise.splunk.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: Status of standalone instances
+    name: Phase
+    type: string
+  - JSONPath: .status.replicas
+    description: Number of desired standalone instances
+    name: Desired
+    type: integer
+  - JSONPath: .status.readyReplicas
+    description: Current number of ready standalone instances
+    name: Ready
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of standalone resource
+    name: Age
+    type: date
   group: enterprise.splunk.com
   names:
     kind: Standalone
@@ -10,2433 +27,2356 @@ spec:
     plural: standalones
     singular: standalone
   scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: Status of standalone instances
-      jsonPath: .status.phase
-      name: Phase
-      type: string
-    - description: Number of desired standalone instances
-      jsonPath: .status.replicas
-      name: Desired
-      type: integer
-    - description: Current number of ready standalone instances
-      jsonPath: .status.readyReplicas
-      name: Ready
-      type: integer
-    - description: Age of standalone resource
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        description: Standalone is the Schema for a Splunk Enterprise standalone instances.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: StandaloneSpec defines the desired state of a Splunk Enterprise
-              standalone instances.
-            properties:
-              Mock:
-                description: Mock to differentiate between UTs and actual reconcile
-                type: boolean
-              affinity:
-                description: Kubernetes Affinity rules that control how pods are assigned
-                  to particular nodes.
-                properties:
-                  nodeAffinity:
-                    description: Describes node affinity scheduling rules for the
-                      pod.
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node matches
-                          the corresponding matchExpressions; the node(s) with the
-                          highest sum are the most preferred.
-                        items:
-                          description: An empty preferred scheduling term matches
-                            all objects with implicit weight 0 (i.e. it's a no-op).
-                            A null preferred scheduling term matches no objects (i.e.
-                            is also a no-op).
-                          properties:
-                            preference:
-                              description: A node selector term, associated with the
-                                corresponding weight.
-                              properties:
-                                matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            weight:
-                              description: Weight associated with matching the corresponding
-                                nodeSelectorTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - preference
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to an update), the system may or may not try to
-                          eventually evict the pod from its node.
+  subresources:
+    scale:
+      labelSelectorPath: .status.selector
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Standalone is the Schema for a Splunk Enterprise standalone instances.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: StandaloneSpec defines the desired state of a Splunk Enterprise
+            standalone instances.
+          properties:
+            Mock:
+              description: Mock to differentiate between UTs and actual reconcile
+              type: boolean
+            affinity:
+              description: Kubernetes Affinity rules that control how pods are assigned
+                to particular nodes.
+              properties:
+                nodeAffinity:
+                  description: Describes node affinity scheduling rules for the pod.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node matches the corresponding matchExpressions; the
+                        node(s) with the highest sum are the most preferred.
+                      items:
+                        description: An empty preferred scheduling term matches all
+                          objects with implicit weight 0 (i.e. it's a no-op). A null
+                          preferred scheduling term matches no objects (i.e. is also
+                          a no-op).
                         properties:
-                          nodeSelectorTerms:
-                            description: Required. A list of node selector terms.
-                              The terms are ORed.
-                            items:
-                              description: A null or empty node selector term matches
-                                no objects. The requirements of them are ANDed. The
-                                TopologySelectorTerm type implements a subset of the
-                                NodeSelectorTerm.
-                              properties:
-                                matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
+                          preference:
+                            description: A node selector term, associated with the
+                              corresponding weight.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
                                         type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
                                         type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            type: array
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          weight:
+                            description: Weight associated with matching the corresponding
+                              nodeSelectorTerm, in the range 1-100.
+                            format: int32
+                            type: integer
                         required:
-                        - nodeSelectorTerms
+                        - preference
+                        - weight
                         type: object
-                    type: object
-                  podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate
-                      this pod in the same node, zone, etc. as some other pod(s)).
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
-                        items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
-                          properties:
-                            podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to an update), the system may or may not try to
+                        eventually evict the pod from its node.
+                      properties:
+                        nodeSelectorTerms:
+                          description: Required. A list of node selector terms. The
+                            terms are ORed.
+                          items:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
                                   type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                      required:
+                      - nodeSelectorTerms
+                      type: object
+                  type: object
+                podAffinity:
+                  description: Describes pod affinity scheduling rules (e.g. co-locate
+                    this pod in the same node, zone, etc. as some other pod(s)).
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node has pods which matches the corresponding podAffinityTerm;
+                        the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Required. A pod affinity term, associated
+                              with the corresponding weight.
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
                                   type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to a pod label update), the system may or may not
+                        try to eventually evict the pod from its node. When there
+                        are multiple elements, the lists of nodes corresponding to
+                        each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources, in
+                              this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+                podAntiAffinity:
+                  description: Describes pod anti-affinity scheduling rules (e.g.
+                    avoid putting this pod in the same node, zone, etc. as some other
+                    pod(s)).
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the anti-affinity expressions specified by this
+                        field, but it may choose a node that violates one or more
+                        of the expressions. The node that is most preferred is the
+                        one with the greatest sum of weights, i.e. for each node that
+                        meets all of the scheduling requirements (resource request,
+                        requiredDuringScheduling anti-affinity expressions, etc.),
+                        compute a sum by iterating through the elements of this field
+                        and adding "weight" to the sum if the node has pods which
+                        matches the corresponding podAffinityTerm; the node(s) with
+                        the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Required. A pod affinity term, associated
+                              with the corresponding weight.
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the anti-affinity requirements specified by
+                        this field are not met at scheduling time, the pod will not
+                        be scheduled onto the node. If the anti-affinity requirements
+                        specified by this field cease to be met at some point during
+                        pod execution (e.g. due to a pod label update), the system
+                        may or may not try to eventually evict the pod from its node.
+                        When there are multiple elements, the lists of nodes corresponding
+                        to each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources, in
+                              this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            clusterMasterRef:
+              description: ClusterMasterRef refers to a Splunk Enterprise indexer
+                cluster managed by the operator within Kubernetes
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            defaults:
+              description: Inline map of default.yml overrides used to initialize
+                the environment
+              type: string
+            defaultsUrl:
+              description: Full path or URL for one or more default.yml files, separated
+                by commas
+              type: string
+            ephemeralStorage:
+              description: If true, ephemeral (emptyDir) storage will be used for
+                /opt/splunk/etc and /opt/splunk/var volumes
+              type: boolean
+            etcStorage:
+              description: Storage capacity to request for /opt/splunk/etc persistent
+                volume claims (default=”1Gi”)
+              type: string
+            image:
+              description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
+                environment variables)
+              type: string
+            imagePullPolicy:
+              description: 'Sets pull policy for all images (either “Always” or the
+                default: “IfNotPresent”)'
+              enum:
+              - Always
+              - IfNotPresent
+              type: string
+            licenseMasterRef:
+              description: LicenseMasterRef refers to a Splunk Enterprise license
+                master managed by the operator within Kubernetes
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            licenseUrl:
+              description: Full path or URL for a Splunk Enterprise license file
+              type: string
+            replicas:
+              description: Number of standalone pods
+              format: int32
+              type: integer
+            resources:
+              description: resource requirements for the pod containers
+              properties:
+                limits:
+                  additionalProperties:
+                    type: string
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    type: string
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
+            schedulerName:
+              description: Name of Scheduler to use for pod placement (defaults to
+                “default-scheduler”)
+              type: string
+            serviceTemplate:
+              description: ServiceTemplate is a template used to create Kubernetes
+                services
+              properties:
+                apiVersion:
+                  description: 'APIVersion defines the versioned schema of this representation
+                    of an object. Servers should convert recognized schemas to the
+                    latest internal value, and may reject unrecognized values. More
+                    info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                  type: string
+                kind:
+                  description: 'Kind is a string value representing the REST resource
+                    this object represents. Servers may infer this from the endpoint
+                    the client submits requests to. Cannot be updated. In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                metadata:
+                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                  type: object
+                spec:
+                  description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                  properties:
+                    clusterIP:
+                      description: 'clusterIP is the IP address of the service and
+                        is usually assigned randomly by the master. If an address
+                        is specified manually and is not in use by others, it will
+                        be allocated to the service; otherwise, creation of the service
+                        will fail. This field can not be changed through updates.
+                        Valid values are "None", empty string (""), or a valid IP
+                        address. "None" can be specified for headless services when
+                        proxying is not required. Only applies to types ClusterIP,
+                        NodePort, and LoadBalancer. Ignored if type is ExternalName.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    externalIPs:
+                      description: externalIPs is a list of IP addresses for which
+                        nodes in the cluster will also accept traffic for this service.  These
+                        IPs are not managed by Kubernetes.  The user is responsible
+                        for ensuring that traffic arrives at a node with this IP.  A
+                        common example is external load-balancers that are not part
+                        of the Kubernetes system.
+                      items:
+                        type: string
+                      type: array
+                    externalName:
+                      description: externalName is the external reference that kubedns
+                        or equivalent will return as a CNAME record for this service.
+                        No proxying will be involved. Must be a valid RFC-1123 hostname
+                        (https://tools.ietf.org/html/rfc1123) and requires Type to
+                        be ExternalName.
+                      type: string
+                    externalTrafficPolicy:
+                      description: externalTrafficPolicy denotes if this Service desires
+                        to route external traffic to node-local or cluster-wide endpoints.
+                        "Local" preserves the client source IP and avoids a second
+                        hop for LoadBalancer and Nodeport type services, but risks
+                        potentially imbalanced traffic spreading. "Cluster" obscures
+                        the client source IP and may cause a second hop to another
+                        node, but should have good overall load-spreading.
+                      type: string
+                    healthCheckNodePort:
+                      description: healthCheckNodePort specifies the healthcheck nodePort
+                        for the service. If not specified, HealthCheckNodePort is
+                        created by the service api backend with the allocated nodePort.
+                        Will use user-specified nodePort value if specified by the
+                        client. Only effects when Type is set to LoadBalancer and
+                        ExternalTrafficPolicy is set to Local.
+                      format: int32
+                      type: integer
+                    ipFamily:
+                      description: ipFamily specifies whether this Service has a preference
+                        for a particular IP family (e.g. IPv4 vs. IPv6).  If a specific
+                        IP family is requested, the clusterIP field will be allocated
+                        from that family, if it is available in the cluster.  If no
+                        IP family is requested, the cluster's primary IP family will
+                        be used. Other IP fields (loadBalancerIP, loadBalancerSourceRanges,
+                        externalIPs) and controllers which allocate external load-balancers
+                        should use the same IP family.  Endpoints for this Service
+                        will be of this family.  This field is immutable after creation.
+                        Assigning a ServiceIPFamily not available in the cluster (e.g.
+                        IPv6 in IPv4 only cluster) is an error condition and will
+                        fail during clusterIP assignment.
+                      type: string
+                    loadBalancerIP:
+                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                        will get created with the IP specified in this field. This
+                        feature depends on whether the underlying cloud-provider supports
+                        specifying the loadBalancerIP when a load balancer is created.
+                        This field will be ignored if the cloud-provider does not
+                        support the feature.'
+                      type: string
+                    loadBalancerSourceRanges:
+                      description: 'If specified and supported by the platform, this
+                        will restrict traffic through the cloud-provider load-balancer
+                        will be restricted to the specified client IPs. This field
+                        will be ignored if the cloud-provider does not support the
+                        feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: 'The list of ports that are exposed by this service.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      items:
+                        description: ServicePort contains information on service's
+                          port.
+                        properties:
+                          name:
+                            description: The name of this port within the service.
+                              This must be a DNS_LABEL. All ports within a ServiceSpec
+                              must have unique names. When considering the endpoints
+                              for a Service, this must match the 'name' field in the
+                              EndpointPort. Optional if only one ServicePort is defined
+                              on this service.
+                            type: string
+                          nodePort:
+                            description: 'The port on each node on which this service
+                              is exposed when type=NodePort or LoadBalancer. Usually
+                              assigned by the system. If specified, it will be allocated
+                              to the service if unused or else creation of the service
+                              will fail. Default is to auto-allocate a port if the
+                              ServiceType of this Service requires one. More info:
+                              https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                            format: int32
+                            type: integer
+                          port:
+                            description: The port that will be exposed by this service.
+                            format: int32
+                            type: integer
+                          protocol:
+                            description: The IP protocol for this port. Supports "TCP",
+                              "UDP", and "SCTP". Default is TCP.
+                            type: string
+                          targetPort:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: 'Number or name of the port to access on
+                              the pods targeted by the service. Number must be in
+                              the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              If this is a string, it will be looked up as a named
+                              port in the target Pod''s container ports. If this is
+                              not specified, the value of the ''port'' field is used
+                              (an identity map). This field is ignored for services
+                              with clusterIP=None, and should be omitted or set equal
+                              to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      type: array
+                    publishNotReadyAddresses:
+                      description: publishNotReadyAddresses, when set to true, indicates
+                        that DNS implementations must publish the notReadyAddresses
+                        of subsets for the Endpoints associated with the Service.
+                        The default value is false. The primary use case for setting
+                        this field is to use a StatefulSet's Headless Service to propagate
+                        SRV records for its Pods without respect to their readiness
+                        for purpose of peer discovery.
+                      type: boolean
+                    selector:
+                      additionalProperties:
+                        type: string
+                      description: 'Route service traffic to pods with label keys
+                        and values matching this selector. If empty or not present,
+                        the service is assumed to have an external process managing
+                        its endpoints, which Kubernetes will not modify. Only applies
+                        to types ClusterIP, NodePort, and LoadBalancer. Ignored if
+                        type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                      type: object
+                    sessionAffinity:
+                      description: 'Supports "ClientIP" and "None". Used to maintain
+                        session affinity. Enable client IP based session affinity.
+                        Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    sessionAffinityConfig:
+                      description: sessionAffinityConfig contains the configurations
+                        of session affinity.
+                      properties:
+                        clientIP:
+                          description: clientIP contains the configurations of Client
+                            IP based session affinity.
+                          properties:
+                            timeoutSeconds:
+                              description: timeoutSeconds specifies the seconds of
+                                ClientIP type session sticky time. The value must
+                                be >0 && <=86400(for 1 day) if ServiceAffinity ==
+                                "ClientIP". Default value is 10800(for 3 hours).
                               format: int32
                               type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
                           type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to a pod label update), the system may or may
-                          not try to eventually evict the pod from its node. When
-                          there are multiple elements, the lists of nodes corresponding
-                          to each podAffinityTerm are intersected, i.e. all terms
-                          must be satisfied.
-                        items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
-                          properties:
-                            labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            namespaces:
-                              description: namespaces specifies which namespaces the
-                                labelSelector applies to (matches against); null or
-                                empty list means "this pod's namespace"
-                              items:
+                      type: object
+                    type:
+                      description: 'type determines how the Service is exposed. Defaults
+                        to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort,
+                        and LoadBalancer. "ExternalName" maps to the specified externalName.
+                        "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                        to endpoints. Endpoints are determined by the selector or
+                        if that is not specified, by manual construction of an Endpoints
+                        object. If clusterIP is "None", no virtual IP is allocated
+                        and the endpoints are published as a set of endpoints rather
+                        than a stable IP. "NodePort" builds on ClusterIP and allocates
+                        a port on every node which routes to the clusterIP. "LoadBalancer"
+                        builds on NodePort and creates an external load-balancer (if
+                        supported in the current cloud) which routes to the clusterIP.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                      type: string
+                  type: object
+                status:
+                  description: 'Most recently observed status of the service. Populated
+                    by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                  properties:
+                    loadBalancer:
+                      description: LoadBalancer contains the current status of the
+                        load-balancer, if one is present.
+                      properties:
+                        ingress:
+                          description: Ingress is a list containing ingress points
+                            for the load-balancer. Traffic intended for the service
+                            should be sent to these ingress points.
+                          items:
+                            description: 'LoadBalancerIngress represents the status
+                              of a load-balancer ingress point: traffic intended for
+                              the service should be sent to an ingress point.'
+                            properties:
+                              hostname:
+                                description: Hostname is set for load-balancer ingress
+                                  points that are DNS based (typically AWS load-balancers)
                                 type: string
-                              type: array
-                            topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                  podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g.
-                      avoid putting this pod in the same node, zone, etc. as some
-                      other pod(s)).
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the anti-affinity expressions specified
-                          by this field, but it may choose a node that violates one
-                          or more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling anti-affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
-                        items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
-                          properties:
-                            podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the anti-affinity requirements specified by
-                          this field are not met at scheduling time, the pod will
-                          not be scheduled onto the node. If the anti-affinity requirements
-                          specified by this field cease to be met at some point during
-                          pod execution (e.g. due to a pod label update), the system
-                          may or may not try to eventually evict the pod from its
-                          node. When there are multiple elements, the lists of nodes
-                          corresponding to each podAffinityTerm are intersected, i.e.
-                          all terms must be satisfied.
-                        items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
-                          properties:
-                            labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            namespaces:
-                              description: namespaces specifies which namespaces the
-                                labelSelector applies to (matches against); null or
-                                empty list means "this pod's namespace"
-                              items:
+                              ip:
+                                description: IP is set for load-balancer ingress points
+                                  that are IP based (typically GCE or OpenStack load-balancers)
                                 type: string
-                              type: array
-                            topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                type: object
-              clusterMasterRef:
-                description: ClusterMasterRef refers to a Splunk Enterprise indexer
-                  cluster managed by the operator within Kubernetes
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              defaults:
-                description: Inline map of default.yml overrides used to initialize
-                  the environment
-                type: string
-              defaultsUrl:
-                description: Full path or URL for one or more default.yml files, separated
-                  by commas
-                type: string
-              ephemeralStorage:
-                description: If true, ephemeral (emptyDir) storage will be used for
-                  /opt/splunk/etc and /opt/splunk/var volumes
-                type: boolean
-              etcStorage:
-                description: Storage capacity to request for /opt/splunk/etc persistent
-                  volume claims (default=”1Gi”)
-                type: string
-              image:
-                description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
-                  environment variables)
-                type: string
-              imagePullPolicy:
-                description: 'Sets pull policy for all images (either “Always” or
-                  the default: “IfNotPresent”)'
-                enum:
-                - Always
-                - IfNotPresent
-                type: string
-              licenseMasterRef:
-                description: LicenseMasterRef refers to a Splunk Enterprise license
-                  master managed by the operator within Kubernetes
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              licenseUrl:
-                description: Full path or URL for a Splunk Enterprise license file
-                type: string
-              replicas:
-                description: Number of standalone pods
-                format: int32
-                type: integer
-              resources:
-                description: resource requirements for the pod containers
-                properties:
-                  limits:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                    type: object
-                  requests:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                    type: object
-                type: object
-              schedulerName:
-                description: Name of Scheduler to use for pod placement (defaults
-                  to “default-scheduler”)
-                type: string
-              serviceTemplate:
-                description: ServiceTemplate is a template used to create Kubernetes
-                  services
-                properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  metadata:
-                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                    type: object
-                  spec:
-                    description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+              type: object
+            smartstore:
+              description: Splunk Smartstore configuration. Refer to indexes.conf.spec
+                on docs.splunk.com
+              properties:
+                indexes:
+                  description: List of Splunk indexes
+                  items:
+                    description: IndexSpec defines Splunk index name and storage path
                     properties:
-                      clusterIP:
-                        description: 'clusterIP is the IP address of the service and
-                          is usually assigned randomly by the master. If an address
-                          is specified manually and is not in use by others, it will
-                          be allocated to the service; otherwise, creation of the
-                          service will fail. This field can not be changed through
-                          updates. Valid values are "None", empty string (""), or
-                          a valid IP address. "None" can be specified for headless
-                          services when proxying is not required. Only applies to
-                          types ClusterIP, NodePort, and LoadBalancer. Ignored if
-                          type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      name:
+                        description: Splunk index name
                         type: string
-                      externalIPs:
-                        description: externalIPs is a list of IP addresses for which
-                          nodes in the cluster will also accept traffic for this service.  These
-                          IPs are not managed by Kubernetes.  The user is responsible
-                          for ensuring that traffic arrives at a node with this IP.  A
-                          common example is external load-balancers that are not part
-                          of the Kubernetes system.
-                        items:
-                          type: string
-                        type: array
-                      externalName:
-                        description: externalName is the external reference that kubedns
-                          or equivalent will return as a CNAME record for this service.
-                          No proxying will be involved. Must be a valid RFC-1123 hostname
-                          (https://tools.ietf.org/html/rfc1123) and requires Type
-                          to be ExternalName.
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
                         type: string
-                      externalTrafficPolicy:
-                        description: externalTrafficPolicy denotes if this Service
-                          desires to route external traffic to node-local or cluster-wide
-                          endpoints. "Local" preserves the client source IP and avoids
-                          a second hop for LoadBalancer and Nodeport type services,
-                          but risks potentially imbalanced traffic spreading. "Cluster"
-                          obscures the client source IP and may cause a second hop
-                          to another node, but should have good overall load-spreading.
+                      volumeName:
+                        description: Remote Volume name
                         type: string
-                      healthCheckNodePort:
-                        description: healthCheckNodePort specifies the healthcheck
-                          nodePort for the service. If not specified, HealthCheckNodePort
-                          is created by the service api backend with the allocated
-                          nodePort. Will use user-specified nodePort value if specified
-                          by the client. Only effects when Type is set to LoadBalancer
-                          and ExternalTrafficPolicy is set to Local.
+                    type: object
+                  type: array
+                volumes:
+                  description: List of remote storage volumes
+                  items:
+                    description: VolumeSpec defines remote volume name and remote
+                      volume URI
+                    properties:
+                      endpoint:
+                        description: Remote volume URI
+                        type: string
+                      name:
+                        description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
+                        type: string
+                    type: object
+                  type: array
+              type: object
+            sparkImage:
+              description: Image to use for Spark pod containers (overrides RELATED_IMAGE_SPLUNK_SPARK
+                environment variables)
+              type: string
+            sparkRef:
+              description: SparkRef refers to a Spark cluster managed by the operator
+                within Kubernetes When defined, Data Fabric Search (DFS) will be enabled
+                and configured to use the Spark cluster.
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            storageClassName:
+              description: Name of StorageClass to use for persistent volume claims
+              type: string
+            tolerations:
+              description: Pod's tolerations for Kubernetes node's taint
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+                type: object
+              type: array
+            varStorage:
+              description: Storage capacity to request for /opt/splunk/var persistent
+                volume claims (default=”50Gi”)
+              type: string
+            volumes:
+              description: List of one or more Kubernetes volumes. These will be mounted
+                in all pod containers as as /mnt/<name>
+              items:
+                description: Volume represents a named volume in a pod that may be
+                  accessed by any container in the pod.
+                properties:
+                  awsElasticBlockStore:
+                    description: 'AWSElasticBlockStore represents an AWS Disk resource
+                      that is attached to a kubelet''s host machine and then exposed
+                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty).'
                         format: int32
                         type: integer
-                      ipFamily:
-                        description: ipFamily specifies whether this Service has a
-                          preference for a particular IP family (e.g. IPv4 vs. IPv6).  If
-                          a specific IP family is requested, the clusterIP field will
-                          be allocated from that family, if it is available in the
-                          cluster.  If no IP family is requested, the cluster's primary
-                          IP family will be used. Other IP fields (loadBalancerIP,
-                          loadBalancerSourceRanges, externalIPs) and controllers which
-                          allocate external load-balancers should use the same IP
-                          family.  Endpoints for this Service will be of this family.  This
-                          field is immutable after creation. Assigning a ServiceIPFamily
-                          not available in the cluster (e.g. IPv6 in IPv4 only cluster)
-                          is an error condition and will fail during clusterIP assignment.
+                      readOnly:
+                        description: 'Specify "true" to force and set the ReadOnly
+                          property in VolumeMounts to "true". If omitted, the default
+                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: boolean
+                      volumeID:
+                        description: 'Unique ID of the persistent disk resource in
+                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                         type: string
-                      loadBalancerIP:
-                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                          will get created with the IP specified in this field. This
-                          feature depends on whether the underlying cloud-provider
-                          supports specifying the loadBalancerIP when a load balancer
-                          is created. This field will be ignored if the cloud-provider
-                          does not support the feature.'
+                    required:
+                    - volumeID
+                    type: object
+                  azureDisk:
+                    description: AzureDisk represents an Azure Data Disk mount on
+                      the host and bind mount to the pod.
+                    properties:
+                      cachingMode:
+                        description: 'Host Caching mode: None, Read Only, Read Write.'
                         type: string
-                      loadBalancerSourceRanges:
-                        description: 'If specified and supported by the platform,
-                          this will restrict traffic through the cloud-provider load-balancer
-                          will be restricted to the specified client IPs. This field
-                          will be ignored if the cloud-provider does not support the
-                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                      diskName:
+                        description: The Name of the data disk in the blob storage
+                        type: string
+                      diskURI:
+                        description: The URI the data disk in the blob storage
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      kind:
+                        description: 'Expected values Shared: multiple blob disks
+                          per storage account  Dedicated: single blob disk per storage
+                          account  Managed: azure managed data disk (only in managed
+                          availability set). defaults to shared'
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                    required:
+                    - diskName
+                    - diskURI
+                    type: object
+                  azureFile:
+                    description: AzureFile represents an Azure File Service mount
+                      on the host and bind mount to the pod.
+                    properties:
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretName:
+                        description: the name of secret that contains Azure Storage
+                          Account Name and Key
+                        type: string
+                      shareName:
+                        description: Share Name
+                        type: string
+                    required:
+                    - secretName
+                    - shareName
+                    type: object
+                  cephfs:
+                    description: CephFS represents a Ceph FS mount on the host that
+                      shares a pod's lifetime
+                    properties:
+                      monitors:
+                        description: 'Required: Monitors is a collection of Ceph monitors
+                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                         items:
                           type: string
                         type: array
-                      ports:
-                        description: 'The list of ports that are exposed by this service.
-                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      path:
+                        description: 'Optional: Used as the mounted root, rather than
+                          the full Ceph tree, default is /'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: boolean
+                      secretFile:
+                        description: 'Optional: SecretFile is the path to key ring
+                          for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                      secretRef:
+                        description: 'Optional: SecretRef is reference to the authentication
+                          secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      user:
+                        description: 'Optional: User is the rados user name, default
+                          is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                    required:
+                    - monitors
+                    type: object
+                  cinder:
+                    description: 'Cinder represents a cinder volume attached and mounted
+                      on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Examples: "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: boolean
+                      secretRef:
+                        description: 'Optional: points to a secret object containing
+                          parameters used to connect to OpenStack.'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      volumeID:
+                        description: 'volume id used to identify the volume in cinder.
+                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  configMap:
+                    description: ConfigMap represents a configMap that should populate
+                      this volume
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced ConfigMap will be projected into
+                          the volume as a file whose name is the key and content is
+                          the value. If specified, the listed keys will be projected
+                          into the specified paths, and unlisted keys will not be
+                          present. If a key is specified which is not present in the
+                          ConfigMap, the volume setup will error unless it is marked
+                          optional. Paths must be relative and may not contain the
+                          '..' path or start with '..'.
                         items:
-                          description: ServicePort contains information on service's
-                            port.
+                          description: Maps a string key to a path within a volume.
                           properties:
-                            name:
-                              description: The name of this port within the service.
-                                This must be a DNS_LABEL. All ports within a ServiceSpec
-                                must have unique names. When considering the endpoints
-                                for a Service, this must match the 'name' field in
-                                the EndpointPort. Optional if only one ServicePort
-                                is defined on this service.
+                            key:
+                              description: The key to project.
                               type: string
-                            nodePort:
-                              description: 'The port on each node on which this service
-                                is exposed when type=NodePort or LoadBalancer. Usually
-                                assigned by the system. If specified, it will be allocated
-                                to the service if unused or else creation of the service
-                                will fail. Default is to auto-allocate a port if the
-                                ServiceType of this Service requires one. More info:
-                                https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
                               format: int32
                               type: integer
-                            port:
-                              description: The port that will be exposed by this service.
-                              format: int32
-                              type: integer
-                            protocol:
-                              description: The IP protocol for this port. Supports
-                                "TCP", "UDP", and "SCTP". Default is TCP.
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
                               type: string
-                            targetPort:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              description: 'Number or name of the port to access on
-                                the pods targeted by the service. Number must be in
-                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                                If this is a string, it will be looked up as a named
-                                port in the target Pod''s container ports. If this
-                                is not specified, the value of the ''port'' field
-                                is used (an identity map). This field is ignored for
-                                services with clusterIP=None, and should be omitted
-                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
-                              x-kubernetes-int-or-string: true
                           required:
-                          - port
+                          - key
+                          - path
                           type: object
                         type: array
-                        x-kubernetes-list-map-keys:
-                        - port
-                        - protocol
-                        x-kubernetes-list-type: map
-                      publishNotReadyAddresses:
-                        description: publishNotReadyAddresses, when set to true, indicates
-                          that DNS implementations must publish the notReadyAddresses
-                          of subsets for the Endpoints associated with the Service.
-                          The default value is false. The primary use case for setting
-                          this field is to use a StatefulSet's Headless Service to
-                          propagate SRV records for its Pods without respect to their
-                          readiness for purpose of peer discovery.
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the ConfigMap or its keys must
+                          be defined
                         type: boolean
-                      selector:
+                    type: object
+                  csi:
+                    description: CSI (Container Storage Interface) represents storage
+                      that is handled by an external CSI driver (Alpha feature).
+                    properties:
+                      driver:
+                        description: Driver is the name of the CSI driver that handles
+                          this volume. Consult with your admin for the correct name
+                          as registered in the cluster.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Ex. "ext4", "xfs",
+                          "ntfs". If not provided, the empty value is passed to the
+                          associated CSI driver which will determine the default filesystem
+                          to apply.
+                        type: string
+                      nodePublishSecretRef:
+                        description: NodePublishSecretRef is a reference to the secret
+                          object containing sensitive information to pass to the CSI
+                          driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
+                          calls. This field is optional, and  may be empty if no secret
+                          is required. If the secret object contains more than one
+                          secret, all secret references are passed.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      readOnly:
+                        description: Specifies a read-only configuration for the volume.
+                          Defaults to false (read/write).
+                        type: boolean
+                      volumeAttributes:
                         additionalProperties:
                           type: string
-                        description: 'Route service traffic to pods with label keys
-                          and values matching this selector. If empty or not present,
-                          the service is assumed to have an external process managing
-                          its endpoints, which Kubernetes will not modify. Only applies
-                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
-                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                        description: VolumeAttributes stores driver-specific properties
+                          that are passed to the CSI driver. Consult your driver's
+                          documentation for supported values.
                         type: object
-                      sessionAffinity:
-                        description: 'Supports "ClientIP" and "None". Used to maintain
-                          session affinity. Enable client IP based session affinity.
-                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                        type: string
-                      sessionAffinityConfig:
-                        description: sessionAffinityConfig contains the configurations
-                          of session affinity.
-                        properties:
-                          clientIP:
-                            description: clientIP contains the configurations of Client
-                              IP based session affinity.
-                            properties:
-                              timeoutSeconds:
-                                description: timeoutSeconds specifies the seconds
-                                  of ClientIP type session sticky time. The value
-                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
-                                  == "ClientIP". Default value is 10800(for 3 hours).
-                                format: int32
-                                type: integer
-                            type: object
-                        type: object
-                      type:
-                        description: 'type determines how the Service is exposed.
-                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
-                          NodePort, and LoadBalancer. "ExternalName" maps to the specified
-                          externalName. "ClusterIP" allocates a cluster-internal IP
-                          address for load-balancing to endpoints. Endpoints are determined
-                          by the selector or if that is not specified, by manual construction
-                          of an Endpoints object. If clusterIP is "None", no virtual
-                          IP is allocated and the endpoints are published as a set
-                          of endpoints rather than a stable IP. "NodePort" builds
-                          on ClusterIP and allocates a port on every node which routes
-                          to the clusterIP. "LoadBalancer" builds on NodePort and
-                          creates an external load-balancer (if supported in the current
-                          cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
-                        type: string
+                    required:
+                    - driver
                     type: object
-                  status:
-                    description: 'Most recently observed status of the service. Populated
-                      by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                  downwardAPI:
+                    description: DownwardAPI represents downward API about the pod
+                      that should populate this volume
                     properties:
-                      loadBalancer:
-                        description: LoadBalancer contains the current status of the
-                          load-balancer, if one is present.
-                        properties:
-                          ingress:
-                            description: Ingress is a list containing ingress points
-                              for the load-balancer. Traffic intended for the service
-                              should be sent to these ingress points.
-                            items:
-                              description: 'LoadBalancerIngress represents the status
-                                of a load-balancer ingress point: traffic intended
-                                for the service should be sent to an ingress point.'
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: Items is a list of downward API volume file
+                        items:
+                          description: DownwardAPIVolumeFile represents information
+                            to create the file containing the pod field
+                          properties:
+                            fieldRef:
+                              description: 'Required: Selects a field of the pod:
+                                only annotations, labels, name and namespace are supported.'
                               properties:
-                                hostname:
-                                  description: Hostname is set for load-balancer ingress
-                                    points that are DNS based (typically AWS load-balancers)
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
                                   type: string
-                                ip:
-                                  description: IP is set for load-balancer ingress
-                                    points that are IP based (typically GCE or OpenStack
-                                    load-balancers)
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
                                   type: string
+                              required:
+                              - fieldPath
                               type: object
-                            type: array
-                        type: object
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: 'Required: Path is  the relative path name
+                                of the file to be created. Must not be absolute or
+                                contain the ''..'' path. Must be utf-8 encoded. The
+                                first item of the relative path must not start with
+                                ''..'''
+                              type: string
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                requests.cpu and requests.memory) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  type: string
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                          required:
+                          - path
+                          type: object
+                        type: array
                     type: object
-                type: object
-              smartstore:
-                description: Splunk Smartstore configuration. Refer to indexes.conf.spec
-                  on docs.splunk.com
-                properties:
-                  indexes:
-                    description: List of Splunk indexes
-                    items:
-                      description: IndexSpec defines Splunk index name and storage
-                        path
-                      properties:
-                        name:
-                          description: Splunk index name
+                  emptyDir:
+                    description: 'EmptyDir represents a temporary directory that shares
+                      a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                    properties:
+                      medium:
+                        description: 'What type of storage medium should back this
+                          directory. The default is "" which means to use the node''s
+                          default medium. Must be an empty string (default) or Memory.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        type: string
+                      sizeLimit:
+                        description: 'Total amount of local storage required for this
+                          EmptyDir volume. The size limit is also applicable for memory
+                          medium. The maximum usage on memory medium EmptyDir would
+                          be the minimum value between the SizeLimit specified here
+                          and the sum of memory limits of all containers in a pod.
+                          The default is nil which means that the limit is undefined.
+                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                        type: string
+                    type: object
+                  fc:
+                    description: FC represents a Fibre Channel resource that is attached
+                      to a kubelet's host machine and then exposed to the pod.
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      lun:
+                        description: 'Optional: FC target lun number'
+                        format: int32
+                        type: integer
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      targetWWNs:
+                        description: 'Optional: FC target worldwide names (WWNs)'
+                        items:
                           type: string
-                        remotePath:
-                          description: Index location relative to the remote volume
-                            path
+                        type: array
+                      wwids:
+                        description: 'Optional: FC volume world wide identifiers (wwids)
+                          Either wwids or combination of targetWWNs and lun must be
+                          set, but not both simultaneously.'
+                        items:
                           type: string
-                        volumeName:
-                          description: Remote Volume name
+                        type: array
+                    type: object
+                  flexVolume:
+                    description: FlexVolume represents a generic volume resource that
+                      is provisioned/attached using an exec based plugin.
+                    properties:
+                      driver:
+                        description: Driver is the name of the driver to use for this
+                          volume.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". The default filesystem depends on FlexVolume
+                          script.
+                        type: string
+                      options:
+                        additionalProperties:
                           type: string
-                      type: object
-                    type: array
-                  volumes:
-                    description: List of remote storage volumes
-                    items:
-                      description: VolumeSpec defines remote volume name and remote
-                        volume URI
-                      properties:
-                        endpoint:
-                          description: Remote volume URI
+                        description: 'Optional: Extra command options if any.'
+                        type: object
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      secretRef:
+                        description: 'Optional: SecretRef is reference to the secret
+                          object containing sensitive information to pass to the plugin
+                          scripts. This may be empty if no secret object is specified.
+                          If the secret object contains more than one secret, all
+                          secrets are passed to the plugin scripts.'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                    required:
+                    - driver
+                    type: object
+                  flocker:
+                    description: Flocker represents a Flocker volume attached to a
+                      kubelet's host machine. This depends on the Flocker control
+                      service being running
+                    properties:
+                      datasetName:
+                        description: Name of the dataset stored as metadata -> name
+                          on the dataset for Flocker should be considered as deprecated
+                        type: string
+                      datasetUUID:
+                        description: UUID of the dataset. This is unique identifier
+                          of a Flocker dataset
+                        type: string
+                    type: object
+                  gcePersistentDisk:
+                    description: 'GCEPersistentDisk represents a GCE Disk resource
+                      that is attached to a kubelet''s host machine and then exposed
+                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        format: int32
+                        type: integer
+                      pdName:
+                        description: 'Unique name of the PD resource in GCE. Used
+                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: boolean
+                    required:
+                    - pdName
+                    type: object
+                  gitRepo:
+                    description: 'GitRepo represents a git repository at a particular
+                      revision. DEPRECATED: GitRepo is deprecated. To provision a
+                      container with a git repo, mount an EmptyDir into an InitContainer
+                      that clones the repo using git, then mount the EmptyDir into
+                      the Pod''s container.'
+                    properties:
+                      directory:
+                        description: Target directory name. Must not contain or start
+                          with '..'.  If '.' is supplied, the volume directory will
+                          be the git repository.  Otherwise, if specified, the volume
+                          will contain the git repository in the subdirectory with
+                          the given name.
+                        type: string
+                      repository:
+                        description: Repository URL
+                        type: string
+                      revision:
+                        description: Commit hash for the specified revision.
+                        type: string
+                    required:
+                    - repository
+                    type: object
+                  glusterfs:
+                    description: 'Glusterfs represents a Glusterfs mount on the host
+                      that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                    properties:
+                      endpoints:
+                        description: 'EndpointsName is the endpoint name that details
+                          Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      path:
+                        description: 'Path is the Glusterfs volume path. More info:
+                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the Glusterfs volume
+                          to be mounted with read-only permissions. Defaults to false.
+                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: boolean
+                    required:
+                    - endpoints
+                    - path
+                    type: object
+                  hostPath:
+                    description: 'HostPath represents a pre-existing file or directory
+                      on the host machine that is directly exposed to the container.
+                      This is generally used for system agents or other privileged
+                      things that are allowed to see the host machine. Most containers
+                      will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                      --- TODO(jonesdl) We need to restrict who can use host directory
+                      mounts and who can/can not mount host directories as read/write.'
+                    properties:
+                      path:
+                        description: 'Path of the directory on the host. If the path
+                          is a symlink, it will follow the link to the real path.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                      type:
+                        description: 'Type for HostPath Volume Defaults to "" More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                    required:
+                    - path
+                    type: object
+                  iscsi:
+                    description: 'ISCSI represents an ISCSI Disk resource that is
+                      attached to a kubelet''s host machine and then exposed to the
+                      pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                    properties:
+                      chapAuthDiscovery:
+                        description: whether support iSCSI Discovery CHAP authentication
+                        type: boolean
+                      chapAuthSession:
+                        description: whether support iSCSI Session CHAP authentication
+                        type: boolean
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      initiatorName:
+                        description: Custom iSCSI Initiator Name. If initiatorName
+                          is specified with iscsiInterface simultaneously, new iSCSI
+                          interface <target portal>:<volume name> will be created
+                          for the connection.
+                        type: string
+                      iqn:
+                        description: Target iSCSI Qualified Name.
+                        type: string
+                      iscsiInterface:
+                        description: iSCSI Interface Name that uses an iSCSI transport.
+                          Defaults to 'default' (tcp).
+                        type: string
+                      lun:
+                        description: iSCSI Target Lun number.
+                        format: int32
+                        type: integer
+                      portals:
+                        description: iSCSI Target Portal List. The portal is either
+                          an IP or ip_addr:port if the port is other than default
+                          (typically TCP ports 860 and 3260).
+                        items:
                           type: string
-                        name:
-                          description: Remote volume name
-                          type: string
-                        path:
-                          description: Remote volume path
-                          type: string
-                      type: object
-                    type: array
-                type: object
-              sparkImage:
-                description: Image to use for Spark pod containers (overrides RELATED_IMAGE_SPLUNK_SPARK
-                  environment variables)
-                type: string
-              sparkRef:
-                description: SparkRef refers to a Spark cluster managed by the operator
-                  within Kubernetes When defined, Data Fabric Search (DFS) will be
-                  enabled and configured to use the Spark cluster.
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
+                        type: array
+                      readOnly:
+                        description: ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false.
+                        type: boolean
+                      secretRef:
+                        description: CHAP Secret for iSCSI target and initiator authentication
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      targetPortal:
+                        description: iSCSI Target Portal. The Portal is either an
+                          IP or ip_addr:port if the port is other than default (typically
+                          TCP ports 860 and 3260).
+                        type: string
+                    required:
+                    - iqn
+                    - lun
+                    - targetPortal
+                    type: object
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
+                      the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
+                  nfs:
+                    description: 'NFS represents an NFS mount on the host that shares
+                      a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                    properties:
+                      path:
+                        description: 'Path that is exported by the NFS server. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the NFS export to be
+                          mounted with read-only permissions. Defaults to false. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: boolean
+                      server:
+                        description: 'Server is the hostname or IP address of the
+                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                    required:
+                    - path
+                    - server
+                    type: object
+                  persistentVolumeClaim:
+                    description: 'PersistentVolumeClaimVolumeSource represents a reference
+                      to a PersistentVolumeClaim in the same namespace. More info:
+                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                    properties:
+                      claimName:
+                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                          in the same namespace as the pod using this volume. More
+                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        type: string
+                      readOnly:
+                        description: Will force the ReadOnly setting in VolumeMounts.
+                          Default false.
+                        type: boolean
+                    required:
+                    - claimName
+                    type: object
+                  photonPersistentDisk:
+                    description: PhotonPersistentDisk represents a PhotonController
+                      persistent disk attached and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      pdID:
+                        description: ID that identifies Photon Controller persistent
+                          disk
+                        type: string
+                    required:
+                    - pdID
+                    type: object
+                  portworxVolume:
+                    description: PortworxVolume represents a portworx volume attached
+                      and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: FSType represents the filesystem type to mount
+                          Must be a filesystem type supported by the host operating
+                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                          if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      volumeID:
+                        description: VolumeID uniquely identifies a Portworx volume
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  projected:
+                    description: Items for all in one resources secrets, configmaps,
+                      and downward API
+                    properties:
+                      defaultMode:
+                        description: Mode bits to use on created files by default.
+                          Must be a value between 0 and 0777. Directories within the
+                          path are not affected by this setting. This might be in
+                          conflict with other options that affect the file mode, like
+                          fsGroup, and the result can be other mode bits set.
+                        format: int32
+                        type: integer
+                      sources:
+                        description: list of volume projections
+                        items:
+                          description: Projection that may be projected along with
+                            other supported volume types
+                          properties:
+                            configMap:
+                              description: information about the configMap data to
+                                project
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    keys must be defined
+                                  type: boolean
+                              type: object
+                            downwardAPI:
+                              description: information about the downwardAPI data
+                                to project
+                              properties:
+                                items:
+                                  description: Items is a list of DownwardAPIVolume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, requests.cpu and requests.memory)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            secret:
+                              description: information about the secret data to project
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced Secret will
+                                    be projected into the volume as a file whose name
+                                    is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              type: object
+                            serviceAccountToken:
+                              description: information about the serviceAccountToken
+                                data to project
+                              properties:
+                                audience:
+                                  description: Audience is the intended audience of
+                                    the token. A recipient of a token must identify
+                                    itself with an identifier specified in the audience
+                                    of the token, and otherwise should reject the
+                                    token. The audience defaults to the identifier
+                                    of the apiserver.
+                                  type: string
+                                expirationSeconds:
+                                  description: ExpirationSeconds is the requested
+                                    duration of validity of the service account token.
+                                    As the token approaches expiration, the kubelet
+                                    volume plugin will proactively rotate the service
+                                    account token. The kubelet will start trying to
+                                    rotate the token if the token is older than 80
+                                    percent of its time to live or if the token is
+                                    older than 24 hours.Defaults to 1 hour and must
+                                    be at least 10 minutes.
+                                  format: int64
+                                  type: integer
+                                path:
+                                  description: Path is the path relative to the mount
+                                    point of the file to project the token into.
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                          type: object
+                        type: array
+                    required:
+                    - sources
+                    type: object
+                  quobyte:
+                    description: Quobyte represents a Quobyte mount on the host that
+                      shares a pod's lifetime
+                    properties:
+                      group:
+                        description: Group to map volume access to Default is no group
+                        type: string
+                      readOnly:
+                        description: ReadOnly here will force the Quobyte volume to
+                          be mounted with read-only permissions. Defaults to false.
+                        type: boolean
+                      registry:
+                        description: Registry represents a single or multiple Quobyte
+                          Registry services specified as a string as host:port pair
+                          (multiple entries are separated with commas) which acts
+                          as the central registry for volumes
+                        type: string
+                      tenant:
+                        description: Tenant owning the given Quobyte volume in the
+                          Backend Used with dynamically provisioned Quobyte volumes,
+                          value is set by the plugin
+                        type: string
+                      user:
+                        description: User to map volume access to Defaults to serivceaccount
+                          user
+                        type: string
+                      volume:
+                        description: Volume is a string that references an already
+                          created Quobyte volume by name.
+                        type: string
+                    required:
+                    - registry
+                    - volume
+                    type: object
+                  rbd:
+                    description: 'RBD represents a Rados Block Device mount on the
+                      host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      image:
+                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      keyring:
+                        description: 'Keyring is the path to key ring for RBDUser.
+                          Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      monitors:
+                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        items:
+                          type: string
+                        type: array
+                      pool:
+                        description: 'The rados pool name. Default is rbd. More info:
+                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: boolean
+                      secretRef:
+                        description: 'SecretRef is name of the authentication secret
+                          for RBDUser. If provided overrides keyring. Default is nil.
+                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      user:
+                        description: 'The rados user name. Default is admin. More
+                          info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                    required:
+                    - image
+                    - monitors
+                    type: object
+                  scaleIO:
+                    description: ScaleIO represents a ScaleIO persistent volume attached
+                      and mounted on Kubernetes nodes.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Default is "xfs".
+                        type: string
+                      gateway:
+                        description: The host address of the ScaleIO API Gateway.
+                        type: string
+                      protectionDomain:
+                        description: The name of the ScaleIO Protection Domain for
+                          the configured storage.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: SecretRef references to the secret for ScaleIO
+                          user and other sensitive information. If this is not provided,
+                          Login operation will fail.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      sslEnabled:
+                        description: Flag to enable/disable SSL communication with
+                          Gateway, default false
+                        type: boolean
+                      storageMode:
+                        description: Indicates whether the storage for a volume should
+                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                        type: string
+                      storagePool:
+                        description: The ScaleIO Storage Pool associated with the
+                          protection domain.
+                        type: string
+                      system:
+                        description: The name of the storage system as configured
+                          in ScaleIO.
+                        type: string
+                      volumeName:
+                        description: The name of a volume already created in the ScaleIO
+                          system that is associated with this volume source.
+                        type: string
+                    required:
+                    - gateway
+                    - secretRef
+                    - system
+                    type: object
+                  secret:
+                    description: 'Secret represents a secret that should populate
+                      this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced Secret will be projected into the
+                          volume as a file whose name is the key and content is the
+                          value. If specified, the listed keys will be projected into
+                          the specified paths, and unlisted keys will not be present.
+                          If a key is specified which is not present in the Secret,
+                          the volume setup will error unless it is marked optional.
+                          Paths must be relative and may not contain the '..' path
+                          or start with '..'.
+                        items:
+                          description: Maps a string key to a path within a volume.
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          type: object
+                        type: array
+                      optional:
+                        description: Specify whether the Secret or its keys must be
+                          defined
+                        type: boolean
+                      secretName:
+                        description: 'Name of the secret in the pod''s namespace to
+                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        type: string
+                    type: object
+                  storageos:
+                    description: StorageOS represents a StorageOS volume attached
+                      and mounted on Kubernetes nodes.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: SecretRef specifies the secret to use for obtaining
+                          the StorageOS API credentials.  If not specified, default
+                          values will be attempted.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      volumeName:
+                        description: VolumeName is the human-readable name of the
+                          StorageOS volume.  Volume names are only unique within a
+                          namespace.
+                        type: string
+                      volumeNamespace:
+                        description: VolumeNamespace specifies the scope of the volume
+                          within StorageOS.  If no namespace is specified then the
+                          Pod's namespace will be used.  This allows the Kubernetes
+                          name scoping to be mirrored within StorageOS for tighter
+                          integration. Set VolumeName to any name to override the
+                          default behaviour. Set to "default" if you are not using
+                          namespaces within StorageOS. Namespaces that do not pre-exist
+                          within StorageOS will be created.
+                        type: string
+                    type: object
+                  vsphereVolume:
+                    description: VsphereVolume represents a vSphere volume attached
+                      and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      storagePolicyID:
+                        description: Storage Policy Based Management (SPBM) profile
+                          ID associated with the StoragePolicyName.
+                        type: string
+                      storagePolicyName:
+                        description: Storage Policy Based Management (SPBM) profile
+                          name.
+                        type: string
+                      volumePath:
+                        description: Path that identifies vSphere volume vmdk
+                        type: string
+                    required:
+                    - volumePath
+                    type: object
+                required:
+                - name
                 type: object
-              storageClassName:
-                description: Name of StorageClass to use for persistent volume claims
-                type: string
-              tolerations:
-                description: Pod's tolerations for Kubernetes node's taint
-                items:
-                  description: The pod this Toleration is attached to tolerates any
-                    taint that matches the triple <key,value,effect> using the matching
-                    operator <operator>.
-                  properties:
-                    effect:
-                      description: Effect indicates the taint effect to match. Empty
-                        means match all taint effects. When specified, allowed values
-                        are NoSchedule, PreferNoSchedule and NoExecute.
-                      type: string
-                    key:
-                      description: Key is the taint key that the toleration applies
-                        to. Empty means match all taint keys. If the key is empty,
-                        operator must be Exists; this combination means to match all
-                        values and all keys.
-                      type: string
-                    operator:
-                      description: Operator represents a key's relationship to the
-                        value. Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod
-                        can tolerate all taints of a particular category.
-                      type: string
-                    tolerationSeconds:
-                      description: TolerationSeconds represents the period of time
-                        the toleration (which must be of effect NoExecute, otherwise
-                        this field is ignored) tolerates the taint. By default, it
-                        is not set, which means tolerate the taint forever (do not
-                        evict). Zero and negative values will be treated as 0 (evict
-                        immediately) by the system.
-                      format: int64
-                      type: integer
-                    value:
-                      description: Value is the taint value the toleration matches
-                        to. If the operator is Exists, the value should be empty,
-                        otherwise just a regular string.
-                      type: string
-                  type: object
-                type: array
-              varStorage:
-                description: Storage capacity to request for /opt/splunk/var persistent
-                  volume claims (default=”50Gi”)
-                type: string
-              volumes:
-                description: List of one or more Kubernetes volumes. These will be
-                  mounted in all pod containers as as /mnt/<name>
-                items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
-                  properties:
-                    awsElasticBlockStore:
-                      description: 'AWSElasticBlockStore represents an AWS Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        partition:
-                          description: 'The partition in the volume that you want
-                            to mount. If omitted, the default is to mount by volume
-                            name. Examples: For volume /dev/sda1, you specify the
-                            partition as "1". Similarly, the volume partition for
-                            /dev/sda is "0" (or you can leave the property empty).'
-                          format: int32
-                          type: integer
-                        readOnly:
-                          description: 'Specify "true" to force and set the ReadOnly
-                            property in VolumeMounts to "true". If omitted, the default
-                            is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                          type: boolean
-                        volumeID:
-                          description: 'Unique ID of the persistent disk resource
-                            in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    azureDisk:
-                      description: AzureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
-                      properties:
-                        cachingMode:
-                          description: 'Host Caching mode: None, Read Only, Read Write.'
-                          type: string
-                        diskName:
-                          description: The Name of the data disk in the blob storage
-                          type: string
-                        diskURI:
-                          description: The URI the data disk in the blob storage
-                          type: string
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        kind:
-                          description: 'Expected values Shared: multiple blob disks
-                            per storage account  Dedicated: single blob disk per storage
-                            account  Managed: azure managed data disk (only in managed
-                            availability set). defaults to shared'
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                      required:
-                      - diskName
-                      - diskURI
-                      type: object
-                    azureFile:
-                      description: AzureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
-                      properties:
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretName:
-                          description: the name of secret that contains Azure Storage
-                            Account Name and Key
-                          type: string
-                        shareName:
-                          description: Share Name
-                          type: string
-                      required:
-                      - secretName
-                      - shareName
-                      type: object
-                    cephfs:
-                      description: CephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
-                      properties:
-                        monitors:
-                          description: 'Required: Monitors is a collection of Ceph
-                            monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          items:
-                            type: string
-                          type: array
-                        path:
-                          description: 'Optional: Used as the mounted root, rather
-                            than the full Ceph tree, default is /'
-                          type: string
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: boolean
-                        secretFile:
-                          description: 'Optional: SecretFile is the path to key ring
-                            for User, default is /etc/ceph/user.secret More info:
-                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: string
-                        secretRef:
-                          description: 'Optional: SecretRef is reference to the authentication
-                            secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        user:
-                          description: 'Optional: User is the rados user name, default
-                            is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: string
-                      required:
-                      - monitors
-                      type: object
-                    cinder:
-                      description: 'Cinder represents a cinder volume attached and
-                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: string
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: boolean
-                        secretRef:
-                          description: 'Optional: points to a secret object containing
-                            parameters used to connect to OpenStack.'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        volumeID:
-                          description: 'volume id used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    configMap:
-                      description: ConfigMap represents a configMap that should populate
-                        this volume
-                      properties:
-                        defaultMode:
-                          description: 'Optional: mode bits to use on created files
-                            by default. Must be a value between 0 and 0777. Defaults
-                            to 0644. Directories within the path are not affected
-                            by this setting. This might be in conflict with other
-                            options that affect the file mode, like fsGroup, and the
-                            result can be other mode bits set.'
-                          format: int32
-                          type: integer
-                        items:
-                          description: If unspecified, each key-value pair in the
-                            Data field of the referenced ConfigMap will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the ConfigMap, the volume setup will error unless it is
-                            marked optional. Paths must be relative and may not contain
-                            the '..' path or start with '..'.
-                          items:
-                            description: Maps a string key to a path within a volume.
-                            properties:
-                              key:
-                                description: The key to project.
-                                type: string
-                              mode:
-                                description: 'Optional: mode bits to use on this file,
-                                  must be a value between 0 and 0777. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: The relative path of the file to map
-                                  the key to. May not be an absolute path. May not
-                                  contain the path element '..'. May not start with
-                                  the string '..'.
-                                type: string
-                            required:
-                            - key
-                            - path
-                            type: object
-                          type: array
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                        optional:
-                          description: Specify whether the ConfigMap or its keys must
-                            be defined
-                          type: boolean
-                      type: object
-                    csi:
-                      description: CSI (Container Storage Interface) represents storage
-                        that is handled by an external CSI driver (Alpha feature).
-                      properties:
-                        driver:
-                          description: Driver is the name of the CSI driver that handles
-                            this volume. Consult with your admin for the correct name
-                            as registered in the cluster.
-                          type: string
-                        fsType:
-                          description: Filesystem type to mount. Ex. "ext4", "xfs",
-                            "ntfs". If not provided, the empty value is passed to
-                            the associated CSI driver which will determine the default
-                            filesystem to apply.
-                          type: string
-                        nodePublishSecretRef:
-                          description: NodePublishSecretRef is a reference to the
-                            secret object containing sensitive information to pass
-                            to the CSI driver to complete the CSI NodePublishVolume
-                            and NodeUnpublishVolume calls. This field is optional,
-                            and  may be empty if no secret is required. If the secret
-                            object contains more than one secret, all secret references
-                            are passed.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        readOnly:
-                          description: Specifies a read-only configuration for the
-                            volume. Defaults to false (read/write).
-                          type: boolean
-                        volumeAttributes:
-                          additionalProperties:
-                            type: string
-                          description: VolumeAttributes stores driver-specific properties
-                            that are passed to the CSI driver. Consult your driver's
-                            documentation for supported values.
-                          type: object
-                      required:
-                      - driver
-                      type: object
-                    downwardAPI:
-                      description: DownwardAPI represents downward API about the pod
-                        that should populate this volume
-                      properties:
-                        defaultMode:
-                          description: 'Optional: mode bits to use on created files
-                            by default. Must be a value between 0 and 0777. Defaults
-                            to 0644. Directories within the path are not affected
-                            by this setting. This might be in conflict with other
-                            options that affect the file mode, like fsGroup, and the
-                            result can be other mode bits set.'
-                          format: int32
-                          type: integer
-                        items:
-                          description: Items is a list of downward API volume file
-                          items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
-                            properties:
-                              fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
-                                properties:
-                                  apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
-                                    type: string
-                                required:
-                                - fieldPath
-                                type: object
-                              mode:
-                                description: 'Optional: mode bits to use on this file,
-                                  must be a value between 0 and 0777. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
-                                type: string
-                              resourceFieldRef:
-                                description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, requests.cpu and requests.memory)
-                                  are currently supported.'
-                                properties:
-                                  containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: 'Required: resource to select'
-                                    type: string
-                                required:
-                                - resource
-                                type: object
-                            required:
-                            - path
-                            type: object
-                          type: array
-                      type: object
-                    emptyDir:
-                      description: 'EmptyDir represents a temporary directory that
-                        shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                      properties:
-                        medium:
-                          description: 'What type of storage medium should back this
-                            directory. The default is "" which means to use the node''s
-                            default medium. Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                          type: string
-                        sizeLimit:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          description: 'Total amount of local storage required for
-                            this EmptyDir volume. The size limit is also applicable
-                            for memory medium. The maximum usage on memory medium
-                            EmptyDir would be the minimum value between the SizeLimit
-                            specified here and the sum of memory limits of all containers
-                            in a pod. The default is nil which means that the limit
-                            is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                      type: object
-                    fc:
-                      description: FC represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
-                      properties:
-                        fsType:
-                          description: 'Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        lun:
-                          description: 'Optional: FC target lun number'
-                          format: int32
-                          type: integer
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
-                          type: boolean
-                        targetWWNs:
-                          description: 'Optional: FC target worldwide names (WWNs)'
-                          items:
-                            type: string
-                          type: array
-                        wwids:
-                          description: 'Optional: FC volume world wide identifiers
-                            (wwids) Either wwids or combination of targetWWNs and
-                            lun must be set, but not both simultaneously.'
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    flexVolume:
-                      description: FlexVolume represents a generic volume resource
-                        that is provisioned/attached using an exec based plugin.
-                      properties:
-                        driver:
-                          description: Driver is the name of the driver to use for
-                            this volume.
-                          type: string
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". The default filesystem depends on FlexVolume
-                            script.
-                          type: string
-                        options:
-                          additionalProperties:
-                            type: string
-                          description: 'Optional: Extra command options if any.'
-                          type: object
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
-                          type: boolean
-                        secretRef:
-                          description: 'Optional: SecretRef is reference to the secret
-                            object containing sensitive information to pass to the
-                            plugin scripts. This may be empty if no secret object
-                            is specified. If the secret object contains more than
-                            one secret, all secrets are passed to the plugin scripts.'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                      required:
-                      - driver
-                      type: object
-                    flocker:
-                      description: Flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
-                      properties:
-                        datasetName:
-                          description: Name of the dataset stored as metadata -> name
-                            on the dataset for Flocker should be considered as deprecated
-                          type: string
-                        datasetUUID:
-                          description: UUID of the dataset. This is unique identifier
-                            of a Flocker dataset
-                          type: string
-                      type: object
-                    gcePersistentDisk:
-                      description: 'GCEPersistentDisk represents a GCE Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        partition:
-                          description: 'The partition in the volume that you want
-                            to mount. If omitted, the default is to mount by volume
-                            name. Examples: For volume /dev/sda1, you specify the
-                            partition as "1". Similarly, the volume partition for
-                            /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          format: int32
-                          type: integer
-                        pdName:
-                          description: 'Unique name of the PD resource in GCE. Used
-                            to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          type: boolean
-                      required:
-                      - pdName
-                      type: object
-                    gitRepo:
-                      description: 'GitRepo represents a git repository at a particular
-                        revision. DEPRECATED: GitRepo is deprecated. To provision
-                        a container with a git repo, mount an EmptyDir into an InitContainer
-                        that clones the repo using git, then mount the EmptyDir into
-                        the Pod''s container.'
-                      properties:
-                        directory:
-                          description: Target directory name. Must not contain or
-                            start with '..'.  If '.' is supplied, the volume directory
-                            will be the git repository.  Otherwise, if specified,
-                            the volume will contain the git repository in the subdirectory
-                            with the given name.
-                          type: string
-                        repository:
-                          description: Repository URL
-                          type: string
-                        revision:
-                          description: Commit hash for the specified revision.
-                          type: string
-                      required:
-                      - repository
-                      type: object
-                    glusterfs:
-                      description: 'Glusterfs represents a Glusterfs mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
-                      properties:
-                        endpoints:
-                          description: 'EndpointsName is the endpoint name that details
-                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: string
-                        path:
-                          description: 'Path is the Glusterfs volume path. More info:
-                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the Glusterfs volume
-                            to be mounted with read-only permissions. Defaults to
-                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: boolean
-                      required:
-                      - endpoints
-                      - path
-                      type: object
-                    hostPath:
-                      description: 'HostPath represents a pre-existing file or directory
-                        on the host machine that is directly exposed to the container.
-                        This is generally used for system agents or other privileged
-                        things that are allowed to see the host machine. Most containers
-                        will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        --- TODO(jonesdl) We need to restrict who can use host directory
-                        mounts and who can/can not mount host directories as read/write.'
-                      properties:
-                        path:
-                          description: 'Path of the directory on the host. If the
-                            path is a symlink, it will follow the link to the real
-                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                          type: string
-                        type:
-                          description: 'Type for HostPath Volume Defaults to "" More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                          type: string
-                      required:
-                      - path
-                      type: object
-                    iscsi:
-                      description: 'ISCSI represents an ISCSI Disk resource that is
-                        attached to a kubelet''s host machine and then exposed to
-                        the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
-                      properties:
-                        chapAuthDiscovery:
-                          description: whether support iSCSI Discovery CHAP authentication
-                          type: boolean
-                        chapAuthSession:
-                          description: whether support iSCSI Session CHAP authentication
-                          type: boolean
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        initiatorName:
-                          description: Custom iSCSI Initiator Name. If initiatorName
-                            is specified with iscsiInterface simultaneously, new iSCSI
-                            interface <target portal>:<volume name> will be created
-                            for the connection.
-                          type: string
-                        iqn:
-                          description: Target iSCSI Qualified Name.
-                          type: string
-                        iscsiInterface:
-                          description: iSCSI Interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
-                          type: string
-                        lun:
-                          description: iSCSI Target Lun number.
-                          format: int32
-                          type: integer
-                        portals:
-                          description: iSCSI Target Portal List. The portal is either
-                            an IP or ip_addr:port if the port is other than default
-                            (typically TCP ports 860 and 3260).
-                          items:
-                            type: string
-                          type: array
-                        readOnly:
-                          description: ReadOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false.
-                          type: boolean
-                        secretRef:
-                          description: CHAP Secret for iSCSI target and initiator
-                            authentication
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        targetPortal:
-                          description: iSCSI Target Portal. The Portal is either an
-                            IP or ip_addr:port if the port is other than default (typically
-                            TCP ports 860 and 3260).
-                          type: string
-                      required:
-                      - iqn
-                      - lun
-                      - targetPortal
-                      type: object
-                    name:
-                      description: 'Volume''s name. Must be a DNS_LABEL and unique
-                        within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                      type: string
-                    nfs:
-                      description: 'NFS represents an NFS mount on the host that shares
-                        a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                      properties:
-                        path:
-                          description: 'Path that is exported by the NFS server. More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the NFS export to
-                            be mounted with read-only permissions. Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: boolean
-                        server:
-                          description: 'Server is the hostname or IP address of the
-                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: string
-                      required:
-                      - path
-                      - server
-                      type: object
-                    persistentVolumeClaim:
-                      description: 'PersistentVolumeClaimVolumeSource represents a
-                        reference to a PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                      properties:
-                        claimName:
-                          description: 'ClaimName is the name of a PersistentVolumeClaim
-                            in the same namespace as the pod using this volume. More
-                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                          type: string
-                        readOnly:
-                          description: Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
-                          type: boolean
-                      required:
-                      - claimName
-                      type: object
-                    photonPersistentDisk:
-                      description: PhotonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        pdID:
-                          description: ID that identifies Photon Controller persistent
-                            disk
-                          type: string
-                      required:
-                      - pdID
-                      type: object
-                    portworxVolume:
-                      description: PortworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: FSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating
-                            system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                            if unspecified.
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        volumeID:
-                          description: VolumeID uniquely identifies a Portworx volume
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    projected:
-                      description: Items for all in one resources secrets, configmaps,
-                        and downward API
-                      properties:
-                        defaultMode:
-                          description: Mode bits to use on created files by default.
-                            Must be a value between 0 and 0777. Directories within
-                            the path are not affected by this setting. This might
-                            be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits
-                            set.
-                          format: int32
-                          type: integer
-                        sources:
-                          description: list of volume projections
-                          items:
-                            description: Projection that may be projected along with
-                              other supported volume types
-                            properties:
-                              configMap:
-                                description: information about the configMap data
-                                  to project
-                                properties:
-                                  items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced ConfigMap
-                                      will be projected into the volume as a file
-                                      whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the ConfigMap, the volume
-                                      setup will error unless it is marked optional.
-                                      Paths must be relative and may not contain the
-                                      '..' path or start with '..'.
-                                    items:
-                                      description: Maps a string key to a path within
-                                        a volume.
-                                      properties:
-                                        key:
-                                          description: The key to project.
-                                          type: string
-                                        mode:
-                                          description: 'Optional: mode bits to use
-                                            on this file, must be a value between
-                                            0 and 0777. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element
-                                            '..'. May not start with the string '..'.
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or
-                                      its keys must be defined
-                                    type: boolean
-                                type: object
-                              downwardAPI:
-                                description: information about the downwardAPI data
-                                  to project
-                                properties:
-                                  items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
-                                    items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
-                                      properties:
-                                        fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
-                                          properties:
-                                            apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
-                                              type: string
-                                            fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
-                                              type: string
-                                          required:
-                                          - fieldPath
-                                          type: object
-                                        mode:
-                                          description: 'Optional: mode bits to use
-                                            on this file, must be a value between
-                                            0 and 0777. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
-                                          type: string
-                                        resourceFieldRef:
-                                          description: 'Selects a resource of the
-                                            container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu
-                                            and requests.memory) are currently supported.'
-                                          properties:
-                                            containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
-                                              type: string
-                                            divisor:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            resource:
-                                              description: 'Required: resource to
-                                                select'
-                                              type: string
-                                          required:
-                                          - resource
-                                          type: object
-                                      required:
-                                      - path
-                                      type: object
-                                    type: array
-                                type: object
-                              secret:
-                                description: information about the secret data to
-                                  project
-                                properties:
-                                  items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced Secret will
-                                      be projected into the volume as a file whose
-                                      name is the key and content is the value. If
-                                      specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the Secret, the volume setup
-                                      will error unless it is marked optional. Paths
-                                      must be relative and may not contain the '..'
-                                      path or start with '..'.
-                                    items:
-                                      description: Maps a string key to a path within
-                                        a volume.
-                                      properties:
-                                        key:
-                                          description: The key to project.
-                                          type: string
-                                        mode:
-                                          description: 'Optional: mode bits to use
-                                            on this file, must be a value between
-                                            0 and 0777. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element
-                                            '..'. May not start with the string '..'.
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
-                                    type: boolean
-                                type: object
-                              serviceAccountToken:
-                                description: information about the serviceAccountToken
-                                  data to project
-                                properties:
-                                  audience:
-                                    description: Audience is the intended audience
-                                      of the token. A recipient of a token must identify
-                                      itself with an identifier specified in the audience
-                                      of the token, and otherwise should reject the
-                                      token. The audience defaults to the identifier
-                                      of the apiserver.
-                                    type: string
-                                  expirationSeconds:
-                                    description: ExpirationSeconds is the requested
-                                      duration of validity of the service account
-                                      token. As the token approaches expiration, the
-                                      kubelet volume plugin will proactively rotate
-                                      the service account token. The kubelet will
-                                      start trying to rotate the token if the token
-                                      is older than 80 percent of its time to live
-                                      or if the token is older than 24 hours.Defaults
-                                      to 1 hour and must be at least 10 minutes.
-                                    format: int64
-                                    type: integer
-                                  path:
-                                    description: Path is the path relative to the
-                                      mount point of the file to project the token
-                                      into.
-                                    type: string
-                                required:
-                                - path
-                                type: object
-                            type: object
-                          type: array
-                      required:
-                      - sources
-                      type: object
-                    quobyte:
-                      description: Quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
-                      properties:
-                        group:
-                          description: Group to map volume access to Default is no
-                            group
-                          type: string
-                        readOnly:
-                          description: ReadOnly here will force the Quobyte volume
-                            to be mounted with read-only permissions. Defaults to
-                            false.
-                          type: boolean
-                        registry:
-                          description: Registry represents a single or multiple Quobyte
-                            Registry services specified as a string as host:port pair
-                            (multiple entries are separated with commas) which acts
-                            as the central registry for volumes
-                          type: string
-                        tenant:
-                          description: Tenant owning the given Quobyte volume in the
-                            Backend Used with dynamically provisioned Quobyte volumes,
-                            value is set by the plugin
-                          type: string
-                        user:
-                          description: User to map volume access to Defaults to serivceaccount
-                            user
-                          type: string
-                        volume:
-                          description: Volume is a string that references an already
-                            created Quobyte volume by name.
-                          type: string
-                      required:
-                      - registry
-                      - volume
-                      type: object
-                    rbd:
-                      description: 'RBD represents a Rados Block Device mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        image:
-                          description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        keyring:
-                          description: 'Keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        monitors:
-                          description: 'A collection of Ceph monitors. More info:
-                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          items:
-                            type: string
-                          type: array
-                        pool:
-                          description: 'The rados pool name. Default is rbd. More
-                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: boolean
-                        secretRef:
-                          description: 'SecretRef is name of the authentication secret
-                            for RBDUser. If provided overrides keyring. Default is
-                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        user:
-                          description: 'The rados user name. Default is admin. More
-                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                      required:
-                      - image
-                      - monitors
-                      type: object
-                    scaleIO:
-                      description: ScaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Default is "xfs".
-                          type: string
-                        gateway:
-                          description: The host address of the ScaleIO API Gateway.
-                          type: string
-                        protectionDomain:
-                          description: The name of the ScaleIO Protection Domain for
-                            the configured storage.
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretRef:
-                          description: SecretRef references to the secret for ScaleIO
-                            user and other sensitive information. If this is not provided,
-                            Login operation will fail.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        sslEnabled:
-                          description: Flag to enable/disable SSL communication with
-                            Gateway, default false
-                          type: boolean
-                        storageMode:
-                          description: Indicates whether the storage for a volume
-                            should be ThickProvisioned or ThinProvisioned. Default
-                            is ThinProvisioned.
-                          type: string
-                        storagePool:
-                          description: The ScaleIO Storage Pool associated with the
-                            protection domain.
-                          type: string
-                        system:
-                          description: The name of the storage system as configured
-                            in ScaleIO.
-                          type: string
-                        volumeName:
-                          description: The name of a volume already created in the
-                            ScaleIO system that is associated with this volume source.
-                          type: string
-                      required:
-                      - gateway
-                      - secretRef
-                      - system
-                      type: object
-                    secret:
-                      description: 'Secret represents a secret that should populate
-                        this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                      properties:
-                        defaultMode:
-                          description: 'Optional: mode bits to use on created files
-                            by default. Must be a value between 0 and 0777. Defaults
-                            to 0644. Directories within the path are not affected
-                            by this setting. This might be in conflict with other
-                            options that affect the file mode, like fsGroup, and the
-                            result can be other mode bits set.'
-                          format: int32
-                          type: integer
-                        items:
-                          description: If unspecified, each key-value pair in the
-                            Data field of the referenced Secret will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the Secret, the volume setup will error unless it is marked
-                            optional. Paths must be relative and may not contain the
-                            '..' path or start with '..'.
-                          items:
-                            description: Maps a string key to a path within a volume.
-                            properties:
-                              key:
-                                description: The key to project.
-                                type: string
-                              mode:
-                                description: 'Optional: mode bits to use on this file,
-                                  must be a value between 0 and 0777. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: The relative path of the file to map
-                                  the key to. May not be an absolute path. May not
-                                  contain the path element '..'. May not start with
-                                  the string '..'.
-                                type: string
-                            required:
-                            - key
-                            - path
-                            type: object
-                          type: array
-                        optional:
-                          description: Specify whether the Secret or its keys must
-                            be defined
-                          type: boolean
-                        secretName:
-                          description: 'Name of the secret in the pod''s namespace
-                            to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                          type: string
-                      type: object
-                    storageos:
-                      description: StorageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretRef:
-                          description: SecretRef specifies the secret to use for obtaining
-                            the StorageOS API credentials.  If not specified, default
-                            values will be attempted.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        volumeName:
-                          description: VolumeName is the human-readable name of the
-                            StorageOS volume.  Volume names are only unique within
-                            a namespace.
-                          type: string
-                        volumeNamespace:
-                          description: VolumeNamespace specifies the scope of the
-                            volume within StorageOS.  If no namespace is specified
-                            then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS
-                            for tighter integration. Set VolumeName to any name to
-                            override the default behaviour. Set to "default" if you
-                            are not using namespaces within StorageOS. Namespaces
-                            that do not pre-exist within StorageOS will be created.
-                          type: string
-                      type: object
-                    vsphereVolume:
-                      description: VsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        storagePolicyID:
-                          description: Storage Policy Based Management (SPBM) profile
-                            ID associated with the StoragePolicyName.
-                          type: string
-                        storagePolicyName:
-                          description: Storage Policy Based Management (SPBM) profile
-                            name.
-                          type: string
-                        volumePath:
-                          description: Path that identifies vSphere volume vmdk
-                          type: string
-                      required:
-                      - volumePath
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
-            type: object
-          status:
-            description: StandaloneStatus defines the observed state of a Splunk Enterprise
-              standalone instances.
-            properties:
-              phase:
-                description: current phase of the standalone instances
-                enum:
-                - Pending
-                - Ready
-                - Updating
-                - ScalingUp
-                - ScalingDown
-                - Terminating
-                - Error
-                type: string
-              readyReplicas:
-                description: current number of ready standalone instances
-                format: int32
-                type: integer
-              replicas:
-                description: number of desired standalone instances
-                format: int32
-                type: integer
-              selector:
-                description: selector for pods, used by HorizontalPodAutoscaler
-                type: string
-              smartstore:
-                description: Splunk Smartstore configuration. Refer to indexes.conf.spec
-                  on docs.splunk.com
-                properties:
-                  indexes:
-                    description: List of Splunk indexes
-                    items:
-                      description: IndexSpec defines Splunk index name and storage
-                        path
-                      properties:
-                        name:
-                          description: Splunk index name
-                          type: string
-                        remotePath:
-                          description: Index location relative to the remote volume
-                            path
-                          type: string
-                        volumeName:
-                          description: Remote Volume name
-                          type: string
-                      type: object
-                    type: array
-                  volumes:
-                    description: List of remote storage volumes
-                    items:
-                      description: VolumeSpec defines remote volume name and remote
-                        volume URI
-                      properties:
-                        endpoint:
-                          description: Remote volume URI
-                          type: string
-                        name:
-                          description: Remote volume name
-                          type: string
-                        path:
-                          description: Remote volume path
-                          type: string
-                      type: object
-                    type: array
-                type: object
-            type: object
-        type: object
+              type: array
+          type: object
+        status:
+          description: StandaloneStatus defines the observed state of a Splunk Enterprise
+            standalone instances.
+          properties:
+            phase:
+              description: current phase of the standalone instances
+              enum:
+              - Pending
+              - Ready
+              - Updating
+              - ScalingUp
+              - ScalingDown
+              - Terminating
+              - Error
+              type: string
+            readyReplicas:
+              description: current number of ready standalone instances
+              format: int32
+              type: integer
+            replicas:
+              description: number of desired standalone instances
+              format: int32
+              type: integer
+            selector:
+              description: selector for pods, used by HorizontalPodAutoscaler
+              type: string
+            smartstore:
+              description: Splunk Smartstore configuration. Refer to indexes.conf.spec
+                on docs.splunk.com
+              properties:
+                indexes:
+                  description: List of Splunk indexes
+                  items:
+                    description: IndexSpec defines Splunk index name and storage path
+                    properties:
+                      name:
+                        description: Splunk index name
+                        type: string
+                      remotePath:
+                        description: Index location relative to the remote volume
+                          path
+                        type: string
+                      volumeName:
+                        description: Remote Volume name
+                        type: string
+                    type: object
+                  type: array
+                volumes:
+                  description: List of remote storage volumes
+                  items:
+                    description: VolumeSpec defines remote volume name and remote
+                      volume URI
+                    properties:
+                      endpoint:
+                        description: Remote volume URI
+                        type: string
+                      name:
+                        description: Remote volume name
+                        type: string
+                      path:
+                        description: Remote volume path
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+      type: object
+  version: v1alpha3
+  versions:
+  - name: v1alpha3
     served: true
     storage: true
-    subresources:
-      scale:
-        labelSelectorPath: .status.selector
-        specReplicasPath: .spec.replicas
-        statusReplicasPath: .status.replicas
-      status: {}
+  - name: v1alpha2
+    served: true
+    storage: false

--- a/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
@@ -1,25 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: standalones.enterprise.splunk.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: Status of standalone instances
-    name: Phase
-    type: string
-  - JSONPath: .status.replicas
-    description: Number of desired standalone instances
-    name: Desired
-    type: integer
-  - JSONPath: .status.readyReplicas
-    description: Current number of ready standalone instances
-    name: Ready
-    type: integer
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of standalone resource
-    name: Age
-    type: date
   group: enterprise.splunk.com
   names:
     kind: Standalone
@@ -27,2353 +10,2433 @@ spec:
     plural: standalones
     singular: standalone
   scope: Namespaced
-  subresources:
-    scale:
-      labelSelectorPath: .status.selector
-      specReplicasPath: .spec.replicas
-      statusReplicasPath: .status.replicas
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Standalone is the Schema for a Splunk Enterprise standalone instances.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: StandaloneSpec defines the desired state of a Splunk Enterprise
-            standalone instances.
-          properties:
-            affinity:
-              description: Kubernetes Affinity rules that control how pods are assigned
-                to particular nodes.
-              properties:
-                nodeAffinity:
-                  description: Describes node affinity scheduling rules for the pod.
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node matches the corresponding matchExpressions; the
-                        node(s) with the highest sum are the most preferred.
-                      items:
-                        description: An empty preferred scheduling term matches all
-                          objects with implicit weight 0 (i.e. it's a no-op). A null
-                          preferred scheduling term matches no objects (i.e. is also
-                          a no-op).
+  versions:
+  - additionalPrinterColumns:
+    - description: Status of standalone instances
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Number of desired standalone instances
+      jsonPath: .status.replicas
+      name: Desired
+      type: integer
+    - description: Current number of ready standalone instances
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Age of standalone resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: Standalone is the Schema for a Splunk Enterprise standalone instances.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StandaloneSpec defines the desired state of a Splunk Enterprise
+              standalone instances.
+            properties:
+              Mock:
+                description: Mock to differentiate between UTs and actual reconcile
+                type: boolean
+              affinity:
+                description: Kubernetes Affinity rules that control how pods are assigned
+                  to particular nodes.
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
                         properties:
-                          preference:
-                            description: A node selector term, associated with the
-                              corresponding weight.
-                            properties:
-                              matchExpressions:
-                                description: A list of node selector requirements
-                                  by node's labels.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchFields:
-                                description: A list of node selector requirements
-                                  by node's fields.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
                                         type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                            type: object
-                          weight:
-                            description: Weight associated with matching the corresponding
-                              nodeSelectorTerm, in the range 1-100.
-                            format: int32
-                            type: integer
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
                         required:
-                        - preference
-                        - weight
+                        - nodeSelectorTerms
                         type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to an update), the system may or may not try to
-                        eventually evict the pod from its node.
-                      properties:
-                        nodeSelectorTerms:
-                          description: Required. A list of node selector terms. The
-                            terms are ORed.
-                          items:
-                            description: A null or empty node selector term matches
-                              no objects. The requirements of them are ANDed. The
-                              TopologySelectorTerm type implements a subset of the
-                              NodeSelectorTerm.
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              clusterMasterRef:
+                description: ClusterMasterRef refers to a Splunk Enterprise indexer
+                  cluster managed by the operator within Kubernetes
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              defaults:
+                description: Inline map of default.yml overrides used to initialize
+                  the environment
+                type: string
+              defaultsUrl:
+                description: Full path or URL for one or more default.yml files, separated
+                  by commas
+                type: string
+              ephemeralStorage:
+                description: If true, ephemeral (emptyDir) storage will be used for
+                  /opt/splunk/etc and /opt/splunk/var volumes
+                type: boolean
+              etcStorage:
+                description: Storage capacity to request for /opt/splunk/etc persistent
+                  volume claims (default=”1Gi”)
+                type: string
+              image:
+                description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
+                  environment variables)
+                type: string
+              imagePullPolicy:
+                description: 'Sets pull policy for all images (either “Always” or
+                  the default: “IfNotPresent”)'
+                enum:
+                - Always
+                - IfNotPresent
+                type: string
+              licenseMasterRef:
+                description: LicenseMasterRef refers to a Splunk Enterprise license
+                  master managed by the operator within Kubernetes
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              licenseUrl:
+                description: Full path or URL for a Splunk Enterprise license file
+                type: string
+              replicas:
+                description: Number of standalone pods
+                format: int32
+                type: integer
+              resources:
+                description: resource requirements for the pod containers
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+              schedulerName:
+                description: Name of Scheduler to use for pod placement (defaults
+                  to “default-scheduler”)
+                type: string
+              serviceTemplate:
+                description: ServiceTemplate is a template used to create Kubernetes
+                  services
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      clusterIP:
+                        description: 'clusterIP is the IP address of the service and
+                          is usually assigned randomly by the master. If an address
+                          is specified manually and is not in use by others, it will
+                          be allocated to the service; otherwise, creation of the
+                          service will fail. This field can not be changed through
+                          updates. Valid values are "None", empty string (""), or
+                          a valid IP address. "None" can be specified for headless
+                          services when proxying is not required. Only applies to
+                          types ClusterIP, NodePort, and LoadBalancer. Ignored if
+                          type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      externalIPs:
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for this service.  These
+                          IPs are not managed by Kubernetes.  The user is responsible
+                          for ensuring that traffic arrives at a node with this IP.  A
+                          common example is external load-balancers that are not part
+                          of the Kubernetes system.
+                        items:
+                          type: string
+                        type: array
+                      externalName:
+                        description: externalName is the external reference that kubedns
+                          or equivalent will return as a CNAME record for this service.
+                          No proxying will be involved. Must be a valid RFC-1123 hostname
+                          (https://tools.ietf.org/html/rfc1123) and requires Type
+                          to be ExternalName.
+                        type: string
+                      externalTrafficPolicy:
+                        description: externalTrafficPolicy denotes if this Service
+                          desires to route external traffic to node-local or cluster-wide
+                          endpoints. "Local" preserves the client source IP and avoids
+                          a second hop for LoadBalancer and Nodeport type services,
+                          but risks potentially imbalanced traffic spreading. "Cluster"
+                          obscures the client source IP and may cause a second hop
+                          to another node, but should have good overall load-spreading.
+                        type: string
+                      healthCheckNodePort:
+                        description: healthCheckNodePort specifies the healthcheck
+                          nodePort for the service. If not specified, HealthCheckNodePort
+                          is created by the service api backend with the allocated
+                          nodePort. Will use user-specified nodePort value if specified
+                          by the client. Only effects when Type is set to LoadBalancer
+                          and ExternalTrafficPolicy is set to Local.
+                        format: int32
+                        type: integer
+                      ipFamily:
+                        description: ipFamily specifies whether this Service has a
+                          preference for a particular IP family (e.g. IPv4 vs. IPv6).  If
+                          a specific IP family is requested, the clusterIP field will
+                          be allocated from that family, if it is available in the
+                          cluster.  If no IP family is requested, the cluster's primary
+                          IP family will be used. Other IP fields (loadBalancerIP,
+                          loadBalancerSourceRanges, externalIPs) and controllers which
+                          allocate external load-balancers should use the same IP
+                          family.  Endpoints for this Service will be of this family.  This
+                          field is immutable after creation. Assigning a ServiceIPFamily
+                          not available in the cluster (e.g. IPv6 in IPv4 only cluster)
+                          is an error condition and will fail during clusterIP assignment.
+                        type: string
+                      loadBalancerIP:
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in this field. This
+                          feature depends on whether the underlying cloud-provider
+                          supports specifying the loadBalancerIP when a load balancer
+                          is created. This field will be ignored if the cloud-provider
+                          does not support the feature.'
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: 'If specified and supported by the platform,
+                          this will restrict traffic through the cloud-provider load-balancer
+                          will be restricted to the specified client IPs. This field
+                          will be ignored if the cloud-provider does not support the
+                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        description: 'The list of ports that are exposed by this service.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            name:
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names. When considering the endpoints
+                                for a Service, this must match the 'name' field in
+                                the EndpointPort. Optional if only one ServicePort
+                                is defined on this service.
+                              type: string
+                            nodePort:
+                              description: 'The port on each node on which this service
+                                is exposed when type=NodePort or LoadBalancer. Usually
+                                assigned by the system. If specified, it will be allocated
+                                to the service if unused or else creation of the service
+                                will fail. Default is to auto-allocate a port if the
+                                ServiceType of this Service requires one. More info:
+                                https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'Number or name of the port to access on
+                                the pods targeted by the service. Number must be in
+                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                If this is a string, it will be looked up as a named
+                                port in the target Pod''s container ports. If this
+                                is not specified, the value of the ''port'' field
+                                is used (an identity map). This field is ignored for
+                                services with clusterIP=None, and should be omitted
+                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        description: publishNotReadyAddresses, when set to true, indicates
+                          that DNS implementations must publish the notReadyAddresses
+                          of subsets for the Endpoints associated with the Service.
+                          The default value is false. The primary use case for setting
+                          this field is to use a StatefulSet's Headless Service to
+                          propagate SRV records for its Pods without respect to their
+                          readiness for purpose of peer discovery.
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: 'Route service traffic to pods with label keys
+                          and values matching this selector. If empty or not present,
+                          the service is assumed to have an external process managing
+                          its endpoints, which Kubernetes will not modify. Only applies
+                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
+                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                        type: object
+                      sessionAffinity:
+                        description: 'Supports "ClientIP" and "None". Used to maintain
+                          session affinity. Enable client IP based session affinity.
+                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
                             properties:
-                              matchExpressions:
-                                description: A list of node selector requirements
-                                  by node's labels.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchFields:
-                                description: A list of node selector requirements
-                                  by node's fields.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
+                              timeoutSeconds:
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time. The value
+                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                  == "ClientIP". Default value is 10800(for 3 hours).
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      type:
+                        description: 'type determines how the Service is exposed.
+                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
+                          NodePort, and LoadBalancer. "ExternalName" maps to the specified
+                          externalName. "ClusterIP" allocates a cluster-internal IP
+                          address for load-balancing to endpoints. Endpoints are determined
+                          by the selector or if that is not specified, by manual construction
+                          of an Endpoints object. If clusterIP is "None", no virtual
+                          IP is allocated and the endpoints are published as a set
+                          of endpoints rather than a stable IP. "NodePort" builds
+                          on ClusterIP and allocates a port on every node which routes
+                          to the clusterIP. "LoadBalancer" builds on NodePort and
+                          creates an external load-balancer (if supported in the current
+                          cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                        type: string
+                    type: object
+                  status:
+                    description: 'Most recently observed status of the service. Populated
+                      by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      loadBalancer:
+                        description: LoadBalancer contains the current status of the
+                          load-balancer, if one is present.
+                        properties:
+                          ingress:
+                            description: Ingress is a list containing ingress points
+                              for the load-balancer. Traffic intended for the service
+                              should be sent to these ingress points.
+                            items:
+                              description: 'LoadBalancerIngress represents the status
+                                of a load-balancer ingress point: traffic intended
+                                for the service should be sent to an ingress point.'
+                              properties:
+                                hostname:
+                                  description: Hostname is set for load-balancer ingress
+                                    points that are DNS based (typically AWS load-balancers)
+                                  type: string
+                                ip:
+                                  description: IP is set for load-balancer ingress
+                                    points that are IP based (typically GCE or OpenStack
+                                    load-balancers)
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                type: object
+              smartstore:
+                description: Splunk Smartstore configuration. Refer to indexes.conf.spec
+                  on docs.splunk.com
+                properties:
+                  indexes:
+                    description: List of Splunk indexes
+                    items:
+                      description: IndexSpec defines Splunk index name and storage
+                        path
+                      properties:
+                        name:
+                          description: Splunk index name
+                          type: string
+                        remotePath:
+                          description: Index location relative to the remote volume
+                            path
+                          type: string
+                        volumeName:
+                          description: Remote Volume name
+                          type: string
+                      type: object
+                    type: array
+                  volumes:
+                    description: List of remote storage volumes
+                    items:
+                      description: VolumeSpec defines remote volume name and remote
+                        volume URI
+                      properties:
+                        endpoint:
+                          description: Remote volume URI
+                          type: string
+                        name:
+                          description: Remote volume name
+                          type: string
+                        path:
+                          description: Remote volume path
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              sparkImage:
+                description: Image to use for Spark pod containers (overrides RELATED_IMAGE_SPLUNK_SPARK
+                  environment variables)
+                type: string
+              sparkRef:
+                description: SparkRef refers to a Spark cluster managed by the operator
+                  within Kubernetes When defined, Data Fabric Search (DFS) will be
+                  enabled and configured to use the Spark cluster.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              storageClassName:
+                description: Name of StorageClass to use for persistent volume claims
+                type: string
+              tolerations:
+                description: Pod's tolerations for Kubernetes node's taint
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              varStorage:
+                description: Storage capacity to request for /opt/splunk/var persistent
+                  volume claims (default=”50Gi”)
+                type: string
+              volumes:
+                description: List of one or more Kubernetes volumes. These will be
+                  mounted in all pod containers as as /mnt/<name>
+                items:
+                  description: Volume represents a named volume in a pod that may
+                    be accessed by any container in the pod.
+                  properties:
+                    awsElasticBlockStore:
+                      description: 'AWSElasticBlockStore represents an AWS Disk resource
+                        that is attached to a kubelet''s host machine and then exposed
+                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      properties:
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        partition:
+                          description: 'The partition in the volume that you want
+                            to mount. If omitted, the default is to mount by volume
+                            name. Examples: For volume /dev/sda1, you specify the
+                            partition as "1". Similarly, the volume partition for
+                            /dev/sda is "0" (or you can leave the property empty).'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: 'Specify "true" to force and set the ReadOnly
+                            property in VolumeMounts to "true". If omitted, the default
+                            is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          type: boolean
+                        volumeID:
+                          description: 'Unique ID of the persistent disk resource
+                            in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    azureDisk:
+                      description: AzureDisk represents an Azure Data Disk mount on
+                        the host and bind mount to the pod.
+                      properties:
+                        cachingMode:
+                          description: 'Host Caching mode: None, Read Only, Read Write.'
+                          type: string
+                        diskName:
+                          description: The Name of the data disk in the blob storage
+                          type: string
+                        diskURI:
+                          description: The URI the data disk in the blob storage
+                          type: string
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        kind:
+                          description: 'Expected values Shared: multiple blob disks
+                            per storage account  Dedicated: single blob disk per storage
+                            account  Managed: azure managed data disk (only in managed
+                            availability set). defaults to shared'
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                      required:
+                      - diskName
+                      - diskURI
+                      type: object
+                    azureFile:
+                      description: AzureFile represents an Azure File Service mount
+                        on the host and bind mount to the pod.
+                      properties:
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretName:
+                          description: the name of secret that contains Azure Storage
+                            Account Name and Key
+                          type: string
+                        shareName:
+                          description: Share Name
+                          type: string
+                      required:
+                      - secretName
+                      - shareName
+                      type: object
+                    cephfs:
+                      description: CephFS represents a Ceph FS mount on the host that
+                        shares a pod's lifetime
+                      properties:
+                        monitors:
+                          description: 'Required: Monitors is a collection of Ceph
+                            monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          items:
+                            type: string
+                          type: array
+                        path:
+                          description: 'Optional: Used as the mounted root, rather
+                            than the full Ceph tree, default is /'
+                          type: string
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: boolean
+                        secretFile:
+                          description: 'Optional: SecretFile is the path to key ring
+                            for User, default is /etc/ceph/user.secret More info:
+                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: string
+                        secretRef:
+                          description: 'Optional: SecretRef is reference to the authentication
+                            secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        user:
+                          description: 'Optional: User is the rados user name, default
+                            is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: string
+                      required:
+                      - monitors
+                      type: object
+                    cinder:
+                      description: 'Cinder represents a cinder volume attached and
+                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      properties:
+                        fsType:
+                          description: 'Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: string
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: boolean
+                        secretRef:
+                          description: 'Optional: points to a secret object containing
+                            parameters used to connect to OpenStack.'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        volumeID:
+                          description: 'volume id used to identify the volume in cinder.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    configMap:
+                      description: ConfigMap represents a configMap that should populate
+                        this volume
+                      properties:
+                        defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default. Must be a value between 0 and 0777. Defaults
+                            to 0644. Directories within the path are not affected
+                            by this setting. This might be in conflict with other
+                            options that affect the file mode, like fsGroup, and the
+                            result can be other mode bits set.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: If unspecified, each key-value pair in the
+                            Data field of the referenced ConfigMap will be projected
+                            into the volume as a file whose name is the key and content
+                            is the value. If specified, the listed keys will be projected
+                            into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in
+                            the ConfigMap, the volume setup will error unless it is
+                            marked optional. Paths must be relative and may not contain
+                            the '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
+                            properties:
+                              key:
+                                description: The key to project.
+                                type: string
+                              mode:
+                                description: 'Optional: mode bits to use on this file,
+                                  must be a value between 0 and 0777. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: The relative path of the file to map
+                                  the key to. May not be an absolute path. May not
+                                  contain the path element '..'. May not start with
+                                  the string '..'.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap or its keys must
+                            be defined
+                          type: boolean
+                      type: object
+                    csi:
+                      description: CSI (Container Storage Interface) represents storage
+                        that is handled by an external CSI driver (Alpha feature).
+                      properties:
+                        driver:
+                          description: Driver is the name of the CSI driver that handles
+                            this volume. Consult with your admin for the correct name
+                            as registered in the cluster.
+                          type: string
+                        fsType:
+                          description: Filesystem type to mount. Ex. "ext4", "xfs",
+                            "ntfs". If not provided, the empty value is passed to
+                            the associated CSI driver which will determine the default
+                            filesystem to apply.
+                          type: string
+                        nodePublishSecretRef:
+                          description: NodePublishSecretRef is a reference to the
+                            secret object containing sensitive information to pass
+                            to the CSI driver to complete the CSI NodePublishVolume
+                            and NodeUnpublishVolume calls. This field is optional,
+                            and  may be empty if no secret is required. If the secret
+                            object contains more than one secret, all secret references
+                            are passed.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        readOnly:
+                          description: Specifies a read-only configuration for the
+                            volume. Defaults to false (read/write).
+                          type: boolean
+                        volumeAttributes:
+                          additionalProperties:
+                            type: string
+                          description: VolumeAttributes stores driver-specific properties
+                            that are passed to the CSI driver. Consult your driver's
+                            documentation for supported values.
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    downwardAPI:
+                      description: DownwardAPI represents downward API about the pod
+                        that should populate this volume
+                      properties:
+                        defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default. Must be a value between 0 and 0777. Defaults
+                            to 0644. Directories within the path are not affected
+                            by this setting. This might be in conflict with other
+                            options that affect the file mode, like fsGroup, and the
+                            result can be other mode bits set.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: Items is a list of downward API volume file
+                          items:
+                            description: DownwardAPIVolumeFile represents information
+                              to create the file containing the pod field
+                            properties:
+                              fieldRef:
+                                description: 'Required: Selects a field of the pod:
+                                  only annotations, labels, name and namespace are
+                                  supported.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                              mode:
+                                description: 'Optional: mode bits to use on this file,
+                                  must be a value between 0 and 0777. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: 'Required: Path is  the relative path
+                                  name of the file to be created. Must not be absolute
+                                  or contain the ''..'' path. Must be utf-8 encoded.
+                                  The first item of the relative path must not start
+                                  with ''..'''
+                                type: string
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, requests.cpu and requests.memory)
+                                  are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                            required:
+                            - path
+                            type: object
+                          type: array
+                      type: object
+                    emptyDir:
+                      description: 'EmptyDir represents a temporary directory that
+                        shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      properties:
+                        medium:
+                          description: 'What type of storage medium should back this
+                            directory. The default is "" which means to use the node''s
+                            default medium. Must be an empty string (default) or Memory.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          type: string
+                        sizeLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'Total amount of local storage required for
+                            this EmptyDir volume. The size limit is also applicable
+                            for memory medium. The maximum usage on memory medium
+                            EmptyDir would be the minimum value between the SizeLimit
+                            specified here and the sum of memory limits of all containers
+                            in a pod. The default is nil which means that the limit
+                            is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    fc:
+                      description: FC represents a Fibre Channel resource that is
+                        attached to a kubelet's host machine and then exposed to the
+                        pod.
+                      properties:
+                        fsType:
+                          description: 'Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        lun:
+                          description: 'Optional: FC target lun number'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                          type: boolean
+                        targetWWNs:
+                          description: 'Optional: FC target worldwide names (WWNs)'
+                          items:
+                            type: string
+                          type: array
+                        wwids:
+                          description: 'Optional: FC volume world wide identifiers
+                            (wwids) Either wwids or combination of targetWWNs and
+                            lun must be set, but not both simultaneously.'
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    flexVolume:
+                      description: FlexVolume represents a generic volume resource
+                        that is provisioned/attached using an exec based plugin.
+                      properties:
+                        driver:
+                          description: Driver is the name of the driver to use for
+                            this volume.
+                          type: string
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". The default filesystem depends on FlexVolume
+                            script.
+                          type: string
+                        options:
+                          additionalProperties:
+                            type: string
+                          description: 'Optional: Extra command options if any.'
+                          type: object
+                        readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                          type: boolean
+                        secretRef:
+                          description: 'Optional: SecretRef is reference to the secret
+                            object containing sensitive information to pass to the
+                            plugin scripts. This may be empty if no secret object
+                            is specified. If the secret object contains more than
+                            one secret, all secrets are passed to the plugin scripts.'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    flocker:
+                      description: Flocker represents a Flocker volume attached to
+                        a kubelet's host machine. This depends on the Flocker control
+                        service being running
+                      properties:
+                        datasetName:
+                          description: Name of the dataset stored as metadata -> name
+                            on the dataset for Flocker should be considered as deprecated
+                          type: string
+                        datasetUUID:
+                          description: UUID of the dataset. This is unique identifier
+                            of a Flocker dataset
+                          type: string
+                      type: object
+                    gcePersistentDisk:
+                      description: 'GCEPersistentDisk represents a GCE Disk resource
+                        that is attached to a kubelet''s host machine and then exposed
+                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      properties:
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        partition:
+                          description: 'The partition in the volume that you want
+                            to mount. If omitted, the default is to mount by volume
+                            name. Examples: For volume /dev/sda1, you specify the
+                            partition as "1". Similarly, the volume partition for
+                            /dev/sda is "0" (or you can leave the property empty).
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          format: int32
+                          type: integer
+                        pdName:
+                          description: 'Unique name of the PD resource in GCE. Used
+                            to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          type: boolean
+                      required:
+                      - pdName
+                      type: object
+                    gitRepo:
+                      description: 'GitRepo represents a git repository at a particular
+                        revision. DEPRECATED: GitRepo is deprecated. To provision
+                        a container with a git repo, mount an EmptyDir into an InitContainer
+                        that clones the repo using git, then mount the EmptyDir into
+                        the Pod''s container.'
+                      properties:
+                        directory:
+                          description: Target directory name. Must not contain or
+                            start with '..'.  If '.' is supplied, the volume directory
+                            will be the git repository.  Otherwise, if specified,
+                            the volume will contain the git repository in the subdirectory
+                            with the given name.
+                          type: string
+                        repository:
+                          description: Repository URL
+                          type: string
+                        revision:
+                          description: Commit hash for the specified revision.
+                          type: string
+                      required:
+                      - repository
+                      type: object
+                    glusterfs:
+                      description: 'Glusterfs represents a Glusterfs mount on the
+                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                      properties:
+                        endpoints:
+                          description: 'EndpointsName is the endpoint name that details
+                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: string
+                        path:
+                          description: 'Path is the Glusterfs volume path. More info:
+                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the Glusterfs volume
+                            to be mounted with read-only permissions. Defaults to
+                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: boolean
+                      required:
+                      - endpoints
+                      - path
+                      type: object
+                    hostPath:
+                      description: 'HostPath represents a pre-existing file or directory
+                        on the host machine that is directly exposed to the container.
+                        This is generally used for system agents or other privileged
+                        things that are allowed to see the host machine. Most containers
+                        will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                        --- TODO(jonesdl) We need to restrict who can use host directory
+                        mounts and who can/can not mount host directories as read/write.'
+                      properties:
+                        path:
+                          description: 'Path of the directory on the host. If the
+                            path is a symlink, it will follow the link to the real
+                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          type: string
+                        type:
+                          description: 'Type for HostPath Volume Defaults to "" More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    iscsi:
+                      description: 'ISCSI represents an ISCSI Disk resource that is
+                        attached to a kubelet''s host machine and then exposed to
+                        the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                      properties:
+                        chapAuthDiscovery:
+                          description: whether support iSCSI Discovery CHAP authentication
+                          type: boolean
+                        chapAuthSession:
+                          description: whether support iSCSI Session CHAP authentication
+                          type: boolean
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        initiatorName:
+                          description: Custom iSCSI Initiator Name. If initiatorName
+                            is specified with iscsiInterface simultaneously, new iSCSI
+                            interface <target portal>:<volume name> will be created
+                            for the connection.
+                          type: string
+                        iqn:
+                          description: Target iSCSI Qualified Name.
+                          type: string
+                        iscsiInterface:
+                          description: iSCSI Interface Name that uses an iSCSI transport.
+                            Defaults to 'default' (tcp).
+                          type: string
+                        lun:
+                          description: iSCSI Target Lun number.
+                          format: int32
+                          type: integer
+                        portals:
+                          description: iSCSI Target Portal List. The portal is either
+                            an IP or ip_addr:port if the port is other than default
+                            (typically TCP ports 860 and 3260).
+                          items:
+                            type: string
+                          type: array
+                        readOnly:
+                          description: ReadOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false.
+                          type: boolean
+                        secretRef:
+                          description: CHAP Secret for iSCSI target and initiator
+                            authentication
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        targetPortal:
+                          description: iSCSI Target Portal. The Portal is either an
+                            IP or ip_addr:port if the port is other than default (typically
+                            TCP ports 860 and 3260).
+                          type: string
+                      required:
+                      - iqn
+                      - lun
+                      - targetPortal
+                      type: object
+                    name:
+                      description: 'Volume''s name. Must be a DNS_LABEL and unique
+                        within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    nfs:
+                      description: 'NFS represents an NFS mount on the host that shares
+                        a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      properties:
+                        path:
+                          description: 'Path that is exported by the NFS server. More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the NFS export to
+                            be mounted with read-only permissions. Defaults to false.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: boolean
+                        server:
+                          description: 'Server is the hostname or IP address of the
+                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: string
+                      required:
+                      - path
+                      - server
+                      type: object
+                    persistentVolumeClaim:
+                      description: 'PersistentVolumeClaimVolumeSource represents a
+                        reference to a PersistentVolumeClaim in the same namespace.
+                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                      properties:
+                        claimName:
+                          description: 'ClaimName is the name of a PersistentVolumeClaim
+                            in the same namespace as the pod using this volume. More
+                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          type: string
+                        readOnly:
+                          description: Will force the ReadOnly setting in VolumeMounts.
+                            Default false.
+                          type: boolean
+                      required:
+                      - claimName
+                      type: object
+                    photonPersistentDisk:
+                      description: PhotonPersistentDisk represents a PhotonController
+                        persistent disk attached and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        pdID:
+                          description: ID that identifies Photon Controller persistent
+                            disk
+                          type: string
+                      required:
+                      - pdID
+                      type: object
+                    portworxVolume:
+                      description: PortworxVolume represents a portworx volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: FSType represents the filesystem type to mount
+                            Must be a filesystem type supported by the host operating
+                            system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        volumeID:
+                          description: VolumeID uniquely identifies a Portworx volume
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    projected:
+                      description: Items for all in one resources secrets, configmaps,
+                        and downward API
+                      properties:
+                        defaultMode:
+                          description: Mode bits to use on created files by default.
+                            Must be a value between 0 and 0777. Directories within
+                            the path are not affected by this setting. This might
+                            be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits
+                            set.
+                          format: int32
+                          type: integer
+                        sources:
+                          description: list of volume projections
+                          items:
+                            description: Projection that may be projected along with
+                              other supported volume types
+                            properties:
+                              configMap:
+                                description: information about the configMap data
+                                  to project
+                                properties:
+                                  items:
+                                    description: If unspecified, each key-value pair
+                                      in the Data field of the referenced ConfigMap
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the ConfigMap, the volume
+                                      setup will error unless it is marked optional.
+                                      Paths must be relative and may not contain the
+                                      '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: The key to project.
+                                          type: string
+                                        mode:
+                                          description: 'Optional: mode bits to use
+                                            on this file, must be a value between
+                                            0 and 0777. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: The relative path of the file
+                                            to map the key to. May not be an absolute
+                                            path. May not contain the path element
+                                            '..'. May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its keys must be defined
+                                    type: boolean
+                                type: object
+                              downwardAPI:
+                                description: information about the downwardAPI data
+                                  to project
+                                properties:
+                                  items:
+                                    description: Items is a list of DownwardAPIVolume
+                                      file
+                                    items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
+                                      properties:
+                                        fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name and namespace are supported.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                        mode:
+                                          description: 'Optional: mode bits to use
+                                            on this file, must be a value between
+                                            0 and 0777. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path. Must be utf-8 encoded. The first
+                                            item of the relative path must not start
+                                            with ''..'''
+                                          type: string
+                                        resourceFieldRef:
+                                          description: 'Selects a resource of the
+                                            container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu
+                                            and requests.memory) are currently supported.'
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                type: object
+                              secret:
+                                description: information about the secret data to
+                                  project
+                                properties:
+                                  items:
+                                    description: If unspecified, each key-value pair
+                                      in the Data field of the referenced Secret will
+                                      be projected into the volume as a file whose
+                                      name is the key and content is the value. If
+                                      specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the Secret, the volume setup
+                                      will error unless it is marked optional. Paths
+                                      must be relative and may not contain the '..'
+                                      path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: The key to project.
+                                          type: string
+                                        mode:
+                                          description: 'Optional: mode bits to use
+                                            on this file, must be a value between
+                                            0 and 0777. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: The relative path of the file
+                                            to map the key to. May not be an absolute
+                                            path. May not contain the path element
+                                            '..'. May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                type: object
+                              serviceAccountToken:
+                                description: information about the serviceAccountToken
+                                  data to project
+                                properties:
+                                  audience:
+                                    description: Audience is the intended audience
+                                      of the token. A recipient of a token must identify
+                                      itself with an identifier specified in the audience
+                                      of the token, and otherwise should reject the
+                                      token. The audience defaults to the identifier
+                                      of the apiserver.
+                                    type: string
+                                  expirationSeconds:
+                                    description: ExpirationSeconds is the requested
+                                      duration of validity of the service account
+                                      token. As the token approaches expiration, the
+                                      kubelet volume plugin will proactively rotate
+                                      the service account token. The kubelet will
+                                      start trying to rotate the token if the token
+                                      is older than 80 percent of its time to live
+                                      or if the token is older than 24 hours.Defaults
+                                      to 1 hour and must be at least 10 minutes.
+                                    format: int64
+                                    type: integer
+                                  path:
+                                    description: Path is the path relative to the
+                                      mount point of the file to project the token
+                                      into.
+                                    type: string
+                                required:
+                                - path
+                                type: object
                             type: object
                           type: array
                       required:
-                      - nodeSelectorTerms
+                      - sources
                       type: object
-                  type: object
-                podAffinity:
-                  description: Describes pod affinity scheduling rules (e.g. co-locate
-                    this pod in the same node, zone, etc. as some other pod(s)).
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node has pods which matches the corresponding podAffinityTerm;
-                        the node(s) with the highest sum are the most preferred.
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            format: int32
-                            type: integer
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to a pod label update), the system may or may not
-                        try to eventually evict the pod from its node. When there
-                        are multiple elements, the lists of nodes corresponding to
-                        each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            items:
-                              type: string
-                            type: array
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-                        required:
-                        - topologyKey
-                        type: object
-                      type: array
-                  type: object
-                podAntiAffinity:
-                  description: Describes pod anti-affinity scheduling rules (e.g.
-                    avoid putting this pod in the same node, zone, etc. as some other
-                    pod(s)).
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the anti-affinity expressions specified by this
-                        field, but it may choose a node that violates one or more
-                        of the expressions. The node that is most preferred is the
-                        one with the greatest sum of weights, i.e. for each node that
-                        meets all of the scheduling requirements (resource request,
-                        requiredDuringScheduling anti-affinity expressions, etc.),
-                        compute a sum by iterating through the elements of this field
-                        and adding "weight" to the sum if the node has pods which
-                        matches the corresponding podAffinityTerm; the node(s) with
-                        the highest sum are the most preferred.
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            format: int32
-                            type: integer
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the anti-affinity requirements specified by
-                        this field are not met at scheduling time, the pod will not
-                        be scheduled onto the node. If the anti-affinity requirements
-                        specified by this field cease to be met at some point during
-                        pod execution (e.g. due to a pod label update), the system
-                        may or may not try to eventually evict the pod from its node.
-                        When there are multiple elements, the lists of nodes corresponding
-                        to each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            items:
-                              type: string
-                            type: array
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-                        required:
-                        - topologyKey
-                        type: object
-                      type: array
-                  type: object
-              type: object
-            clusterMasterRef:
-              description: ClusterMasterRef refers to a Splunk Enterprise indexer
-                cluster managed by the operator within Kubernetes
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            defaults:
-              description: Inline map of default.yml overrides used to initialize
-                the environment
-              type: string
-            defaultsUrl:
-              description: Full path or URL for one or more default.yml files, separated
-                by commas
-              type: string
-            ephemeralStorage:
-              description: If true, ephemeral (emptyDir) storage will be used for
-                /opt/splunk/etc and /opt/splunk/var volumes
-              type: boolean
-            etcStorage:
-              description: Storage capacity to request for /opt/splunk/etc persistent
-                volume claims (default=”1Gi”)
-              type: string
-            image:
-              description: Image to use for Splunk pod containers (overrides RELATED_IMAGE_SPLUNK_ENTERPRISE
-                environment variables)
-              type: string
-            imagePullPolicy:
-              description: 'Sets pull policy for all images (either “Always” or the
-                default: “IfNotPresent”)'
-              enum:
-              - Always
-              - IfNotPresent
-              type: string
-            licenseMasterRef:
-              description: LicenseMasterRef refers to a Splunk Enterprise license
-                master managed by the operator within Kubernetes
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            licenseUrl:
-              description: Full path or URL for a Splunk Enterprise license file
-              type: string
-            replicas:
-              description: Number of standalone pods
-              format: int32
-              type: integer
-            resources:
-              description: resource requirements for the pod containers
-              properties:
-                limits:
-                  additionalProperties:
-                    type: string
-                  description: 'Limits describes the maximum amount of compute resources
-                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                requests:
-                  additionalProperties:
-                    type: string
-                  description: 'Requests describes the minimum amount of compute resources
-                    required. If Requests is omitted for a container, it defaults
-                    to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-              type: object
-            schedulerName:
-              description: Name of Scheduler to use for pod placement (defaults to
-                “default-scheduler”)
-              type: string
-            serviceTemplate:
-              description: ServiceTemplate is a template used to create Kubernetes
-                services
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
-                    of an object. Servers should convert recognized schemas to the
-                    latest internal value, and may reject unrecognized values. More
-                    info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource
-                    this object represents. Servers may infer this from the endpoint
-                    the client submits requests to. Cannot be updated. In CamelCase.
-                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                  type: object
-                spec:
-                  description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                  properties:
-                    clusterIP:
-                      description: 'clusterIP is the IP address of the service and
-                        is usually assigned randomly by the master. If an address
-                        is specified manually and is not in use by others, it will
-                        be allocated to the service; otherwise, creation of the service
-                        will fail. This field can not be changed through updates.
-                        Valid values are "None", empty string (""), or a valid IP
-                        address. "None" can be specified for headless services when
-                        proxying is not required. Only applies to types ClusterIP,
-                        NodePort, and LoadBalancer. Ignored if type is ExternalName.
-                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                      type: string
-                    externalIPs:
-                      description: externalIPs is a list of IP addresses for which
-                        nodes in the cluster will also accept traffic for this service.  These
-                        IPs are not managed by Kubernetes.  The user is responsible
-                        for ensuring that traffic arrives at a node with this IP.  A
-                        common example is external load-balancers that are not part
-                        of the Kubernetes system.
-                      items:
-                        type: string
-                      type: array
-                    externalName:
-                      description: externalName is the external reference that kubedns
-                        or equivalent will return as a CNAME record for this service.
-                        No proxying will be involved. Must be a valid RFC-1123 hostname
-                        (https://tools.ietf.org/html/rfc1123) and requires Type to
-                        be ExternalName.
-                      type: string
-                    externalTrafficPolicy:
-                      description: externalTrafficPolicy denotes if this Service desires
-                        to route external traffic to node-local or cluster-wide endpoints.
-                        "Local" preserves the client source IP and avoids a second
-                        hop for LoadBalancer and Nodeport type services, but risks
-                        potentially imbalanced traffic spreading. "Cluster" obscures
-                        the client source IP and may cause a second hop to another
-                        node, but should have good overall load-spreading.
-                      type: string
-                    healthCheckNodePort:
-                      description: healthCheckNodePort specifies the healthcheck nodePort
-                        for the service. If not specified, HealthCheckNodePort is
-                        created by the service api backend with the allocated nodePort.
-                        Will use user-specified nodePort value if specified by the
-                        client. Only effects when Type is set to LoadBalancer and
-                        ExternalTrafficPolicy is set to Local.
-                      format: int32
-                      type: integer
-                    ipFamily:
-                      description: ipFamily specifies whether this Service has a preference
-                        for a particular IP family (e.g. IPv4 vs. IPv6).  If a specific
-                        IP family is requested, the clusterIP field will be allocated
-                        from that family, if it is available in the cluster.  If no
-                        IP family is requested, the cluster's primary IP family will
-                        be used. Other IP fields (loadBalancerIP, loadBalancerSourceRanges,
-                        externalIPs) and controllers which allocate external load-balancers
-                        should use the same IP family.  Endpoints for this Service
-                        will be of this family.  This field is immutable after creation.
-                        Assigning a ServiceIPFamily not available in the cluster (e.g.
-                        IPv6 in IPv4 only cluster) is an error condition and will
-                        fail during clusterIP assignment.
-                      type: string
-                    loadBalancerIP:
-                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                        will get created with the IP specified in this field. This
-                        feature depends on whether the underlying cloud-provider supports
-                        specifying the loadBalancerIP when a load balancer is created.
-                        This field will be ignored if the cloud-provider does not
-                        support the feature.'
-                      type: string
-                    loadBalancerSourceRanges:
-                      description: 'If specified and supported by the platform, this
-                        will restrict traffic through the cloud-provider load-balancer
-                        will be restricted to the specified client IPs. This field
-                        will be ignored if the cloud-provider does not support the
-                        feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
-                      items:
-                        type: string
-                      type: array
-                    ports:
-                      description: 'The list of ports that are exposed by this service.
-                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                      items:
-                        description: ServicePort contains information on service's
-                          port.
-                        properties:
-                          name:
-                            description: The name of this port within the service.
-                              This must be a DNS_LABEL. All ports within a ServiceSpec
-                              must have unique names. When considering the endpoints
-                              for a Service, this must match the 'name' field in the
-                              EndpointPort. Optional if only one ServicePort is defined
-                              on this service.
-                            type: string
-                          nodePort:
-                            description: 'The port on each node on which this service
-                              is exposed when type=NodePort or LoadBalancer. Usually
-                              assigned by the system. If specified, it will be allocated
-                              to the service if unused or else creation of the service
-                              will fail. Default is to auto-allocate a port if the
-                              ServiceType of this Service requires one. More info:
-                              https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
-                            format: int32
-                            type: integer
-                          port:
-                            description: The port that will be exposed by this service.
-                            format: int32
-                            type: integer
-                          protocol:
-                            description: The IP protocol for this port. Supports "TCP",
-                              "UDP", and "SCTP". Default is TCP.
-                            type: string
-                          targetPort:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: 'Number or name of the port to access on
-                              the pods targeted by the service. Number must be in
-                              the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                              If this is a string, it will be looked up as a named
-                              port in the target Pod''s container ports. If this is
-                              not specified, the value of the ''port'' field is used
-                              (an identity map). This field is ignored for services
-                              with clusterIP=None, and should be omitted or set equal
-                              to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
-                            x-kubernetes-int-or-string: true
-                        required:
-                        - port
-                        type: object
-                      type: array
-                    publishNotReadyAddresses:
-                      description: publishNotReadyAddresses, when set to true, indicates
-                        that DNS implementations must publish the notReadyAddresses
-                        of subsets for the Endpoints associated with the Service.
-                        The default value is false. The primary use case for setting
-                        this field is to use a StatefulSet's Headless Service to propagate
-                        SRV records for its Pods without respect to their readiness
-                        for purpose of peer discovery.
-                      type: boolean
-                    selector:
-                      additionalProperties:
-                        type: string
-                      description: 'Route service traffic to pods with label keys
-                        and values matching this selector. If empty or not present,
-                        the service is assumed to have an external process managing
-                        its endpoints, which Kubernetes will not modify. Only applies
-                        to types ClusterIP, NodePort, and LoadBalancer. Ignored if
-                        type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
-                      type: object
-                    sessionAffinity:
-                      description: 'Supports "ClientIP" and "None". Used to maintain
-                        session affinity. Enable client IP based session affinity.
-                        Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                      type: string
-                    sessionAffinityConfig:
-                      description: sessionAffinityConfig contains the configurations
-                        of session affinity.
+                    quobyte:
+                      description: Quobyte represents a Quobyte mount on the host
+                        that shares a pod's lifetime
                       properties:
-                        clientIP:
-                          description: clientIP contains the configurations of Client
-                            IP based session affinity.
-                          properties:
-                            timeoutSeconds:
-                              description: timeoutSeconds specifies the seconds of
-                                ClientIP type session sticky time. The value must
-                                be >0 && <=86400(for 1 day) if ServiceAffinity ==
-                                "ClientIP". Default value is 10800(for 3 hours).
-                              format: int32
-                              type: integer
-                          type: object
+                        group:
+                          description: Group to map volume access to Default is no
+                            group
+                          type: string
+                        readOnly:
+                          description: ReadOnly here will force the Quobyte volume
+                            to be mounted with read-only permissions. Defaults to
+                            false.
+                          type: boolean
+                        registry:
+                          description: Registry represents a single or multiple Quobyte
+                            Registry services specified as a string as host:port pair
+                            (multiple entries are separated with commas) which acts
+                            as the central registry for volumes
+                          type: string
+                        tenant:
+                          description: Tenant owning the given Quobyte volume in the
+                            Backend Used with dynamically provisioned Quobyte volumes,
+                            value is set by the plugin
+                          type: string
+                        user:
+                          description: User to map volume access to Defaults to serivceaccount
+                            user
+                          type: string
+                        volume:
+                          description: Volume is a string that references an already
+                            created Quobyte volume by name.
+                          type: string
+                      required:
+                      - registry
+                      - volume
                       type: object
-                    type:
-                      description: 'type determines how the Service is exposed. Defaults
-                        to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort,
-                        and LoadBalancer. "ExternalName" maps to the specified externalName.
-                        "ClusterIP" allocates a cluster-internal IP address for load-balancing
-                        to endpoints. Endpoints are determined by the selector or
-                        if that is not specified, by manual construction of an Endpoints
-                        object. If clusterIP is "None", no virtual IP is allocated
-                        and the endpoints are published as a set of endpoints rather
-                        than a stable IP. "NodePort" builds on ClusterIP and allocates
-                        a port on every node which routes to the clusterIP. "LoadBalancer"
-                        builds on NodePort and creates an external load-balancer (if
-                        supported in the current cloud) which routes to the clusterIP.
-                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
-                      type: string
-                  type: object
-                status:
-                  description: 'Most recently observed status of the service. Populated
-                    by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-                  properties:
-                    loadBalancer:
-                      description: LoadBalancer contains the current status of the
-                        load-balancer, if one is present.
+                    rbd:
+                      description: 'RBD represents a Rados Block Device mount on the
+                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                       properties:
-                        ingress:
-                          description: Ingress is a list containing ingress points
-                            for the load-balancer. Traffic intended for the service
-                            should be sent to these ingress points.
+                        fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        image:
+                          description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        keyring:
+                          description: 'Keyring is the path to key ring for RBDUser.
+                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        monitors:
+                          description: 'A collection of Ceph monitors. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           items:
-                            description: 'LoadBalancerIngress represents the status
-                              of a load-balancer ingress point: traffic intended for
-                              the service should be sent to an ingress point.'
+                            type: string
+                          type: array
+                        pool:
+                          description: 'The rados pool name. Default is rbd. More
+                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        readOnly:
+                          description: 'ReadOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: boolean
+                        secretRef:
+                          description: 'SecretRef is name of the authentication secret
+                            for RBDUser. If provided overrides keyring. Default is
+                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        user:
+                          description: 'The rados user name. Default is admin. More
+                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                      required:
+                      - image
+                      - monitors
+                      type: object
+                    scaleIO:
+                      description: ScaleIO represents a ScaleIO persistent volume
+                        attached and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Default is "xfs".
+                          type: string
+                        gateway:
+                          description: The host address of the ScaleIO API Gateway.
+                          type: string
+                        protectionDomain:
+                          description: The name of the ScaleIO Protection Domain for
+                            the configured storage.
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: SecretRef references to the secret for ScaleIO
+                            user and other sensitive information. If this is not provided,
+                            Login operation will fail.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        sslEnabled:
+                          description: Flag to enable/disable SSL communication with
+                            Gateway, default false
+                          type: boolean
+                        storageMode:
+                          description: Indicates whether the storage for a volume
+                            should be ThickProvisioned or ThinProvisioned. Default
+                            is ThinProvisioned.
+                          type: string
+                        storagePool:
+                          description: The ScaleIO Storage Pool associated with the
+                            protection domain.
+                          type: string
+                        system:
+                          description: The name of the storage system as configured
+                            in ScaleIO.
+                          type: string
+                        volumeName:
+                          description: The name of a volume already created in the
+                            ScaleIO system that is associated with this volume source.
+                          type: string
+                      required:
+                      - gateway
+                      - secretRef
+                      - system
+                      type: object
+                    secret:
+                      description: 'Secret represents a secret that should populate
+                        this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                      properties:
+                        defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default. Must be a value between 0 and 0777. Defaults
+                            to 0644. Directories within the path are not affected
+                            by this setting. This might be in conflict with other
+                            options that affect the file mode, like fsGroup, and the
+                            result can be other mode bits set.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: If unspecified, each key-value pair in the
+                            Data field of the referenced Secret will be projected
+                            into the volume as a file whose name is the key and content
+                            is the value. If specified, the listed keys will be projected
+                            into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in
+                            the Secret, the volume setup will error unless it is marked
+                            optional. Paths must be relative and may not contain the
+                            '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
                             properties:
-                              hostname:
-                                description: Hostname is set for load-balancer ingress
-                                  points that are DNS based (typically AWS load-balancers)
+                              key:
+                                description: The key to project.
                                 type: string
-                              ip:
-                                description: IP is set for load-balancer ingress points
-                                  that are IP based (typically GCE or OpenStack load-balancers)
+                              mode:
+                                description: 'Optional: mode bits to use on this file,
+                                  must be a value between 0 and 0777. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: The relative path of the file to map
+                                  the key to. May not be an absolute path. May not
+                                  contain the path element '..'. May not start with
+                                  the string '..'.
                                 type: string
+                            required:
+                            - key
+                            - path
                             type: object
                           type: array
+                        optional:
+                          description: Specify whether the Secret or its keys must
+                            be defined
+                          type: boolean
+                        secretName:
+                          description: 'Name of the secret in the pod''s namespace
+                            to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                          type: string
                       type: object
+                    storageos:
+                      description: StorageOS represents a StorageOS volume attached
+                        and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: SecretRef specifies the secret to use for obtaining
+                            the StorageOS API credentials.  If not specified, default
+                            values will be attempted.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        volumeName:
+                          description: VolumeName is the human-readable name of the
+                            StorageOS volume.  Volume names are only unique within
+                            a namespace.
+                          type: string
+                        volumeNamespace:
+                          description: VolumeNamespace specifies the scope of the
+                            volume within StorageOS.  If no namespace is specified
+                            then the Pod's namespace will be used.  This allows the
+                            Kubernetes name scoping to be mirrored within StorageOS
+                            for tighter integration. Set VolumeName to any name to
+                            override the default behaviour. Set to "default" if you
+                            are not using namespaces within StorageOS. Namespaces
+                            that do not pre-exist within StorageOS will be created.
+                          type: string
+                      type: object
+                    vsphereVolume:
+                      description: VsphereVolume represents a vSphere volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        storagePolicyID:
+                          description: Storage Policy Based Management (SPBM) profile
+                            ID associated with the StoragePolicyName.
+                          type: string
+                        storagePolicyName:
+                          description: Storage Policy Based Management (SPBM) profile
+                            name.
+                          type: string
+                        volumePath:
+                          description: Path that identifies vSphere volume vmdk
+                          type: string
+                      required:
+                      - volumePath
+                      type: object
+                  required:
+                  - name
                   type: object
-              type: object
-            smartstore:
-              description: Splunk Smartstore configuration. Refer to indexes.conf.spec
-                on docs.splunk.com
-              properties:
-                indexes:
-                  description: List of Splunk indexes
-                  items:
-                    description: IndexSpec defines Splunk index name and storage path
-                    properties:
-                      name:
-                        description: Splunk index name
-                        type: string
-                      remotePath:
-                        description: Index location relative to the remote volume
-                          path
-                        type: string
-                      volumeName:
-                        description: Remote Volume name
-                        type: string
-                    type: object
-                  type: array
-                volumes:
-                  description: List of remote storage volumes
-                  items:
-                    description: VolumeSpec defines remote volume name and remote
-                      volume URI
-                    properties:
-                      endpoint:
-                        description: Remote volume URI
-                        type: string
-                      name:
-                        description: Remote volume name
-                        type: string
-                      path:
-                        description: Remote volume path
-                        type: string
-                    type: object
-                  type: array
-              type: object
-            sparkImage:
-              description: Image to use for Spark pod containers (overrides RELATED_IMAGE_SPLUNK_SPARK
-                environment variables)
-              type: string
-            sparkRef:
-              description: SparkRef refers to a Spark cluster managed by the operator
-                within Kubernetes When defined, Data Fabric Search (DFS) will be enabled
-                and configured to use the Spark cluster.
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            storageClassName:
-              description: Name of StorageClass to use for persistent volume claims
-              type: string
-            tolerations:
-              description: Pod's tolerations for Kubernetes node's taint
-              items:
-                description: The pod this Toleration is attached to tolerates any
-                  taint that matches the triple <key,value,effect> using the matching
-                  operator <operator>.
+                type: array
+            type: object
+          status:
+            description: StandaloneStatus defines the observed state of a Splunk Enterprise
+              standalone instances.
+            properties:
+              phase:
+                description: current phase of the standalone instances
+                enum:
+                - Pending
+                - Ready
+                - Updating
+                - ScalingUp
+                - ScalingDown
+                - Terminating
+                - Error
+                type: string
+              readyReplicas:
+                description: current number of ready standalone instances
+                format: int32
+                type: integer
+              replicas:
+                description: number of desired standalone instances
+                format: int32
+                type: integer
+              selector:
+                description: selector for pods, used by HorizontalPodAutoscaler
+                type: string
+              smartstore:
+                description: Splunk Smartstore configuration. Refer to indexes.conf.spec
+                  on docs.splunk.com
                 properties:
-                  effect:
-                    description: Effect indicates the taint effect to match. Empty
-                      means match all taint effects. When specified, allowed values
-                      are NoSchedule, PreferNoSchedule and NoExecute.
-                    type: string
-                  key:
-                    description: Key is the taint key that the toleration applies
-                      to. Empty means match all taint keys. If the key is empty, operator
-                      must be Exists; this combination means to match all values and
-                      all keys.
-                    type: string
-                  operator:
-                    description: Operator represents a key's relationship to the value.
-                      Valid operators are Exists and Equal. Defaults to Equal. Exists
-                      is equivalent to wildcard for value, so that a pod can tolerate
-                      all taints of a particular category.
-                    type: string
-                  tolerationSeconds:
-                    description: TolerationSeconds represents the period of time the
-                      toleration (which must be of effect NoExecute, otherwise this
-                      field is ignored) tolerates the taint. By default, it is not
-                      set, which means tolerate the taint forever (do not evict).
-                      Zero and negative values will be treated as 0 (evict immediately)
-                      by the system.
-                    format: int64
-                    type: integer
-                  value:
-                    description: Value is the taint value the toleration matches to.
-                      If the operator is Exists, the value should be empty, otherwise
-                      just a regular string.
-                    type: string
+                  indexes:
+                    description: List of Splunk indexes
+                    items:
+                      description: IndexSpec defines Splunk index name and storage
+                        path
+                      properties:
+                        name:
+                          description: Splunk index name
+                          type: string
+                        remotePath:
+                          description: Index location relative to the remote volume
+                            path
+                          type: string
+                        volumeName:
+                          description: Remote Volume name
+                          type: string
+                      type: object
+                    type: array
+                  volumes:
+                    description: List of remote storage volumes
+                    items:
+                      description: VolumeSpec defines remote volume name and remote
+                        volume URI
+                      properties:
+                        endpoint:
+                          description: Remote volume URI
+                          type: string
+                        name:
+                          description: Remote volume name
+                          type: string
+                        path:
+                          description: Remote volume path
+                          type: string
+                      type: object
+                    type: array
                 type: object
-              type: array
-            varStorage:
-              description: Storage capacity to request for /opt/splunk/var persistent
-                volume claims (default=”50Gi”)
-              type: string
-            volumes:
-              description: List of one or more Kubernetes volumes. These will be mounted
-                in all pod containers as as /mnt/<name>
-              items:
-                description: Volume represents a named volume in a pod that may be
-                  accessed by any container in the pod.
-                properties:
-                  awsElasticBlockStore:
-                    description: 'AWSElasticBlockStore represents an AWS Disk resource
-                      that is attached to a kubelet''s host machine and then exposed
-                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      partition:
-                        description: 'The partition in the volume that you want to
-                          mount. If omitted, the default is to mount by volume name.
-                          Examples: For volume /dev/sda1, you specify the partition
-                          as "1". Similarly, the volume partition for /dev/sda is
-                          "0" (or you can leave the property empty).'
-                        format: int32
-                        type: integer
-                      readOnly:
-                        description: 'Specify "true" to force and set the ReadOnly
-                          property in VolumeMounts to "true". If omitted, the default
-                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                        type: boolean
-                      volumeID:
-                        description: 'Unique ID of the persistent disk resource in
-                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  azureDisk:
-                    description: AzureDisk represents an Azure Data Disk mount on
-                      the host and bind mount to the pod.
-                    properties:
-                      cachingMode:
-                        description: 'Host Caching mode: None, Read Only, Read Write.'
-                        type: string
-                      diskName:
-                        description: The Name of the data disk in the blob storage
-                        type: string
-                      diskURI:
-                        description: The URI the data disk in the blob storage
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      kind:
-                        description: 'Expected values Shared: multiple blob disks
-                          per storage account  Dedicated: single blob disk per storage
-                          account  Managed: azure managed data disk (only in managed
-                          availability set). defaults to shared'
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                    required:
-                    - diskName
-                    - diskURI
-                    type: object
-                  azureFile:
-                    description: AzureFile represents an Azure File Service mount
-                      on the host and bind mount to the pod.
-                    properties:
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretName:
-                        description: the name of secret that contains Azure Storage
-                          Account Name and Key
-                        type: string
-                      shareName:
-                        description: Share Name
-                        type: string
-                    required:
-                    - secretName
-                    - shareName
-                    type: object
-                  cephfs:
-                    description: CephFS represents a Ceph FS mount on the host that
-                      shares a pod's lifetime
-                    properties:
-                      monitors:
-                        description: 'Required: Monitors is a collection of Ceph monitors
-                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        items:
-                          type: string
-                        type: array
-                      path:
-                        description: 'Optional: Used as the mounted root, rather than
-                          the full Ceph tree, default is /'
-                        type: string
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts. More
-                          info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: boolean
-                      secretFile:
-                        description: 'Optional: SecretFile is the path to key ring
-                          for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: string
-                      secretRef:
-                        description: 'Optional: SecretRef is reference to the authentication
-                          secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      user:
-                        description: 'Optional: User is the rados user name, default
-                          is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: string
-                    required:
-                    - monitors
-                    type: object
-                  cinder:
-                    description: 'Cinder represents a cinder volume attached and mounted
-                      on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Examples: "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: string
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts. More
-                          info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: boolean
-                      secretRef:
-                        description: 'Optional: points to a secret object containing
-                          parameters used to connect to OpenStack.'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      volumeID:
-                        description: 'volume id used to identify the volume in cinder.
-                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  configMap:
-                    description: ConfigMap represents a configMap that should populate
-                      this volume
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: If unspecified, each key-value pair in the Data
-                          field of the referenced ConfigMap will be projected into
-                          the volume as a file whose name is the key and content is
-                          the value. If specified, the listed keys will be projected
-                          into the specified paths, and unlisted keys will not be
-                          present. If a key is specified which is not present in the
-                          ConfigMap, the volume setup will error unless it is marked
-                          optional. Paths must be relative and may not contain the
-                          '..' path or start with '..'.
-                        items:
-                          description: Maps a string key to a path within a volume.
-                          properties:
-                            key:
-                              description: The key to project.
-                              type: string
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: The relative path of the file to map the
-                                key to. May not be an absolute path. May not contain
-                                the path element '..'. May not start with the string
-                                '..'.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          type: object
-                        type: array
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
-                        type: string
-                      optional:
-                        description: Specify whether the ConfigMap or its keys must
-                          be defined
-                        type: boolean
-                    type: object
-                  csi:
-                    description: CSI (Container Storage Interface) represents storage
-                      that is handled by an external CSI driver (Alpha feature).
-                    properties:
-                      driver:
-                        description: Driver is the name of the CSI driver that handles
-                          this volume. Consult with your admin for the correct name
-                          as registered in the cluster.
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Ex. "ext4", "xfs",
-                          "ntfs". If not provided, the empty value is passed to the
-                          associated CSI driver which will determine the default filesystem
-                          to apply.
-                        type: string
-                      nodePublishSecretRef:
-                        description: NodePublishSecretRef is a reference to the secret
-                          object containing sensitive information to pass to the CSI
-                          driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
-                          calls. This field is optional, and  may be empty if no secret
-                          is required. If the secret object contains more than one
-                          secret, all secret references are passed.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      readOnly:
-                        description: Specifies a read-only configuration for the volume.
-                          Defaults to false (read/write).
-                        type: boolean
-                      volumeAttributes:
-                        additionalProperties:
-                          type: string
-                        description: VolumeAttributes stores driver-specific properties
-                          that are passed to the CSI driver. Consult your driver's
-                          documentation for supported values.
-                        type: object
-                    required:
-                    - driver
-                    type: object
-                  downwardAPI:
-                    description: DownwardAPI represents downward API about the pod
-                      that should populate this volume
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: Items is a list of downward API volume file
-                        items:
-                          description: DownwardAPIVolumeFile represents information
-                            to create the file containing the pod field
-                          properties:
-                            fieldRef:
-                              description: 'Required: Selects a field of the pod:
-                                only annotations, labels, name and namespace are supported.'
-                              properties:
-                                apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
-                                  type: string
-                                fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
-                                  type: string
-                              required:
-                              - fieldPath
-                              type: object
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: 'Required: Path is  the relative path name
-                                of the file to be created. Must not be absolute or
-                                contain the ''..'' path. Must be utf-8 encoded. The
-                                first item of the relative path must not start with
-                                ''..'''
-                              type: string
-                            resourceFieldRef:
-                              description: 'Selects a resource of the container: only
-                                resources limits and requests (limits.cpu, limits.memory,
-                                requests.cpu and requests.memory) are currently supported.'
-                              properties:
-                                containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
-                                  type: string
-                                divisor:
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
-                                  type: string
-                                resource:
-                                  description: 'Required: resource to select'
-                                  type: string
-                              required:
-                              - resource
-                              type: object
-                          required:
-                          - path
-                          type: object
-                        type: array
-                    type: object
-                  emptyDir:
-                    description: 'EmptyDir represents a temporary directory that shares
-                      a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                    properties:
-                      medium:
-                        description: 'What type of storage medium should back this
-                          directory. The default is "" which means to use the node''s
-                          default medium. Must be an empty string (default) or Memory.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                        type: string
-                      sizeLimit:
-                        description: 'Total amount of local storage required for this
-                          EmptyDir volume. The size limit is also applicable for memory
-                          medium. The maximum usage on memory medium EmptyDir would
-                          be the minimum value between the SizeLimit specified here
-                          and the sum of memory limits of all containers in a pod.
-                          The default is nil which means that the limit is undefined.
-                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                        type: string
-                    type: object
-                  fc:
-                    description: FC represents a Fibre Channel resource that is attached
-                      to a kubelet's host machine and then exposed to the pod.
-                    properties:
-                      fsType:
-                        description: 'Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      lun:
-                        description: 'Optional: FC target lun number'
-                        format: int32
-                        type: integer
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts.'
-                        type: boolean
-                      targetWWNs:
-                        description: 'Optional: FC target worldwide names (WWNs)'
-                        items:
-                          type: string
-                        type: array
-                      wwids:
-                        description: 'Optional: FC volume world wide identifiers (wwids)
-                          Either wwids or combination of targetWWNs and lun must be
-                          set, but not both simultaneously.'
-                        items:
-                          type: string
-                        type: array
-                    type: object
-                  flexVolume:
-                    description: FlexVolume represents a generic volume resource that
-                      is provisioned/attached using an exec based plugin.
-                    properties:
-                      driver:
-                        description: Driver is the name of the driver to use for this
-                          volume.
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". The default filesystem depends on FlexVolume
-                          script.
-                        type: string
-                      options:
-                        additionalProperties:
-                          type: string
-                        description: 'Optional: Extra command options if any.'
-                        type: object
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts.'
-                        type: boolean
-                      secretRef:
-                        description: 'Optional: SecretRef is reference to the secret
-                          object containing sensitive information to pass to the plugin
-                          scripts. This may be empty if no secret object is specified.
-                          If the secret object contains more than one secret, all
-                          secrets are passed to the plugin scripts.'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                    required:
-                    - driver
-                    type: object
-                  flocker:
-                    description: Flocker represents a Flocker volume attached to a
-                      kubelet's host machine. This depends on the Flocker control
-                      service being running
-                    properties:
-                      datasetName:
-                        description: Name of the dataset stored as metadata -> name
-                          on the dataset for Flocker should be considered as deprecated
-                        type: string
-                      datasetUUID:
-                        description: UUID of the dataset. This is unique identifier
-                          of a Flocker dataset
-                        type: string
-                    type: object
-                  gcePersistentDisk:
-                    description: 'GCEPersistentDisk represents a GCE Disk resource
-                      that is attached to a kubelet''s host machine and then exposed
-                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      partition:
-                        description: 'The partition in the volume that you want to
-                          mount. If omitted, the default is to mount by volume name.
-                          Examples: For volume /dev/sda1, you specify the partition
-                          as "1". Similarly, the volume partition for /dev/sda is
-                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        format: int32
-                        type: integer
-                      pdName:
-                        description: 'Unique name of the PD resource in GCE. Used
-                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        type: boolean
-                    required:
-                    - pdName
-                    type: object
-                  gitRepo:
-                    description: 'GitRepo represents a git repository at a particular
-                      revision. DEPRECATED: GitRepo is deprecated. To provision a
-                      container with a git repo, mount an EmptyDir into an InitContainer
-                      that clones the repo using git, then mount the EmptyDir into
-                      the Pod''s container.'
-                    properties:
-                      directory:
-                        description: Target directory name. Must not contain or start
-                          with '..'.  If '.' is supplied, the volume directory will
-                          be the git repository.  Otherwise, if specified, the volume
-                          will contain the git repository in the subdirectory with
-                          the given name.
-                        type: string
-                      repository:
-                        description: Repository URL
-                        type: string
-                      revision:
-                        description: Commit hash for the specified revision.
-                        type: string
-                    required:
-                    - repository
-                    type: object
-                  glusterfs:
-                    description: 'Glusterfs represents a Glusterfs mount on the host
-                      that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
-                    properties:
-                      endpoints:
-                        description: 'EndpointsName is the endpoint name that details
-                          Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: string
-                      path:
-                        description: 'Path is the Glusterfs volume path. More info:
-                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the Glusterfs volume
-                          to be mounted with read-only permissions. Defaults to false.
-                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: boolean
-                    required:
-                    - endpoints
-                    - path
-                    type: object
-                  hostPath:
-                    description: 'HostPath represents a pre-existing file or directory
-                      on the host machine that is directly exposed to the container.
-                      This is generally used for system agents or other privileged
-                      things that are allowed to see the host machine. Most containers
-                      will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                      --- TODO(jonesdl) We need to restrict who can use host directory
-                      mounts and who can/can not mount host directories as read/write.'
-                    properties:
-                      path:
-                        description: 'Path of the directory on the host. If the path
-                          is a symlink, it will follow the link to the real path.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                        type: string
-                      type:
-                        description: 'Type for HostPath Volume Defaults to "" More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                        type: string
-                    required:
-                    - path
-                    type: object
-                  iscsi:
-                    description: 'ISCSI represents an ISCSI Disk resource that is
-                      attached to a kubelet''s host machine and then exposed to the
-                      pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
-                    properties:
-                      chapAuthDiscovery:
-                        description: whether support iSCSI Discovery CHAP authentication
-                        type: boolean
-                      chapAuthSession:
-                        description: whether support iSCSI Session CHAP authentication
-                        type: boolean
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      initiatorName:
-                        description: Custom iSCSI Initiator Name. If initiatorName
-                          is specified with iscsiInterface simultaneously, new iSCSI
-                          interface <target portal>:<volume name> will be created
-                          for the connection.
-                        type: string
-                      iqn:
-                        description: Target iSCSI Qualified Name.
-                        type: string
-                      iscsiInterface:
-                        description: iSCSI Interface Name that uses an iSCSI transport.
-                          Defaults to 'default' (tcp).
-                        type: string
-                      lun:
-                        description: iSCSI Target Lun number.
-                        format: int32
-                        type: integer
-                      portals:
-                        description: iSCSI Target Portal List. The portal is either
-                          an IP or ip_addr:port if the port is other than default
-                          (typically TCP ports 860 and 3260).
-                        items:
-                          type: string
-                        type: array
-                      readOnly:
-                        description: ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false.
-                        type: boolean
-                      secretRef:
-                        description: CHAP Secret for iSCSI target and initiator authentication
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      targetPortal:
-                        description: iSCSI Target Portal. The Portal is either an
-                          IP or ip_addr:port if the port is other than default (typically
-                          TCP ports 860 and 3260).
-                        type: string
-                    required:
-                    - iqn
-                    - lun
-                    - targetPortal
-                    type: object
-                  name:
-                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
-                      the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  nfs:
-                    description: 'NFS represents an NFS mount on the host that shares
-                      a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                    properties:
-                      path:
-                        description: 'Path that is exported by the NFS server. More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the NFS export to be
-                          mounted with read-only permissions. Defaults to false. More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: boolean
-                      server:
-                        description: 'Server is the hostname or IP address of the
-                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: string
-                    required:
-                    - path
-                    - server
-                    type: object
-                  persistentVolumeClaim:
-                    description: 'PersistentVolumeClaimVolumeSource represents a reference
-                      to a PersistentVolumeClaim in the same namespace. More info:
-                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                    properties:
-                      claimName:
-                        description: 'ClaimName is the name of a PersistentVolumeClaim
-                          in the same namespace as the pod using this volume. More
-                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                        type: string
-                      readOnly:
-                        description: Will force the ReadOnly setting in VolumeMounts.
-                          Default false.
-                        type: boolean
-                    required:
-                    - claimName
-                    type: object
-                  photonPersistentDisk:
-                    description: PhotonPersistentDisk represents a PhotonController
-                      persistent disk attached and mounted on kubelets host machine
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      pdID:
-                        description: ID that identifies Photon Controller persistent
-                          disk
-                        type: string
-                    required:
-                    - pdID
-                    type: object
-                  portworxVolume:
-                    description: PortworxVolume represents a portworx volume attached
-                      and mounted on kubelets host machine
-                    properties:
-                      fsType:
-                        description: FSType represents the filesystem type to mount
-                          Must be a filesystem type supported by the host operating
-                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                          if unspecified.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      volumeID:
-                        description: VolumeID uniquely identifies a Portworx volume
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  projected:
-                    description: Items for all in one resources secrets, configmaps,
-                      and downward API
-                    properties:
-                      defaultMode:
-                        description: Mode bits to use on created files by default.
-                          Must be a value between 0 and 0777. Directories within the
-                          path are not affected by this setting. This might be in
-                          conflict with other options that affect the file mode, like
-                          fsGroup, and the result can be other mode bits set.
-                        format: int32
-                        type: integer
-                      sources:
-                        description: list of volume projections
-                        items:
-                          description: Projection that may be projected along with
-                            other supported volume types
-                          properties:
-                            configMap:
-                              description: information about the configMap data to
-                                project
-                              properties:
-                                items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced ConfigMap
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the ConfigMap, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
-                                  items:
-                                    description: Maps a string key to a path within
-                                      a volume.
-                                    properties:
-                                      key:
-                                        description: The key to project.
-                                        type: string
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap or its
-                                    keys must be defined
-                                  type: boolean
-                              type: object
-                            downwardAPI:
-                              description: information about the downwardAPI data
-                                to project
-                              properties:
-                                items:
-                                  description: Items is a list of DownwardAPIVolume
-                                    file
-                                  items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
-                                    properties:
-                                      fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
-                                        properties:
-                                          apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
-                                            type: string
-                                          fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
-                                        type: string
-                                      resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, requests.cpu and requests.memory)
-                                          are currently supported.'
-                                        properties:
-                                          containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
-                                            type: string
-                                          divisor:
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
-                                            type: string
-                                          resource:
-                                            description: 'Required: resource to select'
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                    required:
-                                    - path
-                                    type: object
-                                  type: array
-                              type: object
-                            secret:
-                              description: information about the secret data to project
-                              properties:
-                                items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced Secret will
-                                    be projected into the volume as a file whose name
-                                    is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the Secret, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
-                                  items:
-                                    description: Maps a string key to a path within
-                                      a volume.
-                                    properties:
-                                      key:
-                                        description: The key to project.
-                                        type: string
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
-                                  type: boolean
-                              type: object
-                            serviceAccountToken:
-                              description: information about the serviceAccountToken
-                                data to project
-                              properties:
-                                audience:
-                                  description: Audience is the intended audience of
-                                    the token. A recipient of a token must identify
-                                    itself with an identifier specified in the audience
-                                    of the token, and otherwise should reject the
-                                    token. The audience defaults to the identifier
-                                    of the apiserver.
-                                  type: string
-                                expirationSeconds:
-                                  description: ExpirationSeconds is the requested
-                                    duration of validity of the service account token.
-                                    As the token approaches expiration, the kubelet
-                                    volume plugin will proactively rotate the service
-                                    account token. The kubelet will start trying to
-                                    rotate the token if the token is older than 80
-                                    percent of its time to live or if the token is
-                                    older than 24 hours.Defaults to 1 hour and must
-                                    be at least 10 minutes.
-                                  format: int64
-                                  type: integer
-                                path:
-                                  description: Path is the path relative to the mount
-                                    point of the file to project the token into.
-                                  type: string
-                              required:
-                              - path
-                              type: object
-                          type: object
-                        type: array
-                    required:
-                    - sources
-                    type: object
-                  quobyte:
-                    description: Quobyte represents a Quobyte mount on the host that
-                      shares a pod's lifetime
-                    properties:
-                      group:
-                        description: Group to map volume access to Default is no group
-                        type: string
-                      readOnly:
-                        description: ReadOnly here will force the Quobyte volume to
-                          be mounted with read-only permissions. Defaults to false.
-                        type: boolean
-                      registry:
-                        description: Registry represents a single or multiple Quobyte
-                          Registry services specified as a string as host:port pair
-                          (multiple entries are separated with commas) which acts
-                          as the central registry for volumes
-                        type: string
-                      tenant:
-                        description: Tenant owning the given Quobyte volume in the
-                          Backend Used with dynamically provisioned Quobyte volumes,
-                          value is set by the plugin
-                        type: string
-                      user:
-                        description: User to map volume access to Defaults to serivceaccount
-                          user
-                        type: string
-                      volume:
-                        description: Volume is a string that references an already
-                          created Quobyte volume by name.
-                        type: string
-                    required:
-                    - registry
-                    - volume
-                    type: object
-                  rbd:
-                    description: 'RBD represents a Rados Block Device mount on the
-                      host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
-                        type: string
-                      image:
-                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      keyring:
-                        description: 'Keyring is the path to key ring for RBDUser.
-                          Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      monitors:
-                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        items:
-                          type: string
-                        type: array
-                      pool:
-                        description: 'The rados pool name. Default is rbd. More info:
-                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: boolean
-                      secretRef:
-                        description: 'SecretRef is name of the authentication secret
-                          for RBDUser. If provided overrides keyring. Default is nil.
-                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      user:
-                        description: 'The rados user name. Default is admin. More
-                          info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                    required:
-                    - image
-                    - monitors
-                    type: object
-                  scaleIO:
-                    description: ScaleIO represents a ScaleIO persistent volume attached
-                      and mounted on Kubernetes nodes.
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Default is "xfs".
-                        type: string
-                      gateway:
-                        description: The host address of the ScaleIO API Gateway.
-                        type: string
-                      protectionDomain:
-                        description: The name of the ScaleIO Protection Domain for
-                          the configured storage.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretRef:
-                        description: SecretRef references to the secret for ScaleIO
-                          user and other sensitive information. If this is not provided,
-                          Login operation will fail.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      sslEnabled:
-                        description: Flag to enable/disable SSL communication with
-                          Gateway, default false
-                        type: boolean
-                      storageMode:
-                        description: Indicates whether the storage for a volume should
-                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
-                        type: string
-                      storagePool:
-                        description: The ScaleIO Storage Pool associated with the
-                          protection domain.
-                        type: string
-                      system:
-                        description: The name of the storage system as configured
-                          in ScaleIO.
-                        type: string
-                      volumeName:
-                        description: The name of a volume already created in the ScaleIO
-                          system that is associated with this volume source.
-                        type: string
-                    required:
-                    - gateway
-                    - secretRef
-                    - system
-                    type: object
-                  secret:
-                    description: 'Secret represents a secret that should populate
-                      this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: If unspecified, each key-value pair in the Data
-                          field of the referenced Secret will be projected into the
-                          volume as a file whose name is the key and content is the
-                          value. If specified, the listed keys will be projected into
-                          the specified paths, and unlisted keys will not be present.
-                          If a key is specified which is not present in the Secret,
-                          the volume setup will error unless it is marked optional.
-                          Paths must be relative and may not contain the '..' path
-                          or start with '..'.
-                        items:
-                          description: Maps a string key to a path within a volume.
-                          properties:
-                            key:
-                              description: The key to project.
-                              type: string
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: The relative path of the file to map the
-                                key to. May not be an absolute path. May not contain
-                                the path element '..'. May not start with the string
-                                '..'.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          type: object
-                        type: array
-                      optional:
-                        description: Specify whether the Secret or its keys must be
-                          defined
-                        type: boolean
-                      secretName:
-                        description: 'Name of the secret in the pod''s namespace to
-                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                        type: string
-                    type: object
-                  storageos:
-                    description: StorageOS represents a StorageOS volume attached
-                      and mounted on Kubernetes nodes.
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretRef:
-                        description: SecretRef specifies the secret to use for obtaining
-                          the StorageOS API credentials.  If not specified, default
-                          values will be attempted.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      volumeName:
-                        description: VolumeName is the human-readable name of the
-                          StorageOS volume.  Volume names are only unique within a
-                          namespace.
-                        type: string
-                      volumeNamespace:
-                        description: VolumeNamespace specifies the scope of the volume
-                          within StorageOS.  If no namespace is specified then the
-                          Pod's namespace will be used.  This allows the Kubernetes
-                          name scoping to be mirrored within StorageOS for tighter
-                          integration. Set VolumeName to any name to override the
-                          default behaviour. Set to "default" if you are not using
-                          namespaces within StorageOS. Namespaces that do not pre-exist
-                          within StorageOS will be created.
-                        type: string
-                    type: object
-                  vsphereVolume:
-                    description: VsphereVolume represents a vSphere volume attached
-                      and mounted on kubelets host machine
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      storagePolicyID:
-                        description: Storage Policy Based Management (SPBM) profile
-                          ID associated with the StoragePolicyName.
-                        type: string
-                      storagePolicyName:
-                        description: Storage Policy Based Management (SPBM) profile
-                          name.
-                        type: string
-                      volumePath:
-                        description: Path that identifies vSphere volume vmdk
-                        type: string
-                    required:
-                    - volumePath
-                    type: object
-                required:
-                - name
-                type: object
-              type: array
-          type: object
-        status:
-          description: StandaloneStatus defines the observed state of a Splunk Enterprise
-            standalone instances.
-          properties:
-            phase:
-              description: current phase of the standalone instances
-              enum:
-              - Pending
-              - Ready
-              - Updating
-              - ScalingUp
-              - ScalingDown
-              - Terminating
-              - Error
-              type: string
-            readyReplicas:
-              description: current number of ready standalone instances
-              format: int32
-              type: integer
-            replicas:
-              description: number of desired standalone instances
-              format: int32
-              type: integer
-            selector:
-              description: selector for pods, used by HorizontalPodAutoscaler
-              type: string
-            smartstore:
-              description: Splunk Smartstore configuration. Refer to indexes.conf.spec
-                on docs.splunk.com
-              properties:
-                indexes:
-                  description: List of Splunk indexes
-                  items:
-                    description: IndexSpec defines Splunk index name and storage path
-                    properties:
-                      name:
-                        description: Splunk index name
-                        type: string
-                      remotePath:
-                        description: Index location relative to the remote volume
-                          path
-                        type: string
-                      volumeName:
-                        description: Remote Volume name
-                        type: string
-                    type: object
-                  type: array
-                volumes:
-                  description: List of remote storage volumes
-                  items:
-                    description: VolumeSpec defines remote volume name and remote
-                      volume URI
-                    properties:
-                      endpoint:
-                        description: Remote volume URI
-                        type: string
-                      name:
-                        description: Remote volume name
-                        type: string
-                      path:
-                        description: Remote volume path
-                        type: string
-                    type: object
-                  type: array
-              type: object
-          type: object
-      type: object
-  version: v1alpha3
-  versions:
-  - name: v1alpha3
+            type: object
+        type: object
     served: true
     storage: true
-  - name: v1alpha2
-    served: true
-    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_clustermasters_crd.yaml
+++ b/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_clustermasters_crd.yaml
@@ -38,6 +38,9 @@ spec:
         spec:
           description: ClusterMasterSpec defines the desired state of ClusterMaster
           properties:
+            Mock:
+              description: Mock to differentiate between UTs and actual reconcile
+              type: boolean
             affinity:
               description: Kubernetes Affinity rules that control how pods are assigned
                 to particular nodes.

--- a/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_indexerclusters_crd.yaml
+++ b/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_indexerclusters_crd.yaml
@@ -60,6 +60,9 @@ spec:
           description: IndexerClusterSpec defines the desired state of a Splunk Enterprise
             indexer cluster
           properties:
+            Mock:
+              description: Mock to differentiate between UTs and actual reconcile
+              type: boolean
             affinity:
               description: Kubernetes Affinity rules that control how pods are assigned
                 to particular nodes.

--- a/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_licensemasters_crd.yaml
+++ b/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_licensemasters_crd.yaml
@@ -43,6 +43,9 @@ spec:
           description: LicenseMasterSpec defines the desired state of a Splunk Enterprise
             license master.
           properties:
+            Mock:
+              description: Mock to differentiate between UTs and actual reconcile
+              type: boolean
             affinity:
               description: Kubernetes Affinity rules that control how pods are assigned
                 to particular nodes.

--- a/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_searchheadclusters_crd.yaml
+++ b/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_searchheadclusters_crd.yaml
@@ -60,6 +60,9 @@ spec:
           description: SearchHeadClusterSpec defines the desired state of a Splunk
             Enterprise search head cluster
           properties:
+            Mock:
+              description: Mock to differentiate between UTs and actual reconcile
+              type: boolean
             affinity:
               description: Kubernetes Affinity rules that control how pods are assigned
                 to particular nodes.

--- a/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_standalones_crd.yaml
@@ -53,6 +53,9 @@ spec:
           description: StandaloneSpec defines the desired state of a Splunk Enterprise
             standalone instances.
           properties:
+            Mock:
+              description: Mock to differentiate between UTs and actual reconcile
+              type: boolean
             affinity:
               description: Kubernetes Affinity rules that control how pods are assigned
                 to particular nodes.

--- a/pkg/apis/enterprise/v1alpha3/common_types.go
+++ b/pkg/apis/enterprise/v1alpha3/common_types.go
@@ -66,6 +66,9 @@ type CommonSplunkSpec struct {
 
 	// ClusterMasterRef refers to a Splunk Enterprise indexer cluster managed by the operator within Kubernetes
 	ClusterMasterRef corev1.ObjectReference `json:"clusterMasterRef"`
+
+	// Mock to differentiate between UTs and actual reconcile
+	Mock bool `json:"Mock"`
 }
 
 // SmartStoreSpec defines Splunk indexes and remote storage volume configuration

--- a/pkg/splunk/client/enterprise_test.go
+++ b/pkg/splunk/client/enterprise_test.go
@@ -17,6 +17,7 @@ package client
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	spltest "github.com/splunk/splunk-operator/pkg/splunk/test"
@@ -25,6 +26,20 @@ import (
 func splunkClientTester(t *testing.T, testMethod string, status int, body string, wantRequest *http.Request, test func(SplunkClient) error) {
 	mockSplunkClient := &spltest.MockHTTPClient{}
 	mockSplunkClient.AddHandler(wantRequest, status, body, nil)
+	c := NewSplunkClient("https://localhost:8089", "admin", "p@ssw0rd")
+	c.Client = mockSplunkClient
+	err := test(*c)
+	if err != nil {
+		t.Errorf("%s err = %v", testMethod, err)
+	}
+	mockSplunkClient.CheckRequests(t, testMethod)
+}
+
+func splunkClientMultipleRequestTester(t *testing.T, testMethod string, status []int, body []string, wantRequest []*http.Request, test func(SplunkClient) error) {
+	mockSplunkClient := &spltest.MockHTTPClient{}
+	for i := 0; i < len(wantRequest); i++ {
+		mockSplunkClient.AddHandler(wantRequest[i], status[i], body[i], nil)
+	}
 	c := NewSplunkClient("https://localhost:8089", "admin", "p@ssw0rd")
 	c.Client = mockSplunkClient
 	err := test(*c)
@@ -343,6 +358,174 @@ func TestDecommissionIndexerClusterPeer(t *testing.T) {
 		return c.DecommissionIndexerClusterPeer(true)
 	}
 	splunkClientTester(t, "TestDecommissionIndexerClusterPeer", 200, "", wantRequest, test)
+}
+
+func TestAutomateMCApplyChanges(t *testing.T) {
+	request1, _ := http.NewRequest("GET", "https://localhost:8089/services/server/info/server-info?count=0&output_mode=json", nil)
+	request2, _ := http.NewRequest("GET", "https://localhost:8089/services/search/distributed/peers?count=0&output_mode=json", nil)
+	request3, _ := http.NewRequest("POST", "https://localhost:8089/services/search/distributed/groups/dmc_group_indexer/edit", nil)
+	request4, _ := http.NewRequest("POST", "https://localhost:8089/services/search/distributed/groups/dmc_group_license_master/edit", nil)
+	request5, _ := http.NewRequest("POST", "https://localhost:8089/services/search/distributed/groups/dmc_indexerclustergroup_idxc_label/edit", nil)
+	request6, _ := http.NewRequest("GET", "https://localhost:8089/servicesNS/nobody/splunk_monitoring_console/saved/searches/DMC%20Asset%20-%20Build%20Full?count=0&output_mode=json", nil)
+	request7, _ := http.NewRequest("POST", "https://localhost:8089/servicesNS/nobody/splunk_monitoring_console/saved/searches/DMC%20Asset%20-%20Build%20Full/dispatch", nil)
+	request8, _ := http.NewRequest("GET", "https://localhost:8089/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/default.distributed?count=0&output_mode=json", nil)
+	request9, _ := http.NewRequest("POST", "https://localhost:8089/servicesNS/nobody/splunk_monitoring_console/configs/conf-splunk_monitoring_console_assets/settings", nil)
+	request10, _ := http.NewRequest("POST", "https://localhost:8089/servicesNS/nobody/system/apps/local/splunk_monitoring_console", nil)
+	var wantRequests []*http.Request
+	wantRequests = []*http.Request(append(wantRequests, request1, request2, request3, request4, request5, request6, request7, request8, request9, request10))
+	body := []string{
+		`{"links":{},"origin":"https://localhost:8089/services/server/info","updated":"2020-09-24T06:38:53+00:00","generator":{"build":"a1a6394cc5ae","version":"8.0.5"},"entry":[{"name":"server-info","id":"https://localhost:8089/services/server/info/server-info","updated":"1970-01-01T00:00:00+00:00","links":{"alternate":"/services/server/info/server-info","list":"/services/server/info/server-info"},"author":"system","acl":{"app":"","can_list":true,"can_write":true,"modifiable":false,"owner":"system","perms":{"read":["*"],"write":[]},"removable":false,"sharing":"system"},"fields":{"required":[],"optional":[],"wildcard":[]},"content":{"activeLicenseGroup":"Trial","activeLicenseSubgroup":"Production","addOns":{"DFS":{"parameters":{"vCPU":"0"},"type":"add_on"},"hadoop":{"parameters":{"erp_type":"report","guid":"6F416E61-B40E-461C-A782-CBC186E98133","maxNodes":"200"},"type":"external_results_provider"}},"build":"a1a6394cc5ae","cluster_label":["idxc_label"],"cpu_arch":"x86_64","dfs_enabled":false,"eai:acl":null,"fips_mode":false,"guid":"0F93F33C-4BDA-4A74-AD9F-3FCE26C6AFF0","health_info":"green","health_version":1,"host":"splunk-default-monitoring-console-86bc9b7c8c-d96x2","host_fqdn":"splunk-default-monitoring-console-86bc9b7c8c-d96x2","host_resolved":"splunk-default-monitoring-console-86bc9b7c8c-d96x2","isForwarding":true,"isFree":false,"isTrial":true,"kvStoreStatus":"ready","licenseKeys":["5C52DA5145AD67B8188604C49962D12F2C3B2CF1B82A6878E46F68CA2812807B"],"licenseSignature":"139bf73ec92c84121c79a9b8307a6724","licenseState":"OK","license_labels":["Splunk Enterprise   Splunk Analytics for Hadoop Download Trial"],"master_guid":"0F93F33C-4BDA-4A74-AD9F-3FCE26C6AFF0","master_uri":"self","max_users":4294967295,"mode":"normal","numberOfCores":1,"numberOfVirtualCores":2,"os_build":"#1 SMP Thu Sep 3 19:04:44 UTC 2020","os_name":"Linux","os_name_extended":"Linux","os_version":"4.14.193-149.317.amzn2.x86_64","physicalMemoryMB":7764,"product_type":"enterprise","rtsearch_enabled":true,"serverName":"splunk-default-monitoring-console-86bc9b7c8c-d96x2","server_roles":["license_master","cluster_search_head","search_head"],"startup_time":1600928786,"staticAssetId":"CFE3D41EE2CCD1465E8C8453F83E4ECFFF540780B4490E84458DD4A3694CE4D1","version":"8.0.5"}}],"paging":{"total":1,"perPage":30,"offset":0},"messages":[]}`,
+		`{"links":{"create":"/services/search/distributed/peers/_new","_reload":"/services/search/distributed/peers/_reload"},"origin":"https://localhost:8089/services/search/distributed/peers","updated":"2020-09-22T21:43:33+00:00","generator":{"build":"a1a6394cc5ae","version":"8.0.5"},"entry":[{"name":"splunk-example-cluster-master-service:8089","id":"https://localhost:8089/services/search/distributed/peers/splunk-example-cluster-master-service%3A8089","updated":"1970-01-01T00:00:00+00:00","links":{"alternate":"/services/search/distributed/peers/splunk-example-cluster-master-service%3A8089","list":"/services/search/distributed/peers/splunk-example-cluster-master-service%3A8089","_reload":"/services/search/distributed/peers/splunk-example-cluster-master-service%3A8089/_reload","edit":"/services/search/distributed/peers/splunk-example-cluster-master-service%3A8089","remove":"/services/search/distributed/peers/splunk-example-cluster-master-service%3A8089","disable":"/services/search/distributed/peers/splunk-example-cluster-master-service%3A8089/disable","quarantine":"/services/search/distributed/peers/splunk-example-cluster-master-service%3A8089/quarantine"},"author":"system","acl":{"app":"","can_list":true,"can_write":true,"modifiable":false,"owner":"system","perms":{"read":["admin","splunk-system-role"],"write":["admin","splunk-system-role"]},"removable":false,"sharing":"system"},"content":{"build":"a1a6394cc5ae","bundle_isIndexing":["15065687072217053252 - false","16923722576385601869 - false","8527338655074501134 - false","5466829646820181037 - false","12887664000706842849 - false"],"bundle_versions":["15065687072217053252","16923722576385601869","8527338655074501134","5466829646820181037","12887664000706842849"],"cluster_label":["idxc_label"],"cpu_arch":"x86_64","disabled":false,"eai:acl":null,"enableRFSMonitoring":false,"guid":"19F5CA13-A561-4D1B-9341-A7BFC3E92F06","host":"splunk-example-cluster-master-0","host_fqdn":"splunk-example-cluster-master-0","isForwarding":true,"is_https":true,"licenseSignature":"c2bf3f573bbaf36ae13f326762945905","numberOfCores":"1","numberOfVirtualCores":"2","os_build":"#1 SMP Thu Sep 3 19:04:44 UTC 2020","os_name":"Linux","os_version":"4.14.193-149.317.amzn2.x86_64","peerName":"splunk-example-cluster-master-0","peerType":"configured","physicalMemoryMB":"7764","remote_session":"2bOC3nPGg_s2UREElAhLcKFXxuMNgwasCQPJG^tlXJ5LMzX1aCC8zwgWN2dCtUD2TyQ1szY0sdQhOwJyK_Igj6JUfEmcVGrsd3BtBvFOb0R_6F9kYRzHKz3","replicationStatus":"Successful","rtsearch_enabled":true,"search_groups":["dmc_group_cluster_master","dmc_group_license_master","dmc_indexerclustergroup_idxc_label"],"searchable_indexes":["_audit","_internal","_introspection","_metrics","_metrics_rollup","_telemetry","_thefishbucket","history","main","summary"],"server_roles":["license_master","cluster_master","search_head"],"shcluster_label":"","startup_time":1600810341,"status":"Up","status_details":[],"version":"8.0.5"}}],"paging":{"total":4,"perPage":30,"offset":0},"messages":[]}`,
+		"",
+		"",
+		"",
+		`{"links":{"create":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/_new","_reload":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/_reload","_acl":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/_acl"},"origin":"https://localhost:8089/servicesNS/nobody/splunk_monitoring_console/data/ui/nav","updated":"2020-09-23T23:50:25+00:00","generator":{"build":"a1a6394cc5ae","version":"8.0.5"},"entry":[{"name":"default.distributed","id":"https://localhost:8089/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/default.distributed","updated":"1970-01-01T00:00:00+00:00","links":{"alternate":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/default.distributed","list":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/default.distributed","_reload":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/default.distributed/_reload","edit":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/default.distributed"},"author":"nobody","acl":{"app":"splunk_monitoring_console","can_change_perms":true,"can_list":true,"can_share_app":true,"can_share_global":true,"can_share_user":false,"can_write":true,"modifiable":true,"owner":"nobody","perms":{"read":["admin"],"write":["admin"]},"removable":false,"sharing":"app"},"fields":{"required":["eai:data"],"optional":[],"wildcard":[]},"content":{"disabled":false,"eai:acl":null,"eai:appName":"splunk_monitoring_console","eai:data":"<nav color=\"#3C444D\">\n  <view name=\"monitoringconsole_overview\" default=\"true\" />\n  <view name=\"monitoringconsole_landing\" />\n  <view name=\"monitoringconsole_check\" />\n  <view name=\"monitoringconsole_instances\" />\n  <collection label=\"Indexing\">\n    <collection label=\"Performance\">\n      <view name=\"indexing_performance_instance\" />\n      <view name=\"indexing_performance_advanced\" />\n      <view name=\"indexing_performance_deployment\" />\n    <\/collection>\n    <collection label=\"Indexer Clustering\">\n        <!--<a href=\"Clustering\">Indexer Clustering: Status<\/a>-->\n      <view name=\"indexer_clustering_status\" />\n      <view name=\"indexer_clustering_service_activity\" />\n    <\/collection>\n    <collection label=\"Indexes and Volumes\">\n      <view name=\"indexes_and_volumes_instance\" />\n      <view name=\"indexes_and_volumes_deployment\" />\n      <view name=\"index_detail_instance\" />\n      <view name=\"index_detail_deployment\" />\n      <view name=\"volume_detail_instance\" />\n      <view name=\"volume_detail_deployment\" />\n    <\/collection>\n    <collection label=\"Inputs\">\n      <view name=\"http_event_collector_instance\" />\n      <view name=\"http_event_collector_deployment\" />\n      <view name=\"splunk_tcpin_performance_instance\" />\n      <view name=\"splunk_tcpin_performance_deployment\" />\n      <view name=\"data_quality\" />\n    <\/collection>\n    <collection label=\"License Usage\">\n      <view name=\"license_usage_today\" />\n      <view name=\"license_usage_30days\" />\n    <\/collection>\n    <collection label=\"SmartStore\">\n      <view name=\"smartstore_activity_instance\" />\n      <view name=\"smartstore_activity_deployment\" />\n      <view name=\"smartstore_cache_performance_instance\" />\n      <view name=\"smartstore_cache_performance_deployment\" />\n    <\/collection>\n  <\/collection>\n  <collection label=\"Search\">\n    <collection label=\"Activity\">\n      <view name=\"search_activity_instance\" />\n      <view name=\"search_activity_deployment\" />\n      <view name=\"search_usage_statistics_instance\" />\n      <view name=\"search_usage_statistics_deployment\" />\n    <\/collection>\n    <collection label=\"Distributed Search\">\n      <view name=\"distributed_search_instance\" />\n      <view name=\"distributed_search_deployment\" />\n    <\/collection>\n    <collection label=\"Search Head Clustering\">\n      <view name=\"shc_status_and_conf\" />\n      <view name=\"shc_conf_rep\" />\n      <view name=\"shc_artifact_replication\" />\n      <view name=\"shc_scheduler_delegation_statistics\" />\n      <view name=\"shc_app_deployment\" />\n    <\/collection>\n    <collection label=\"Scheduler Activity\">\n      <view name=\"scheduler_activity_instance\" />\n      <view name=\"scheduler_activity_deployment\" />\n    <\/collection>\n    <collection label=\"KV Store\">\n      <view name=\"kv_store_instance\" />\n      <view name=\"kv_store_deployment\" />\n    <\/collection>\n    <collection label=\"Knowledge Bundle Replication\">\n      <view name=\"bundle_replication\" />\n      <view name=\"cascading_replication\" />\n    <\/collection>\n  <\/collection>\n  <collection label=\"Resource Usage\">\n    <view name=\"resource_usage_instance\" />\n    <view name=\"resource_usage_machine\" />\n    <view name=\"resource_usage_deployment\" />\n    <view name=\"resource_usage_cpu_instance\" />\n    <view name=\"resource_usage_cpu_deployment\" />\n    <collection label=\"Workload Management\">\n      <view name=\"workload_management\" />\n      <view name=\"workload_management_per_pool_instance\" />\n      <view name=\"workload_management_per_pool_deployment\" />\n    <\/collection>\n  <\/collection>\n  <collection label=\"Forwarders\">\n    <view name=\"forwarder_instance\" />\n    <view name=\"forwarder_deployment\" />\n  <\/collection>\n  <collection label=\"Settings\">\n    <view name=\"monitoringconsole_configure\" />\n    <view name=\"monitoringconsole_forwarder_setup\" />\n    <view name=\"monitoringconsole_alerts_setup\" />\n    <view name=\"monitoringconsole_overview_preferences\"/>\n    <view name=\"monitoringconsole_check_list\" />\n  <\/collection>\n  <a href=\"search\">Run a Search<\/a>\n<\/nav>","eai:digest":"31adb23c29a2d1402e5867ee6b9b5a92","eai:userName":"nobody","rootNode":"nav"}}],"paging":{"total":1,"perPage":30,"offset":0},"messages":[]}`,
+		"",
+		`{"links":{"create":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/_new","_reload":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/_reload","_acl":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/_acl"},"origin":"https://localhost:8089/servicesNS/nobody/splunk_monitoring_console/data/ui/nav","updated":"2020-09-23T23:50:25+00:00","generator":{"build":"a1a6394cc5ae","version":"8.0.5"},"entry":[{"name":"default.distributed","id":"https://localhost:8089/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/default.distributed","updated":"1970-01-01T00:00:00+00:00","links":{"alternate":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/default.distributed","list":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/default.distributed","_reload":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/default.distributed/_reload","edit":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/default.distributed"},"author":"nobody","acl":{"app":"splunk_monitoring_console","can_change_perms":true,"can_list":true,"can_share_app":true,"can_share_global":true,"can_share_user":false,"can_write":true,"modifiable":true,"owner":"nobody","perms":{"read":["admin"],"write":["admin"]},"removable":false,"sharing":"app"},"fields":{"required":["eai:data"],"optional":[],"wildcard":[]},"content":{"disabled":false,"eai:acl":null,"eai:appName":"splunk_monitoring_console","eai:data":"<nav color=\"#3C444D\">\n  <view name=\"monitoringconsole_overview\" default=\"true\" />\n  <view name=\"monitoringconsole_landing\" />\n  <view name=\"monitoringconsole_check\" />\n  <view name=\"monitoringconsole_instances\" />\n  <collection label=\"Indexing\">\n    <collection label=\"Performance\">\n      <view name=\"indexing_performance_instance\" />\n      <view name=\"indexing_performance_advanced\" />\n      <view name=\"indexing_performance_deployment\" />\n    <\/collection>\n    <collection label=\"Indexer Clustering\">\n        <!--<a href=\"Clustering\">Indexer Clustering: Status<\/a>-->\n      <view name=\"indexer_clustering_status\" />\n      <view name=\"indexer_clustering_service_activity\" />\n    <\/collection>\n    <collection label=\"Indexes and Volumes\">\n      <view name=\"indexes_and_volumes_instance\" />\n      <view name=\"indexes_and_volumes_deployment\" />\n      <view name=\"index_detail_instance\" />\n      <view name=\"index_detail_deployment\" />\n      <view name=\"volume_detail_instance\" />\n      <view name=\"volume_detail_deployment\" />\n    <\/collection>\n    <collection label=\"Inputs\">\n      <view name=\"http_event_collector_instance\" />\n      <view name=\"http_event_collector_deployment\" />\n      <view name=\"splunk_tcpin_performance_instance\" />\n      <view name=\"splunk_tcpin_performance_deployment\" />\n      <view name=\"data_quality\" />\n    <\/collection>\n    <collection label=\"License Usage\">\n      <view name=\"license_usage_today\" />\n      <view name=\"license_usage_30days\" />\n    <\/collection>\n    <collection label=\"SmartStore\">\n      <view name=\"smartstore_activity_instance\" />\n      <view name=\"smartstore_activity_deployment\" />\n      <view name=\"smartstore_cache_performance_instance\" />\n      <view name=\"smartstore_cache_performance_deployment\" />\n    <\/collection>\n  <\/collection>\n  <collection label=\"Search\">\n    <collection label=\"Activity\">\n      <view name=\"search_activity_instance\" />\n      <view name=\"search_activity_deployment\" />\n      <view name=\"search_usage_statistics_instance\" />\n      <view name=\"search_usage_statistics_deployment\" />\n    <\/collection>\n    <collection label=\"Distributed Search\">\n      <view name=\"distributed_search_instance\" />\n      <view name=\"distributed_search_deployment\" />\n    <\/collection>\n    <collection label=\"Search Head Clustering\">\n      <view name=\"shc_status_and_conf\" />\n      <view name=\"shc_conf_rep\" />\n      <view name=\"shc_artifact_replication\" />\n      <view name=\"shc_scheduler_delegation_statistics\" />\n      <view name=\"shc_app_deployment\" />\n    <\/collection>\n    <collection label=\"Scheduler Activity\">\n      <view name=\"scheduler_activity_instance\" />\n      <view name=\"scheduler_activity_deployment\" />\n    <\/collection>\n    <collection label=\"KV Store\">\n      <view name=\"kv_store_instance\" />\n      <view name=\"kv_store_deployment\" />\n    <\/collection>\n    <collection label=\"Knowledge Bundle Replication\">\n      <view name=\"bundle_replication\" />\n      <view name=\"cascading_replication\" />\n    <\/collection>\n  <\/collection>\n  <collection label=\"Resource Usage\">\n    <view name=\"resource_usage_instance\" />\n    <view name=\"resource_usage_machine\" />\n    <view name=\"resource_usage_deployment\" />\n    <view name=\"resource_usage_cpu_instance\" />\n    <view name=\"resource_usage_cpu_deployment\" />\n    <collection label=\"Workload Management\">\n      <view name=\"workload_management\" />\n      <view name=\"workload_management_per_pool_instance\" />\n      <view name=\"workload_management_per_pool_deployment\" />\n    <\/collection>\n  <\/collection>\n  <collection label=\"Forwarders\">\n    <view name=\"forwarder_instance\" />\n    <view name=\"forwarder_deployment\" />\n  <\/collection>\n  <collection label=\"Settings\">\n    <view name=\"monitoringconsole_configure\" />\n    <view name=\"monitoringconsole_forwarder_setup\" />\n    <view name=\"monitoringconsole_alerts_setup\" />\n    <view name=\"monitoringconsole_overview_preferences\"/>\n    <view name=\"monitoringconsole_check_list\" />\n  <\/collection>\n  <a href=\"search\">Run a Search<\/a>\n<\/nav>","eai:digest":"31adb23c29a2d1402e5867ee6b9b5a92","eai:userName":"nobody","rootNode":"nav"}}],"paging":{"total":1,"perPage":30,"offset":0},"messages":[]}`,
+		"",
+		"",
+	}
+	test := func(c SplunkClient) error {
+		return c.AutomateMCApplyChanges(false)
+	}
+	status := []int{
+		200, 200, 200, 200, 200, 200, 201, 200, 200, 200, 200,
+	}
+	splunkClientMultipleRequestTester(t, "TestAutomateMCApplyChanges", status, body, wantRequests, test)
+}
+func TestGetMonitoringconsoleServerRoles(t *testing.T) {
+	wantRequest, _ := http.NewRequest("GET", "https://localhost:8089/services/server/info/server-info?count=0&output_mode=json", nil)
+	test := func(c SplunkClient) error {
+		info, err := c.GetMonitoringconsoleServerRoles()
+		if err != nil {
+			return err
+		}
+		if len(info.ServerRoles) == 0 {
+			t.Errorf("There should be atleast one server role assigned to this host")
+		}
+		return nil
+	}
+	body := `{"links":{},"origin":"https://localhost:8089/services/server/info","updated":"2020-09-24T06:38:53+00:00","generator":{"build":"a1a6394cc5ae","version":"8.0.5"},"entry":[{"name":"server-info","id":"https://localhost:8089/services/server/info/server-info","updated":"1970-01-01T00:00:00+00:00","links":{"alternate":"/services/server/info/server-info","list":"/services/server/info/server-info"},"author":"system","acl":{"app":"","can_list":true,"can_write":true,"modifiable":false,"owner":"system","perms":{"read":["*"],"write":[]},"removable":false,"sharing":"system"},"fields":{"required":[],"optional":[],"wildcard":[]},"content":{"activeLicenseGroup":"Trial","activeLicenseSubgroup":"Production","addOns":{"DFS":{"parameters":{"vCPU":"0"},"type":"add_on"},"hadoop":{"parameters":{"erp_type":"report","guid":"6F416E61-B40E-461C-A782-CBC186E98133","maxNodes":"200"},"type":"external_results_provider"}},"build":"a1a6394cc5ae","cluster_label":["idxc_label"],"cpu_arch":"x86_64","dfs_enabled":false,"eai:acl":null,"fips_mode":false,"guid":"0F93F33C-4BDA-4A74-AD9F-3FCE26C6AFF0","health_info":"green","health_version":1,"host":"splunk-default-monitoring-console-86bc9b7c8c-d96x2","host_fqdn":"splunk-default-monitoring-console-86bc9b7c8c-d96x2","host_resolved":"splunk-default-monitoring-console-86bc9b7c8c-d96x2","isForwarding":true,"isFree":false,"isTrial":true,"kvStoreStatus":"ready","licenseKeys":["5C52DA5145AD67B8188604C49962D12F2C3B2CF1B82A6878E46F68CA2812807B"],"licenseSignature":"139bf73ec92c84121c79a9b8307a6724","licenseState":"OK","license_labels":["Splunk Enterprise   Splunk Analytics for Hadoop Download Trial"],"master_guid":"0F93F33C-4BDA-4A74-AD9F-3FCE26C6AFF0","master_uri":"self","max_users":4294967295,"mode":"normal","numberOfCores":1,"numberOfVirtualCores":2,"os_build":"#1 SMP Thu Sep 3 19:04:44 UTC 2020","os_name":"Linux","os_name_extended":"Linux","os_version":"4.14.193-149.317.amzn2.x86_64","physicalMemoryMB":7764,"product_type":"enterprise","rtsearch_enabled":true,"serverName":"splunk-default-monitoring-console-86bc9b7c8c-d96x2","server_roles":["license_master","cluster_search_head","search_head"],"startup_time":1600928786,"staticAssetId":"CFE3D41EE2CCD1465E8C8453F83E4ECFFF540780B4490E84458DD4A3694CE4D1","version":"8.0.5"}}],"paging":{"total":1,"perPage":30,"offset":0},"messages":[]}`
+	splunkClientTester(t, "TestGetMonitoringconsoleServerRoles", 200, body, wantRequest, test)
+}
+func TestUpdateDMCGroups(t *testing.T) {
+	wantRequest, _ := http.NewRequest("POST", "https://localhost:8089/services/search/distributed/groups/indexer/edit", nil)
+	test := func(c SplunkClient) error {
+		err := c.UpdateDMCGroups("indexer", "splunk_cluster_master")
+		if err != nil {
+			t.Errorf("Unable to update monitoring console clustering groups")
+		}
+		return nil
+	}
+	splunkClientTester(t, "TestUpdateDMCGroups", 201, "", wantRequest, test)
+}
+func TestUpdateDMCClusteringLabelGroup(t *testing.T) {
+	wantRequest, _ := http.NewRequest("POST", "https://localhost:8089/services/search/distributed/groups/dmc_indexerclustergroup_abc/edit", nil)
+	test := func(c SplunkClient) error {
+		err := c.UpdateDMCClusteringLabelGroup("abc", "splunk_cluster_master")
+		if err != nil {
+			t.Errorf("Unable to update monitoring console clustering groups")
+		}
+		return nil
+	}
+	splunkClientTester(t, "TestUpdateDMCClusteringLabelGroup", 201, "", wantRequest, test)
+}
+
+func TestGetMonitoringconsoleAssetTable(t *testing.T) {
+	wantRequest, _ := http.NewRequest("GET", "https://localhost:8089/servicesNS/nobody/splunk_monitoring_console/saved/searches/DMC%20Asset%20-%20Build%20Full?count=0&output_mode=json", nil)
+	wantDispatchBuckets := int64(0)
+	test := func(c SplunkClient) error {
+		info, err := c.GetMonitoringconsoleAssetTable()
+		if err != nil {
+			return err
+		}
+		if info.DispatchBuckets != wantDispatchBuckets {
+			t.Errorf("info.Status=%d; want %d", info.DispatchBuckets, wantDispatchBuckets)
+		}
+		return nil
+	}
+	body := `{"links":{"create":"/services/search/distributed/peers/_new","_reload":"/services/search/distributed/peers/_reload"},"origin":"https://localhost:8089/services/search/distributed/peers","updated":"2020-09-22T21:43:33+00:00","generator":{"build":"a1a6394cc5ae","version":"8.0.5"},"entry":[{"name":"splunk-example-cluster-master-service:8089","id":"https://localhost:8089/services/search/distributed/peers/splunk-example-cluster-master-service%3A8089","updated":"1970-01-01T00:00:00+00:00","links":{"alternate":"/services/search/distributed/peers/splunk-example-cluster-master-service%3A8089","list":"/services/search/distributed/peers/splunk-example-cluster-master-service%3A8089","_reload":"/services/search/distributed/peers/splunk-example-cluster-master-service%3A8089/_reload","edit":"/services/search/distributed/peers/splunk-example-cluster-master-service%3A8089","remove":"/services/search/distributed/peers/splunk-example-cluster-master-service%3A8089","disable":"/services/search/distributed/peers/splunk-example-cluster-master-service%3A8089/disable","quarantine":"/services/search/distributed/peers/splunk-example-cluster-master-service%3A8089/quarantine"},"author":"system","acl":{"app":"","can_list":true,"can_write":true,"modifiable":false,"owner":"system","perms":{"read":["admin","splunk-system-role"],"write":["admin","splunk-system-role"]},"removable":false,"sharing":"system"},"content":{"build":"a1a6394cc5ae","bundle_isIndexing":["15065687072217053252 - false","16923722576385601869 - false","8527338655074501134 - false","5466829646820181037 - false","12887664000706842849 - false"],"bundle_versions":["15065687072217053252","16923722576385601869","8527338655074501134","5466829646820181037","12887664000706842849"],"cluster_label":["idxc_label"],"cpu_arch":"x86_64","disabled":false,"eai:acl":null,"enableRFSMonitoring":false,"guid":"19F5CA13-A561-4D1B-9341-A7BFC3E92F06","host":"splunk-example-cluster-master-0","host_fqdn":"splunk-example-cluster-master-0","isForwarding":true,"is_https":true,"licenseSignature":"c2bf3f573bbaf36ae13f326762945905","numberOfCores":"1","numberOfVirtualCores":"2","os_build":"#1 SMP Thu Sep 3 19:04:44 UTC 2020","os_name":"Linux","os_version":"4.14.193-149.317.amzn2.x86_64","peerName":"splunk-example-cluster-master-0","peerType":"configured","physicalMemoryMB":"7764","remote_session":"2bOC3nPGg_s2UREElAhLcKFXxuMNgwasCQPJG^tlXJ5LMzX1aCC8zwgWN2dCtUD2TyQ1szY0sdQhOwJyK_Igj6JUfEmcVGrsd3BtBvFOb0R_6F9kYRzHKz3","replicationStatus":"Successful","rtsearch_enabled":true,"search_groups":["dmc_group_cluster_master","dmc_group_license_master","dmc_indexerclustergroup_idxc_label"],"searchable_indexes":["_audit","_internal","_introspection","_metrics","_metrics_rollup","_telemetry","_thefishbucket","history","main","summary"],"server_roles":["license_master","cluster_master","search_head"],"shcluster_label":"","startup_time":1600810341,"status":"Up","status_details":[],"version":"8.0.5"}}],"paging":{"total":4,"perPage":30,"offset":0},"messages":[]}`
+	splunkClientTester(t, "TestGetMonitoringconsoleAssetTable", 200, body, wantRequest, test)
+}
+
+func TestPostMonitoringConsoleAssetTable(t *testing.T) {
+	apiResponseMCAssetBuild := new(MCAssetBuildTable)
+	apiResponseMCAssetBuild = &MCAssetBuildTable{
+		DispatchAutoCancel: "30",
+		DispatchBuckets:    int64(0),
+	}
+
+	body := strings.NewReader("output_mode=json&trigger_actions=true&dispatch.auto_cancel=30&dispatch.buckets=300&dispatch.enablePreview=true")
+	wantRequest, _ := http.NewRequest("POST", "https://localhost:8089/servicesNS/nobody/splunk_monitoring_console/saved/searches/DMC%20Asset%20-%20Build%20Full/dispatch", body)
+	wantRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	test := func(c SplunkClient) error {
+		return c.PostMonitoringConsoleAssetTable(apiResponseMCAssetBuild)
+	}
+	splunkClientTester(t, "TestPostMonitoringConsoleAssetTable", 201, "", wantRequest, test)
+}
+
+func TestGetMonitoringConsoleUISettings(t *testing.T) {
+	wantRequest, _ := http.NewRequest("GET", "https://localhost:8089/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/default.distributed?count=0&output_mode=json", nil)
+	wantEaiAppName := "splunk_monitoring_console"
+	test := func(c SplunkClient) error {
+		info, err := c.GetMonitoringConsoleUISettings()
+		if err != nil {
+			return err
+		}
+		if info.EaiAppName != wantEaiAppName {
+			t.Errorf("info.Status=%s; want %s", info.EaiAppName, wantEaiAppName)
+		}
+		return nil
+	}
+	body := `{"links":{"create":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/_new","_reload":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/_reload","_acl":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/_acl"},"origin":"https://localhost:8089/servicesNS/nobody/splunk_monitoring_console/data/ui/nav","updated":"2020-09-23T23:50:25+00:00","generator":{"build":"a1a6394cc5ae","version":"8.0.5"},"entry":[{"name":"default.distributed","id":"https://localhost:8089/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/default.distributed","updated":"1970-01-01T00:00:00+00:00","links":{"alternate":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/default.distributed","list":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/default.distributed","_reload":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/default.distributed/_reload","edit":"/servicesNS/nobody/splunk_monitoring_console/data/ui/nav/default.distributed"},"author":"nobody","acl":{"app":"splunk_monitoring_console","can_change_perms":true,"can_list":true,"can_share_app":true,"can_share_global":true,"can_share_user":false,"can_write":true,"modifiable":true,"owner":"nobody","perms":{"read":["admin"],"write":["admin"]},"removable":false,"sharing":"app"},"fields":{"required":["eai:data"],"optional":[],"wildcard":[]},"content":{"disabled":false,"eai:acl":null,"eai:appName":"splunk_monitoring_console","eai:data":"<nav color=\"#3C444D\">\n  <view name=\"monitoringconsole_overview\" default=\"true\" />\n  <view name=\"monitoringconsole_landing\" />\n  <view name=\"monitoringconsole_check\" />\n  <view name=\"monitoringconsole_instances\" />\n  <collection label=\"Indexing\">\n    <collection label=\"Performance\">\n      <view name=\"indexing_performance_instance\" />\n      <view name=\"indexing_performance_advanced\" />\n      <view name=\"indexing_performance_deployment\" />\n    <\/collection>\n    <collection label=\"Indexer Clustering\">\n        <!--<a href=\"Clustering\">Indexer Clustering: Status<\/a>-->\n      <view name=\"indexer_clustering_status\" />\n      <view name=\"indexer_clustering_service_activity\" />\n    <\/collection>\n    <collection label=\"Indexes and Volumes\">\n      <view name=\"indexes_and_volumes_instance\" />\n      <view name=\"indexes_and_volumes_deployment\" />\n      <view name=\"index_detail_instance\" />\n      <view name=\"index_detail_deployment\" />\n      <view name=\"volume_detail_instance\" />\n      <view name=\"volume_detail_deployment\" />\n    <\/collection>\n    <collection label=\"Inputs\">\n      <view name=\"http_event_collector_instance\" />\n      <view name=\"http_event_collector_deployment\" />\n      <view name=\"splunk_tcpin_performance_instance\" />\n      <view name=\"splunk_tcpin_performance_deployment\" />\n      <view name=\"data_quality\" />\n    <\/collection>\n    <collection label=\"License Usage\">\n      <view name=\"license_usage_today\" />\n      <view name=\"license_usage_30days\" />\n    <\/collection>\n    <collection label=\"SmartStore\">\n      <view name=\"smartstore_activity_instance\" />\n      <view name=\"smartstore_activity_deployment\" />\n      <view name=\"smartstore_cache_performance_instance\" />\n      <view name=\"smartstore_cache_performance_deployment\" />\n    <\/collection>\n  <\/collection>\n  <collection label=\"Search\">\n    <collection label=\"Activity\">\n      <view name=\"search_activity_instance\" />\n      <view name=\"search_activity_deployment\" />\n      <view name=\"search_usage_statistics_instance\" />\n      <view name=\"search_usage_statistics_deployment\" />\n    <\/collection>\n    <collection label=\"Distributed Search\">\n      <view name=\"distributed_search_instance\" />\n      <view name=\"distributed_search_deployment\" />\n    <\/collection>\n    <collection label=\"Search Head Clustering\">\n      <view name=\"shc_status_and_conf\" />\n      <view name=\"shc_conf_rep\" />\n      <view name=\"shc_artifact_replication\" />\n      <view name=\"shc_scheduler_delegation_statistics\" />\n      <view name=\"shc_app_deployment\" />\n    <\/collection>\n    <collection label=\"Scheduler Activity\">\n      <view name=\"scheduler_activity_instance\" />\n      <view name=\"scheduler_activity_deployment\" />\n    <\/collection>\n    <collection label=\"KV Store\">\n      <view name=\"kv_store_instance\" />\n      <view name=\"kv_store_deployment\" />\n    <\/collection>\n    <collection label=\"Knowledge Bundle Replication\">\n      <view name=\"bundle_replication\" />\n      <view name=\"cascading_replication\" />\n    <\/collection>\n  <\/collection>\n  <collection label=\"Resource Usage\">\n    <view name=\"resource_usage_instance\" />\n    <view name=\"resource_usage_machine\" />\n    <view name=\"resource_usage_deployment\" />\n    <view name=\"resource_usage_cpu_instance\" />\n    <view name=\"resource_usage_cpu_deployment\" />\n    <collection label=\"Workload Management\">\n      <view name=\"workload_management\" />\n      <view name=\"workload_management_per_pool_instance\" />\n      <view name=\"workload_management_per_pool_deployment\" />\n    <\/collection>\n  <\/collection>\n  <collection label=\"Forwarders\">\n    <view name=\"forwarder_instance\" />\n    <view name=\"forwarder_deployment\" />\n  <\/collection>\n  <collection label=\"Settings\">\n    <view name=\"monitoringconsole_configure\" />\n    <view name=\"monitoringconsole_forwarder_setup\" />\n    <view name=\"monitoringconsole_alerts_setup\" />\n    <view name=\"monitoringconsole_overview_preferences\"/>\n    <view name=\"monitoringconsole_check_list\" />\n  <\/collection>\n  <a href=\"search\">Run a Search<\/a>\n<\/nav>","eai:digest":"31adb23c29a2d1402e5867ee6b9b5a92","eai:userName":"nobody","rootNode":"nav"}}],"paging":{"total":1,"perPage":30,"offset":0},"messages":[]}`
+	splunkClientTester(t, "TestGetMonitoringconsoleAssetTable", 200, body, wantRequest, test)
+}
+
+func TestUpdateLookupUISettings(t *testing.T) {
+	apiResponseUISettings := new(UISettings)
+	apiResponseUISettings = &UISettings{
+		Disabled:    false,
+		EaiACL:      "",
+		EaiAppName:  "splunk_monitoring_console",
+		EaiUserName: "nobody",
+	}
+	wantconfiguredPeers := "&member=splunk-example-cluster-master-service:8089&"
+	body := strings.NewReader("output_mode=json&trigger_actions=true&dispatch.auto_cancel=30&dispatch.buckets=300&dispatch.enablePreview=true")
+	wantRequest, _ := http.NewRequest("POST", "https://localhost:8089/servicesNS/nobody/splunk_monitoring_console/configs/conf-splunk_monitoring_console_assets/settings", body)
+	wantRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	test := func(c SplunkClient) error {
+		return c.UpdateLookupUISettings(wantconfiguredPeers, apiResponseUISettings)
+	}
+	splunkClientTester(t, "TestPostMonitoringconsoleAssetTable", 200, "", wantRequest, test)
+}
+
+func TestUpdateMonitoringConsoleApp(t *testing.T) {
+	wantRequest, _ := http.NewRequest("POST", "https://localhost:8089/servicesNS/nobody/system/apps/local/splunk_monitoring_console", nil)
+	test := func(c SplunkClient) error {
+		err := c.UpdateMonitoringConsoleApp()
+		if err != nil {
+			t.Errorf("MonitoringConsole App not updated")
+		}
+		return nil
+	}
+	splunkClientTester(t, "TestUpdateMonitoringConsoleApp", 200, "", wantRequest, test)
+}
+
+func TestGetClusterInfo(t *testing.T) {
+	wantRequest, _ := http.NewRequest("GET", "https://localhost:8089/services/cluster/config?count=0&output_mode=json", nil)
+	wantMultisite := ""
+	test := func(c SplunkClient) error {
+		info, err := c.GetClusterInfo(false)
+		if err != nil {
+			return err
+		}
+		if info.MultiSite != wantMultisite {
+			t.Errorf("info.MultiSite=%s; want %s", info.MultiSite, wantMultisite)
+		}
+		return nil
+	}
+	body := `{"links":{},"origin":"https://localhost:8089/services/server/info","updated":"2020-09-24T06:38:53+00:00","generator":{"build":"a1a6394cc5ae","version":"8.0.5"},"entry":[{"name":"server-info","id":"https://localhost:8089/services/server/info/server-info","updated":"1970-01-01T00:00:00+00:00","links":{"alternate":"/services/server/info/server-info","list":"/services/server/info/server-info"},"author":"system","acl":{"app":"","can_list":true,"can_write":true,"modifiable":false,"owner":"system","perms":{"read":["*"],"write":[]},"removable":false,"sharing":"system"},"fields":{"required":[],"optional":[],"wildcard":[]},"content":{"activeLicenseGroup":"Trial","activeLicenseSubgroup":"Production","addOns":{"DFS":{"parameters":{"vCPU":"0"},"type":"add_on"},"hadoop":{"parameters":{"erp_type":"report","guid":"6F416E61-B40E-461C-A782-CBC186E98133","maxNodes":"200"},"type":"external_results_provider"}},"build":"a1a6394cc5ae","cluster_label":["idxc_label"],"cpu_arch":"x86_64","dfs_enabled":false,"eai:acl":null,"fips_mode":false,"guid":"0F93F33C-4BDA-4A74-AD9F-3FCE26C6AFF0","health_info":"green","health_version":1,"host":"splunk-default-monitoring-console-86bc9b7c8c-d96x2","host_fqdn":"splunk-default-monitoring-console-86bc9b7c8c-d96x2","host_resolved":"splunk-default-monitoring-console-86bc9b7c8c-d96x2","isForwarding":true,"isFree":false,"isTrial":true,"kvStoreStatus":"ready","licenseKeys":["5C52DA5145AD67B8188604C49962D12F2C3B2CF1B82A6878E46F68CA2812807B"],"licenseSignature":"139bf73ec92c84121c79a9b8307a6724","licenseState":"OK","license_labels":["Splunk Enterprise   Splunk Analytics for Hadoop Download Trial"],"master_guid":"0F93F33C-4BDA-4A74-AD9F-3FCE26C6AFF0","master_uri":"self","max_users":4294967295,"mode":"normal","numberOfCores":1,"numberOfVirtualCores":2,"os_build":"#1 SMP Thu Sep 3 19:04:44 UTC 2020","os_name":"Linux","os_name_extended":"Linux","os_version":"4.14.193-149.317.amzn2.x86_64","physicalMemoryMB":7764,"product_type":"enterprise","rtsearch_enabled":true,"serverName":"splunk-default-monitoring-console-86bc9b7c8c-d96x2","server_roles":["license_master","cluster_search_head","search_head"],"startup_time":1600928786,"staticAssetId":"CFE3D41EE2CCD1465E8C8453F83E4ECFFF540780B4490E84458DD4A3694CE4D1","version":"8.0.5"}}],"paging":{"total":1,"perPage":30,"offset":0},"messages":[]}`
+	splunkClientTester(t, "TestGetClusterInfo", 200, body, wantRequest, test)
 }
 
 func TestSetIdxcSecret(t *testing.T) {

--- a/pkg/splunk/enterprise/clustermaster_test.go
+++ b/pkg/splunk/enterprise/clustermaster_test.go
@@ -61,6 +61,11 @@ func TestApplyClusterMaster(t *testing.T) {
 			Name:      "stack1",
 			Namespace: "test",
 		},
+		Spec: enterprisev1.ClusterMasterSpec{
+			CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
+				Mock: true,
+			},
+		},
 	}
 	revised := current.DeepCopy()
 	revised.Spec.Image = "splunk/test"
@@ -160,6 +165,9 @@ func TestApplyClusterMasterWithSmartstore(t *testing.T) {
 					{Name: "salesdata2", RemotePath: "salesdata2", VolName: "msos_s2s3_vol"},
 					{Name: "salesdata3", RemotePath: "", VolName: "msos_s2s3_vol"},
 				},
+			},
+			CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
+				Mock: true,
 			},
 		},
 	}

--- a/pkg/splunk/enterprise/indexercluster_test.go
+++ b/pkg/splunk/enterprise/indexercluster_test.go
@@ -55,7 +55,7 @@ func TestApplyIndexerCluster(t *testing.T) {
 	}
 	listmockCall := []spltest.MockFuncCall{
 		{ListOpts: listOpts}}
-	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[0], funcCalls[2], funcCalls[3], funcCalls[6], funcCalls[7]}, "List": {listmockCall[0]}, "Update": {funcCalls[0]}}
+	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[0], funcCalls[2], funcCalls[3], funcCalls[6], funcCalls[7]}, "Update": {funcCalls[0]}, "List": {listmockCall[0]}}
 	updateCalls := map[string][]spltest.MockFuncCall{"Get": {funcCalls[0], funcCalls[2], funcCalls[3], funcCalls[4], funcCalls[5], funcCalls[6], funcCalls[7], funcCalls[8]}, "Update": {funcCalls[7]}, "List": {listmockCall[0]}}
 
 	current := enterprisev1.IndexerCluster{
@@ -72,6 +72,7 @@ func TestApplyIndexerCluster(t *testing.T) {
 				ClusterMasterRef: corev1.ObjectReference{
 					Name: "master1",
 				},
+				Mock: true,
 			},
 		},
 	}

--- a/pkg/splunk/enterprise/licensemaster_test.go
+++ b/pkg/splunk/enterprise/licensemaster_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -32,13 +31,6 @@ func TestApplyLicenseMaster(t *testing.T) {
 	funcCalls := []spltest.MockFuncCall{
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
-		{MetaName: "*v1.Secret-test-splunk-test-secret"},
-		{MetaName: "*v1.Secret-test-splunk-test-monitoring-console-secret-v1"},
-		{MetaName: "*v1.Service-test-splunk-test-monitoring-console-service"},
-		{MetaName: "*v1.Service-test-splunk-test-monitoring-console-headless"},
-		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console"},
-		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console"},
-		{MetaName: "*v1.StatefulSet-test-splunk-test-monitoring-console"},
 		{MetaName: "*v1.Service-test-splunk-stack1-license-master-service"},
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
 		{MetaName: "*v1.Secret-test-splunk-stack1-license-master-secret-v1"},
@@ -54,9 +46,8 @@ func TestApplyLicenseMaster(t *testing.T) {
 	}
 	listmockCall := []spltest.MockFuncCall{
 		{ListOpts: listOpts}}
-
-	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[0], funcCalls[3], funcCalls[4], funcCalls[5], funcCalls[6], funcCalls[8], funcCalls[9], funcCalls[11], funcCalls[12]}, "List": {listmockCall[0], listmockCall[0]}, "Update": {funcCalls[0]}}
-	updateCalls := map[string][]spltest.MockFuncCall{"Get": {funcCalls[0], funcCalls[2], funcCalls[3], funcCalls[4], funcCalls[5], funcCalls[6], funcCalls[7], funcCalls[8], funcCalls[9], funcCalls[10], funcCalls[11], funcCalls[12]}, "Update": {funcCalls[8], funcCalls[12]}, "List": {listmockCall[0], listmockCall[0]}}
+	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[0], funcCalls[2], funcCalls[4], funcCalls[5]}, "Update": {funcCalls[0]}, "List": {listmockCall[0]}}
+	updateCalls := map[string][]spltest.MockFuncCall{"Get": {funcCalls[0], funcCalls[2], funcCalls[3], funcCalls[4], funcCalls[5]}, "Update": {funcCalls[5]}, "List": {listmockCall[0]}}
 	current := enterprisev1.LicenseMaster{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "LicenseMaster",
@@ -113,42 +104,4 @@ func TestGetLicenseMasterStatefulSet(t *testing.T) {
 
 	cr.Spec.LicenseURL = "/mnt/splunk.lic"
 	test(`{"kind":"StatefulSet","apiVersion":"apps/v1","metadata":{"name":"splunk-stack1-license-master","namespace":"test","creationTimestamp":null,"ownerReferences":[{"apiVersion":"","kind":"","name":"stack1","uid":"","controller":true}]},"spec":{"replicas":1,"selector":{"matchLabels":{"app.kubernetes.io/component":"license-master","app.kubernetes.io/instance":"splunk-stack1-license-master","app.kubernetes.io/managed-by":"splunk-operator","app.kubernetes.io/name":"license-master","app.kubernetes.io/part-of":"splunk-stack1-license-master"}},"template":{"metadata":{"creationTimestamp":null,"labels":{"app.kubernetes.io/component":"license-master","app.kubernetes.io/instance":"splunk-stack1-license-master","app.kubernetes.io/managed-by":"splunk-operator","app.kubernetes.io/name":"license-master","app.kubernetes.io/part-of":"splunk-stack1-license-master"},"annotations":{"traffic.sidecar.istio.io/excludeOutboundPorts":"8089,8191,9997,7777,9000,17000,17500,19000","traffic.sidecar.istio.io/includeInboundPorts":"8000"}},"spec":{"volumes":[{"name":"mnt-splunk-secrets","secret":{"secretName":"splunk-stack1-license-master-secret-v1","defaultMode":420}}],"containers":[{"name":"splunk","image":"splunk/splunk","ports":[{"name":"splunkweb","containerPort":8000,"protocol":"TCP"},{"name":"splunkd","containerPort":8089,"protocol":"TCP"}],"env":[{"name":"SPLUNK_HOME","value":"/opt/splunk"},{"name":"SPLUNK_START_ARGS","value":"--accept-license"},{"name":"SPLUNK_DEFAULTS_URL","value":"/mnt/splunk-secrets/default.yml"},{"name":"SPLUNK_HOME_OWNERSHIP_ENFORCEMENT","value":"false"},{"name":"SPLUNK_ROLE","value":"splunk_license_master"},{"name":"SPLUNK_DECLARATIVE_ADMIN_PASSWORD","value":"true"},{"name":"SPLUNK_LICENSE_URI","value":"/mnt/splunk.lic"}],"resources":{"limits":{"cpu":"4","memory":"8Gi"},"requests":{"cpu":"100m","memory":"512Mi"}},"volumeMounts":[{"name":"pvc-etc","mountPath":"/opt/splunk/etc"},{"name":"pvc-var","mountPath":"/opt/splunk/var"},{"name":"mnt-splunk-secrets","mountPath":"/mnt/splunk-secrets"}],"livenessProbe":{"exec":{"command":["/sbin/checkstate.sh"]},"initialDelaySeconds":300,"timeoutSeconds":30,"periodSeconds":30},"readinessProbe":{"exec":{"command":["/bin/grep","started","/opt/container_artifact/splunk-container.state"]},"initialDelaySeconds":10,"timeoutSeconds":5,"periodSeconds":5},"imagePullPolicy":"IfNotPresent"}],"securityContext":{"runAsUser":41812,"fsGroup":41812},"affinity":{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"weight":100,"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/instance","operator":"In","values":["splunk-stack1-license-master"]}]},"topologyKey":"kubernetes.io/hostname"}}]}},"schedulerName":"default-scheduler"}},"volumeClaimTemplates":[{"metadata":{"name":"pvc-etc","namespace":"test","creationTimestamp":null,"labels":{"app.kubernetes.io/component":"license-master","app.kubernetes.io/instance":"splunk-stack1-license-master","app.kubernetes.io/managed-by":"splunk-operator","app.kubernetes.io/name":"license-master","app.kubernetes.io/part-of":"splunk-stack1-license-master"}},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"10Gi"}}},"status":{}},{"metadata":{"name":"pvc-var","namespace":"test","creationTimestamp":null,"labels":{"app.kubernetes.io/component":"license-master","app.kubernetes.io/instance":"splunk-stack1-license-master","app.kubernetes.io/managed-by":"splunk-operator","app.kubernetes.io/name":"license-master","app.kubernetes.io/part-of":"splunk-stack1-license-master"}},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"100Gi"}}},"status":{}}],"serviceName":"splunk-stack1-license-master-headless","podManagementPolicy":"Parallel","updateStrategy":{"type":"OnDelete"}},"status":{"replicas":0}}`)
-}
-
-func TestGetLicenseMasterURL(t *testing.T) {
-	cr := enterprisev1.LicenseMaster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "stack1",
-			Namespace: "test",
-		},
-	}
-
-	cr.Spec.LicenseMasterRef.Name = "stack1"
-	got := getLicenseMasterURL(&cr, &cr.Spec.CommonSplunkSpec)
-	want := []corev1.EnvVar{
-		{
-			Name:  "SPLUNK_LICENSE_MASTER_URL",
-			Value: "splunk-stack1-license-master-service",
-		},
-	}
-	result := splcommon.CompareEnvs(got, want)
-	//if differ then CompareEnvs returns true
-	if result == true {
-		t.Errorf("getLicenseMasterURL(\"%s\") = %s; want %s", SplunkLicenseMaster, got, want)
-	}
-
-	cr.Spec.LicenseMasterRef.Namespace = "test"
-	got = getLicenseMasterURL(&cr, &cr.Spec.CommonSplunkSpec)
-	want = []corev1.EnvVar{
-		{
-			Name:  "SPLUNK_LICENSE_MASTER_URL",
-			Value: "splunk-stack1-license-master-service.test.svc.cluster.local",
-		},
-	}
-
-	result = splcommon.CompareEnvs(got, want)
-	//if differ then CompareEnvs returns true
-	if result == true {
-		t.Errorf("getLicenseMasterURL(\"%s\") = %s; want %s", SplunkLicenseMaster, got, want)
-	}
 }

--- a/pkg/splunk/enterprise/monitoringconsole.go
+++ b/pkg/splunk/enterprise/monitoringconsole.go
@@ -49,9 +49,6 @@ func ApplyMonitoringConsole(client splcommon.ControllerClient, cr splcommon.Meta
 		mgr := monitoringConsolePodManager{cr: &cr, spec: &spec, secrets: secrets, newSplunkClient: splclient.NewSplunkClient}
 		c := mgr.getMonitoringConsoleClient(cr)
 		err := c.AutomateMCApplyChanges(spec.Mock)
-		if err != nil {
-			return err
-		}
 		return err
 	}
 
@@ -100,9 +97,6 @@ func ApplyMonitoringConsole(client splcommon.ControllerClient, cr splcommon.Meta
 
 	mgr := splctrl.DefaultStatefulSetPodManager{}
 	_, err = mgr.Update(client, statefulset, 1)
-	if err != nil {
-		return err
-	}
 
 	return err
 }

--- a/pkg/splunk/enterprise/monitoringconsole.go
+++ b/pkg/splunk/enterprise/monitoringconsole.go
@@ -16,11 +16,13 @@ package enterprise
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"sort"
 	"strings"
 
 	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1alpha3"
+	splclient "github.com/splunk/splunk-operator/pkg/splunk/client"
 	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 	splctrl "github.com/splunk/splunk-operator/pkg/splunk/controller"
 	splutil "github.com/splunk/splunk-operator/pkg/splunk/util"
@@ -40,6 +42,17 @@ func ApplyMonitoringConsole(client splcommon.ControllerClient, cr splcommon.Meta
 	secretName := ""
 	if secrets != nil {
 		secretName = secrets.GetName()
+	}
+
+	//For IndexerCluster custom resource click "Apply changes" on MC and return
+	if cr.GetObjectKind().GroupVersionKind().Kind == "IndexerCluster" {
+		mgr := monitoringConsolePodManager{cr: &cr, spec: &spec, secrets: secrets, newSplunkClient: splclient.NewSplunkClient}
+		c := mgr.getMonitoringConsoleClient(cr)
+		err := c.AutomateMCApplyChanges(spec.Mock)
+		if err != nil {
+			return err
+		}
+		return err
 	}
 
 	// create or update a regular monitoring console service
@@ -66,13 +79,27 @@ func ApplyMonitoringConsole(client splcommon.ControllerClient, cr splcommon.Meta
 		return err
 	}
 
-	statefulsetMC, err := getMonitoringConsoleStatefulSet(client, cr, &spec, SplunkMonitoringConsole, secretName)
+	//by default set multisite to false
+	multiSite := "false"
+
+	//get cluster info from cluster master
+	if cr.GetObjectKind().GroupVersionKind().Kind == "ClusterMaster" && !spec.Mock {
+		mgr := monitoringConsolePodManager{cr: &cr, spec: &spec, secrets: secrets, newSplunkClient: splclient.NewSplunkClient}
+		c := mgr.getClusterMasterClient(cr)
+		clusterInfo, err := c.GetClusterInfo(spec.Mock)
+		if err != nil {
+			return err
+		}
+		multiSite = clusterInfo.MultiSite
+	}
+
+	statefulset, err := getMonitoringConsoleStatefulSet(client, cr, &spec, SplunkMonitoringConsole, secretName, multiSite)
 	if err != nil {
 		return err
 	}
 
 	mgr := splctrl.DefaultStatefulSetPodManager{}
-	_, err = mgr.Update(client, statefulsetMC, 1)
+	_, err = mgr.Update(client, statefulset, 1)
 	if err != nil {
 		return err
 	}
@@ -80,9 +107,31 @@ func ApplyMonitoringConsole(client splcommon.ControllerClient, cr splcommon.Meta
 	return err
 }
 
+// getMonitoringConsoleClient for monitoringConsolePodManager returns a SplunkClient for monitoring console
+func (mgr *monitoringConsolePodManager) getMonitoringConsoleClient(cr splcommon.MetaObject) *splclient.SplunkClient {
+	fqdnName := splcommon.GetServiceFQDN(cr.GetNamespace(), GetSplunkServiceName(SplunkMonitoringConsole, cr.GetNamespace(), false))
+	return mgr.newSplunkClient(fmt.Sprintf("https://%s:8089", fqdnName), "admin", string(mgr.secrets.Data["password"]))
+}
+
+// getClusterMasterClient for monitoringConsolePodManager returns a SplunkClient for cluster master
+func (mgr *monitoringConsolePodManager) getClusterMasterClient(cr splcommon.MetaObject) *splclient.SplunkClient {
+	fqdnName := splcommon.GetServiceFQDN(cr.GetNamespace(), GetSplunkServiceName(SplunkClusterMaster, cr.GetName(), false))
+	return mgr.newSplunkClient(fmt.Sprintf("https://%s:8089", fqdnName), "admin", string(mgr.secrets.Data["password"]))
+}
+
+// monitoringConsolePodManager is used to manage the monitoring console pod
+type monitoringConsolePodManager struct {
+	cr              *splcommon.MetaObject
+	spec            *enterprisev1.CommonSplunkSpec
+	secrets         *corev1.Secret
+	newSplunkClient func(managementURI, username, password string) *splclient.SplunkClient
+}
+
 // getMonitoringConsoleStatefulSet returns a Kubernetes Statefulset object for Splunk Enterprise monitoring console instance.
-func getMonitoringConsoleStatefulSet(client splcommon.ControllerClient, cr splcommon.MetaObject, spec *enterprisev1.CommonSplunkSpec, instanceType InstanceType, secretName string) (*appsv1.StatefulSet, error) {
+func getMonitoringConsoleStatefulSet(client splcommon.ControllerClient, cr splcommon.MetaObject, spec *enterprisev1.CommonSplunkSpec, instanceType InstanceType, secretName string, MultiSite string) (*appsv1.StatefulSet, error) {
 	var partOfIdentifier string
+	var monitoringConsoleConfigMap *corev1.ConfigMap
+	var emptyEnv []corev1.EnvVar
 	// there will be always 1 replica of monitoring console
 	replicas := int32(1)
 	ports := splcommon.SortContainerPorts(getSplunkContainerPorts(SplunkMonitoringConsole))
@@ -151,6 +200,10 @@ func getMonitoringConsoleStatefulSet(client splcommon.ControllerClient, cr splco
 
 	env := []corev1.EnvVar{}
 
+	if MultiSite == "true" {
+		env = append(env, corev1.EnvVar{Name: "SPLUNK_SITE", Value: "site0"}, corev1.EnvVar{Name: "SPLUNK_MULTISITE_MASTER", Value: GetSplunkServiceName(SplunkClusterMaster, cr.GetName(), false)})
+	}
+
 	// append labels and annotations from parent
 	splcommon.AppendParentMeta(statefulSet.Spec.Template.GetObjectMeta(), cr.GetObjectMeta())
 
@@ -158,11 +211,12 @@ func getMonitoringConsoleStatefulSet(client splcommon.ControllerClient, cr splco
 	updateSplunkPodTemplateWithConfig(client, &statefulSet.Spec.Template, cr, spec, instanceType, env, secretName)
 
 	//update podTemplate annotation with configMap resource version
-	var monitoringConsoleConfigMap *corev1.ConfigMap
+	//use emptyEnv here to avoid adding site amd multisite_master info in configMap
+	//TODO: Update this configMap retrieval by API from PR #134
 	if cr.GetObjectMeta().GetDeletionTimestamp() != nil {
-		monitoringConsoleConfigMap, _ = ApplyMonitoringConsoleEnvConfigMap(client, cr.GetNamespace(), cr.GetName(), env, false)
+		monitoringConsoleConfigMap, _ = ApplyMonitoringConsoleEnvConfigMap(client, cr.GetNamespace(), cr.GetName(), emptyEnv, false)
 	} else {
-		monitoringConsoleConfigMap, _ = ApplyMonitoringConsoleEnvConfigMap(client, cr.GetNamespace(), cr.GetName(), env, true)
+		monitoringConsoleConfigMap, _ = ApplyMonitoringConsoleEnvConfigMap(client, cr.GetNamespace(), cr.GetName(), emptyEnv, true)
 	}
 	statefulSet.Spec.Template.ObjectMeta.Annotations[monitoringConsoleConfigRev] = monitoringConsoleConfigMap.ResourceVersion
 

--- a/pkg/splunk/enterprise/searchheadcluster_test.go
+++ b/pkg/splunk/enterprise/searchheadcluster_test.go
@@ -37,13 +37,6 @@ func TestApplySearchHeadCluster(t *testing.T) {
 	funcCalls := []spltest.MockFuncCall{
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
-		{MetaName: "*v1.Secret-test-splunk-test-secret"},
-		{MetaName: "*v1.Secret-test-splunk-test-monitoring-console-secret-v1"},
-		{MetaName: "*v1.Service-test-splunk-test-monitoring-console-service"},
-		{MetaName: "*v1.Service-test-splunk-test-monitoring-console-headless"},
-		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console"},
-		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console"},
-		{MetaName: "*v1.StatefulSet-test-splunk-test-monitoring-console"},
 		{MetaName: "*v1.Service-test-splunk-stack1-search-head-headless"},
 		{MetaName: "*v1.Service-test-splunk-stack1-search-head-service"},
 		{MetaName: "*v1.Service-test-splunk-stack1-deployer-service"},
@@ -66,8 +59,8 @@ func TestApplySearchHeadCluster(t *testing.T) {
 	listmockCall := []spltest.MockFuncCall{
 		{ListOpts: listOpts}}
 
-	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[0], funcCalls[3], funcCalls[4], funcCalls[5], funcCalls[6], funcCalls[8], funcCalls[9], funcCalls[10], funcCalls[11], funcCalls[13], funcCalls[14], funcCalls[16], funcCalls[17]}, "List": {listmockCall[0], listmockCall[0], listmockCall[0]}, "Update": {funcCalls[0]}}
-	updateCalls := map[string][]spltest.MockFuncCall{"Get": {funcCalls[0], funcCalls[2], funcCalls[3], funcCalls[4], funcCalls[5], funcCalls[6], funcCalls[7], funcCalls[8], funcCalls[9], funcCalls[10], funcCalls[11], funcCalls[12], funcCalls[13], funcCalls[14], funcCalls[15], funcCalls[16], funcCalls[17], funcCalls[18]}, "Update": {funcCalls[8], funcCalls[14], funcCalls[17]}, "List": {listmockCall[0], listmockCall[0], listmockCall[0]}}
+	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[0], funcCalls[2], funcCalls[3], funcCalls[4], funcCalls[6], funcCalls[7], funcCalls[9], funcCalls[10]}, "Update": {funcCalls[0]}, "List": {listmockCall[0], listmockCall[0]}}
+	updateCalls := map[string][]spltest.MockFuncCall{"Get": {funcCalls[0], funcCalls[2], funcCalls[3], funcCalls[4], funcCalls[5], funcCalls[6], funcCalls[7], funcCalls[8], funcCalls[9], funcCalls[10], funcCalls[11]}, "Update": {funcCalls[7], funcCalls[10]}, "List": {listmockCall[0], listmockCall[0]}}
 	statefulSet := enterprisev1.SearchHeadCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "SearchHeadCluster",

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -71,13 +71,13 @@ func ApplyStandalone(client splcommon.ControllerClient, cr *enterprisev1.Standal
 		return result, err
 	}
 
-	err = ApplyMonitoringConsole(client, cr, cr.Spec.CommonSplunkSpec, getStandaloneExtraEnv(cr, cr.Spec.Replicas))
-	if err != nil {
-		return result, err
-	}
-
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
+		//update monitoring console configMap after custom resource deletion is requested
+		err = ApplyMonitoringConsole(client, cr, cr.Spec.CommonSplunkSpec, getStandaloneExtraEnv(cr, cr.Spec.Replicas))
+		if err != nil {
+			return result, err
+		}
 		terminating, err := splctrl.CheckForDeletion(cr, client)
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after
 			cr.Status.Phase = splcommon.PhaseTerminating
@@ -114,6 +114,10 @@ func ApplyStandalone(client splcommon.ControllerClient, cr *enterprisev1.Standal
 
 	// no need to requeue if everything is ready
 	if cr.Status.Phase == splcommon.PhaseReady {
+		err = ApplyMonitoringConsole(client, cr, cr.Spec.CommonSplunkSpec, getStandaloneExtraEnv(cr, cr.Spec.Replicas))
+		if err != nil {
+			return result, err
+		}
 		result.Requeue = false
 	}
 	return result, nil
@@ -148,14 +152,4 @@ func validateStandaloneSpec(spec *enterprisev1.StandaloneSpec) error {
 
 	spec.SparkImage = spark.GetSparkImage(spec.SparkImage)
 	return validateCommonSplunkSpec(&spec.CommonSplunkSpec)
-}
-
-// getStandaloneExtraEnv returns extra environment variables used by monitoring console
-func getStandaloneExtraEnv(cr splcommon.MetaObject, replicas int32) []corev1.EnvVar {
-	return []corev1.EnvVar{
-		{
-			Name:  "SPLUNK_STANDALONE_URL",
-			Value: GetSplunkStatefulsetUrls(cr.GetNamespace(), SplunkStandalone, cr.GetName(), replicas, false),
-		},
-	}
 }

--- a/pkg/splunk/enterprise/standalone_test.go
+++ b/pkg/splunk/enterprise/standalone_test.go
@@ -33,13 +33,6 @@ func TestApplyStandalone(t *testing.T) {
 	funcCalls := []spltest.MockFuncCall{
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
-		{MetaName: "*v1.Secret-test-splunk-test-secret"},
-		{MetaName: "*v1.Secret-test-splunk-test-monitoring-console-secret-v1"},
-		{MetaName: "*v1.Service-test-splunk-test-monitoring-console-service"},
-		{MetaName: "*v1.Service-test-splunk-test-monitoring-console-headless"},
-		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console"},
-		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console"},
-		{MetaName: "*v1.StatefulSet-test-splunk-test-monitoring-console"},
 		{MetaName: "*v1.Service-test-splunk-stack1-standalone-headless"},
 		{MetaName: "*v1.Service-test-splunk-stack1-standalone-service"},
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
@@ -57,9 +50,8 @@ func TestApplyStandalone(t *testing.T) {
 	listmockCall := []spltest.MockFuncCall{
 		{ListOpts: listOpts}}
 
-	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[0], funcCalls[3], funcCalls[4], funcCalls[5], funcCalls[6], funcCalls[8], funcCalls[9], funcCalls[10], funcCalls[12], funcCalls[13]}, "List": {listmockCall[0], listmockCall[0]}, "Update": {funcCalls[0]}}
-	updateCalls := map[string][]spltest.MockFuncCall{"Get": {funcCalls[0], funcCalls[2], funcCalls[3], funcCalls[4], funcCalls[5], funcCalls[6], funcCalls[7], funcCalls[8], funcCalls[9], funcCalls[10], funcCalls[11], funcCalls[12], funcCalls[13]}, "Update": {funcCalls[8], funcCalls[13]}, "List": {listmockCall[0], listmockCall[0]}}
-
+	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[0], funcCalls[2], funcCalls[3], funcCalls[5], funcCalls[6]}, "Update": {funcCalls[0]}, "List": {listmockCall[0]}}
+	updateCalls := map[string][]spltest.MockFuncCall{"Get": {funcCalls[0], funcCalls[2], funcCalls[3], funcCalls[4], funcCalls[5], funcCalls[6]}, "Update": {funcCalls[6]}, "List": {listmockCall[0]}}
 	current := enterprisev1.Standalone{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "Standalone",
@@ -94,13 +86,6 @@ func TestApplyStandaloneWithSmartstore(t *testing.T) {
 		{MetaName: "*v1.ConfigMap-test-splunk-stack1-standalone-smartstore"},
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
-		{MetaName: "*v1.Secret-test-splunk-test-secret"},
-		{MetaName: "*v1.Secret-test-splunk-test-monitoring-console-secret-v1"},
-		{MetaName: "*v1.Service-test-splunk-test-monitoring-console-service"},
-		{MetaName: "*v1.Service-test-splunk-test-monitoring-console-headless"},
-		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console"},
-		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console"},
-		{MetaName: "*v1.StatefulSet-test-splunk-test-monitoring-console"},
 		{MetaName: "*v1.Service-test-splunk-stack1-standalone-headless"},
 		{MetaName: "*v1.Service-test-splunk-stack1-standalone-service"},
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
@@ -118,8 +103,8 @@ func TestApplyStandaloneWithSmartstore(t *testing.T) {
 	listmockCall := []spltest.MockFuncCall{
 		{ListOpts: listOpts}}
 
-	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[1], funcCalls[5], funcCalls[6], funcCalls[7], funcCalls[8], funcCalls[10], funcCalls[11], funcCalls[12], funcCalls[14], funcCalls[15]}, "List": {listmockCall[0], listmockCall[0]}, "Update": {funcCalls[0]}}
-	updateCalls := map[string][]spltest.MockFuncCall{"Get": {funcCalls[0], funcCalls[1], funcCalls[3], funcCalls[4], funcCalls[5], funcCalls[6], funcCalls[7], funcCalls[8], funcCalls[9], funcCalls[10], funcCalls[11], funcCalls[12], funcCalls[13], funcCalls[14], funcCalls[15]}, "Update": {funcCalls[10], funcCalls[15]}, "List": {listmockCall[0], listmockCall[0]}}
+	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[1], funcCalls[4], funcCalls[5], funcCalls[7], funcCalls[8]}, "Update": {funcCalls[0]}, "List": {listmockCall[0]}}
+	updateCalls := map[string][]spltest.MockFuncCall{"Get": {funcCalls[0], funcCalls[1], funcCalls[3], funcCalls[4], funcCalls[5], funcCalls[6], funcCalls[7], funcCalls[8]}, "Update": {funcCalls[8]}, "List": {listmockCall[0]}}
 
 	current := enterprisev1.Standalone{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -71,18 +71,6 @@ func getIndexerExtraEnv(cr splcommon.MetaObject, replicas int32) []corev1.EnvVar
 
 // getClusterMasterExtraEnv returns extra environment variables used by indexer clusters
 func getClusterMasterExtraEnv(cr splcommon.MetaObject, spec *enterprisev1.CommonSplunkSpec) []corev1.EnvVar {
-	if spec.ClusterMasterRef.Name != "" {
-		clusterMasterURL := GetSplunkServiceName(SplunkClusterMaster, spec.ClusterMasterRef.Name, false)
-		if spec.ClusterMasterRef.Namespace != "" {
-			clusterMasterURL = splcommon.GetServiceFQDN(spec.ClusterMasterRef.Namespace, clusterMasterURL)
-		}
-		return []corev1.EnvVar{
-			{
-				Name:  "SPLUNK_CLUSTER_MASTER_URL",
-				Value: clusterMasterURL,
-			},
-		}
-	}
 	return []corev1.EnvVar{
 		{
 			Name:  "SPLUNK_CLUSTER_MASTER_URL",


### PR DESCRIPTION
Automate Splunk monitoring console app for indexer clustering
- Add cluster master URL to MC configMap
- Add MC as a searchhead on CM to get indexer info
- Automate the "Apply Changes" button on the monitoring console app when IndexerCluster custom resource is applied
- For multi-site get cluster-info and append "SPLUNK_SITE" and "SPLUNK_MULTISITE_MASTER" env variables to MC
