### PR TITLE
CSPL-950-add-test-case-to-verify-mc-with-multiple-cr-with-different-r…

### DIFF
--- a/test/monitoring_console/monitoring_console_test.go
+++ b/test/monitoring_console/monitoring_console_test.go
@@ -23,6 +23,8 @@ import (
 	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1"
 	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 	"github.com/splunk/splunk-operator/test/testenv"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 var _ = Describe("Monitoring Console test", func() {
@@ -75,8 +77,27 @@ var _ = Describe("Monitoring Console test", func() {
 			// Add another standalone instance in namespace
 			testenvInstance.Log.Info("Adding second standalone deployment to namespace")
 			// CSPL-901 standaloneTwoName := deployment.GetName() + "-two"
-			standaloneTwoName := "standalone-" + testenv.RandomDNSName(2)
-			standaloneTwo, err := deployment.DeployStandalone(standaloneTwoName)
+			standaloneTwoName := "standalone-" + testenv.RandomDNSName(3)
+			// Configure Resources on second standalone CSPL-555
+			standaloneTwoSpec := enterprisev1.StandaloneSpec{
+				CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
+					Spec: splcommon.Spec{
+						ImagePullPolicy: "IfNotPresent",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"cpu":    resource.MustParse("2"),
+								"memory": resource.MustParse("4Gi"),
+							},
+							Requests: corev1.ResourceList{
+								"cpu":    resource.MustParse("0.2"),
+								"memory": resource.MustParse("256Mi"),
+							},
+						},
+					},
+					Volumes: []corev1.Volume{},
+				},
+			}
+			standaloneTwo, err := deployment.DeployStandalonewithGivenSpec(standaloneTwoName, standaloneTwoSpec)
 			Expect(err).To(Succeed(), "Unable to deploy standalone instance ")
 
 			// Wait for standalone two to be in READY status
@@ -99,6 +120,26 @@ var _ = Describe("Monitoring Console test", func() {
 			Expect(testenv.CheckPodNameOnMC(testenvInstance.GetName(), podNameOne), true)
 			testenvInstance.Log.Info("Checking Standalone on MC", "Standalone POD Name", podNameTwo)
 			Expect(testenv.CheckPodNameOnMC(testenvInstance.GetName(), podNameTwo), true)
+
+			// Delete Standlone TWO of the standalone and ensure MC is updated
+			testenvInstance.Log.Info("Deleting second standalone deployment to namespace", "Standalone Name", standaloneTwoName)
+			deployment.GetInstance(standaloneTwoName, standaloneTwo)
+			err = deployment.DeleteCR(standaloneTwo)
+			Expect(err).To(Succeed(), "Unable to delete standalone instance", "Standalone Name", standaloneTwo)
+
+			// Wait for Monitoring Console Pod to be in READY status
+			testenv.MCPodReady(testenvInstance.GetName(), deployment)
+
+			// Check Monitoring console is configured with all standalone instances in namespace
+			peerList = testenv.GetConfiguredPeers(testenvInstance.GetName())
+			testenvInstance.Log.Info("Peer List", "instance", peerList)
+
+			// Only 1 peer expected in MC peer list
+			Expect(len(peerList)).To(Equal(1))
+
+			podName = fmt.Sprintf(testenv.StandalonePod, standaloneOneName, 0)
+			testenvInstance.Log.Info("Check standalone instance in MC Peer list", "Standalone Pod", podName, "Peer in peer list", peerList[0])
+			Expect(strings.Contains(peerList[0], podName)).To(Equal(true))
 		})
 	})
 

--- a/test/testenv/deployment.go
+++ b/test/testenv/deployment.go
@@ -270,6 +270,13 @@ func (d *Deployment) UpdateCR(cr runtime.Object) error {
 	return err
 }
 
+// DeleteCR deletes the given CR
+func (d *Deployment) DeleteCR(cr runtime.Object) error {
+
+	err := d.testenv.GetKubeClient().Delete(context.TODO(), cr)
+	return err
+}
+
 // DeploySingleSiteCluster deploys a lm and indexer cluster (shc optional)
 func (d *Deployment) DeploySingleSiteCluster(name string, indexerReplicas int, shc bool) error {
 


### PR DESCRIPTION
## Test Scenario 
* Create a standalone with default resource spec
* Wait for standalone and mc to go to ready state
* Create a second standalone with following resource spec
* Wait for seconds standalone to go ready state
* Wait for MC to go to ready state
* Verify both standalone configured on MC
* Delete second standalone
* Verify MC goes to ready state 
* Verify MC is updated

## Passing Run 
```
[1] • [SLOW TEST:396.793 seconds]
[1] Monitoring Console test
[1] /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:30
[1]   Standalone deployment (S1)
[1]   /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:53
[1]     monitoring_console: can deploy a MC with standalone instance and update MC with new standalone deployment
[1]     /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:54
[1] ------------------------------
[1] {"level":"info","ts":1616550639.5238452,"msg":"testenv deleted.\n","testenv":"mc-wl"}
[1] 
[1] JUnit report was created: /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/mc-wl_junit.xml
[1] 
[1] Ran 1 of 1 Specs in 403.298 seconds
[1] SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[1] PASS

Ginkgo ran 1 suite in 6m47.458691423s
Test Suite Passed```