### PR TITLE
fix IndexerCluster clusterMasterRef yaml in doc

### DIFF
--- a/docs/CustomResources.md
+++ b/docs/CustomResources.md
@@ -244,7 +244,8 @@ metadata:
   name: example
 spec:
   replicas: 3
-  clusterMasterRef: example-cm
+  clusterMasterRef: 
+    name: example-cm
 ```
 Note:  `clusterMasterRef` is required field in case of IndexerCluster resource since it will be used to connect the IndexerCluster to ClusterMaster resource.
 


### PR DESCRIPTION
Seeing an error when applying example yaml in [doc](https://github.com/splunk/splunk-operator/blob/master/docs/CustomResources.md#indexercluster-resource-spec-parameters):
```
apiVersion: enterprise.splunk.com/v1beta1
kind: IndexerCluster
metadata:
  name: example
spec:
  replicas: 3
  clusterMasterRef: example-cm
```

```
The IndexerCluster "example" is invalid: spec.clusterMasterRef: Invalid value: "string": spec.clusterMasterRef in body must be of type object: "string"
```
turns out the ref should be a map instead of pure string

operator: `docker.io/splunk/splunk-operator:0.2.0`
configs:

- master:
```
apiVersion: enterprise.splunk.com/v1beta1
kind: ClusterMaster
metadata:
  name: example-cm
```
- indexer cluster (this works)
```
apiVersion: enterprise.splunk.com/v1beta1
kind: IndexerCluster
metadata:
  name: example
spec:
  replicas: 3
  clusterMasterRef: 
    name: example-cm
```

some contents from describing crd (`indexerclusters.enterprise.splunk.com`): 
```
kubectl describe crd indexerclusters.enterprise.splunk.com


...
              Cluster Master Ref:
                Description:  ClusterMasterRef refers to a Splunk Enterprise indexer cluster managed by the operator within Kubernetes
                Properties:
                  API Version:
                    Description:  API version of the referent.
                    Type:         string
                  Field Path:
                    Description:  If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.
                    Type:         string
                  Kind:
                    Description:  Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                    Type:         string
                  Name:
                    Description:  Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                    Type:         string
                  Namespace:
                    Description:  Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                    Type:         string
                  Resource Version:
                    Description:  Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                    Type:         string
                  UID:
                    Description:  UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                    Type:         string
                Type:             object
...


```
Note the type of `ClusterMasterRef` is `object`, not string

