### PR TITLE
CSPL-499: Attaching PVC volumes to splunk monitoring console pod

### DIFF
--- a/pkg/splunk/client/enterprise.go
+++ b/pkg/splunk/client/enterprise.go
@@ -945,3 +945,17 @@ func (c *SplunkClient) RestartSplunk() error {
 	expectedStatus := []int{200}
 	return c.Do(request, expectedStatus, nil)
 }
+
+// RemoveSearchPeers updates etc/system/local/distsearch.conf
+func (c *SplunkClient) RemoveSearchPeers(deletedPeers string, mock bool) error {
+	if mock {
+		return nil
+	}
+	endpoint := fmt.Sprintf("%s/servicesNS/-/search/search/distributed/peers/%s:8089", c.ManagementURI, deletedPeers)
+	request, err := http.NewRequest("DELETE", endpoint, nil)
+	if err != nil {
+		return err
+	}
+	expectedStatus := []int{200, 404}
+	return c.Do(request, expectedStatus, nil)
+}

--- a/pkg/splunk/client/enterprise_test.go
+++ b/pkg/splunk/client/enterprise_test.go
@@ -556,3 +556,11 @@ func TestRestartSplunk(t *testing.T) {
 	}
 	splunkClientTester(t, "TestRestartSplunk", 200, "", wantRequest, test)
 }
+
+func TestRemoveSearchPeers(t *testing.T) {
+	wantRequest, _ := http.NewRequest("DELETE", "https://localhost:8089/servicesNS/-/search/search/distributed/peers/a:8089", nil)
+	test := func(c SplunkClient) error {
+		return c.RemoveSearchPeers("a", false)
+	}
+	splunkClientTester(t, "TestRestartSplunk", 200, "", wantRequest, test)
+}

--- a/pkg/splunk/controller/configmap.go
+++ b/pkg/splunk/controller/configmap.go
@@ -75,13 +75,7 @@ func SetConfigMapOwnerRef(client splcommon.ControllerClient, cr splcommon.MetaOb
 	// Owner ref doesn't exist, update statefulset with owner references
 	configMap.SetOwnerReferences(append(configMap.GetOwnerReferences(), splcommon.AsOwner(cr, false)))
 
-	// Update owner reference if needed
-	err = splutil.UpdateResource(client, configMap)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return splutil.UpdateResource(client, configMap)
 }
 
 // GetConfigMap gets the ConfigMap resource in a given namespace

--- a/pkg/splunk/controller/configmap_test.go
+++ b/pkg/splunk/controller/configmap_test.go
@@ -21,9 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1beta1"
 	spltest "github.com/splunk/splunk-operator/pkg/splunk/test"
-	splutil "github.com/splunk/splunk-operator/pkg/splunk/util"
 )
 
 func TestApplyConfigMap(t *testing.T) {

--- a/pkg/splunk/controller/configmap_test.go
+++ b/pkg/splunk/controller/configmap_test.go
@@ -66,19 +66,19 @@ func TestSetConfigMapOwnerRef(t *testing.T) {
 
 	err := SetConfigMapOwnerRef(c, &cr, namespacedName)
 	if err.Error() != "NotFound" {
-		t.Errorf("Couldn't detect resource %s", current.GetName())
+		t.Errorf("Found resource before creating it %s", current.GetName())
 	}
 
 	// Create configMap
 	err = splutil.CreateResource(c, &current)
 	if err != nil {
-		t.Errorf("Failed to create owner reference  %s", current.GetName())
+		t.Errorf("Failed to create resource %s", current.GetName())
 	}
 
 	// Test existing owner reference
 	err = SetConfigMapOwnerRef(c, &cr, namespacedName)
 	if err != nil {
-		t.Errorf("Couldn't set owner ref for resource %s", current.GetName())
+		t.Errorf("Couldn't set owner ref for configMap %s", current.GetName())
 	}
 
 	// Try adding same owner again
@@ -101,7 +101,7 @@ func TestGetConfigMap(t *testing.T) {
 
 	_, err := ApplyConfigMap(c, &current)
 	if err != nil {
-		return
+		t.Errorf(err.Error())
 	}
 
 	namespacedName := types.NamespacedName{Namespace: "test", Name: "splunk-test-monitoring-console"}

--- a/pkg/splunk/enterprise/clustermaster_test.go
+++ b/pkg/splunk/enterprise/clustermaster_test.go
@@ -148,6 +148,7 @@ func TestApplyClusterMasterWithSmartstore(t *testing.T) {
 		{MetaName: "*v1.Service-test-splunk-test-monitoring-console-headless"},
 		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console"},
 		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console"},
+		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console"},
 		{MetaName: "*v1.StatefulSet-test-splunk-test-monitoring-console"},
 		{MetaName: "*v1.StatefulSet-test-splunk-test-monitoring-console"},
 	}
@@ -161,7 +162,7 @@ func TestApplyClusterMasterWithSmartstore(t *testing.T) {
 	}
 	listmockCall := []spltest.MockFuncCall{
 		{ListOpts: listOpts}}
-	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[6], funcCalls[7], funcCalls[9], funcCalls[15], funcCalls[16], funcCalls[17], funcCalls[18], funcCalls[20]}, "List": {listmockCall[0], listmockCall[0], listmockCall[0]}, "Update": {funcCalls[0], funcCalls[3], funcCalls[20]}}
+	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[6], funcCalls[7], funcCalls[9], funcCalls[15], funcCalls[16], funcCalls[17], funcCalls[18], funcCalls[21]}, "List": {listmockCall[0], listmockCall[0], listmockCall[0]}, "Update": {funcCalls[0], funcCalls[3], funcCalls[20], funcCalls[21]}}
 	updateCalls := map[string][]spltest.MockFuncCall{"Get": {funcCalls[0], funcCalls[1], funcCalls[2], funcCalls[3], funcCalls[5], funcCalls[5], funcCalls[6], funcCalls[7], funcCalls[8], funcCalls[9], funcCalls[11], funcCalls[11], funcCalls[12]}, "Update": {funcCalls[10], funcCalls[12]}, "List": {listmockCall[0]}}
 
 	current := enterprisev1.ClusterMaster{

--- a/pkg/splunk/enterprise/finalizers_test.go
+++ b/pkg/splunk/enterprise/finalizers_test.go
@@ -81,6 +81,7 @@ func splunkDeletionTester(t *testing.T, cr splcommon.MetaObject, delete func(spl
 		if cr.GetObjectKind().GroupVersionKind().Kind != "IndexerCluster" {
 			mockCalls["Update"] = []spltest.MockFuncCall{
 				{MetaName: "*v1.Secret-test-splunk-test-secret"},
+				{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console"},
 				{MetaName: "*v1.StatefulSet-test-splunk-test-monitoring-console"},
 				{MetaName: "*v1.StatefulSet-test-splunk-test-monitoring-console"},
 				{MetaName: "*v1.Secret-test-splunk-test-secret"},
@@ -101,6 +102,7 @@ func splunkDeletionTester(t *testing.T, cr splcommon.MetaObject, delete func(spl
 				{MetaName: "*v1.Secret-test-splunk-test-monitoring-console-secret-v1"},
 				{MetaName: "*v1.Service-test-splunk-test-monitoring-console-service"},
 				{MetaName: "*v1.Service-test-splunk-test-monitoring-console-headless"},
+				{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console"},
 				{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console"},
 				{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console"},
 				{MetaName: "*v1.StatefulSet-test-splunk-test-monitoring-console"},

--- a/pkg/splunk/enterprise/monitoringconsole.go
+++ b/pkg/splunk/enterprise/monitoringconsole.go
@@ -362,7 +362,7 @@ func DeleteURLsConfigMap(revised *corev1.ConfigMap, crName string, newURLs []cor
 			if strings.Contains(curr, crName) {
 				if deleteCR {
 					revised.Data[url.Name] = strings.ReplaceAll(revised.Data[url.Name], url.Value, "")
-					if url.Name != "SPLUNK_MULTISITE_MASTER" && url.Name != "SPLUNK_DEPLOYER_URL" && url.Name != "SPLUNK_SEARCH_HEAD_CAPTAIN_URL" {
+					if url.Name != "SPLUNK_MULTISITE_MASTER" && url.Name != "SPLUNK_DEPLOYER_URL" && url.Name != "SPLUNK_SEARCH_HEAD_CAPTAIN_URL" && url.Name != "SPLUNK_SITE" {
 						deletedPeersTemp := strings.Split(url.Value, ",")
 						for i := 0; i < len(deletedPeersTemp); i++ {
 							deletedPeers = append(deletedPeers, deletedPeersTemp[i])

--- a/pkg/splunk/enterprise/monitoringconsole.go
+++ b/pkg/splunk/enterprise/monitoringconsole.go
@@ -362,6 +362,7 @@ func DeleteURLsConfigMap(revised *corev1.ConfigMap, crName string, newURLs []cor
 			if strings.Contains(curr, crName) {
 				if deleteCR {
 					revised.Data[url.Name] = strings.ReplaceAll(revised.Data[url.Name], url.Value, "")
+					//need to only update mc distsearch.conf with "SPLUNK_STANDALONE_URL"/"SPLUNK_CLUSTER_MASTER_URL"/"SPLUNK_SEARCH_HEAD_URL" data
 					if url.Name != "SPLUNK_MULTISITE_MASTER" && url.Name != "SPLUNK_DEPLOYER_URL" && url.Name != "SPLUNK_SEARCH_HEAD_CAPTAIN_URL" && url.Name != "SPLUNK_SITE" {
 						deletedPeersTemp := strings.Split(url.Value, ",")
 						for i := 0; i < len(deletedPeersTemp); i++ {

--- a/pkg/splunk/enterprise/monitoringconsole_test.go
+++ b/pkg/splunk/enterprise/monitoringconsole_test.go
@@ -45,6 +45,7 @@ func TestApplyMonitoringConsole(t *testing.T) {
 		{MetaName: "*v1.Service-test-splunk-test-monitoring-console-headless"},
 		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console"},
 		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console"},
+		{MetaName: "*v1.ConfigMap-test-splunk-test-monitoring-console"},
 		{MetaName: "*v1.StatefulSet-test-splunk-test-monitoring-console"},
 		{MetaName: "*v1.StatefulSet-test-splunk-test-monitoring-console"},
 	}
@@ -59,7 +60,7 @@ func TestApplyMonitoringConsole(t *testing.T) {
 	listmockCall := []spltest.MockFuncCall{
 		{ListOpts: listOpts}}
 
-	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[1], funcCalls[2], funcCalls[3], funcCalls[5]}, "Update": {funcCalls[6], funcCalls[6]}, "List": {listmockCall[0]}}
+	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[1], funcCalls[2], funcCalls[3], funcCalls[5]}, "Update": {funcCalls[6], funcCalls[7], funcCalls[7]}, "List": {listmockCall[0]}}
 	updateCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Update": {funcCalls[7]}, "List": {listmockCall[0]}}
 	c := spltest.NewMockClient()
 

--- a/pkg/splunk/enterprise/monitoringconsole_test.go
+++ b/pkg/splunk/enterprise/monitoringconsole_test.go
@@ -205,39 +205,3 @@ func TestApplyMonitoringConsoleEnvConfigMap(t *testing.T) {
 
 	spltest.ReconcileTester(t, "TestApplyMonitoringConsoleEnvConfigMap", "test", "test", createCalls, updateCalls, reconcile, false, &current)
 }
-
-func TestRemoveSearchPeers(t *testing.T) {
-	deletedPeers := []string{"a", "b"}
-	cr := enterprisev1.Standalone{
-		TypeMeta: metav1.TypeMeta{
-			Kind: "Standalone",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "stack1",
-			Namespace: "test",
-		},
-	}
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "splunk-stack1-0",
-			Namespace: "test",
-			Labels: map[string]string{
-				"controller-revision-hash": "v1",
-			},
-		},
-		Status: corev1.PodStatus{
-			Phase: corev1.PodRunning,
-			ContainerStatuses: []corev1.ContainerStatus{
-				{Ready: true},
-			},
-		},
-	}
-
-	c := spltest.NewMockClient()
-	c.AddObject(pod)
-	err := RemoveSearchPeers(c, &cr, cr.Spec.CommonSplunkSpec, deletedPeers)
-	if err != nil {
-		return
-	}
-}

--- a/pkg/splunk/enterprise/monitoringconsole_test.go
+++ b/pkg/splunk/enterprise/monitoringconsole_test.go
@@ -105,7 +105,7 @@ func TestApplyMonitoringConsoleEnvConfigMap(t *testing.T) {
 
 	newURLsAdded := true
 	reconcile := func(c *spltest.MockClient, cr interface{}) error {
-		_, err := ApplyMonitoringConsoleEnvConfigMap(c, "test", "test", env, newURLsAdded)
+		_, _, err := ApplyMonitoringConsoleEnvConfigMap(c, "test", "test", env, newURLsAdded)
 		return err
 	}
 
@@ -204,4 +204,40 @@ func TestApplyMonitoringConsoleEnvConfigMap(t *testing.T) {
 	newURLsAdded = true
 
 	spltest.ReconcileTester(t, "TestApplyMonitoringConsoleEnvConfigMap", "test", "test", createCalls, updateCalls, reconcile, false, &current)
+}
+
+func TestRemoveSearchPeers(t *testing.T) {
+	deletedPeers := []string{"a", "b"}
+	cr := enterprisev1.Standalone{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Standalone",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stack1",
+			Namespace: "test",
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-stack1-0",
+			Namespace: "test",
+			Labels: map[string]string{
+				"controller-revision-hash": "v1",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Ready: true},
+			},
+		},
+	}
+
+	c := spltest.NewMockClient()
+	c.AddObject(pod)
+	err := RemoveSearchPeers(c, &cr, cr.Spec.CommonSplunkSpec, deletedPeers)
+	if err != nil {
+		return
+	}
 }


### PR DESCRIPTION
-Attaching PVC volumes to Splunk monitoring console pod and updating distsearch.conf when any search peer gets deleted
-Updating distsearch.conf on CR deletion
-Adding owner ref to MC configMap