### PR TITLE
CSPL-955: Verbose level change

### DIFF
--- a/test/deploy-eks-cluster.sh
+++ b/test/deploy-eks-cluster.sh
@@ -33,7 +33,7 @@ function createCluster() {
     return 1
   fi
 
-  found=$(eksctl get cluster --name "${CLUSTER_NAME}")
+  found=$(eksctl get cluster --name "${CLUSTER_NAME}" -v 0)
   if [ -z "${found}" ]; then
     eksctl create cluster --name=${CLUSTER_NAME} --nodes=${CLUSTER_WORKERS} --vpc-public-subnets=${EKS_VPC_PUBLIC_SUBNET_STRING} --vpc-private-subnets=${EKS_VPC_PRIVATE_SUBNET_STRING}
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
EKS Cluster creation is failing on Circle CI due condition mismatch in following snippet :
```
 found=$(eksctl get cluster --name "${CLUSTER_NAME}" )
  if [ -z "${found}" ]; then
```

On Ubuntu `eksctl` has default verbose level of 3 which prints extra lines 
```
2021-04-09 16:06:21 [ℹ]  eksctl version 0.44.0
2021-04-09 16:06:21 [ℹ]  using region us-west-2
Error: unable to describe control plane "integration-test-cluster-eks": ResourceNotFoundException: No cluster found for name: integration-test-cluster-eks.
{
  RespMetadata: {
    StatusCode: 404,
    RequestID: "3068b8e5-0286-4025-a226-7f8f5049e215"
  },
  Message_: "No cluster found for name: integration-test-cluster-eks."
}
```

This passes the `if` condition hence cluster is never created. 

However on setting the verbose level to 0 the `if` condition works as expected. 

Circle CI VM Run:

**make cluster-up**
```
circleci@default-9a1cfd9c-7824-4beb-a5bf-b8f920a7f98f:~/project$ make cluster-up
Error: unable to describe control plane "integration-test-cluster-eks": ResourceNotFoundException: No cluster found for name: integration-test-cluster-eks.
{
  RespMetadata: {
    StatusCode: 404,
    RequestID: "b7946113-07e3-455b-bb75-e630d1a35115"
  },
  Message_: "No cluster found for name: integration-test-cluster-eks."
}
2021-04-09 16:07:08 [ℹ]  eksctl version 0.44.0
2021-04-09 16:07:08 [ℹ]  using region us-west-2
2021-04-09 16:07:09 [✔]  using existing VPC (vpc-09000e2e9fb844f28) and subnets (private:map[us-west-2a:{subnet-0fa22fc6046b4591f us-west-2a 192.168.160.0/19} us-west-2b:{subnet-0b9a43cb73e3f9799 us-west-2b 192.168.128.0/19} us-west-2c:{subnet-0c068ca7d9c468e09 us-west-2c 192.168.96.0/19}] public:map[us-west-2a:{subnet-0dec6ad34b32e791f us-west-2a 192.168.64.0/19} us-west-2b:{subnet-0dbbc27abdf4a416e us-west-2b 192.168.32.0/19} us-west-2c:{subnet-0921cea9bcffd7b77 us-west-2c 192.168.0.0/19}])
2021-04-09 16:07:09 [!]  custom VPC/subnets will be used; if resulting cluster doesn't function as expected, make sure to review the configuration of VPC/subnets
2021-04-09 16:07:09 [ℹ]  nodegroup "ng-a9fb00e3" will use "ami-0cdd9b2ea797fd5db" [AmazonLinux2/1.18]
2021-04-09 16:07:09 [ℹ]  using Kubernetes version 1.18
2021-04-09 16:07:09 [ℹ]  creating EKS cluster "integration-test-cluster-eks" in "us-west-2" region with un-managed nodes
2021-04-09 16:07:09 [ℹ]  will create 2 separate CloudFormation stacks for cluster itself and the initial nodegroup
2021-04-09 16:07:09 [ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=us-west-2 --cluster=integration-test-cluster-eks'
2021-04-09 16:07:09 [ℹ]  CloudWatch logging will not be enabled for cluster "integration-test-cluster-eks" in "us-west-2"
2021-04-09 16:07:09 [ℹ]  you can enable it with 'eksctl utils update-cluster-logging --enable-types={SPECIFY-YOUR-LOG-TYPES-HERE (e.g. all)} --region=us-west-2 --cluster=integration-test-cluster-eks'
2021-04-09 16:07:09 [ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "integration-test-cluster-eks" in "us-west-2"
2021-04-09 16:07:09 [ℹ]  2 sequential tasks: { create cluster control plane "integration-test-cluster-eks", 3 sequential sub-tasks: { wait for control plane to become ready, create addons, create nodegroup "ng-a9fb00e3" } }
2021-04-09 16:07:09 [ℹ]  building cluster stack "eksctl-integration-test-cluster-eks-cluster"
2021-04-09 16:07:10 [ℹ]  deploying stack "eksctl-integration-test-cluster-eks-cluster"
2021-04-09 16:07:40 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-cluster"
2021-04-09 16:08:10 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-cluster"
2021-04-09 16:09:11 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-cluster"
2021-04-09 16:10:11 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-cluster"
2021-04-09 16:11:11 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-cluster"
2021-04-09 16:12:12 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-cluster"
2021-04-09 16:13:12 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-cluster"
2021-04-09 16:14:13 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-cluster"
2021-04-09 16:15:13 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-cluster"
2021-04-09 16:16:13 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-cluster"
2021-04-09 16:17:14 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-cluster"
2021-04-09 16:18:14 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-cluster"
2021-04-09 16:19:16 [ℹ]  building nodegroup stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:19:16 [ℹ]  --nodes-min=5 was set automatically for nodegroup ng-a9fb00e3
2021-04-09 16:19:16 [ℹ]  --nodes-max=5 was set automatically for nodegroup ng-a9fb00e3
2021-04-09 16:19:17 [ℹ]  deploying stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:19:17 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:19:33 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:19:51 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:20:10 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:20:27 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:20:48 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:21:07 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:21:26 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:21:44 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:22:02 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:22:19 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:22:35 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:22:54 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:23:10 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:23:26 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:23:27 [ℹ]  waiting for the control plane availability...
2021-04-09 16:23:27 [✔]  saved kubeconfig as "/home/circleci/.kube/config"
2021-04-09 16:23:27 [ℹ]  no tasks
2021-04-09 16:23:27 [✔]  all EKS cluster resources for "integration-test-cluster-eks" have been created
2021-04-09 16:23:27 [ℹ]  adding identity "arn:aws:iam::667741767953:role/eksctl-integration-test-cluster-e-NodeInstanceRole-1VOSKDRRYYF0H" to auth ConfigMap
2021-04-09 16:23:27 [ℹ]  nodegroup "ng-a9fb00e3" has 0 node(s)
2021-04-09 16:23:27 [ℹ]  waiting for at least 5 node(s) to become ready in "ng-a9fb00e3"
2021-04-09 16:24:04 [ℹ]  nodegroup "ng-a9fb00e3" has 5 node(s)
2021-04-09 16:24:04 [ℹ]  node "ip-192-168-4-148.us-west-2.compute.internal" is ready
2021-04-09 16:24:04 [ℹ]  node "ip-192-168-45-150.us-west-2.compute.internal" is ready
2021-04-09 16:24:04 [ℹ]  node "ip-192-168-6-244.us-west-2.compute.internal" is ready
2021-04-09 16:24:04 [ℹ]  node "ip-192-168-62-77.us-west-2.compute.internal" is ready
2021-04-09 16:24:04 [ℹ]  node "ip-192-168-94-168.us-west-2.compute.internal" is ready
2021-04-09 16:24:06 [ℹ]  kubectl command should work with "/home/circleci/.kube/config", try 'kubectl get nodes'
2021-04-09 16:24:06 [✔]  EKS cluster "integration-test-cluster-eks" in "us-west-2" region is ready
Logging in to ECR
WARNING! Your password will be stored unencrypted in /home/circleci/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

EKS cluster nodes:
2021-04-09 16:24:08 [ℹ]  eksctl version 0.44.0
2021-04-09 16:24:08 [ℹ]  using region us-west-2
NAME				VERSION	STATUS	CREATED			VPC			SUBNETS												SECURITYGROUPS
integration-test-cluster-eks	1.18	ACTIVE	2021-04-09T16:08:10Z	vpc-09000e2e9fb844f28	subnet-0921cea9bcffd7b77,subnet-0b9a43cb73e3f9799,subnet-0c068ca7d9c468e09,subnet-0dbbc27abdf4a416e,subnet-0dec6ad34b32e791f,subnet-0fa22fc6046b4591f	sg-0507c0fbc27aacd31
circleci@default-9a1cfd9c-7824-4beb-a5bf-b8f920a7f98f:~/project$
```

**make cluster-down** output
```
circleci@default-9a1cfd9c-7824-4beb-a5bf-b8f920a7f98f:~/project$ make cluster-down
2021-04-09 16:25:37 [ℹ]  eksctl version 0.44.0
2021-04-09 16:25:37 [ℹ]  using region us-west-2
2021-04-09 16:25:37 [ℹ]  deleting EKS cluster "integration-test-cluster-eks"
2021-04-09 16:25:38 [ℹ]  deleted 0 Fargate profile(s)
2021-04-09 16:25:39 [✔]  kubeconfig has been updated
2021-04-09 16:25:39 [ℹ]  cleaning up AWS load balancers created by Kubernetes objects of Kind Service or Ingress
2021-04-09 16:25:42 [ℹ]  2 sequential tasks: { delete nodegroup "ng-a9fb00e3", delete cluster control plane "integration-test-cluster-eks" [async] }
2021-04-09 16:25:43 [ℹ]  will delete stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:25:43 [ℹ]  waiting for stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3" to get deleted
2021-04-09 16:25:43 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:25:59 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:26:16 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:26:36 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:26:53 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:27:13 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:27:33 [ℹ]  waiting for CloudFormation stack "eksctl-integration-test-cluster-eks-nodegroup-ng-a9fb00e3"
2021-04-09 16:27:34 [ℹ]  will delete stack "eksctl-integration-test-cluster-eks-cluster"
2021-04-09 16:27:34 [✔]  all cluster resources were deleted
```


