### PR TITLE
Cspl 545: Secret object Delete scenario with standalone deployment

### DIFF
--- a/test/testenv/deployment.go
+++ b/test/testenv/deployment.go
@@ -277,6 +277,13 @@ func (d *Deployment) DeleteCR(cr runtime.Object) error {
 	return err
 }
 
+// DeleteCR method to delete existing CR spec
+func (d *Deployment) DeleteCR(cr runtime.Object) error {
+
+	err := d.testenv.GetKubeClient().Delete(context.TODO(), cr)
+	return err
+}
+
 // DeploySingleSiteCluster deploys a lm and indexer cluster (shc optional)
 func (d *Deployment) DeploySingleSiteCluster(name string, indexerReplicas int, shc bool) error {
 

--- a/test/testenv/deployment.go
+++ b/test/testenv/deployment.go
@@ -277,13 +277,6 @@ func (d *Deployment) DeleteCR(cr runtime.Object) error {
 	return err
 }
 
-// DeleteCR method to delete existing CR spec
-func (d *Deployment) DeleteCR(cr runtime.Object) error {
-
-	err := d.testenv.GetKubeClient().Delete(context.TODO(), cr)
-	return err
-}
-
 // DeploySingleSiteCluster deploys a lm and indexer cluster (shc optional)
 func (d *Deployment) DeploySingleSiteCluster(name string, indexerReplicas int, shc bool) error {
 

--- a/test/testenv/verificationutils.go
+++ b/test/testenv/verificationutils.go
@@ -441,6 +441,36 @@ func VerifySecretsUpdatedOnPod(deployment *Deployment, testenvInstance *TestEnv,
 	}
 }
 
+// VerifyNewSecretValueOnVersionedSecretObject Check whether the new versioned secret object is created with new value
+func VerifyNewSecretValueOnVersionedSecretObject(deployment *Deployment, testenvInstance *TestEnv, verificationSecrets []string, secretKey string, previousValue string) {
+	for _, secretObject := range verificationSecrets {
+		found := false
+		currentValue := GetSecretKey(deployment, testenvInstance.GetName(), secretKey, secretObject)
+		if currentValue == previousValue {
+			testenvInstance.Log.Info("New Key Not created ", "Secret Object Name", secretObject, "Secret Key", secretKey, "Previous Value of Key", previousValue, "Key Value found", currentValue)
+		} else {
+			testenvInstance.Log.Info("New key created ", "Secret Object Name", secretObject, "Secret Key", secretKey, "Previous Value of Key", previousValue, "Key Value found", currentValue)
+			found = true
+		}
+		gomega.Expect(found).Should(gomega.Equal(true))
+	}
+}
+
+// VerifyNewVersionedSecretValueUpdatedOnPod Check whether the new secret object value is mounted on all pods
+func VerifyNewVersionedSecretValueUpdatedOnPod(deployment *Deployment, testenvInstance *TestEnv, verificationPods []string, secretKey string, previousValue string) {
+	for _, pod := range verificationPods {
+		found := false
+		currentValue := GetMountedKey(deployment, pod, secretKey)
+		if currentValue == previousValue {
+			testenvInstance.Log.Info("New Key not updated on pod", "Pod Name ", pod, "Secret Key", secretKey, "Previous Value of Key", previousValue, "Key Value found", currentValue)
+		} else {
+			testenvInstance.Log.Info("New Key verified on pod", "Pod Name ", pod, "Secret Key", secretKey, "Previous Value of Key", previousValue, "Key Value found", currentValue)
+			found = true
+		}
+		gomega.Expect(found).Should(gomega.Equal(true))
+	}
+}
+
 // VerifyClusterMasterPhase verify phase of cluster master
 func VerifyClusterMasterPhase(deployment *Deployment, testenvInstance *TestEnv, phase splcommon.Phase) {
 	cm := &enterprisev1.ClusterMaster{}


### PR DESCRIPTION
## Splunk SVA Covered
* S1 ( Standalone)

## Test Scenario:
* Setup the Test SVA
* Delete the splunk secret object  / Delete Secret Data in Secret Object
* Verify a new splunk secret object is created
* Wait of Splunk Pods to recycle
* Verify new HEC token, admin password, idxc_secret, shc_secret, pass4SymmKey is present on the new versioned secret
* Verify new HEC token, admin password, idxc_secret, shc_secret, pass4SymmKey is mounted on the PODs

**Added delete only for Standalone as deleting the secrets leads to pod recycling which takes around 20-30 mins on C3 and M4**

## Test Results

```
[1] secret test
[1] /Users/tpereira/Git/splunk-operator/test/secret/secret_test.go:26
[1]   Multisite cluster deployment (M13 - Multisite indexer cluster, Search head cluster)
[1]   /Users/tpereira/Git/splunk-operator/test/secret/secret_test.go:299
[1]     secret: secret update on multisite indexers and search head cluster
[1]     /Users/tpereira/Git/splunk-operator/test/secret/secret_test.go:300
[1] ------------------------------
[1] {"level":"info","ts":1616459710.788005,"msg":"testenv deleted.\n","testenv":"secret-mb"}
[1]
[1] JUnit report was created: /Users/tpereira/Git/splunk-operator/test/secret/secret-mb_junit.xml
[1]
[1] Ran 2 of 2 Specs in 3583.450 seconds
[1] SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped
[1] PASS
```

```
[2] secret test
[2] /Users/tpereira/Git/splunk-operator/test/secret/secret_test.go:26
[2]   Standalone deployment (S1) with LM
[2]   /Users/tpereira/Git/splunk-operator/test/secret/secret_test.go:46
[2]     secret: Secret update on a standalone instance
[2]     /Users/tpereira/Git/splunk-operator/test/secret/secret_test.go:47
[2] ------------------------------
[2] {"level":"info","ts":1616529304.866903,"msg":"testenv deleted.\n","testenv":"secret-yn"}
[2]
[2] JUnit report was created: /Users/tpereira/Git/splunk-operator/test/secret/secret-yn_junit.xml
[2]
[2] Ran 1 of 1 Specs in 1100.302 seconds
[2] SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[2] PASS```