### PR TITLE
CSPL-521: Added more delay and checks for MC pod to be ready

### DIFF
--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -309,6 +309,8 @@ var _ = Describe("Smoke test", func() {
 				return siteIndexerStatus
 			}, deployment.GetTimeout(), PollInterval).Should(Equal(siteIndexerMap))
 
+			// Verify MC Pod is Ready
+			testenv.MCPodReady(testenvInstance.GetName(), deployment)
 		})
 	})
 })

--- a/test/testenv/mcutil.go
+++ b/test/testenv/mcutil.go
@@ -116,6 +116,14 @@ func MCPodReady(ns string, deployment *Deployment) {
 		DumpGetPods(ns)
 		return check
 	}, deployment.GetTimeout(), PollInterval).Should(gomega.Equal(true))
+
+	// Verify MC Pod Stays in ready state
+	gomega.Consistently(func() bool {
+		logf.Log.Info("Checking status of Monitoring Console Pod")
+		check := CheckMCPodReady(ns)
+		DumpGetPods(ns)
+		return check
+	}, ConsistentDuration, ConsistentPollInterval).Should(gomega.Equal(true))
 }
 
 // GetSearchHeadPeersOnMC GET Search head configured on MC

--- a/test/testenv/testenv.go
+++ b/test/testenv/testenv.go
@@ -31,7 +31,7 @@ const (
 	defaultSparkImage    = "splunk/spark"
 
 	// defaultTestTimeout is the max timeout in seconds before async test failed.
-	defaultTestTimeout = 900
+	defaultTestTimeout = 1500
 
 	// PollInterval specifies the polling interval
 	PollInterval = 5 * time.Second


### PR DESCRIPTION
Made following changes to address flakiness related to MC test. 

* Changed wait time to 1500 seconds. 
* Added check to verify MC pod stays in ready state.