### PR TITLE
CSPL-780 Deployer PVCs Not Deleted

### DIFF
--- a/pkg/splunk/enterprise/finalizers_test.go
+++ b/pkg/splunk/enterprise/finalizers_test.go
@@ -95,6 +95,18 @@ func splunkDeletionTester(t *testing.T, cr splcommon.MetaObject, delete func(spl
 				{ListOpts: listOptsA},
 				{ListOpts: listOptsB},
 			}
+			// account for extra calls in the shc case due to the deployer
+			if component == "search-head" {
+				labelsC := map[string]string{
+					"app.kubernetes.io/instance": fmt.Sprintf("splunk-%s-%s", cr.GetName(), "deployer"),
+				}
+				listOptsC := []client.ListOption{
+					client.InNamespace(cr.GetNamespace()),
+					client.MatchingLabels(labelsC),
+				}
+				mockCalls["Delete"] = append(mockCalls["Delete"], spltest.MockFuncCall{MetaName: "*v1.PersistentVolumeClaim-test-splunk-pvc-stack1-var"})
+				mockCalls["List"] = append(mockCalls["List"], spltest.MockFuncCall{ListOpts: listOptsC})
+			}
 			mockCalls["Get"] = []spltest.MockFuncCall{
 				{MetaName: "*v1.StatefulSet-test-splunk-test-monitoring-console"},
 				{MetaName: "*v1.Secret-test-splunk-test-secret"},


### PR DESCRIPTION
When deleting SHC custom resources we would only delete PVCs with the "search-head" descriptor and ignore those with the "deployer" descriptor despite them both being created by the same custom resource.

Fix: When deleting SHC custom resources, delete PVCs for both the "search-head" and "deployer" components.