### PR TITLE
Eks use existing vpc

### DIFF
--- a/test/deploy-eks-cluster.sh
+++ b/test/deploy-eks-cluster.sh
@@ -20,7 +20,7 @@ function createCluster() {
 
   found=$(eksctl get cluster --name "${CLUSTER_NAME}")
   if [ -z "${found}" ]; then
-    eksctl create cluster --name=${CLUSTER_NAME} --nodes=${NUM_WORKERS}
+    eksctl create cluster --name=${CLUSTER_NAME} --nodes=${NUM_WORKERS} --vpc-public-subnets=${VPC_PUBLIC_SUBNET_STRING} --vpc-private-subnets=${VPC_PRIVATE_SUBNET_STRING}
     if [ $? -ne 0 ]; then
       echo "Unable to create cluster - ${CLUSTER_NAME}"
       return 1

--- a/test/env.sh
+++ b/test/env.sh
@@ -8,6 +8,8 @@
 : "${NUM_NODES:=2}"
 : "${COMMIT_HASH:=}"
 : "${ECR_REGISTRY:=}"
+: "${VPC_PUBLIC_SUBNET_STRING:=}"
+: "${VPC_PRIVATE_SUBNET_STRING:=}"
 
 # Docker registry to use to push the test images to and pull from in the cluster
 if [ -z "${PRIVATE_REGISTRY}" ]; then


### PR DESCRIPTION
Updated the eks cluster create script to use existing VPC to avoid resource bottleneck on AWS.
- Added 2 environment variable in env.sh for existing public and private subnet string.
- Updated eksctl create command to use existing subnets.