### PR TITLE
CSPL-592 Trigger app install on defaultsURL change

### DIFF
--- a/pkg/splunk/controller/util.go
+++ b/pkg/splunk/controller/util.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"reflect"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -164,6 +165,22 @@ func MergePodSpecUpdates(current *corev1.PodSpec, revised *corev1.PodSpec, name 
 					"current", current.Containers[idx].Resources,
 					"revised", revised.Containers[idx].Resources)
 				current.Containers[idx].Resources = revised.Containers[idx].Resources
+				result = true
+			}
+
+			// check Env
+			// Skip this check for the Monitoring Console
+			// This is temporary until the MC has it's own CR to control the MC pod env.
+			skipForMC := false
+			if strings.Contains(name, "monitoring-console") {
+				scopedLog.Info("Ignoring Pod Container Envs differences for MC pods", "name", name)
+				skipForMC = true
+			}
+			if !skipForMC && splcommon.CompareEnvs(current.Containers[idx].Env, revised.Containers[idx].Env) {
+				scopedLog.Info("Pod Container Envs differ",
+					"current", current.Containers[idx].Env,
+					"revised", revised.Containers[idx].Env)
+				current.Containers[idx].Env = revised.Containers[idx].Env
 				result = true
 			}
 		}

--- a/pkg/splunk/controller/util_test.go
+++ b/pkg/splunk/controller/util_test.go
@@ -121,6 +121,18 @@ func TestMergePodUpdates(t *testing.T) {
 	matcher = func() bool { return reflect.DeepEqual(current.Spec.Containers, revised.Spec.Containers) }
 	podUpdateTester("Container Resources")
 
+	// check pod env update
+	current.Spec.Containers[0].Env = append(current.Spec.Containers[0].Env, corev1.EnvVar{
+		Name:  "SPLUNK_DEFAULTS_URL",
+		Value: "defaults1.yaml",
+	})
+	revised.Spec.Containers[0].Env = append(revised.Spec.Containers[0].Env, corev1.EnvVar{
+		Name:  "SPLUNK_DEFAULTS_URL",
+		Value: "defaults2.yaml",
+	})
+	matcher = func() bool { return reflect.DeepEqual(current.Spec.Containers[0].Env, revised.Spec.Containers[0].Env) }
+	podUpdateTester("Pod Env changed")
+
 	// check container removed
 	revised.Spec.Containers = []corev1.Container{}
 	matcher = func() bool { return reflect.DeepEqual(current.Spec.Containers, revised.Spec.Containers) }


### PR DESCRIPTION
### Problem
When applying an updated CRD, check the environment variables and push those changes to the running pods.  For example, if the `defaultsUrl` parameter is changed in the CRD yaml and applied; the change is accepted however it is not reflected in the stateful set or the pod itself:
```
$ kubectl apply -f standalone6.yml 
standalone.enterprise.splunk.com/s6 created
$ kubectl describe pod/splunk-s6-standalone-0 
Name:         splunk-s6-standalone-0
Namespace:    default
...
Containers:
  splunk:
    Container ID:   containerd://0982abc2b231545a364eb1da6f4ac3d04358002b75942cb0c01609c7ac5bbe08
    Image:          docker.io/splunk/splunk:8.1.0
...
    Environment:
      SPLUNK_HOME:                        /opt/splunk
      SPLUNK_START_ARGS:                  --accept-license
      SPLUNK_DEFAULTS_URL:                /mnt/apps/defaults_apps2.yml,/mnt/splunk-secrets/default.yml
...
```
Edit standalone6.yml:
```
  defaultsUrl: /mnt/apps/defaults_apps.yml
```
Reapply:
```
$ kubectl apply -f standalone6.yml 
standalone.enterprise.splunk.com/s6 configured
$ kubectl describe pod/splunk-s6-standalone-0 
Name:         splunk-s6-standalone-0
Namespace:    default
Containers:
  splunk:
    Container ID:   containerd://0982abc2b231545a364eb1da6f4ac3d04358002b75942cb0c01609c7ac5bbe08
    Image:          docker.io/splunk/splunk:8.1.0
...
    Environment:
      SPLUNK_HOME:                        /opt/splunk
      SPLUNK_START_ARGS:                  --accept-license
      SPLUNK_DEFAULTS_URL:                /mnt/apps/defaults_apps2.yml,/mnt/splunk-secrets/default.yml
      SPLUNK_HOME_OWNERSHIP_ENFORCEMENT:  false
      SPLUNK_ROLE:                        splunk
```
### History
This change was actually put in place and removed during the development of the monitor console integration for separate reasons ( https://github.com/splunk/splunk-operator/commit/74abe9281640a99a826e062f14be7f8c399ed840#diff-f051fa8775a356c08c90ac411f88b50e7455ec17e8f3241a810b64eb7f00a747 ).  It was removed because it was no longer needed for the MC ( https://github.com/splunk/splunk-operator/pull/145/commits/2ca799f2c5294bc8f8950e10ef8ab38bf0ef4835 ), however it is still needed for app installation via defaults.yaml.

### Solution
When merging the changes from the pod spec, check the environment variables.  If they have changed, mark the specs as differing.

### Testing
Validated that the `defaultsUrl` parameter is propagated to the pods using the method described above.  Validate that the stateful set parameters are updated and the correct apps are installed when a new `defaults.yaml` is applied.
