### PR TITLE
Manually fix nightly build after Operator-SDK v0.18.2 upgrade

### DIFF
--- a/deploy/crds/enterprise.splunk.com_clustermasters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_clustermasters_crd.yaml
@@ -943,6 +943,7 @@ spec:
                               x-kubernetes-int-or-string: true
                           required:
                           - port
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:

--- a/deploy/crds/enterprise.splunk.com_indexerclusters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_indexerclusters_crd.yaml
@@ -967,6 +967,7 @@ spec:
                               x-kubernetes-int-or-string: true
                           required:
                           - port
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:

--- a/deploy/crds/enterprise.splunk.com_licensemasters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_licensemasters_crd.yaml
@@ -948,6 +948,7 @@ spec:
                               x-kubernetes-int-or-string: true
                           required:
                           - port
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:

--- a/deploy/crds/enterprise.splunk.com_searchheadclusters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_searchheadclusters_crd.yaml
@@ -966,6 +966,7 @@ spec:
                               x-kubernetes-int-or-string: true
                           required:
                           - port
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:

--- a/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
@@ -960,6 +960,7 @@ spec:
                               x-kubernetes-int-or-string: true
                           required:
                           - port
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:


### PR DESCRIPTION
After upgrading operator-sdk to v0.18.2 the nightly builds started to fail due to https://github.com/kubernetes/kubernetes/issues/91395 which is an issue with how Kubernetes 1.18 interprets the operator-sdk v0.18.2 generated CRDs.

The issue manifests as :
"The CustomResourceDefinition “clustermasters.enterprise.splunk.com” is invalid: spec.versions[0].schema.openAPIV3Schema.properties[spec].properties[serviceTemplate].properties[spec].properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property"