### PR TITLE
CSPL-955: Fix int-test failure for EKS Cluster. Increased namespace l…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,6 +384,7 @@ jobs:
             echo 'export CLUSTER_NODES=${NUM_NODES}' >> $BASH_ENV
             echo 'export CLUSTER_WORKERS=${NUM_WORKERS}' >> $BASH_ENV
             echo 'export TEST_CLUSTER_PLATFORM=eks' >> $BASH_ENV
+            echo 'export PRIVATE_REGISTRY=$ECR_REPOSITORY' >> $BASH_ENV
       - kubernetes/install
       - aws-cli/install
       - aws-eks/install-eksctl

--- a/test/custom_resource_crud/custom_resource_crud_suite_test.go
+++ b/test/custom_resource_crud/custom_resource_crud_suite_test.go
@@ -35,7 +35,7 @@ const (
 
 var (
 	testenvInstance *testenv.TestEnv
-	testSuiteName   = "crcrud-" + testenv.RandomDNSName(2)
+	testSuiteName   = "crcrud-" + testenv.RandomDNSName(3)
 )
 
 // TestBasic is the main entry point

--- a/test/delete_cr/deletecr_suite_test.go
+++ b/test/delete_cr/deletecr_suite_test.go
@@ -36,7 +36,7 @@ const (
 
 var (
 	testenvInstance *testenv.TestEnv
-	testSuiteName   = "deletecr-" + testenv.RandomDNSName(2)
+	testSuiteName   = "deletecr-" + testenv.RandomDNSName(3)
 )
 
 // TestBasic is the main entry point

--- a/test/ingest_search/ingest_search_suite_test.go
+++ b/test/ingest_search/ingest_search_suite_test.go
@@ -35,7 +35,7 @@ const (
 
 var (
 	testenvInstance *testenv.TestEnv
-	testSuiteName   = "ingestsearch-" + testenv.RandomDNSName(2)
+	testSuiteName   = "ingest-" + testenv.RandomDNSName(3)
 )
 
 // TestBasic is the main entry point

--- a/test/licensemaster/lm_suite_test.go
+++ b/test/licensemaster/lm_suite_test.go
@@ -35,7 +35,7 @@ const (
 
 var (
 	testenvInstance *testenv.TestEnv
-	testSuiteName   = "licensemaster-" + testenv.RandomDNSName(2)
+	testSuiteName   = "lm-" + testenv.RandomDNSName(3)
 )
 
 // TestBasic is the main entry point

--- a/test/monitoring_console/monitoring_console_suite_test.go
+++ b/test/monitoring_console/monitoring_console_suite_test.go
@@ -36,7 +36,7 @@ const (
 
 var (
 	testenvInstance *testenv.TestEnv
-	testSuiteName   = "mc-" + testenv.RandomDNSName(2)
+	testSuiteName   = "mc-" + testenv.RandomDNSName(3)
 )
 
 // TestBasic is the main entry point

--- a/test/scaling_test/scaling_suite_test.go
+++ b/test/scaling_test/scaling_suite_test.go
@@ -36,7 +36,7 @@ const (
 
 var (
 	testenvInstance *testenv.TestEnv
-	testSuiteName   = "scaling-" + testenv.RandomDNSName(2)
+	testSuiteName   = "scaling-" + testenv.RandomDNSName(3)
 )
 
 // TestBasic is the main entry point

--- a/test/smartstore/smartstore_suite_test.go
+++ b/test/smartstore/smartstore_suite_test.go
@@ -22,7 +22,7 @@ const (
 
 var (
 	testenvInstance *testenv.TestEnv
-	testSuiteName   = "smartstore-" + testenv.RandomDNSName(2)
+	testSuiteName   = "smartstore-" + testenv.RandomDNSName(3)
 )
 
 // TestBasic is the main entry point

--- a/test/smoke/smoke_suite_test.go
+++ b/test/smoke/smoke_suite_test.go
@@ -35,7 +35,7 @@ const (
 
 var (
 	testenvInstance *testenv.TestEnv
-	testSuiteName   = "smoke-" + testenv.RandomDNSName(2)
+	testSuiteName   = "smoke-" + testenv.RandomDNSName(3)
 )
 
 // TestBasic is the main entry point


### PR DESCRIPTION
* Fixed logic error related PRIVATE REPOSITORY used by make int-test
* Increated namespace length to avoid `namespace already exists` error
  * This is needed as for executing more test cases in parallel.