### PR TITLE
Fix CRD version in examples under deploy directory and CustomResources.md

### DIFF
--- a/build/make_bundle.sh
+++ b/build/make_bundle.sh
@@ -5,7 +5,7 @@
 set -e
 
 VERSION=`grep "Version.*=.*\".*\"" version/version.go | sed "s,.*Version.*=.*\"\(.*\)\".*,\1,"`
-OLD_VERSIONS="v1alpha3"
+OLD_VERSIONS="v1alpha3 v1alpha2"
 DOCKER_IO_PATH="docker.io/splunk"
 REDHAT_REGISTRY_PATH="registry.connect.redhat.com/splunk"
 OPERATOR_IMAGE="$DOCKER_IO_PATH/splunk-operator:${VERSION}"

--- a/deploy/crds/enterprise.splunk.com_clustermasters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_clustermasters_crd.yaml
@@ -2458,3 +2458,6 @@ spec:
   - name: v1alpha3
     served: true
     storage: false
+  - name: v1alpha2
+    served: true
+    storage: false

--- a/deploy/crds/enterprise.splunk.com_indexerclusters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_indexerclusters_crd.yaml
@@ -2330,3 +2330,6 @@ spec:
   - name: v1alpha3
     served: true
     storage: false
+  - name: v1alpha2
+    served: true
+    storage: false

--- a/deploy/crds/enterprise.splunk.com_licensemasters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_licensemasters_crd.yaml
@@ -2235,3 +2235,6 @@ spec:
   - name: v1alpha3
     served: true
     storage: false
+  - name: v1alpha2
+    served: true
+    storage: false

--- a/deploy/crds/enterprise.splunk.com_searchheadclusters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_searchheadclusters_crd.yaml
@@ -2385,3 +2385,6 @@ spec:
   - name: v1alpha3
     served: true
     storage: false
+  - name: v1alpha2
+    served: true
+    storage: false

--- a/deploy/crds/enterprise.splunk.com_sparks_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_sparks_crd.yaml
@@ -991,3 +991,6 @@ spec:
   - name: v1alpha3
     served: true
     storage: false
+  - name: v1alpha2
+    served: true
+    storage: false

--- a/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
@@ -2513,3 +2513,6 @@ spec:
   - name: v1alpha3
     served: true
     storage: false
+  - name: v1alpha2
+    served: true
+    storage: false

--- a/deploy/examples/clustermaster/default.yaml
+++ b/deploy/examples/clustermaster/default.yaml
@@ -1,5 +1,5 @@
 apiVersion: enterprise.splunk.com/v1beta1
-kind: IndexerCluster
+kind: ClusterMaster
 metadata:
   name: test
 spec: {}

--- a/deploy/examples/licensemaster/default.yaml
+++ b/deploy/examples/licensemaster/default.yaml
@@ -1,4 +1,4 @@
-apiVersion: enterprise.splunk.com/v1alpha2
+apiVersion: enterprise.splunk.com/v1beta1
 kind: LicenseMaster
 metadata:
   name: test

--- a/deploy/examples/searchheadcluster/default.yaml
+++ b/deploy/examples/searchheadcluster/default.yaml
@@ -1,4 +1,4 @@
-apiVersion: enterprise.splunk.com/v1alpha2
+apiVersion: enterprise.splunk.com/v1beta1
 kind: SearchHeadCluster
 metadata:
   name: test

--- a/deploy/examples/spark/default.yaml
+++ b/deploy/examples/spark/default.yaml
@@ -1,4 +1,4 @@
-apiVersion: enterprise.splunk.com/v1alpha2
+apiVersion: enterprise.splunk.com/v1beta1
 kind: Spark
 metadata:
   name: test

--- a/deploy/examples/standalone/default.yaml
+++ b/deploy/examples/standalone/default.yaml
@@ -1,4 +1,4 @@
-apiVersion: enterprise.splunk.com/v1alpha2
+apiVersion: enterprise.splunk.com/v1beta1
 kind: Standalone
 metadata:
   name: test

--- a/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_clustermasters_crd.yaml
+++ b/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_clustermasters_crd.yaml
@@ -2458,3 +2458,6 @@ spec:
   - name: v1alpha3
     served: true
     storage: false
+  - name: v1alpha2
+    served: true
+    storage: false

--- a/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_indexerclusters_crd.yaml
+++ b/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_indexerclusters_crd.yaml
@@ -2330,3 +2330,6 @@ spec:
   - name: v1alpha3
     served: true
     storage: false
+  - name: v1alpha2
+    served: true
+    storage: false

--- a/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_licensemasters_crd.yaml
+++ b/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_licensemasters_crd.yaml
@@ -2235,3 +2235,6 @@ spec:
   - name: v1alpha3
     served: true
     storage: false
+  - name: v1alpha2
+    served: true
+    storage: false

--- a/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_searchheadclusters_crd.yaml
+++ b/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_searchheadclusters_crd.yaml
@@ -2385,3 +2385,6 @@ spec:
   - name: v1alpha3
     served: true
     storage: false
+  - name: v1alpha2
+    served: true
+    storage: false

--- a/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_sparks_crd.yaml
+++ b/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_sparks_crd.yaml
@@ -991,3 +991,6 @@ spec:
   - name: v1alpha3
     served: true
     storage: false
+  - name: v1alpha2
+    served: true
+    storage: false

--- a/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/olm-catalog/splunk/0.2.0/enterprise.splunk.com_standalones_crd.yaml
@@ -2513,3 +2513,6 @@ spec:
   - name: v1alpha3
     served: true
     storage: false
+  - name: v1alpha2
+    served: true
+    storage: false

--- a/deploy/olm-catalog/splunk/splunk.package.yaml
+++ b/deploy/olm-catalog/splunk/splunk.package.yaml
@@ -1,5 +1,5 @@
 channels:
 - currentCSV: splunk.v0.2.0
-  name: alpha
-defaultChannel: alpha
+  name: beta
+defaultChannel: beta
 packageName: splunk

--- a/docs/CustomResources.md
+++ b/docs/CustomResources.md
@@ -33,7 +33,7 @@ you would like the resource to reside within:
 If you do not provide a `namespace`, you current context will be used.
 
 ```yaml
-apiVersion: enterprise.splunk.com/v1alpha3
+apiVersion: enterprise.splunk.com/v1beta1
 kind: Standalone
 metadata:
   name: s1
@@ -51,7 +51,7 @@ associated with the instance when you delete it.
 ## Common Spec Parameters for All Resources
 
 ```yaml
-apiVersion: enterprise.splunk.com/v1alpha3
+apiVersion: enterprise.splunk.com/v1beta1
 kind: Standalone
 metadata:
   name: example
@@ -83,7 +83,7 @@ configuration parameters:
 ## Common Spec Parameters for Splunk Enterprise Resources
 
 ```yaml
-apiVersion: enterprise.splunk.com/v1alpha3
+apiVersion: enterprise.splunk.com/v1beta1
 kind: Standalone
 metadata:
   name: example
@@ -122,7 +122,7 @@ Enterprise resources, including: `Standalone`, `LicenseMaster`,
 ## Spark Resource Spec Parameters
 
 ```yaml
-apiVersion: enterprise.splunk.com/v1alpha3
+apiVersion: enterprise.splunk.com/v1beta1
 kind: Spark
 metadata:
   name: example
@@ -141,7 +141,7 @@ the `Spark` resource provides the following `Spec` configuration parameters:
 ## LicenseMaster Resource Spec Parameters
 
 ```yaml
-apiVersion: enterprise.splunk.com/v1alpha3
+apiVersion: enterprise.splunk.com/v1beta1
 kind: LicenseMaster
 metadata:
   name: example
@@ -161,7 +161,7 @@ The `LicenseMaster` resource does not provide any additional configuration param
 ## Standalone Resource Spec Parameters
 
 ```yaml
-apiVersion: enterprise.splunk.com/v1alpha3
+apiVersion: enterprise.splunk.com/v1beta1
 kind: Standalone
 metadata:
   name: example
@@ -185,7 +185,7 @@ the `Standalone` resource provides the following `Spec` configuration parameters
 ## SearchHeadCluster Resource Spec Parameters
 
 ```yaml
-apiVersion: enterprise.splunk.com/v1alpha3
+apiVersion: enterprise.splunk.com/v1beta1
 kind: SearchHeadCluster
 metadata:
   name: example
@@ -209,7 +209,7 @@ the `SearchHeadCluster` resource provides the following `Spec` configuration par
 ## ClusterMaster Resource Spec Parameters
 ClusterMaster resource does not have a required spec parameter, but to configure SmartStore, you can specify indexes and volume configuration as below -
 ```yaml
-apiVersion: enterprise.splunk.com/v1alpha3
+apiVersion: enterprise.splunk.com/v1beta1
 kind: ClusterMaster
 metadata:
   name: example-cm
@@ -238,7 +238,7 @@ spec:
 ## IndexerCluster Resource Spec Parameters
 
 ```yaml
-apiVersion: enterprise.splunk.com/v1alpha3
+apiVersion: enterprise.splunk.com/v1beta1
 kind: IndexerCluster
 metadata:
   name: example

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -16,7 +16,7 @@ architectures is currently only available from the
 
 For other architectures, we recommend that you try out the
 [Splunk Operator for Kubernetes](https://splunk.github.io/splunk-operator/).
-This open source project is currently an “alpha,” and we welcome any
+This open source project is currently a “beta,” and we welcome any
 [feedback](https://github.com/splunk/splunk-operator/issues)
 on your requirements.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ be more successful and move at a rapid pace.
 ## Known Issues for the Splunk Operator
 
 *Please note that the Splunk Operator is undergoing active development
-and considered to be an "alpha" quality release. We expect significant
+and considered to be a "beta" quality release. We expect significant
 modifications will be made prior to its general availability, it is not
 covered by support, and we strongly discourage using it in production.*
 


### PR DESCRIPTION
In the CRD version change from v1alpha3 to v1beta1 via this PR, the examples under the deploy directory and CustomResources.md were left unchanged. Changing them as a correction via this PR.