### PR TITLE
correct example YAML in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -81,7 +81,7 @@ The `Standalone` custom resource is used to create a single instance deployment 
 
 ```yaml
 cat <<EOF | kubectl apply -f -
-apiVersion: enterprise.splunk.com/v1
+apiVersion: enterprise.splunk.com/v1beta1
 kind: Standalone
 metadata:
   name: s1


### PR DESCRIPTION
The file mentioned on line 60 doesn't have v1 versions of resources - recommend changing this to v1beta1 until the operator install script is updated.