### PR TITLE
CSPL-570 Documentation for configuring indexer clusters and standalones with LM

### DIFF
--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -16,7 +16,7 @@ deployments.
   - [Installing Splunk Apps](#installing-splunk-apps)
   - [Using Apps for Splunk Configuration](#using-apps-for-splunk-configuration)
   - [Creating a LicenseMaster Using a ConfigMap](#creating-a-licensemaster-using-a-configmap)
-  - [Configuring Splunk Enterprise CRs to use License Master](#configuring-splunk-enterprise-crs-to-use-license-master)
+  - [Configuring Standalone to use License Master](#configuring-standalone-to-use-license-master)
   - [Configuring Indexer Clusters to use License Master](#configuring-indexer-clusters-to-use-license-master)
   - [Using an External License Master](#using-an-external-license-master)
   - [Using an External Indexer Cluster](#using-an-external-indexer-cluster)
@@ -580,11 +580,10 @@ Note that `licenseUrl` may specify a local path or URL such as
 "https://myco.com/enterprise.lic", and the `volumes` parameter can
 be used to mount any type of [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/).
 
-## Configuring Splunk Enterprise CRs to use License Master
+## Configuring Standalone to use License Master
 
-Once a LicenseMaster is created, configure your other Splunk Enterprise CR specs to use
-the `LicenseMaster` by adding `licenseMasterRef` to their spec. As an example, you can connect
-a `Standalone` using the following spec:
+Once a LicenseMaster is created, you can configure your `Standalone` to use
+the `LicenseMaster` by adding `licenseMasterRef` to its spec as follows:
 
 ```yaml
 apiVersion: enterprise.splunk.com/v1

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -625,7 +625,7 @@ spec:
 EOF
 ```
 
-If forwarding of LicenseMaster logs to the above `Indexer Cluster` is required, you will need to add `clusterMasterRef` to the `LicenseMaster` spec as follows:
+In order to forward `LicenseMaster` logs to the above `Indexer Cluster`, you need to add `clusterMasterRef` to the `LicenseMaster` spec as follows:
 
 ```yaml
 apiVersion: enterprise.splunk.com/v1

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -26,30 +26,9 @@ deployments.
     - [Updating global kubernetes secret object](#updating-global-kubernetes-secret-object)
     - [Deleting global kubernetes secret object](#deleting-global-kubernetes-secret-object)
 
-## Connecting Splunk Enterprise CRs to use License Master
-
-Once a LicenseMaster is created, configure your other Splunk Enterprise CR specs to use
-the `LicenseMaster` by adding `licenseMasterRef` to their spec. As an example, you can connect
-a `Standalone` using the following spec:
-
-```yaml
-apiVersion: enterprise.splunk.com/v1
-kind: Standalone
-metadata:
-  name: example
-  finalizers:
-  - enterprise.splunk.com/delete-pvc
-spec:
-  licenseMasterRef:
-    name: example
-```
-
-## Connecting Indexer Clusters to use License Master
-
 Please refer to the [Custom Resource Guide](CustomResources.md) for more
 information about the custom resources that you can use with the Splunk
 Operator.
-
 
 ## Creating a Clustered Deployment
 

--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -675,33 +675,29 @@ func updateSplunkPodTemplateWithConfig(client splcommon.ControllerClient, podTem
 		clusterMasterURL = "localhost"
 	} else if spec.ClusterMasterRef.Name != "" {
 		clusterMasterURL = GetSplunkServiceName(SplunkClusterMaster, spec.ClusterMasterRef.Name, false)
+		if spec.ClusterMasterRef.Namespace != "" {
+			clusterMasterURL = splcommon.GetServiceFQDN(spec.ClusterMasterRef.Namespace, clusterMasterURL)
+		}
+		//Check if CM is connected to a LicenseMaster
+		namespacedName := types.NamespacedName{
+			Namespace: cr.GetNamespace(),
+			Name:      spec.ClusterMasterRef.Name,
+		}
+		masterIdxCluster := &enterprisev1.ClusterMaster{}
+		err := client.Get(context.TODO(), namespacedName, masterIdxCluster)
+		if err != nil {
+			scopedLog.Error(err, "Unable to get ClusterMaster")
+		}
 
-		// Avoid for LM
-		if instanceType != SplunkLicenseMaster {
-			if spec.ClusterMasterRef.Namespace != "" {
-				clusterMasterURL = splcommon.GetServiceFQDN(spec.ClusterMasterRef.Namespace, clusterMasterURL)
+		if masterIdxCluster.Spec.LicenseMasterRef.Name != "" {
+			licenseMasterURL := GetSplunkServiceName(SplunkLicenseMaster, masterIdxCluster.Spec.LicenseMasterRef.Name, false)
+			if masterIdxCluster.Spec.LicenseMasterRef.Namespace != "" {
+				licenseMasterURL = splcommon.GetServiceFQDN(masterIdxCluster.Spec.LicenseMasterRef.Namespace, licenseMasterURL)
 			}
-			//Check if CM is connected to a LicenseMaster
-			namespacedName := types.NamespacedName{
-				Namespace: cr.GetNamespace(),
-				Name:      spec.ClusterMasterRef.Name,
-			}
-			masterIdxCluster := &enterprisev1.ClusterMaster{}
-			err := client.Get(context.TODO(), namespacedName, masterIdxCluster)
-			if err != nil {
-				scopedLog.Error(err, "Unable to get ClusterMaster")
-			}
-
-			if masterIdxCluster.Spec.LicenseMasterRef.Name != "" {
-				licenseMasterURL := GetSplunkServiceName(SplunkLicenseMaster, masterIdxCluster.Spec.LicenseMasterRef.Name, false)
-				if masterIdxCluster.Spec.LicenseMasterRef.Namespace != "" {
-					licenseMasterURL = splcommon.GetServiceFQDN(masterIdxCluster.Spec.LicenseMasterRef.Namespace, licenseMasterURL)
-				}
-				env = append(env, corev1.EnvVar{
-					Name:  "SPLUNK_LICENSE_MASTER_URL",
-					Value: licenseMasterURL,
-				})
-			}
+			env = append(env, corev1.EnvVar{
+				Name:  "SPLUNK_LICENSE_MASTER_URL",
+				Value: licenseMasterURL,
+			})
 		}
 	}
 


### PR DESCRIPTION
The JIRA [CSPL-570](https://jira.splunk.com/browse/CSPL-570) points out that the License Master(LM) logs are not forwarded to the Cluster Master(CM) which is configured as a license slave. The reason for this is that the LM has not setup the **outputs.conf** to send to the CM via indexer discovery. To enable the same on the LM, we need to introduce the **clusterMasterRef** in the LM Spec as show in the example below:

```
apiVersion: enterprise.splunk.com/v1beta1
kind: LicenseMaster
metadata:
  name: example
  finalizers:
  - enterprise.splunk.com/delete-pvc
spec:
  clusterMasterRef:
    name: example
  volumes:
    - name: licenses
      configMap:
        name: splunk-licenses
  licenseUrl: /mnt/licenses/enterprise.lic
```

The operator uses the **clusterMasterRef** to introduce the env variable **SPLUNK_CLUSTER_MASTER_URL** which is picked up ansible to setup indexer discovery on **outputs.conf**.

This PR edits the documentation with regards to connecting **IndexerClusters** and **Standalones** to **LicenseMaster**.