### PR TITLE
CSPL-955-changed-cluster-name

### DIFF
--- a/test/deploy-eks-cluster.sh
+++ b/test/deploy-eks-cluster.sh
@@ -47,7 +47,7 @@ function createCluster() {
   fi
 
   echo "Logging in to ECR"
-  rc=$(aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin "${PRIVATE_REGISTRY}"/splunk/splunk-operator)
+  rc=$(aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin "${ECR_REPOSITORY}"/splunk/splunk-operator)
   if [ "$rc" != "Login Succeeded" ]; then
       echo "Unable to login to ECR - $rc"
       return 1

--- a/test/env.sh
+++ b/test/env.sh
@@ -3,7 +3,7 @@
 : "${SPLUNK_OPERATOR_IMAGE:=splunk/splunk-operator:latest}"
 : "${SPLUNK_ENTERPRISE_IMAGE:=splunk/splunk:latest}"
 : "${CLUSTER_PROVIDER:=kind}"
-: "${CLUSTER_NAME:=integration-test-cluster}"
+: "${CLUSTER_NAME:=integration-test-cluster-eks}"
 : "${NUM_WORKERS:=3}"
 : "${NUM_NODES:=2}"
 : "${COMMIT_HASH:=}"


### PR DESCRIPTION
CircleCI pipeline failing for EKS Cluster. 

* Changed Cluster name to circumvent cluster creation errors
* Changed authentication variable name for ECR Repository for eks cluster creation 