### PR TITLE
App Framework POC Phase 2.5

### DIFF
--- a/pkg/apis/enterprise/v1beta1/common_types.go
+++ b/pkg/apis/enterprise/v1beta1/common_types.go
@@ -75,6 +75,27 @@ type CommonSplunkSpec struct {
 
 	// Mock to differentiate between UTs and actual reconcile
 	Mock bool `json:"Mock"`
+
+	// Application framework config details
+	ApplicationFrameworkRef ApplicationFrameworkSpec `json:"applications"`
+}
+
+// ApplicationFrameworkRef defines the application package remote store repository
+type ApplicationFrameworkSpec struct {
+	// App Package Remote Store type
+	Type string `json:"type"`
+
+	// App Package Remote Store Endpoint
+	S3Endpoint string `json:"s3Endpoint"`
+
+	// App Package Remote Store Bucket
+	S3Bucket string `json:"s3Bucket"`
+
+	// App Package Remote Store Credentials
+	S3SecretRef string `json:"s3SecretRef"`
+
+	// App Package Remote Store Polling interval
+	S3PollInternal uint `json:"s3PollInterval"`
 }
 
 // SmartStoreSpec defines Splunk indexes and remote storage volume configuration

--- a/pkg/apis/enterprise/v1beta1/common_types.go
+++ b/pkg/apis/enterprise/v1beta1/common_types.go
@@ -76,11 +76,11 @@ type CommonSplunkSpec struct {
 	// Mock to differentiate between UTs and actual reconcile
 	Mock bool `json:"Mock"`
 
-	// Application framework config details
+	// ApplicationFrameworkRef refers to the config block for App Framework
 	ApplicationFrameworkRef ApplicationFrameworkSpec `json:"applications"`
 }
 
-// ApplicationFrameworkRef defines the application package remote store repository
+// ApplicationFrameworkSpec defines the application package remote store repository
 type ApplicationFrameworkSpec struct {
 	// App Package Remote Store type
 	Type string `json:"type"`

--- a/pkg/splunk/controller/util.go
+++ b/pkg/splunk/controller/util.go
@@ -186,6 +186,17 @@ func MergePodSpecUpdates(current *corev1.PodSpec, revised *corev1.PodSpec, name 
 		}
 	}
 
+	// This is for the app download init container so it comes up with updated apps config.
+	for idx := range current.InitContainers {
+		if splcommon.CompareEnvs(current.InitContainers[idx].Env, revised.InitContainers[idx].Env) {
+			scopedLog.Info("Pod Init Container Envs differ",
+				"current", current.InitContainers[idx].Env,
+				"revised", revised.InitContainers[idx].Env)
+			current.InitContainers[idx].Env = revised.InitContainers[idx].Env
+			result = true
+		}
+	}
+
 	return result
 }
 

--- a/pkg/splunk/enterprise/names.go
+++ b/pkg/splunk/enterprise/names.go
@@ -73,6 +73,9 @@ const (
 
 	//smartstoreconfigToken used to track if the config is reflecting on Pod or not
 	configToken = "conftoken"
+
+	// application bucket mount location for init container, sidecar, and Splunk containers
+	appBktMnt = "/init-apps"
 )
 
 // GetSplunkDeploymentName uses a template to name a Kubernetes Deployment for Splunk instances.

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -130,6 +130,13 @@ func ApplyStandalone(client splcommon.ControllerClient, cr *enterprisev1.Standal
 			return result, err
 		}
 		result.Requeue = false
+		// Requeue this if apps are present at the polling interval time and always check
+		// the apps in S3 during Reconcile.
+		// TODO JR: Evaluate if we should do this.  Any ramifications of keeping this in the Reconcile queue.
+		if cr.Spec.ApplicationFrameworkRef.Type != "" {
+			result.Requeue = true
+			result.RequeueAfter = time.Second * time.Duration(cr.Spec.ApplicationFrameworkRef.S3PollInternal)
+		}
 	}
 	return result, nil
 }

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -51,7 +51,7 @@ func ApplySplunkConfig(client splcommon.ControllerClient, cr splcommon.MetaObjec
 
 	// create splunk defaults (for inline config)
 	if spec.Defaults != "" || spec.ApplicationFrameworkRef.Type != "" {
-		// TODO JR: Do we need to throttle this call since its in th reconcile loop and gets called every 5 seconds when 
+		// TODO JR: Do we need to throttle this call since its in the reconcile loop and gets called every 5 seconds when
 		//          CR is in NotReady phase
 		defaultsApps, installedApps := GetAppListFromS3Bucket(client, cr, &spec.ApplicationFrameworkRef)
 		scopedLog := log.WithName("updateSplunkPodTemplateWithConfig").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())


### PR DESCRIPTION
This commit adds the ability to install application packages to a given CR
from an S3 compatible bucket.

Adds the following configs to the CRDs:
```
spec:
  applications:
    type: s3
    s3Endpoint: "http://remote-store-endpoint"
    s3Bucket: "bkt_name"
    s3SecretRef: mySecret
    s3PollInterval: 60
```
Downloads all apps in the bucket via a custom init container to a shared
host mount on the Splunk instance pod.  The operator also connects to
the remote store to get the list of applications to be installed and
places those in a `default_apps.yml` file in the CR's default ConfigMap.

The application packages and their modtimes are also stored in the
CR's default ConfigMap in CSV format and in running memory in the
operator.  This is done to compare subsequent lists of the buckets
object to see if any package has been updated.

The operator also polls the S3 bucket at the polling interval to check for
changes.  If a change is detected, the ConfigMap is changed causing the
CR to recycle and pick up the new changes.  Apps there then installed
via Ansible at pod startup.

The init container image is a custom build image that is loaded onto the
k8 cluster prior to using any CRD with an applications config block.  The
image uses the minio s3 compatible client binary to download the bucket.
The Dockerfile to build this image is:
```
FROM alpine

ENV AWS_ACCESS_KEY_ID ''
ENV AWS_SECRET_ACCESS_KEY ''
ENV MC_CONFIG_DIR '/tmp'

RUN \
  apk update && \
  apk add --no-cache wget && \
  wget -O /tmp/mc https://dl.min.io/client/mc/release/linux-amd64/mc && \
  mkdir /tmp/.mc && \
  chmod +x /tmp/mc

CMD ["sh", "-c", "cd /tmp; /tmp/mc alias set appbkt $S3_ENDPOINT $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY; /tmp/mc cp --recursive appbkt/$S3_BUCKET $MNT_POINT"]
```
While app installation should work for all CRs, the S3 polling is currently
only used by standalone CRs.