### PR TITLE
Update StatefulSets on environment variable change

### DIFF
--- a/pkg/splunk/controller/util.go
+++ b/pkg/splunk/controller/util.go
@@ -149,6 +149,15 @@ func MergePodSpecUpdates(current *corev1.PodSpec, revised *corev1.PodSpec, name 
 				result = true
 			}
 
+			// check Env
+			if splcommon.CompareEnvs(current.Containers[idx].Env, revised.Containers[idx].Env) {
+				scopedLog.Info("Pod Container Env differ",
+					"current", current.Containers[idx].Env,
+					"revised", revised.Containers[idx].Env)
+				current.Containers[idx].Env = revised.Containers[idx].Env
+				result = true
+			}
+
 			// check VolumeMounts
 			if splcommon.CompareVolumeMounts(current.Containers[idx].VolumeMounts, revised.Containers[idx].VolumeMounts) {
 				scopedLog.Info("Pod Container VolumeMounts differ",

--- a/pkg/splunk/controller/util_test.go
+++ b/pkg/splunk/controller/util_test.go
@@ -102,6 +102,11 @@ func TestMergePodUpdates(t *testing.T) {
 	matcher = func() bool { return reflect.DeepEqual(current.Spec.Containers, revised.Spec.Containers) }
 	podUpdateTester("Container Ports")
 
+	// check container different Env
+	revised.Spec.Containers[0].Env = []corev1.EnvVar{{Name: "A", Value: "ab"}}
+	matcher = func() bool { return reflect.DeepEqual(current.Spec.Containers, revised.Spec.Containers) }
+	podUpdateTester("Container Env")
+
 	// check container different VolumeMounts
 	revised.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{Name: "mnt-spark"}}
 	matcher = func() bool { return reflect.DeepEqual(current.Spec.Containers, revised.Spec.Containers) }


### PR DESCRIPTION
This piece of code was actually added by @kashok-splunk in PR #120 (diff [link](https://github.com/splunk/splunk-operator/pull/120/files#diff-f051fa8775a356c08c90ac411f88b50e7455ec17e8f3241a810b64eb7f00a747)), but removed in PR #145 (diff [link](https://github.com/splunk/splunk-operator/pull/145/files#diff-f051fa8775a356c08c90ac411f88b50e7455ec17e8f3241a810b64eb7f00a747)) because it was not required anymore for its initial purpose, according to the PR comments.

However this also brought significant improvements for application load as described in issue #126. Thanks to this change, it was not required anymore to delete StatefulSets manually to trigger app deployments after updating the ```defaultsUrl``` property of ClusterMaster or SearchHeadCluster CRDs, as the change of ```SPLUNK_DEFAULTS_URL``` triggered the update of the associated StatefulSets. We were able to put a continuous deployment pipeline in place thanks to this behavior, but it does not work anymore with the operator beta version 0.2.0.

**Possible impacts**:

We noticed some impact on the monitoring-console pod, when the ```defaultsUrl``` property is defined in some ClusterMaster or SearchHeadCluster resources. As the reconciliation of any Splunk custom resource calls the code building and applying the StatefulSet of the monitoring-console, and provides its own specs to build it, having a different ```defaultsUrl``` in some ClusterMaster and/or SearchHeadCluster resources seems to cause the monitoring-console StatefulSet to be constantly updated and switching its specs... This impact seems to be limited to the usage of ```defaultsUrl```, as the other variables of the MC StatefulSet are not impacted by the custom resource spec.

This code could be bypassed in the case of a monitoring console, but as the pod metadata is not passed to this method (labels not available), this would have to be done with a loop checking for environment variable ```SPLUNK_ROLE```, which would be a bit dirty. From our perspective this solution of monitoring-console inheriting its specs from a "random" resource has many other impacts and should be reviewed, as described in #189.