### PR TITLE
CSPL-948: Automation for hec token on splunk Instance

### DIFF
--- a/test/deploy-eks-cluster.sh
+++ b/test/deploy-eks-cluster.sh
@@ -12,7 +12,7 @@ fi
 
 if [[ -z "${ECR_REPOSITORY}" ]]; then
   echo "ECR_REPOSITORY not set. Chaning to env.sh value"
-  export ECR_REPOSITORY="${PRIVATE_REGISTORY}"
+  export ECR_REPOSITORY="${PRIVATE_REGISTRY}"
 fi
 
 function deleteCluster() {

--- a/test/secret/secret_c3_test.go
+++ b/test/secret/secret_c3_test.go
@@ -131,6 +131,9 @@ var _ = Describe("Secret Test for SVA C3", func() {
 			// Verify Pass4SymmKey Secrets on ServerConf on MC, LM Pods
 			testenv.VerifySplunkServerConfSecrets(deployment, testenvInstance, verificationPods, updatedSecretData, true)
 
+			// Verify Hec token on InputConf on Pod
+			testenv.VerifySplunkInputConfSecrets(deployment, testenvInstance, verificationPods, updatedSecretData, true)
+
 			// Verify Secrets via api access on Pod
 			testenv.VerifySplunkSecretViaAPI(deployment, testenvInstance, verificationPods, updatedSecretData, true)
 		})

--- a/test/secret/secret_m4_test.go
+++ b/test/secret/secret_m4_test.go
@@ -136,6 +136,9 @@ var _ = Describe("Secret Test for M4 SVA", func() {
 			// Verify Pass4SymmKey Secrets on ServerConf on MC, LM Pods
 			testenv.VerifySplunkServerConfSecrets(deployment, testenvInstance, verificationPods, updatedSecretData, true)
 
+			// Verify Hec token on InputConf on Pod
+			testenv.VerifySplunkInputConfSecrets(deployment, testenvInstance, verificationPods, updatedSecretData, true)
+
 			// Verify Secrets via api access on Pod
 			testenv.VerifySplunkSecretViaAPI(deployment, testenvInstance, verificationPods, updatedSecretData, true)
 		})

--- a/test/secret/secret_s1_test.go
+++ b/test/secret/secret_s1_test.go
@@ -114,6 +114,9 @@ var _ = Describe("Secret Test for SVA S1", func() {
 			// Verify Secrets on ServerConf on Pod
 			testenv.VerifySplunkServerConfSecrets(deployment, testenvInstance, verificationPods, updatedSecretData, true)
 
+			// Verify Hec token on InputConf on Pod
+			testenv.VerifySplunkInputConfSecrets(deployment, testenvInstance, verificationPods, updatedSecretData, true)
+
 			// Verify Secrets via api access on Pod
 			testenv.VerifySplunkSecretViaAPI(deployment, testenvInstance, verificationPods, updatedSecretData, true)
 
@@ -187,6 +190,9 @@ var _ = Describe("Secret Test for SVA S1", func() {
 			// Verify Secrets on ServerConf on Pod
 			testenv.VerifySplunkServerConfSecrets(deployment, testenvInstance, verificationPods, secretStruct.Data, false)
 
+			// Verify Hec token on InputConf on Pod
+			testenv.VerifySplunkInputConfSecrets(deployment, testenvInstance, verificationPods, secretStruct.Data, false)
+
 			// Verify Secrets via api access on Pod
 			testenv.VerifySplunkSecretViaAPI(deployment, testenvInstance, verificationPods, secretStruct.Data, false)
 		})
@@ -245,6 +251,9 @@ var _ = Describe("Secret Test for SVA S1", func() {
 
 			// Verify Secrets on ServerConf on Pod
 			testenv.VerifySplunkServerConfSecrets(deployment, testenvInstance, verificationPods, secretStruct.Data, false)
+
+			// Verify Hec token on InputConf on Pod
+			testenv.VerifySplunkInputConfSecrets(deployment, testenvInstance, verificationPods, secretStruct.Data, false)
 
 			// Verify Secrets via api access on Pod
 			testenv.VerifySplunkSecretViaAPI(deployment, testenvInstance, verificationPods, secretStruct.Data, false)

--- a/test/testenv/testenv.go
+++ b/test/testenv/testenv.go
@@ -104,6 +104,13 @@ var (
 	specifiedCommitHash      = ""
 )
 
+//HTTPCodes Response codes for http request
+var HTTPCodes = map[string]string{
+	"Ok":           "HTTP/1.1 200 OK",
+	"Forbidden":    "HTTP/1.1 403 Forbidden",
+	"Unauthorized": "HTTP/1.1 401 Unauthorized",
+}
+
 type cleanupFunc func() error
 
 // TestEnv represents a namespaced-isolated k8s cluster environment (aka virtual k8s cluster) to run tests against


### PR DESCRIPTION
## Changes
Added Hec token verification to secret object update and delete cases

Fixed spell Error in Deploy EKS-Cluster.sh file

## Test Scenarios: (SVA's covered: S1)
Delete secret data
Verify New versioned secret are created with correct value.
Verify new secrets are mounted on pods.
Verify Input.conf file has updated hec token
Verify old Secrets cannot be used for api access (hec_token)

## Test Scenarios: (SVA's covered: S1, C3, M4)
Update Secrets Data
Verify New versioned secret are created with correct value.
Verify new secrets are mounted on pods.
Verify Input.conf file has updated hec token
Verify New updated Secrets via api access (hec_token)

## Passing Test Runs
S1
```
• [SLOW TEST:501.610 seconds]
[1] Secret Test for SVA S1
[1] /Users/tpereira/Git/splunk-operator/test/secret/secret_s1_test.go:26
[1]   Standalone deployment (S1) with LM
[1]   /Users/tpereira/Git/splunk-operator/test/secret/secret_s1_test.go:46
[1]     secret: Secret update on a standalone instance
[1]     /Users/tpereira/Git/splunk-operator/test/secret/secret_s1_test.go:47
[1] ------------------------------
[1] {"level":"info","ts":1617380918.374582,"msg":"testenv deleted.\n","testenv":"secret-use"}
[1]
[1] JUnit report was created: /Users/tpereira/Git/splunk-operator/test/secret/secret-use_junit.xml
[1]
[1] Ran 1 of 1 Specs in 508.712 seconds
[1] SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[1] PASS

[1] Secret Test for SVA S1
[1] /Users/tpereira/Git/splunk-operator/test/secret/secret_s1_test.go:26
[1]   Standalone deployment (S1) with LM
[1]   /Users/tpereira/Git/splunk-operator/test/secret/secret_s1_test.go:126
[1]     secret: Secret Object is recreated on delete and new secrets are applied to Splunk Pods
[1]     /Users/tpereira/Git/splunk-operator/test/secret/secret_s1_test.go:127
[1] ------------------------------
[1] {"level":"info","ts":1617317372.483045,"msg":"testenv deleted.\n","testenv":"secret-pk0"}
[1]
[1] JUnit report was created: /Users/tpereira/Git/splunk-operator/test/secret/secret-pk0_junit.xml
[1]
[1] Ran 1 of 1 Specs in 538.120 seconds
[1] SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[1] PASS

2] • [SLOW TEST:321.998 seconds]
[2] Secret Test for SVA S1
[2] /Users/tpereira/Git/splunk-operator/test/secret/secret_s1_test.go:26
[2]   Standalone deployment (S1)
[2]   /Users/tpereira/Git/splunk-operator/test/secret/secret_s1_test.go:201
[2]     secret, smoke, integration: Secret Object data is repopulated in secret object on passing empty Data map and new secrets are applied to Splunk Pods
[2]     /Users/tpereira/Git/splunk-operator/test/secret/secret_s1_test.go:202
[2] ------------------------------
[2] {"level":"info","ts":1617382293.73594,"msg":"testenv deleted.\n","testenv":"secret-uq5"}
[2]
[2] JUnit report was created: /Users/tpereira/Git/splunk-operator/test/secret/secret-uq5_junit.xml
[2]
[2] Ran 1 of 1 Specs in 328.990 seconds
[2] SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 0 Skipped
[2] PASS
```

C3
```
[2] • [SLOW TEST:2035.610 seconds]
[2] Secret Test for SVA C3
[2] /Users/tpereira/Git/splunk-operator/test/secret/secret_c3_test.go:26
[2]   Clustered deployment (C3 - clustered indexer, search head cluster)
[2]   /Users/tpereira/Git/splunk-operator/test/secret/secret_c3_test.go:46
[2]     secret: secret update on indexers and search head cluster
[2]     /Users/tpereira/Git/splunk-operator/test/secret/secret_c3_test.go:47
[2] ------------------------------
[2] {"level":"info","ts":1617322038.146726,"msg":"testenv deleted.\n","testenv":"secret-bfw"}
[2]
[2] JUnit report was created: /Users/tpereira/Git/splunk-operator/test/secret/secret-bfw_junit.xml
[2]
[2] Ran 1 of 5 Specs in 2042.410 seconds
[2] SUCCESS! -- 1 Passed | 0 Failed | 4 Pending | 0 Skipped
[2] PASS
```

M4
```
[1] • [SLOW TEST:1970.851 seconds]
[1] Secret Test for M4 SVA
[1] /Users/tpereira/Git/splunk-operator/test/secret/secret_m4_test.go:26
[1]   Multisite cluster deployment (M13 - Multisite indexer cluster, Search head cluster)
[1]   /Users/tpereira/Git/splunk-operator/test/secret/secret_m4_test.go:46
[1]     secret, integration: secret update on multisite indexers and search head cluster
[1]     /Users/tpereira/Git/splunk-operator/test/secret/secret_m4_test.go:47
[1] ------------------------------
[1] {"level":"info","ts":1617319839.4269419,"msg":"testenv deleted.\n","testenv":"secret-axg"}
[1]
[1] JUnit report was created: /Users/tpereira/Git/splunk-operator/test/secret/secret-axg_junit.xml
[1]
[1] Ran 1 of 1 Specs in 1977.784 seconds
[1] SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[1] PASS```

