### PR TITLE
CSPL-529: Fixing a bug where if we delete CM, it also deletes PVCs for IndexerCluster too

### DIFF
--- a/pkg/splunk/enterprise/finalizers.go
+++ b/pkg/splunk/enterprise/finalizers.go
@@ -54,7 +54,7 @@ func DeleteSplunkPvc(cr splcommon.MetaObject, c splcommon.ControllerClient) erro
 		return nil
 	}
 
-	// get list of PVCs for this cluster
+	// get list of PVCs associated with this CR
 	labels := map[string]string{
 		"app.kubernetes.io/instance": fmt.Sprintf("splunk-%s-%s", cr.GetName(), component),
 	}

--- a/pkg/splunk/enterprise/finalizers.go
+++ b/pkg/splunk/enterprise/finalizers.go
@@ -31,19 +31,24 @@ func init() {
 
 // DeleteSplunkPvc removes all corresponding PersistentVolumeClaims that are associated with a custom resource.
 func DeleteSplunkPvc(cr splcommon.MetaObject, c splcommon.ControllerClient) error {
-	scopedLog := log.WithName("DeleteSplunkPvc").WithValues("kind", cr.GetObjectKind().GroupVersionKind().Kind,
+	var objectKind string
+	objectKind = cr.GetObjectKind().GroupVersionKind().Kind
+
+	scopedLog := log.WithName("DeleteSplunkPvc").WithValues("kind", objectKind,
 		"name", cr.GetName(), "namespace", cr.GetNamespace())
 
 	var component string
-	switch cr.GetObjectKind().GroupVersionKind().Kind {
+	switch objectKind {
 	case "Standalone":
 		component = "standalone"
 	case "LicenseMaster":
 		component = "license-master"
 	case "SearchHeadCluster":
 		component = "search-head"
-	case "IndexerCluster", "ClusterMaster":
+	case "IndexerCluster":
 		component = "indexer"
+	case "ClusterMaster":
+		component = "cluster-master"
 	default:
 		scopedLog.Info("Skipping PVC removal")
 		return nil
@@ -51,7 +56,7 @@ func DeleteSplunkPvc(cr splcommon.MetaObject, c splcommon.ControllerClient) erro
 
 	// get list of PVCs for this cluster
 	labels := map[string]string{
-		"app.kubernetes.io/part-of": fmt.Sprintf("splunk-%s-%s", cr.GetName(), component),
+		"app.kubernetes.io/instance": fmt.Sprintf("splunk-%s-%s", cr.GetName(), component),
 	}
 	listOpts := []client.ListOption{
 		client.InNamespace(cr.GetNamespace()),

--- a/pkg/splunk/enterprise/finalizers_test.go
+++ b/pkg/splunk/enterprise/finalizers_test.go
@@ -40,8 +40,10 @@ func splunkDeletionTester(t *testing.T, cr splcommon.MetaObject, delete func(spl
 		component = "license-master"
 	case "SearchHeadCluster":
 		component = "search-head"
-	case "IndexerCluster", "ClusterMaster":
+	case "IndexerCluster":
 		component = "indexer"
+	case "ClusterMaster":
+		component = "cluster-master"
 	}
 
 	labelsA := map[string]string{
@@ -49,7 +51,7 @@ func splunkDeletionTester(t *testing.T, cr splcommon.MetaObject, delete func(spl
 		"app.kubernetes.io/managed-by": "splunk-operator",
 	}
 	labelsB := map[string]string{
-		"app.kubernetes.io/part-of": fmt.Sprintf("splunk-%s-%s", cr.GetName(), component),
+		"app.kubernetes.io/instance": fmt.Sprintf("splunk-%s-%s", cr.GetName(), component),
 	}
 	listOptsA := []client.ListOption{
 		client.InNamespace("test"),
@@ -169,12 +171,14 @@ func splunkPVCDeletionTester(t *testing.T, cr splcommon.MetaObject, delete func(
 		component = "license-master"
 	case "SearchHeadCluster":
 		component = "search-head"
-	case "IndexerCluster", "ClusterMaster":
+	case "IndexerCluster":
 		component = "indexer"
+	case "ClusterMaster":
+		component = "cluster-master"
 	}
 
 	labels := map[string]string{
-		"app.kubernetes.io/part-of": fmt.Sprintf("splunk-%s-%s", cr.GetName(), component),
+		"app.kubernetes.io/instance": fmt.Sprintf("splunk-%s-%s", cr.GetName(), component),
 	}
 	listOpts := []client.ListOption{
 		client.InNamespace(cr.GetNamespace()),


### PR DESCRIPTION
**Problem**
When we were trying to delete ClusterMaster first, then it was also deleting PVCs for IndexerCluster too( in addition to its own PVC).
This was happening because we were looking for PVCs which match the label **app.kubernetes.io/part-of** and all the PVCs of IndexerCluster and PVC of ClusterMaster had this same label. Hence it was deleting all the PVCs.

**Solution**
Now, instead of looking for PVCs with label **app.kubernetes.io/part-of**, we are looking for PVCs with label **app.kubernetes.io/instance**, which is unique per CR and hence only those PVCs which are associated with that PR will be deleted.