### PR TITLE
cspl-490: Configuring Smartstore post deployment doesn't create splunk operator app

### DIFF
--- a/pkg/splunk/controller/util.go
+++ b/pkg/splunk/controller/util.go
@@ -113,6 +113,15 @@ func MergePodSpecUpdates(current *corev1.PodSpec, revised *corev1.PodSpec, name 
 		result = true
 	}
 
+	// Check for changes in Init containers
+	if len(current.InitContainers) != len(revised.InitContainers) {
+		scopedLog.Info("Pod init containers  differ",
+			"current", len(current.InitContainers),
+			"revised", len(revised.InitContainers))
+		current.InitContainers = revised.InitContainers
+		result = true
+	}
+
 	// check for changes in container images; assume that the ordering is same for pods with > 1 container
 	if len(current.Containers) != len(revised.Containers) {
 		scopedLog.Info("Pod Container counts differ",


### PR DESCRIPTION
Update the Pod Spec, when there is a change in InitContainer list.