### PR TITLE
CSPL-534: Fix unnecessary pod recycle during scale up/down

### DIFF
--- a/pkg/apis/enterprise/v1beta1/indexercluster_types.go
+++ b/pkg/apis/enterprise/v1beta1/indexercluster_types.go
@@ -95,6 +95,9 @@ type IndexerClusterStatus struct {
 	// Indicates if the cluster is in maintenance mode.
 	MaintenanceMode bool `json:"maintenance_mode"`
 
+	// Indicates if we need to recheck the revision update on pods
+	SkipRecheckUpdate bool `json:"skip_recheck_update"`
+
 	// status of each indexer cluster peer
 	Peers []IndexerClusterMemberStatus `json:"peers"`
 }

--- a/pkg/apis/enterprise/v1beta1/searchheadcluster_types.go
+++ b/pkg/apis/enterprise/v1beta1/searchheadcluster_types.go
@@ -109,6 +109,9 @@ type SearchHeadClusterStatus struct {
 	// Indicates resource version of namespace scoped secret
 	NamespaceSecretResourceVersion string `json:"namespace_scoped_secret_resource_version"`
 
+	// Indicates if we need to recheck the revision update on pods
+	SkipRecheckUpdate bool `json:"skip_recheck_update"`
+
 	// status of each search head cluster member
 	Members []SearchHeadClusterMemberStatus `json:"members"`
 }

--- a/pkg/splunk/controller/statefulset.go
+++ b/pkg/splunk/controller/statefulset.go
@@ -135,6 +135,7 @@ func UpdatePodRevisionHash(c splcommon.ControllerClient, statefulSet *appsv1.Sta
 	return nil
 }
 
+// isRevisionUpdateSuccessful checks if current revision is different from updated revision
 func isRevisionUpdateSuccessful(c splcommon.ControllerClient, statefulSet *appsv1.StatefulSet) bool {
 	scopedLog := log.WithName("isUpdateSuccessful").WithValues(
 		"name", statefulSet.GetObjectMeta().GetName(),
@@ -158,6 +159,7 @@ func isRevisionUpdateSuccessful(c splcommon.ControllerClient, statefulSet *appsv
 	return true
 }
 
+// checkAndUpdatePodRevision updates the pod revision hash labels on pods if statefulset update was successful
 func checkAndUpdatePodRevision(c splcommon.ControllerClient, statefulSet *appsv1.StatefulSet, readyReplicas int32, skipRecheckUpdate *bool) (bool, error) {
 	scopedLog := log.WithName("UpdateStatefulSetPods").WithValues(
 		"name", statefulSet.GetObjectMeta().GetName(),

--- a/pkg/splunk/controller/statefulset.go
+++ b/pkg/splunk/controller/statefulset.go
@@ -34,8 +34,9 @@ type DefaultStatefulSetPodManager struct{}
 // Update for DefaultStatefulSetPodManager handles all updates for a statefulset of standard pods
 func (mgr *DefaultStatefulSetPodManager) Update(client splcommon.ControllerClient, statefulSet *appsv1.StatefulSet, desiredReplicas int32) (splcommon.Phase, error) {
 	phase, err := ApplyStatefulSet(client, statefulSet)
+	skipRecheckUpdate := false
 	if err == nil && phase == splcommon.PhaseReady {
-		phase, err = UpdateStatefulSetPods(client, statefulSet, mgr, desiredReplicas)
+		phase, err = UpdateStatefulSetPods(client, statefulSet, mgr, desiredReplicas, &skipRecheckUpdate)
 	}
 	return phase, err
 }
@@ -85,8 +86,102 @@ func ApplyStatefulSet(c splcommon.ControllerClient, revised *appsv1.StatefulSet)
 	return splcommon.PhaseReady, nil
 }
 
+// UpdatePodRevisionHash updates the controller-revision-hash label on pods.
+func UpdatePodRevisionHash(c splcommon.ControllerClient, statefulSet *appsv1.StatefulSet, readyReplicas int32) error {
+	scopedLog := log.WithName("updatePodRevisionHash").WithValues(
+		"name", statefulSet.GetObjectMeta().GetName(),
+		"namespace", statefulSet.GetObjectMeta().GetNamespace())
+
+	namespacedName := types.NamespacedName{Namespace: statefulSet.GetNamespace(), Name: statefulSet.GetName()}
+	var current appsv1.StatefulSet
+
+	err := c.Get(context.TODO(), namespacedName, &current)
+	if err != nil {
+		scopedLog.Error(err, "Unable to Get statefulset", "statefulset", statefulSet.GetName())
+	}
+
+	for n := readyReplicas - 1; n >= 0; n-- {
+		// get Pod
+		podName := fmt.Sprintf("%s-%d", current.GetName(), n)
+		namespacedName := types.NamespacedName{Namespace: current.GetNamespace(), Name: podName}
+		var pod corev1.Pod
+		err := c.Get(context.TODO(), namespacedName, &pod)
+		if err != nil {
+			scopedLog.Error(err, "Unable to find Pod", "podName", podName)
+			return err
+		}
+		if pod.Status.Phase != corev1.PodRunning || len(pod.Status.ContainerStatuses) == 0 || pod.Status.ContainerStatuses[0].Ready != true {
+			scopedLog.Error(err, "Waiting for Pod to become ready", "podName", podName)
+			return err
+		}
+
+		labels := pod.GetLabels()
+		revisionHash := labels["controller-revision-hash"]
+		// update pod controller revision hash
+		if current.Status.UpdateRevision != "" && current.Status.UpdateRevision != revisionHash {
+			// update controller-revision-hash label for pod with statefulset update revision
+			labels["controller-revision-hash"] = current.Status.UpdateRevision
+			pod.SetLabels(labels)
+			err = splutil.UpdateResource(c, &pod)
+			if err != nil {
+				scopedLog.Error(err, "Unable to update controller-revision-hash label for pod", "podName", podName)
+				return err
+			}
+			scopedLog.Info("Updated controller-revision-hash label for pod", "podName", podName, "revision", current.Status.UpdateRevision)
+		}
+	}
+
+	scopedLog.Info("Updated controller-revision-hash label for all pods")
+	return nil
+}
+
+func isRevisionUpdateSuccessful(c splcommon.ControllerClient, statefulSet *appsv1.StatefulSet) bool {
+	scopedLog := log.WithName("isUpdateSuccessful").WithValues(
+		"name", statefulSet.GetObjectMeta().GetName(),
+		"namespace", statefulSet.GetObjectMeta().GetNamespace())
+
+	namespacedName := types.NamespacedName{Namespace: statefulSet.GetNamespace(), Name: statefulSet.GetName()}
+	var current appsv1.StatefulSet
+
+	err := c.Get(context.TODO(), namespacedName, &current)
+	if err != nil {
+		scopedLog.Error(err, "Unable to Get statefulset", "statefulset", statefulSet.GetName())
+		return false
+	}
+
+	// Check if current revision is different from update revision
+	if current.Status.CurrentRevision == current.Status.UpdateRevision {
+		scopedLog.Error(err, "Statefulset UpdateRevision not updated yet")
+		return false
+	}
+
+	return true
+}
+
+func checkAndUpdatePodRevision(c splcommon.ControllerClient, statefulSet *appsv1.StatefulSet, readyReplicas int32, skipRecheckUpdate *bool) (bool, error) {
+	scopedLog := log.WithName("UpdateStatefulSetPods").WithValues(
+		"name", statefulSet.GetObjectMeta().GetName(),
+		"namespace", statefulSet.GetObjectMeta().GetNamespace())
+	var err error
+	if !isRevisionUpdateSuccessful(c, statefulSet) {
+		scopedLog.Error(err, "Statefulset not updated yet")
+		*skipRecheckUpdate = false
+		return false, err
+	}
+	// update the controller-revision-hash label on pods to
+	// to avoid unnecessary recycle of pods
+	err = UpdatePodRevisionHash(c, statefulSet, readyReplicas)
+	if err != nil {
+		scopedLog.Error(err, "Unable to update pod-revision-hash for the pods")
+		*skipRecheckUpdate = false
+		return false, err
+	}
+	*skipRecheckUpdate = true
+	return true, nil
+}
+
 // UpdateStatefulSetPods manages scaling and config updates for StatefulSets
-func UpdateStatefulSetPods(c splcommon.ControllerClient, statefulSet *appsv1.StatefulSet, mgr splcommon.StatefulSetPodManager, desiredReplicas int32) (splcommon.Phase, error) {
+func UpdateStatefulSetPods(c splcommon.ControllerClient, statefulSet *appsv1.StatefulSet, mgr splcommon.StatefulSetPodManager, desiredReplicas int32, skipRecheckUpdate *bool) (splcommon.Phase, error) {
 	scopedLog := log.WithName("UpdateStatefulSetPods").WithValues(
 		"name", statefulSet.GetObjectMeta().GetName(),
 		"namespace", statefulSet.GetObjectMeta().GetNamespace())
@@ -97,11 +192,25 @@ func UpdateStatefulSetPods(c splcommon.ControllerClient, statefulSet *appsv1.Sta
 	if readyReplicas < replicas {
 		scopedLog.Info("Waiting for pods to become ready")
 		if readyReplicas > 0 {
+			if !*skipRecheckUpdate {
+				ret, err := checkAndUpdatePodRevision(c, statefulSet, readyReplicas, skipRecheckUpdate)
+				if !ret || err != nil {
+					scopedLog.Error(err, "Unable to update pod-revision-hash for the pods")
+					return splcommon.PhaseError, err
+				}
+			}
 			return splcommon.PhaseScalingUp, nil
 		}
 		return splcommon.PhasePending, nil
 	} else if readyReplicas > replicas {
 		scopedLog.Info("Waiting for scale down to complete")
+		if !*skipRecheckUpdate {
+			ret, err := checkAndUpdatePodRevision(c, statefulSet, readyReplicas-1, skipRecheckUpdate)
+			if !ret || err != nil {
+				scopedLog.Error(err, "Unable to update pod-revision-hash for the pods")
+				return splcommon.PhaseError, err
+			}
+		}
 		return splcommon.PhaseScalingDown, nil
 	}
 
@@ -112,7 +221,23 @@ func UpdateStatefulSetPods(c splcommon.ControllerClient, statefulSet *appsv1.Sta
 		// scale up StatefulSet to match desiredReplicas
 		scopedLog.Info("Scaling replicas up", "replicas", desiredReplicas)
 		*statefulSet.Spec.Replicas = desiredReplicas
-		return splcommon.PhaseScalingUp, splutil.UpdateResource(c, statefulSet)
+		err := splutil.UpdateResource(c, statefulSet)
+		if err != nil {
+			scopedLog.Error(err, "Unable to update statefulset")
+			return splcommon.PhaseError, err
+		}
+
+		// Check if the revision was updated successfully for Statefulset.
+		// It so can happen that it may take few seconds for the update to be
+		// reflected in the resource. In that case, just return from here and
+		// check the status back in the next reconcile loop.
+		var ret bool
+		ret, err = checkAndUpdatePodRevision(c, statefulSet, readyReplicas, skipRecheckUpdate)
+		if !ret || err != nil {
+			scopedLog.Error(err, "Unable to update pod-revision-hash for the pods")
+			return splcommon.PhaseError, err
+		}
+		return splcommon.PhaseScalingUp, err
 	}
 
 	// check for scaling down
@@ -136,6 +261,17 @@ func UpdateStatefulSetPods(c splcommon.ControllerClient, statefulSet *appsv1.Sta
 		err = splutil.UpdateResource(c, statefulSet)
 		if err != nil {
 			scopedLog.Error(err, "Scale down update failed for StatefulSet")
+			return splcommon.PhaseError, err
+		}
+
+		// Check if the revision was updated successfully for Statefulset.
+		// It so can happen that it may take few seconds for the update to be
+		// reflected in the resource. In that case, just return from here and
+		// check the status back in the next reconcile loop.
+		var ret bool
+		ret, err = checkAndUpdatePodRevision(c, statefulSet, readyReplicas-1, skipRecheckUpdate)
+		if !ret || err != nil {
+			scopedLog.Error(err, "Unable to update pod-revision-hash for the pods")
 			return splcommon.PhaseError, err
 		}
 

--- a/pkg/splunk/controller/statefulset_test.go
+++ b/pkg/splunk/controller/statefulset_test.go
@@ -110,13 +110,13 @@ func TestUpdateStatefulSetPods(t *testing.T) {
 	var phase splcommon.Phase
 	phase, err := updateStatefulSetPodsTester(t, &mgr, statefulSet, 1 /*desiredReplicas*/, statefulSet, pod)
 	if err != nil && phase != splcommon.PhaseUpdating {
-		t.Errorf("UpdateStatefulSetPods should not have returned error")
+		t.Errorf("UpdateStatefulSetPods should not have returned error=%s with phase=%s", err, phase)
 	}
 
 	// Check the scenario where UpdatePodRevisionHash should return error when Pod is not added to client.
 	phase, err = updateStatefulSetPodsTester(t, &mgr, statefulSet, 2 /*desiredReplicas*/, statefulSet)
 	if err == nil && phase != splcommon.PhaseError {
-		t.Errorf("UpdateStatefulSetPods should have returned error or phase should have been PhaseError")
+		t.Errorf("UpdateStatefulSetPods should have returned error or phase should have been PhaseError, but we got phase=%s", phase)
 	}
 
 	replicas = 3
@@ -125,7 +125,7 @@ func TestUpdateStatefulSetPods(t *testing.T) {
 	// Check the scenario where UpdatePodRevisionHash should return error when Pod is not added to client.
 	phase, err = updateStatefulSetPodsTester(t, &mgr, statefulSet, 1 /*desiredReplicas*/, statefulSet)
 	if err == nil && phase != splcommon.PhaseError {
-		t.Errorf("UpdateStatefulSetPods should have returned error or phase should have been PhaseError")
+		t.Errorf("UpdateStatefulSetPods should have returned error or phase should have been PhaseError, but we got phase=%s", phase)
 	}
 
 	// readyReplicas < replicas
@@ -135,14 +135,14 @@ func TestUpdateStatefulSetPods(t *testing.T) {
 	// Check the scenario where UpdatePodRevisionHash should return error when readyReplicas < replicas and Pod is not found
 	phase, err = updateStatefulSetPodsTester(t, &mgr, statefulSet, 1 /*desiredReplicas*/, statefulSet, pod)
 	if err == nil && phase != splcommon.PhaseError {
-		t.Errorf("UpdateStatefulSetPods should have returned error or phase should have been PhaseError")
+		t.Errorf("UpdateStatefulSetPods should have returned error or phase should have been PhaseError, but we got phase=%s", phase)
 	}
 
 	// CurrentRevision = UpdateRevision
 	statefulSet.Status.CurrentRevision = "v1"
 	phase, err = updateStatefulSetPodsTester(t, &mgr, statefulSet, 1 /*desiredReplicas*/, statefulSet, pod)
 	if err == nil && phase != splcommon.PhaseError {
-		t.Errorf("UpdateStatefulSetPods should have returned error or phase should have been PhaseError")
+		t.Errorf("UpdateStatefulSetPods should have returned error or phase should have been PhaseError, but we got phase=%s", phase)
 	}
 
 	// readyReplicas > replicas
@@ -153,20 +153,20 @@ func TestUpdateStatefulSetPods(t *testing.T) {
 	// Check the scenario where UpdatePodRevisionHash should return error when readyReplicas > replicas and Pod is not found
 	phase, err = updateStatefulSetPodsTester(t, &mgr, statefulSet, 1 /*desiredReplicas*/, statefulSet, pod)
 	if err == nil && phase != splcommon.PhaseError {
-		t.Errorf("UpdateStatefulSetPods should have returned error or phase should have been PhaseError")
+		t.Errorf("UpdateStatefulSetPods should have returned error or phase should have been PhaseError, but we got phase=%s", phase)
 	}
 
 	// CurrentRevision = UpdateRevision
 	statefulSet.Status.CurrentRevision = "v1"
 	phase, err = updateStatefulSetPodsTester(t, &mgr, statefulSet, 1 /*desiredReplicas*/, statefulSet, pod)
 	if err == nil && phase != splcommon.PhaseError {
-		t.Errorf("UpdateStatefulSetPods should have returned error or phase should have been PhaseError")
+		t.Errorf("UpdateStatefulSetPods should have returned error or phase should have been PhaseError, but we got phase=%s", phase)
 	}
 
 	// Check the scenario where UpdatePodRevisionHash should return error when statefulset is not added to client.
 	phase, err = updateStatefulSetPodsTester(t, &mgr, statefulSet, 2 /*desiredReplicas*/, pod)
 	if err == nil && phase != splcommon.PhaseError {
-		t.Errorf("UpdateStatefulSetPods should have returned error or phase should have been PhaseError")
+		t.Errorf("UpdateStatefulSetPods should have returned error or phase should have been PhaseError, but we got phase=%s", phase)
 	}
 
 }
@@ -216,14 +216,14 @@ func TestUpdatePodRevisionHash(t *testing.T) {
 
 	err := updatePodRevisionHashTester(t, statefulSet, replicas, statefulSet, pod)
 	if err != nil {
-		t.Errorf("UpdatePodRevisionHash should not have returned error")
+		t.Errorf("UpdatePodRevisionHash should not have returned error=%s", err)
 	}
 
 	// Test the negative case where phase != corev1.PodRunning
 	pod.Status.Phase = corev1.PodPending
 	err = updatePodRevisionHashTester(t, statefulSet, replicas, statefulSet, pod)
 	if err != nil {
-		t.Errorf("UpdatePodRevisionHash should not have returned error")
+		t.Errorf("UpdatePodRevisionHash should not have returned error=%s", err)
 	}
 
 	// Test invalid pod name splunk-stack1-1

--- a/pkg/splunk/enterprise/clustermaster_test.go
+++ b/pkg/splunk/enterprise/clustermaster_test.go
@@ -272,8 +272,8 @@ func TestApplyClusterMasterWithSmartstore(t *testing.T) {
 	ss.Spec.Replicas = &replicas
 	ss.Spec.Template.Spec.Containers[0].Image = "splunk/splunk"
 	client.AddObject(ss)
-	if _, err := ApplyClusterMaster(client, &current); err == nil {
-		t.Errorf("ApplyClusterMaster() should have returned error")
+	if result, err := ApplyClusterMaster(client, &current); err == nil && !result.Requeue {
+		t.Errorf("ApplyClusterMaster() should have returned error or result.requeue should have been false")
 	}
 
 	ss.Status.ReadyReplicas = 1

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -371,7 +371,7 @@ func (mgr *indexerClusterPodManager) Update(c splcommon.ControllerClient, statef
 	}
 
 	// manage scaling and updates
-	return splctrl.UpdateStatefulSetPods(c, statefulSet, mgr, desiredReplicas)
+	return splctrl.UpdateStatefulSetPods(c, statefulSet, mgr, desiredReplicas, &mgr.cr.Status.SkipRecheckUpdate)
 }
 
 // PrepareScaleDown for indexerClusterPodManager prepares indexer pod to be removed via scale down event; it returns true when ready

--- a/pkg/splunk/enterprise/indexercluster_test.go
+++ b/pkg/splunk/enterprise/indexercluster_test.go
@@ -604,13 +604,14 @@ func TestIndexerClusterPodManager(t *testing.T) {
 		{MetaName: "*v1.PersistentVolumeClaim-test-pvc-etc-splunk-stack1-1"},
 		{MetaName: "*v1.PersistentVolumeClaim-test-pvc-var-splunk-stack1-1"},
 	}
-	wantCalls = map[string][]spltest.MockFuncCall{"Get": {funcCalls[0], funcCalls[1], funcCalls[3], funcCalls[3]}, "Create": {funcCalls[1]}, "Delete": pvcCalls, "Update": {funcCalls[0]}}
+	wantCalls = map[string][]spltest.MockFuncCall{"Get": {funcCalls[0], funcCalls[1], funcCalls[3], funcCalls[3], funcCalls[0], funcCalls[0], funcCalls[4]}, "Create": {funcCalls[1]}, "Delete": pvcCalls, "Update": {funcCalls[0], funcCalls[4]}}
 	wantCalls["Get"] = append(wantCalls["Get"], pvcCalls...)
 	pvcList := []*corev1.PersistentVolumeClaim{
 		{ObjectMeta: metav1.ObjectMeta{Name: "pvc-etc-splunk-stack1-1", Namespace: "test"}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "pvc-var-splunk-stack1-1", Namespace: "test"}},
 	}
 	method = "indexerClusterPodManager.Update(Decommission)"
+	pod.ObjectMeta.Name = "splunk-stack1-0"
 	indexerClusterPodManagerUpdateTester(t, method, mockHandlers, 1, splcommon.PhaseScalingDown, statefulSet, wantCalls, nil, statefulSet, pod, pvcList[0], pvcList[1])
 }
 

--- a/pkg/splunk/enterprise/searchheadcluster.go
+++ b/pkg/splunk/enterprise/searchheadcluster.go
@@ -347,7 +347,7 @@ func (mgr *searchHeadClusterPodManager) Update(c splcommon.ControllerClient, sta
 	}
 
 	// manage scaling and updates
-	return splctrl.UpdateStatefulSetPods(mgr.c, statefulSet, mgr, desiredReplicas)
+	return splctrl.UpdateStatefulSetPods(mgr.c, statefulSet, mgr, desiredReplicas, &mgr.cr.Status.SkipRecheckUpdate)
 }
 
 // PrepareScaleDown for searchHeadClusterPodManager prepares search head pod to be removed via scale down event; it returns true when ready

--- a/pkg/splunk/enterprise/searchheadcluster_test.go
+++ b/pkg/splunk/enterprise/searchheadcluster_test.go
@@ -294,8 +294,11 @@ func TestSearchHeadClusterPodManager(t *testing.T) {
 	extraCalls := []spltest.MockFuncCall{
 		{MetaName: "*v1.Pod-test-splunk-stack1-search-head-1"},
 		{MetaName: "*v1.Pod-test-splunk-stack1-search-head-1"},
+		{MetaName: "*v1.StatefulSet-test-splunk-stack1"},
+		{MetaName: "*v1.StatefulSet-test-splunk-stack1"},
+		{MetaName: "*v1.Pod-test-splunk-stack1-0"},
 	}
-	//funcCalls[1] = spltest.MockFuncCall{MetaName: "*v1.Pod-test-splunk-stack1-0"}
+
 	wantCalls = map[string][]spltest.MockFuncCall{"Get": {funcCalls[0], funcCalls[1], funcCalls[2]}, "Delete": pvcCalls, "Update": {funcCalls[0]}, "Create": {funcCalls[1]}}
 	wantCalls["Get"] = append(wantCalls["Get"], extraCalls...)
 	wantCalls["Get"] = append(wantCalls["Get"], pvcCalls...)
@@ -303,7 +306,7 @@ func TestSearchHeadClusterPodManager(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "pvc-etc-splunk-stack1-1", Namespace: "test"}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "pvc-var-splunk-stack1-1", Namespace: "test"}},
 	}
-	pod.ObjectMeta.Name = "splunk-stack1-2"
+	pod.ObjectMeta.Name = "splunk-stack1-0"
 	replicas = 2
 	statefulSet.Status.Replicas = 2
 	statefulSet.Status.ReadyReplicas = 2


### PR DESCRIPTION
This PR fixes the problem of unnecessary pod resets/recycles during scale up/down of splunk resources. As part of this solution, as soon as we try to scale up/down pods, we now update the `pod-revision-hash` label on pods to match `updateRevision` of StatefulSet. This prevents the recycle of pods based on `pod-revision-hash` mismatch of pods.