### PR TITLE
CSPL-947: Added admin password verification on splunk instance

### DIFF
--- a/test/licensemaster/lm_c3_test.go
+++ b/test/licensemaster/lm_c3_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2018-2021 Splunk Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package licensemaster
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/splunk/splunk-operator/test/testenv"
+)
+
+var _ = Describe("Licensemaster test", func() {
+
+	var deployment *testenv.Deployment
+
+	BeforeEach(func() {
+		var err error
+		deployment, err = testenvInstance.NewDeployment(testenv.RandomDNSName(3))
+		Expect(err).To(Succeed(), "Unable to create deployment")
+	})
+
+	AfterEach(func() {
+		// When a test spec failed, skip the teardown so we can troubleshoot.
+		if CurrentGinkgoTestDescription().Failed {
+			testenvInstance.SkipTeardown = true
+		}
+		if deployment != nil {
+			deployment.Teardown()
+		}
+	})
+
+	Context("Clustered deployment (C3 - clustered indexer, search head cluster)", func() {
+		It("licensemaster, integration: Splunk Operator can configure License Master with Indexers and Search Heads in C3 SVA", func() {
+
+			// Download License File
+			licenseFilePath, err := testenv.DownloadFromS3Bucket()
+			Expect(err).To(Succeed(), "Unable to download license file")
+
+			// Create License Config Map
+			testenvInstance.CreateLicenseConfigMap(licenseFilePath)
+
+			err = deployment.DeploySingleSiteCluster(deployment.GetName(), 3, true /*shc*/)
+			Expect(err).To(Succeed(), "Unable to deploy cluster")
+
+			// Ensure that the cluster-master goes to Ready phase
+			testenv.ClusterMasterReady(deployment, testenvInstance)
+
+			// Ensure indexers go to Ready phase
+			testenv.SingleSiteIndexersReady(deployment, testenvInstance)
+
+			// Ensure search head cluster go to Ready phase
+			testenv.SearchHeadClusterReady(deployment, testenvInstance)
+
+			// Verify MC Pod is Ready
+			testenv.MCPodReady(testenvInstance.GetName(), deployment)
+
+			// Verify RF SF is met
+			testenv.VerifyRFSFMet(deployment, testenvInstance)
+
+			// Verify LM is configured on indexers
+			indexerPodName := fmt.Sprintf(testenv.IndexerPod, deployment.GetName(), 0)
+			testenv.VerifyLMConfiguredOnPod(deployment, indexerPodName)
+			indexerPodName = fmt.Sprintf(testenv.IndexerPod, deployment.GetName(), 1)
+			testenv.VerifyLMConfiguredOnPod(deployment, indexerPodName)
+			indexerPodName = fmt.Sprintf(testenv.IndexerPod, deployment.GetName(), 2)
+			testenv.VerifyLMConfiguredOnPod(deployment, indexerPodName)
+
+			// Verify LM is configured on SHs
+			searchHeadPodName := fmt.Sprintf(testenv.SearchHeadPod, deployment.GetName(), 0)
+			testenv.VerifyLMConfiguredOnPod(deployment, searchHeadPodName)
+			searchHeadPodName = fmt.Sprintf(testenv.SearchHeadPod, deployment.GetName(), 1)
+			testenv.VerifyLMConfiguredOnPod(deployment, searchHeadPodName)
+			searchHeadPodName = fmt.Sprintf(testenv.SearchHeadPod, deployment.GetName(), 2)
+			testenv.VerifyLMConfiguredOnPod(deployment, searchHeadPodName)
+		})
+	})
+})

--- a/test/licensemaster/lm_m4_test.go
+++ b/test/licensemaster/lm_m4_test.go
@@ -42,52 +42,6 @@ var _ = Describe("Licensemaster test", func() {
 		}
 	})
 
-	Context("Clustered deployment (C3 - clustered indexer, search head cluster)", func() {
-		It("licensemaster, integration: Splunk Operator can configure License Master with Indexers and Search Heads in C3 SVA", func() {
-
-			// Download License File
-			licenseFilePath, err := testenv.DownloadFromS3Bucket()
-			Expect(err).To(Succeed(), "Unable to download license file")
-
-			// Create License Config Map
-			testenvInstance.CreateLicenseConfigMap(licenseFilePath)
-
-			err = deployment.DeploySingleSiteCluster(deployment.GetName(), 3, true /*shc*/)
-			Expect(err).To(Succeed(), "Unable to deploy cluster")
-
-			// Ensure that the cluster-master goes to Ready phase
-			testenv.ClusterMasterReady(deployment, testenvInstance)
-
-			// Ensure indexers go to Ready phase
-			testenv.SingleSiteIndexersReady(deployment, testenvInstance)
-
-			// Ensure search head cluster go to Ready phase
-			testenv.SearchHeadClusterReady(deployment, testenvInstance)
-
-			// Verify MC Pod is Ready
-			testenv.MCPodReady(testenvInstance.GetName(), deployment)
-
-			// Verify RF SF is met
-			testenv.VerifyRFSFMet(deployment, testenvInstance)
-
-			// Verify LM is configured on indexers
-			indexerPodName := fmt.Sprintf(testenv.IndexerPod, deployment.GetName(), 0)
-			testenv.VerifyLMConfiguredOnPod(deployment, indexerPodName)
-			indexerPodName = fmt.Sprintf(testenv.IndexerPod, deployment.GetName(), 1)
-			testenv.VerifyLMConfiguredOnPod(deployment, indexerPodName)
-			indexerPodName = fmt.Sprintf(testenv.IndexerPod, deployment.GetName(), 2)
-			testenv.VerifyLMConfiguredOnPod(deployment, indexerPodName)
-
-			// Verify LM is configured on SHs
-			searchHeadPodName := fmt.Sprintf(testenv.SearchHeadPod, deployment.GetName(), 0)
-			testenv.VerifyLMConfiguredOnPod(deployment, searchHeadPodName)
-			searchHeadPodName = fmt.Sprintf(testenv.SearchHeadPod, deployment.GetName(), 1)
-			testenv.VerifyLMConfiguredOnPod(deployment, searchHeadPodName)
-			searchHeadPodName = fmt.Sprintf(testenv.SearchHeadPod, deployment.GetName(), 2)
-			testenv.VerifyLMConfiguredOnPod(deployment, searchHeadPodName)
-		})
-	})
-
 	Context("Multisite cluster deployment (M4 - Multisite indexer cluster, Search head cluster)", func() {
 		It("licensemaster: Splunk Operator can configure license master with indexers and search head in M4 SVA", func() {
 
@@ -138,32 +92,4 @@ var _ = Describe("Licensemaster test", func() {
 		})
 	})
 
-	Context("Standalone deployment (S1) with LM", func() {
-		It("licensemaster: Splunk Operator can configure License Master with Standalone in S1 SVA", func() {
-
-			// Download License File
-			licenseFilePath, err := testenv.DownloadFromS3Bucket()
-			Expect(err).To(Succeed(), "Unable to download license file")
-
-			// Create License Config Map
-			testenvInstance.CreateLicenseConfigMap(licenseFilePath)
-
-			// Create standalone Deployment with License Master
-			standalone, err := deployment.DeployStandaloneWithLM(deployment.GetName())
-			Expect(err).To(Succeed(), "Unable to deploy standalone instance with LM")
-
-			// Wait for License Master to be in READY status
-			testenv.LicenseMasterReady(deployment, testenvInstance)
-
-			// Wait for Standalone to be in READY status
-			testenv.StandaloneReady(deployment, deployment.GetName(), standalone, testenvInstance)
-
-			// Verify MC Pod is Ready
-			testenv.MCPodReady(testenvInstance.GetName(), deployment)
-
-			// Verify LM is configured on standalone instance
-			standalonePodName := fmt.Sprintf(testenv.StandalonePod, deployment.GetName(), 0)
-			testenv.VerifyLMConfiguredOnPod(deployment, standalonePodName)
-		})
-	})
 })

--- a/test/licensemaster/lm_s1_test.go
+++ b/test/licensemaster/lm_s1_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2018-2021 Splunk Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package licensemaster
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/splunk/splunk-operator/test/testenv"
+)
+
+var _ = Describe("Licensemaster test", func() {
+
+	var deployment *testenv.Deployment
+
+	BeforeEach(func() {
+		var err error
+		deployment, err = testenvInstance.NewDeployment(testenv.RandomDNSName(3))
+		Expect(err).To(Succeed(), "Unable to create deployment")
+	})
+
+	AfterEach(func() {
+		// When a test spec failed, skip the teardown so we can troubleshoot.
+		if CurrentGinkgoTestDescription().Failed {
+			testenvInstance.SkipTeardown = true
+		}
+		if deployment != nil {
+			deployment.Teardown()
+		}
+	})
+
+	Context("Standalone deployment (S1) with LM", func() {
+		It("licensemaster: Splunk Operator can configure License Master with Standalone in S1 SVA", func() {
+
+			// Download License File
+			licenseFilePath, err := testenv.DownloadFromS3Bucket()
+			Expect(err).To(Succeed(), "Unable to download license file")
+
+			// Create License Config Map
+			testenvInstance.CreateLicenseConfigMap(licenseFilePath)
+
+			// Create standalone Deployment with License Master
+			standalone, err := deployment.DeployStandaloneWithLM(deployment.GetName())
+			Expect(err).To(Succeed(), "Unable to deploy standalone instance with LM")
+
+			// Wait for License Master to be in READY status
+			testenv.LicenseMasterReady(deployment, testenvInstance)
+
+			// Wait for Standalone to be in READY status
+			testenv.StandaloneReady(deployment, deployment.GetName(), standalone, testenvInstance)
+
+			// Verify MC Pod is Ready
+			testenv.MCPodReady(testenvInstance.GetName(), deployment)
+
+			// Verify LM is configured on standalone instance
+			standalonePodName := fmt.Sprintf(testenv.StandalonePod, deployment.GetName(), 0)
+			testenv.VerifyLMConfiguredOnPod(deployment, standalonePodName)
+		})
+	})
+})

--- a/test/secret/secret_c3_test.go
+++ b/test/secret/secret_c3_test.go
@@ -50,7 +50,8 @@ var _ = Describe("Secret Test for SVA C3", func() {
 			1. Update Secrets Data
 			2. Verify New versioned secret are created with correct value.
 			3. Verify new secrets are mounted on pods.
-			4. Verify New Secrets are present in server.conf (Pass4SymmKey) */
+			4. Verify New Secrets are present in server.conf (Pass4SymmKey)
+			5. Verify New Secrets via api access (password)*/
 
 			// Download License File
 			licenseFilePath, err := testenv.DownloadFromS3Bucket()
@@ -130,6 +131,8 @@ var _ = Describe("Secret Test for SVA C3", func() {
 			// Verify Pass4SymmKey Secrets on ServerConf on MC, LM Pods
 			testenv.VerifySplunkServerConfSecrets(deployment, testenvInstance, verificationPods, updatedSecretData, true)
 
+			// Verify Secrets via api access on Pod
+			testenv.VerifySplunkSecretViaAPI(deployment, testenvInstance, verificationPods, updatedSecretData, true)
 		})
 	})
 })

--- a/test/secret/secret_m4_test.go
+++ b/test/secret/secret_m4_test.go
@@ -50,7 +50,8 @@ var _ = Describe("Secret Test for M4 SVA", func() {
 			1. Update Secrets Data
 			2. Verify New versioned secret are created with correct value.
 			3. Verify new secrets are mounted on pods.
-			4. Verify New Secrets are present in server.conf (Pass4SymmKey) */
+			4. Verify New Secrets are present in server.conf (Pass4SymmKey)
+			5. Verify New Secrets via api access (password)*/
 
 			// Download License File
 			licenseFilePath, err := testenv.DownloadFromS3Bucket()
@@ -91,6 +92,7 @@ var _ = Describe("Secret Test for M4 SVA", func() {
 			// Verify New versioned secret are created with correct value.
 			// Verify new secrets are mounted on pods.
 			// Verify New Secrets are present in server.conf (Pass4SymmKey)
+			// Verify New Secrets via api access (password)*/
 
 			// Update Secret Value on Secret Object
 			testenvInstance.Log.Info("Data in secret object", "data", secretStruct.Data)
@@ -133,6 +135,9 @@ var _ = Describe("Secret Test for M4 SVA", func() {
 
 			// Verify Pass4SymmKey Secrets on ServerConf on MC, LM Pods
 			testenv.VerifySplunkServerConfSecrets(deployment, testenvInstance, verificationPods, updatedSecretData, true)
+
+			// Verify Secrets via api access on Pod
+			testenv.VerifySplunkSecretViaAPI(deployment, testenvInstance, verificationPods, updatedSecretData, true)
 		})
 	})
 })

--- a/test/secret/secret_s1_test.go
+++ b/test/secret/secret_s1_test.go
@@ -50,7 +50,8 @@ var _ = Describe("Secret Test for SVA S1", func() {
 			1. Update Secrets Data
 			2. Verify New versioned secret are created with correct value.
 			3. Verify new secrets are mounted on pods.
-			4.  Verify New Secrets are present in server.conf (Pass4SymmKey) */
+			4. Verify New Secrets are present in server.conf (Pass4SymmKey)
+			5. Verify New Secrets via api access (password)*/
 
 			// Download License File
 			licenseFilePath, err := testenv.DownloadFromS3Bucket()
@@ -113,6 +114,9 @@ var _ = Describe("Secret Test for SVA S1", func() {
 			// Verify Secrets on ServerConf on Pod
 			testenv.VerifySplunkServerConfSecrets(deployment, testenvInstance, verificationPods, updatedSecretData, true)
 
+			// Verify Secrets via api access on Pod
+			testenv.VerifySplunkSecretViaAPI(deployment, testenvInstance, verificationPods, updatedSecretData, true)
+
 		})
 	})
 
@@ -123,7 +127,8 @@ var _ = Describe("Secret Test for SVA S1", func() {
 			1. Delete Secret Object
 			2. Verify New versioned secret are created with new values.
 			3. Verify New secrets are mounted on pods.
-			4.  Verify New Secrets are present in server.conf (Pass4SymmKey) */
+			4. Verify New Secrets are present in server.conf (Pass4SymmKey)
+			5. Verify New Secrets via api access (password)*/
 
 			// Download License File
 			licenseFilePath, err := testenv.DownloadFromS3Bucket()
@@ -181,6 +186,9 @@ var _ = Describe("Secret Test for SVA S1", func() {
 
 			// Verify Secrets on ServerConf on Pod
 			testenv.VerifySplunkServerConfSecrets(deployment, testenvInstance, verificationPods, secretStruct.Data, false)
+
+			// Verify Secrets via api access on Pod
+			testenv.VerifySplunkSecretViaAPI(deployment, testenvInstance, verificationPods, secretStruct.Data, false)
 		})
 	})
 
@@ -191,7 +199,8 @@ var _ = Describe("Secret Test for SVA S1", func() {
 			1. Delete Secret Passing Empty Data Map to secret Object
 			2. Verify New versioned secret are created with new values.
 			3. Verify New secrets are mounted on pods.
-			4. Verify New Secrets are present in server.conf (Pass4SymmKey) */
+			4. Verify New Secrets are present in server.conf (Pass4SymmKey)
+			5. Verify New Secrets via api access (password)*/
 
 			// Create standalone Deployment with License Master
 			standalone, err := deployment.DeployStandalone(deployment.GetName())
@@ -237,6 +246,8 @@ var _ = Describe("Secret Test for SVA S1", func() {
 			// Verify Secrets on ServerConf on Pod
 			testenv.VerifySplunkServerConfSecrets(deployment, testenvInstance, verificationPods, secretStruct.Data, false)
 
+			// Verify Secrets via api access on Pod
+			testenv.VerifySplunkSecretViaAPI(deployment, testenvInstance, verificationPods, secretStruct.Data, false)
 		})
 	})
 })

--- a/test/testenv/secretutil.go
+++ b/test/testenv/secretutil.go
@@ -159,3 +159,18 @@ func GetSecretDataMap(hecToken string, password string, pass4SymmKey string, idx
 	}
 	return updatedSecretData
 }
+
+// CheckAdminPasswordViaAPI check if password can be used to access api
+func CheckAdminPasswordViaAPI(deployment *Deployment, podName string, password string) bool {
+	cmd := fmt.Sprintf("curl -iks -u admin:%s https://localhost:8089/servicesNS/admin/splunk_httpinput/data/inputs/http?output_mode=json", password)
+	output, err := ExecuteCommandOnPod(deployment, podName, cmd)
+	if err != nil {
+		return false
+	}
+	response := strings.Split(string(output), "\n")
+	if strings.Contains(response[0], "HTTP/1.1 200 OK") {
+		logf.Log.Info("200 OK response found", "pod", podName)
+		return true
+	}
+	return false
+}

--- a/test/testenv/util.go
+++ b/test/testenv/util.go
@@ -521,3 +521,15 @@ func GetConfLineFromPod(podName string, filePath string, ns string, configName s
 	}
 	return config, err
 }
+
+// ExecuteCommandOnPod execute command on given pod and return result
+func ExecuteCommandOnPod(deployment *Deployment, podName string, stdin string) (string, error) {
+	command := []string{"/bin/sh"}
+	stdout, stderr, err := deployment.PodExecCommand(podName, command, stdin, false)
+	if err != nil {
+		logf.Log.Error(err, "Failed to execute command on pod", "pod", podName, "command", command)
+		return "", err
+	}
+	logf.Log.Info("Command executed on pod", "pod", podName, "command", command, "stdin", stdin, "stdout", stdout, "stderr", stderr)
+	return stdout, nil
+}


### PR DESCRIPTION
# Changes

- Added admin password verification to secret object update and delete cases
- Split Licensemaster test case's into individual files based on SVA

Note: Hec_token would also be verified as part of secret object update api access key. Will be added later

**Test Scenarios**: (SVA's covered: S1)
Delete secret data
Verify New versioned secret are created with correct value.
Verify new secrets are mounted on pods.
Verify old Secrets cannot be used for api access (password)

**Test Scenarios**: (SVA's covered: S1, C3, M4)
Update Secrets Data
Verify New versioned secret are created with correct value.
Verify new secrets are mounted on pods.
Verify New Secrets are present in server.conf 
Verify New updated Secrets via api access (password)

# Passing Test Runs
**Secret**
C3/M4 Modify
```
[2] • [SLOW TEST:1906.794 seconds]
[2] Secret Test for M4 SVA
[2] /Users/tpereira/Git/splunk-operator/test/secret/secret_m4_test.go:26
[2]   Multisite cluster deployment (M13 - Multisite indexer cluster, Search head cluster)
[2]   /Users/tpereira/Git/splunk-operator/test/secret/secret_m4_test.go:46
[2]     secret, integration: secret update on multisite indexers and search head cluster
[2]     /Users/tpereira/Git/splunk-operator/test/secret/secret_m4_test.go:47
[2] ------------------------------
[2] {"level":"info","ts":1617130451.0888782,"msg":"testenv deleted.\n","testenv":"secret-ut0"}
[2]
[2] JUnit report was created: /Users/tpereira/Git/splunk-operator/test/secret/secret-ut0_junit.xml
[2]
[2] Ran 1 of 5 Specs in 1913.612 seconds
[2] SUCCESS! -- 1 Passed | 0 Failed | 4 Pending | 0 Skipped
[2] PASS

[1] • [SLOW TEST:1839.767 seconds]
[1] Secret Test for SVA C3
[1] /Users/tpereira/Git/splunk-operator/test/secret/secret_c3_test.go:26
[1]   Clustered deployment (C3 - clustered indexer, search head cluster)
[1]   /Users/tpereira/Git/splunk-operator/test/secret/secret_c3_test.go:46
[1]     secret: secret update on indexers and search head cluster
[1]     /Users/tpereira/Git/splunk-operator/test/secret/secret_c3_test.go:47
[1] ------------------------------
[1] {"level":"info","ts":1617128408.768227,"msg":"testenv deleted.\n","testenv":"secret-ur6"}
[1]
[1] JUnit report was created: /Users/tpereira/Git/splunk-operator/test/secret/secret-ur6_junit.xml
[1]
[1] Ran 1 of 3 Specs in 1846.601 seconds
[1] SUCCESS! -- 1 Passed | 0 Failed | 2 Pending | 0 Skipped
[1] PASS
```
S1 Modify/delete
```
[1] • [SLOW TEST:556.052 seconds]
[1] Secret Test for SVA S1
[1] /Users/tpereira/Git/splunk-operator/test/secret/secret_s1_test.go:26
[1]   Standalone deployment (S1) with LM
[1]   /Users/tpereira/Git/splunk-operator/test/secret/secret_s1_test.go:46
[1]     secret: Secret update on a standalone instance
[1]     /Users/tpereira/Git/splunk-operator/test/secret/secret_s1_test.go:47
[1] ------------------------------
[1] {"level":"info","ts":1617124303.36332,"msg":"testenv deleted.\n","testenv":"secret-uyy"}
[1]
[1] JUnit report was created: /Users/tpereira/Git/splunk-operator/test/secret/secret-uyy_junit.xml
[1]
[1] Ran 1 of 1 Specs in 562.926 seconds
[1] SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[1] PASS

[1] • [SLOW TEST:531.297 seconds]
[1] Secret Test for SVA S1
[1] /Users/tpereira/Git/splunk-operator/test/secret/secret_s1_test.go:26
[1]   Standalone deployment (S1) with LM
[1]   /Users/tpereira/Git/splunk-operator/test/secret/secret_s1_test.go:122
[1]     secret: Secret Object is recreated on delete and new secrets are applied to Splunk Pods
[1]     /Users/tpereira/Git/splunk-operator/test/secret/secret_s1_test.go:123
[1] ------------------------------
[1] {"level":"info","ts":1617125091.854136,"msg":"testenv deleted.\n","testenv":"secret-dc4"}
[1]
[1] JUnit report was created: /Users/tpereira/Git/splunk-operator/test/secret/secret-dc4_junit.xml
[1]
[1] Ran 1 of 1 Specs in 538.122 seconds
[1] SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[1] PASS

[2] • [SLOW TEST:338.035 seconds]
[2] Secret Test for SVA S1
[2] /Users/tpereira/Git/splunk-operator/test/secret/secret_s1_test.go:26
[2]   Standalone deployment (S1)
[2]   /Users/tpereira/Git/splunk-operator/test/secret/secret_s1_test.go:194
[2]     secret, smoke, integration: Secret Object data is repopulated in secret object on passing empty Data map and new secrets are applied to Splunk Pods
[2]     /Users/tpereira/Git/splunk-operator/test/secret/secret_s1_test.go:195
[2] ------------------------------
[2] {"level":"info","ts":1617125777.108496,"msg":"testenv deleted.\n","testenv":"secret-bg3"}
[2]
[2] JUnit report was created: /Users/tpereira/Git/splunk-operator/test/secret/secret-bg3_junit.xml
[2]
[2] Ran 1 of 3 Specs in 344.830 seconds
[2] SUCCESS! -- 1 Passed | 0 Failed | 2 Pending | 0 Skipped
[2] PASS
```
**Licensemaster**
```
[2] • [SLOW TEST:842.198 seconds]
[2] Licensemaster test
[2] /Users/tpereira/Git/splunk-operator/test/licensemaster/lm_m4_test.go:25
[2]   Multisite cluster deployment (M4 - Multisite indexer cluster, Search head cluster)
[2]   /Users/tpereira/Git/splunk-operator/test/licensemaster/lm_m4_test.go:45
[2]     licensemaster: Splunk Operator can configure license master with indexers and search head in M4 SVA
[2]     /Users/tpereira/Git/splunk-operator/test/licensemaster/lm_m4_test.go:46
[2] ------------------------------
[2] {"level":"info","ts":1617138692.6694698,"msg":"testenv deleted.\n","testenv":"licensemaster-wp"}
[2]
[2] JUnit report was created: /Users/tpereira/Git/splunk-operator/test/licensemaster/licensemaster-wp_junit.xml
[2]
[2] Ran 1 of 3 Specs in 849.008 seconds
[2] SUCCESS! -- 1 Passed | 0 Failed | 2 Pending | 0 Skipped
[2] PASS

2] • [SLOW TEST:625.027 seconds]
[2] Licensemaster test
[2] /Users/tpereira/Git/splunk-operator/test/licensemaster/lm_c3_test.go:25
[2]   Clustered deployment (C3 - clustered indexer, search head cluster)
[2]   /Users/tpereira/Git/splunk-operator/test/licensemaster/lm_c3_test.go:45
[2]     licensemaster, integration: Splunk Operator can configure License Master with Indexers and Search Heads in C3 SVA
[2]     /Users/tpereira/Git/splunk-operator/test/licensemaster/lm_c3_test.go:46
[2] ------------------------------
[2] {"level":"info","ts":1617137701.714098,"msg":"testenv deleted.\n","testenv":"licensemaster-bt"}
[2]
[2] JUnit report was created: /Users/tpereira/Git/splunk-operator/test/licensemaster/licensemaster-bt_junit.xml
[2]
[2] Ran 1 of 1 Specs in 632.037 seconds
[2] SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[2] PASS

[2] • [SLOW TEST:316.097 seconds]
[2] Licensemaster test
[2] /Users/tpereira/Git/splunk-operator/test/licensemaster/lm_s1_test.go:25
[2]   Standalone deployment (S1) with LM
[2]   /Users/tpereira/Git/splunk-operator/test/licensemaster/lm_s1_test.go:45
[2]     licensemaster: Splunk Operator can configure License Master with Standalone in S1 SVA
[2]     /Users/tpereira/Git/splunk-operator/test/licensemaster/lm_s1_test.go:46
[2] ------------------------------
[2] {"level":"info","ts":1617137044.6949341,"msg":"testenv deleted.\n","testenv":"licensemaster-ah"}
[2]
[2] JUnit report was created: /Users/tpereira/Git/splunk-operator/test/licensemaster/licensemaster-ah_junit.xml
[2]
[2] Ran 1 of 1 Specs in 322.963 seconds
[2] SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[2] PASS
```