### PR TITLE
CSPL-931: Fix failing secret test

### DIFF
--- a/test/custom_resource_crud/custom_resource_crud_test.go
+++ b/test/custom_resource_crud/custom_resource_crud_test.go
@@ -18,6 +18,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 	"github.com/splunk/splunk-operator/test/testenv"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -69,7 +70,7 @@ var _ = Describe("crcrud test", func() {
 			Expect(err).To(Succeed(), "Unable to deploy standalone instance with updated CR ")
 
 			// Verify Standalone is updating
-			testenv.VerifyStandaloneUpdating(deployment, deployment.GetName(), standalone, testenvInstance)
+			testenv.VerifyStandalonePhase(deployment, testenvInstance, deployment.GetName(), splcommon.PhaseUpdating)
 
 			// Verify Standalone goes to ready state
 			testenv.StandaloneReady(deployment, deployment.GetName(), standalone, testenvInstance)


### PR DESCRIPTION
Fixed the following issues with the secret test:
* GetSecretObject throwing parsing error on unmarshall. Modify the get secret command to get json string output that can be unmarshalled.
* Multiple Log.Info issues (Odd keys value pairs provided resulting in errors during runtime)
* No assertion in Verification methods ( Test are not failing on key mismatch)
* No Update Phase check after new secret are applied resulting in failures due to incorrect phase.
* Incorrect Secret response struct.
* Incorrect parameter names defined for method **VerifySecretObjectUpdate**
* Removed redundant phase check method ( Not related to secret test)
* Added support for verification for **password, idxc_support, pass4symmkey, shc_secret**
* Added proper checks for Splunk Environment to go to Ready Phase