### PR TITLE
Initial commit for S3 framework APIs

### DIFF
--- a/deploy/crds/enterprise.splunk.com_clustermasters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_clustermasters_crd.yaml
@@ -690,6 +690,11 @@ spec:
                         path:
                           description: Remote volume path
                           type: string
+                        provider:
+                          description: 'App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws. TODO: Support minio as well.'
+                          type: string
                         secretRef:
                           description: Secret object name
                           type: string
@@ -1009,7 +1014,6 @@ spec:
                               x-kubernetes-int-or-string: true
                           required:
                           - port
-                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -1218,6 +1222,11 @@ spec:
                           type: string
                         path:
                           description: Remote volume path
+                          type: string
+                        provider:
+                          description: 'App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws. TODO: Support minio as well.'
                           type: string
                         secretRef:
                           description: Secret object name
@@ -2558,6 +2567,11 @@ spec:
                             path:
                               description: Remote volume path
                               type: string
+                            provider:
+                              description: 'App Package Remote Store provider. For
+                                e.g. aws, azure, minio, etc. Currently we are only
+                                supporting aws. TODO: Support minio as well.'
+                              type: string
                             secretRef:
                               description: Secret object name
                               type: string
@@ -2699,6 +2713,11 @@ spec:
                           type: string
                         path:
                           description: Remote volume path
+                          type: string
+                        provider:
+                          description: 'App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws. TODO: Support minio as well.'
                           type: string
                         secretRef:
                           description: Secret object name

--- a/deploy/crds/enterprise.splunk.com_indexerclusters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_indexerclusters_crd.yaml
@@ -967,7 +967,6 @@ spec:
                               x-kubernetes-int-or-string: true
                           required:
                           - port
-                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:

--- a/deploy/crds/enterprise.splunk.com_licensemasters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_licensemasters_crd.yaml
@@ -695,6 +695,11 @@ spec:
                         path:
                           description: Remote volume path
                           type: string
+                        provider:
+                          description: 'App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws. TODO: Support minio as well.'
+                          type: string
                         secretRef:
                           description: Secret object name
                           type: string
@@ -1014,7 +1019,6 @@ spec:
                               x-kubernetes-int-or-string: true
                           required:
                           - port
-                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -2457,6 +2461,11 @@ spec:
                               type: string
                             path:
                               description: Remote volume path
+                              type: string
+                            provider:
+                              description: 'App Package Remote Store provider. For
+                                e.g. aws, azure, minio, etc. Currently we are only
+                                supporting aws. TODO: Support minio as well.'
                               type: string
                             secretRef:
                               description: Secret object name

--- a/deploy/crds/enterprise.splunk.com_searchheadclusters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_searchheadclusters_crd.yaml
@@ -708,6 +708,11 @@ spec:
                         path:
                           description: Remote volume path
                           type: string
+                        provider:
+                          description: 'App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws. TODO: Support minio as well.'
+                          type: string
                         secretRef:
                           description: Secret object name
                           type: string
@@ -1032,7 +1037,6 @@ spec:
                               x-kubernetes-int-or-string: true
                           required:
                           - port
-                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -2486,6 +2490,11 @@ spec:
                               type: string
                             path:
                               description: Remote volume path
+                              type: string
+                            provider:
+                              description: 'App Package Remote Store provider. For
+                                e.g. aws, azure, minio, etc. Currently we are only
+                                supporting aws. TODO: Support minio as well.'
                               type: string
                             secretRef:
                               description: Secret object name

--- a/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
@@ -703,6 +703,11 @@ spec:
                         path:
                           description: Remote volume path
                           type: string
+                        provider:
+                          description: 'App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws. TODO: Support minio as well.'
+                          type: string
                         secretRef:
                           description: Secret object name
                           type: string
@@ -1026,7 +1031,6 @@ spec:
                               x-kubernetes-int-or-string: true
                           required:
                           - port
-                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -1235,6 +1239,11 @@ spec:
                           type: string
                         path:
                           description: Remote volume path
+                          type: string
+                        provider:
+                          description: 'App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws. TODO: Support minio as well.'
                           type: string
                         secretRef:
                           description: Secret object name
@@ -2576,6 +2585,11 @@ spec:
                             path:
                               description: Remote volume path
                               type: string
+                            provider:
+                              description: 'App Package Remote Store provider. For
+                                e.g. aws, azure, minio, etc. Currently we are only
+                                supporting aws. TODO: Support minio as well.'
+                              type: string
                             secretRef:
                               description: Secret object name
                               type: string
@@ -2716,6 +2730,11 @@ spec:
                           type: string
                         path:
                           description: Remote volume path
+                          type: string
+                        provider:
+                          description: 'App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws. TODO: Support minio as well.'
                           type: string
                         secretRef:
                           description: Secret object name

--- a/deploy/olm-catalog/splunk/1.0.0/enterprise.splunk.com_clustermasters_crd.yaml
+++ b/deploy/olm-catalog/splunk/1.0.0/enterprise.splunk.com_clustermasters_crd.yaml
@@ -690,6 +690,11 @@ spec:
                         path:
                           description: Remote volume path
                           type: string
+                        provider:
+                          description: 'App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws. TODO: Support minio as well.'
+                          type: string
                         secretRef:
                           description: Secret object name
                           type: string
@@ -1217,6 +1222,11 @@ spec:
                           type: string
                         path:
                           description: Remote volume path
+                          type: string
+                        provider:
+                          description: 'App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws. TODO: Support minio as well.'
                           type: string
                         secretRef:
                           description: Secret object name
@@ -2557,6 +2567,11 @@ spec:
                             path:
                               description: Remote volume path
                               type: string
+                            provider:
+                              description: 'App Package Remote Store provider. For
+                                e.g. aws, azure, minio, etc. Currently we are only
+                                supporting aws. TODO: Support minio as well.'
+                              type: string
                             secretRef:
                               description: Secret object name
                               type: string
@@ -2698,6 +2713,11 @@ spec:
                           type: string
                         path:
                           description: Remote volume path
+                          type: string
+                        provider:
+                          description: 'App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws. TODO: Support minio as well.'
                           type: string
                         secretRef:
                           description: Secret object name

--- a/deploy/olm-catalog/splunk/1.0.0/enterprise.splunk.com_licensemasters_crd.yaml
+++ b/deploy/olm-catalog/splunk/1.0.0/enterprise.splunk.com_licensemasters_crd.yaml
@@ -695,6 +695,11 @@ spec:
                         path:
                           description: Remote volume path
                           type: string
+                        provider:
+                          description: 'App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws. TODO: Support minio as well.'
+                          type: string
                         secretRef:
                           description: Secret object name
                           type: string
@@ -2456,6 +2461,11 @@ spec:
                               type: string
                             path:
                               description: Remote volume path
+                              type: string
+                            provider:
+                              description: 'App Package Remote Store provider. For
+                                e.g. aws, azure, minio, etc. Currently we are only
+                                supporting aws. TODO: Support minio as well.'
                               type: string
                             secretRef:
                               description: Secret object name

--- a/deploy/olm-catalog/splunk/1.0.0/enterprise.splunk.com_searchheadclusters_crd.yaml
+++ b/deploy/olm-catalog/splunk/1.0.0/enterprise.splunk.com_searchheadclusters_crd.yaml
@@ -708,6 +708,11 @@ spec:
                         path:
                           description: Remote volume path
                           type: string
+                        provider:
+                          description: 'App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws. TODO: Support minio as well.'
+                          type: string
                         secretRef:
                           description: Secret object name
                           type: string
@@ -2485,6 +2490,11 @@ spec:
                               type: string
                             path:
                               description: Remote volume path
+                              type: string
+                            provider:
+                              description: 'App Package Remote Store provider. For
+                                e.g. aws, azure, minio, etc. Currently we are only
+                                supporting aws. TODO: Support minio as well.'
                               type: string
                             secretRef:
                               description: Secret object name

--- a/deploy/olm-catalog/splunk/1.0.0/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/olm-catalog/splunk/1.0.0/enterprise.splunk.com_standalones_crd.yaml
@@ -703,6 +703,11 @@ spec:
                         path:
                           description: Remote volume path
                           type: string
+                        provider:
+                          description: 'App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws. TODO: Support minio as well.'
+                          type: string
                         secretRef:
                           description: Secret object name
                           type: string
@@ -1234,6 +1239,11 @@ spec:
                           type: string
                         path:
                           description: Remote volume path
+                          type: string
+                        provider:
+                          description: 'App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws. TODO: Support minio as well.'
                           type: string
                         secretRef:
                           description: Secret object name
@@ -2575,6 +2585,11 @@ spec:
                             path:
                               description: Remote volume path
                               type: string
+                            provider:
+                              description: 'App Package Remote Store provider. For
+                                e.g. aws, azure, minio, etc. Currently we are only
+                                supporting aws. TODO: Support minio as well.'
+                              type: string
                             secretRef:
                               description: Secret object name
                               type: string
@@ -2715,6 +2730,11 @@ spec:
                           type: string
                         path:
                           description: Remote volume path
+                          type: string
+                        provider:
+                          description: 'App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws. TODO: Support minio as well.'
                           type: string
                         secretRef:
                           description: Secret object name

--- a/pkg/apis/enterprise/v1/common_types.go
+++ b/pkg/apis/enterprise/v1/common_types.go
@@ -146,6 +146,12 @@ type VolumeSpec struct {
 
 	// Remote Storage type.
 	Type string `json:"storageType"`
+
+	// App Package Remote Store provider.
+	// For e.g. aws, azure, minio, etc.
+	// Currently we are only supporting aws.
+	// TODO: Support minio as well.
+	Provider string `json:"provider"`
 }
 
 // VolumeAndTypeSpec used to add any custom varaibles for volume implementation

--- a/pkg/splunk/client/awss3client.go
+++ b/pkg/splunk/client/awss3client.go
@@ -1,0 +1,87 @@
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+// blank assignment to verify that AWSS3Client implements S3Client
+var _ S3Client = &AWSS3Client{}
+
+// AWSS3Client is a client to implement S3 specific APIs
+type AWSS3Client struct {
+	Region             string
+	BucketName         string
+	AWSAccessKeyID     string
+	AWSSecretAccessKey string
+	Prefix             string
+	StartAfter         string
+}
+
+// GetAWSS3Client returns an AWS S3 client
+func GetAWSS3Client(region string, bucketName string, accessKeyID string, secretAccessKey string, prefix string, startAfter string) S3Client {
+	return &AWSS3Client{
+		Region:             region,
+		BucketName:         bucketName,
+		AWSAccessKeyID:     accessKeyID,
+		AWSSecretAccessKey: secretAccessKey,
+		Prefix:             prefix,
+		StartAfter:         startAfter,
+	}
+}
+
+//RegisterAWSS3Client will add the corresponding function pointer to the map
+func RegisterAWSS3Client() {
+	S3Clients["aws"] = GetAWSS3Client
+}
+
+// GetAppsList get the list of apps from remote storage
+func (awsclient *AWSS3Client) GetAppsList() (S3Response, error) {
+	scopedLog := log.WithName("GetRemoteStorageClient")
+
+	scopedLog.Info("Getting Apps list", "AWS S3 Bucket", awsclient.BucketName)
+
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(awsclient.Region),
+		Credentials: credentials.NewStaticCredentials(
+			awsclient.AWSAccessKeyID,     // id
+			awsclient.AWSSecretAccessKey, // secret
+			"")},                         //token
+	)
+
+	// Create S3 service client
+	svc := s3.New(sess)
+
+	options := &s3.ListObjectsV2Input{
+		Bucket:     aws.String(awsclient.BucketName),
+		Prefix:     aws.String(awsclient.Prefix),
+		StartAfter: aws.String(awsclient.StartAfter), //exclude the directory itself from listing
+		MaxKeys:    aws.Int64(4000),                  // return upto 4K keys from S3
+	}
+
+	s3Resp := S3Response{}
+	// List the bucket contents
+	resp, err := svc.ListObjectsV2(options)
+	if err != nil {
+		scopedLog.Error(err, "Unable to list items in bucket ", awsclient.BucketName)
+		return s3Resp, err
+	}
+
+	tmp, err := json.Marshal(resp.Contents)
+	if err != nil {
+		scopedLog.Error(err, "Failed to marshal s3 response")
+		return s3Resp, err
+	}
+
+	err = json.Unmarshal(tmp, &(s3Resp.Objects))
+	if err != nil {
+		scopedLog.Error(err, "Failed to unmarshal s3 response")
+		return s3Resp, err
+	}
+
+	return s3Resp, nil
+}

--- a/pkg/splunk/client/s3client.go
+++ b/pkg/splunk/client/s3client.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+	"time"
+)
+
+//GetS3Client gets the required S3Client based on the provider
+type GetS3Client func(string /* region */, string /* bucket */, string, /* AWS access key ID */
+	string /* AWS secret access key */, string /* Prefix */, string /* StartAfter */) S3Client
+
+// S3Clients is a map of provider name to init functions
+var S3Clients = make(map[string]GetS3Client)
+
+// S3Client is an interface to implement different S3 client APIs
+type S3Client interface {
+	GetAppsList() (S3Response, error)
+}
+
+// S3Response struct contains list of RemoteObject objects as part of S3 response
+type S3Response struct {
+	Objects []*RemoteObject
+}
+
+// RemoteObject struct contains contents returned as part of S3 response
+type RemoteObject struct {
+	Etag         *string
+	Key          *string
+	LastModified *time.Time
+	Size         *int64
+	StorageClass *string
+}
+
+//RegisterS3Client registers the respective Client
+func RegisterS3Client(provider string) {
+	switch provider {
+	case "aws":
+		RegisterAWSS3Client()
+	default:
+	}
+}

--- a/pkg/splunk/enterprise/clustermaster_test.go
+++ b/pkg/splunk/enterprise/clustermaster_test.go
@@ -189,7 +189,7 @@ func TestApplyClusterMasterWithSmartstore(t *testing.T) {
 		Spec: enterprisev1.ClusterMasterSpec{
 			SmartStore: enterprisev1.SmartStoreSpec{
 				VolList: []enterprisev1.VolumeSpec{
-					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "splunk-test-secret"},
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "splunk-test-secret", Type: "s3", Provider: "aws"},
 				},
 
 				IndexList: []enterprisev1.IndexSpec{
@@ -423,7 +423,7 @@ func TestPushMasterAppsBundle(t *testing.T) {
 	}
 }
 
-func TestAppFrameworkClusterMasterShouldNotFail(t *testing.T) {
+func TestAppFrameworkApplyClusterMasterShouldNotFail(t *testing.T) {
 	cr := enterprisev1.ClusterMaster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "stack1",
@@ -432,7 +432,7 @@ func TestAppFrameworkClusterMasterShouldNotFail(t *testing.T) {
 		Spec: enterprisev1.ClusterMasterSpec{
 			AppFrameworkConfig: enterprisev1.AppFrameworkSpec{
 				VolList: []enterprisev1.VolumeSpec{
-					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret"},
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
 				},
 				AppSources: []enterprisev1.AppSourceSpec{
 					{Name: "adminApps",
@@ -454,6 +454,11 @@ func TestAppFrameworkClusterMasterShouldNotFail(t *testing.T) {
 							Scope:   "local"},
 					},
 				},
+			},
+			// TODO gaurav: Remove this dependency on mock setting and try to use
+			// mock client for S3 responses.
+			CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
+				Mock: true,
 			},
 		},
 	}

--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -873,7 +873,7 @@ func ValidateAppFrameworkSpec(appFramework *enterprisev1.AppFrameworkSpec, local
 	}
 
 	scopedLog := log.WithName("ValidateAppFrameworkSpec").WithValues(
-		"localScope: %t", localScope)
+		"localScope", localScope)
 
 	// Todo: sgontla: Enable later. For now, allowing multiple volumes and app sources for UT purpose
 	if len(appFramework.VolList) > 1 || len(appFramework.AppSources) > 2 {
@@ -918,25 +918,26 @@ func validateRemoteVolumeSpec(volList []enterprisev1.VolumeSpec) error {
 			return fmt.Errorf("Duplicate volume name detected: %s. Remove the duplicate entry and reapply the configuration", volume.Name)
 		}
 		duplicateChecker[volume.Name] = true
-
 		// Make sure that the smartstore volume info is correct
 		if volume.Name == "" {
 			return fmt.Errorf("Volume name is missing for volume at : %d", i)
 		}
-
 		if volume.Endpoint == "" {
 			return fmt.Errorf("Volume Endpoint URI is missing")
 		}
-
 		if volume.Path == "" {
 			return fmt.Errorf("Volume Path is missing")
 		}
-
 		if volume.SecretRef == "" {
 			return fmt.Errorf("Volume SecretRef is missing")
 		}
+		if volume.Type == "" {
+			return fmt.Errorf("Remote volume Type is missing")
+		}
+		if volume.Provider == "" {
+			return fmt.Errorf("S3 Provider is missing")
+		}
 	}
-
 	return nil
 }
 
@@ -955,7 +956,6 @@ func validateSplunkIndexesSpec(smartstore *enterprisev1.SmartStoreSpec) error {
 			return fmt.Errorf("Duplicate index name detected: %s.Remove the duplicate entry and reapply the configuration", index.Name)
 		}
 		duplicateChecker[index.Name] = true
-
 		if index.VolName == "" && smartstore.Defaults.VolName == "" {
 			return fmt.Errorf("volumeName is missing for index: %s", index.Name)
 		}

--- a/pkg/splunk/enterprise/configuration_test.go
+++ b/pkg/splunk/enterprise/configuration_test.go
@@ -269,7 +269,7 @@ func TestSmartStoreConfigDoesNotFailOnClusterMasterCR(t *testing.T) {
 		Spec: enterprisev1.ClusterMasterSpec{
 			SmartStore: enterprisev1.SmartStoreSpec{
 				VolList: []enterprisev1.VolumeSpec{
-					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret"},
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
 				},
 
 				IndexList: []enterprisev1.IndexSpec{
@@ -300,7 +300,7 @@ func TestValidateSplunkSmartstoreSpec(t *testing.T) {
 	// Valid smartstore config
 	SmartStore := enterprisev1.SmartStoreSpec{
 		VolList: []enterprisev1.VolumeSpec{
-			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret"},
+			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
 		},
 		IndexList: []enterprisev1.IndexSpec{
 			{Name: "salesdata1", RemotePath: "remotepath1",
@@ -415,7 +415,7 @@ func TestValidateSplunkSmartstoreSpec(t *testing.T) {
 	//Smartstore config Index with VolName, but missing RemotePath errors out
 	SmartStoreWithMissingIndexLocation := enterprisev1.SmartStoreSpec{
 		VolList: []enterprisev1.VolumeSpec{
-			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret"},
+			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
 		},
 		IndexList: []enterprisev1.IndexSpec{
 			{Name: "salesdata1",
@@ -445,7 +445,7 @@ func TestValidateSplunkSmartstoreSpec(t *testing.T) {
 				VolName: "msos_s2s3_vol"},
 		},
 		VolList: []enterprisev1.VolumeSpec{
-			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret"},
+			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
 		},
 		IndexList: []enterprisev1.IndexSpec{
 			{Name: "salesdata1"},
@@ -595,13 +595,13 @@ func TestValidateSplunkSmartstoreSpec(t *testing.T) {
 		t.Errorf("Index with an invalid volume name should return error")
 	}
 }
+
 func TestValidateAppFrameworkSpec(t *testing.T) {
 	var err error
-
-	// Valid App Framework config
+	// Valid app framework config
 	AppFramework := enterprisev1.AppFrameworkSpec{
 		VolList: []enterprisev1.VolumeSpec{
-			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret"},
+			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
 		},
 		AppSources: []enterprisev1.AppSourceSpec{
 			{Name: "adminApps",

--- a/pkg/splunk/enterprise/licensemaster.go
+++ b/pkg/splunk/enterprise/licensemaster.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1"
+	splclient "github.com/splunk/splunk-operator/pkg/splunk/client"
 	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 	splctrl "github.com/splunk/splunk-operator/pkg/splunk/controller"
 )
@@ -37,19 +38,31 @@ func ApplyLicenseMaster(client splcommon.ControllerClient, cr *enterprisev1.Lice
 		RequeueAfter: time.Second * 5,
 	}
 
+	scopedLog := log.WithName("ApplyLicenseMaster").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
+
 	// validate and updates defaults for CR
 	err := validateLicenseMasterSpec(&cr.Spec)
 	if err != nil {
 		return result, err
 	}
 
-	// ToDo sgontla: Handle
-	// 1. Spec update
-	// 2. S3 credentails change
-	// 3. Probe times expired
-	if !reflect.DeepEqual(cr.Status.AppContext.AppFrameworkConfig, cr.Spec.AppFrameworkConfig) {
-		// TBD: Probe the remote store, and handle any changes on remote store
+	if cr.Spec.CommonSplunkSpec.Mock != true && !reflect.DeepEqual(cr.Status.AppContext.AppFrameworkConfig, cr.Spec.AppFrameworkConfig) {
 
+		var sourceToAppsList map[string]splclient.S3Response
+
+		for _, vol := range cr.Spec.AppFrameworkConfig.VolList {
+			splclient.RegisterS3Client(vol.Provider)
+		}
+
+		sourceToAppsList, err = GetAppListFromS3Bucket(client, cr, &cr.Spec.AppFrameworkConfig)
+		if err != nil {
+			scopedLog.Error(err, "Unable to get apps list from remote storage")
+			return result, err
+		}
+
+		for _, appSource := range cr.Spec.AppFrameworkConfig.AppSources {
+			scopedLog.Info("Apps List retrieved from remote storage", "App Source", appSource.Name, "Content", sourceToAppsList[appSource.Name].Objects)
+		}
 		cr.Status.AppContext.AppFrameworkConfig = cr.Spec.AppFrameworkConfig
 	}
 

--- a/pkg/splunk/enterprise/licensemaster_test.go
+++ b/pkg/splunk/enterprise/licensemaster_test.go
@@ -131,7 +131,7 @@ func TestAppFrameworkApplyLicenseMasterShouldNotFail(t *testing.T) {
 		Spec: enterprisev1.LicenseMasterSpec{
 			AppFrameworkConfig: enterprisev1.AppFrameworkSpec{
 				VolList: []enterprisev1.VolumeSpec{
-					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret"},
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
 				},
 				AppSources: []enterprisev1.AppSourceSpec{
 					{Name: "adminApps",
@@ -153,6 +153,11 @@ func TestAppFrameworkApplyLicenseMasterShouldNotFail(t *testing.T) {
 							Scope:   "local"},
 					},
 				},
+			},
+			// TODO gaurav: Remove this dependency on mock setting and try to use
+			// mock client for S3 responses.
+			CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
+				Mock: true,
 			},
 		},
 	}

--- a/pkg/splunk/enterprise/searchheadcluster.go
+++ b/pkg/splunk/enterprise/searchheadcluster.go
@@ -47,12 +47,22 @@ func ApplySearchHeadCluster(client splcommon.ControllerClient, cr *enterprisev1.
 		return result, err
 	}
 
-	// ToDo sgontla: Handle
-	// 1. Spec update
-	// 2. S3 credentails change
-	// 3. Probe times expired
-	if !reflect.DeepEqual(cr.Status.AppContext.AppFrameworkConfig, cr.Spec.AppFrameworkConfig) {
-		// TBD: Probe the remote store, and handle any changes on remote store
+	if cr.Spec.CommonSplunkSpec.Mock != true && !reflect.DeepEqual(cr.Status.AppContext.AppFrameworkConfig, cr.Spec.AppFrameworkConfig) {
+		var sourceToAppsList map[string]splclient.S3Response
+
+		for _, vol := range cr.Spec.AppFrameworkConfig.VolList {
+			splclient.RegisterS3Client(vol.Provider)
+		}
+
+		sourceToAppsList, err = GetAppListFromS3Bucket(client, cr, &cr.Spec.AppFrameworkConfig)
+		if err != nil {
+			scopedLog.Error(err, "Unable to get apps list from remote storage")
+			return result, err
+		}
+
+		for _, appSource := range cr.Spec.AppFrameworkConfig.AppSources {
+			scopedLog.Info("Apps List retrieved from remote storage", "App Source", appSource.Name, "Content", sourceToAppsList[appSource.Name].Objects)
+		}
 
 		cr.Status.AppContext.AppFrameworkConfig = cr.Spec.AppFrameworkConfig
 	}

--- a/pkg/splunk/enterprise/searchheadcluster_test.go
+++ b/pkg/splunk/enterprise/searchheadcluster_test.go
@@ -626,7 +626,7 @@ func TestAppFrameworkSearchHeadClusterShouldNotFail(t *testing.T) {
 			Replicas: 3,
 			AppFrameworkConfig: enterprisev1.AppFrameworkSpec{
 				VolList: []enterprisev1.VolumeSpec{
-					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret"},
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
 				},
 				AppSources: []enterprisev1.AppSourceSpec{
 					{Name: "adminApps",
@@ -648,6 +648,11 @@ func TestAppFrameworkSearchHeadClusterShouldNotFail(t *testing.T) {
 							Scope:   "local"},
 					},
 				},
+			},
+			// TODO gaurav: Remove this dependency on mock setting and try to use
+			// mock client for S3 responses.
+			CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
+				Mock: true,
 			},
 		},
 	}

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1"
+	splclient "github.com/splunk/splunk-operator/pkg/splunk/client"
 	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 	splctrl "github.com/splunk/splunk-operator/pkg/splunk/controller"
 )
@@ -38,6 +39,7 @@ func ApplyStandalone(client splcommon.ControllerClient, cr *enterprisev1.Standal
 		RequeueAfter: time.Second * 5,
 	}
 
+	scopedLog := log.WithName("ApplyStandalone").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
 	if cr.Status.ResourceRevMap == nil {
 		cr.Status.ResourceRevMap = make(map[string]string)
 	}
@@ -67,12 +69,22 @@ func ApplyStandalone(client splcommon.ControllerClient, cr *enterprisev1.Standal
 		cr.Status.SmartStore = cr.Spec.SmartStore
 	}
 
-	// ToDo sgontla: Handle
-	// 1. Spec update
-	// 2. S3 credentails change
-	// 3. Probe times expired
-	if !reflect.DeepEqual(cr.Status.AppContext.AppFrameworkConfig, cr.Spec.AppFrameworkConfig) {
-		// TBD: Probe the remote store, and handle any changes on remote store
+	if cr.Spec.CommonSplunkSpec.Mock != true && !reflect.DeepEqual(cr.Status.AppContext.AppFrameworkConfig, cr.Spec.AppFrameworkConfig) {
+		var sourceToAppsList map[string]splclient.S3Response
+
+		for _, vol := range cr.Spec.AppFrameworkConfig.VolList {
+			splclient.RegisterS3Client(vol.Provider)
+		}
+
+		sourceToAppsList, err = GetAppListFromS3Bucket(client, cr, &cr.Spec.AppFrameworkConfig)
+		if err != nil {
+			scopedLog.Error(err, "Unable to get apps list from remote storage")
+			return result, err
+		}
+
+		for _, appSource := range cr.Spec.AppFrameworkConfig.AppSources {
+			scopedLog.Info("Apps List retrieved from remote storage", "App Source", appSource.Name, "Content", sourceToAppsList[appSource.Name].Objects)
+		}
 
 		cr.Status.AppContext.AppFrameworkConfig = cr.Spec.AppFrameworkConfig
 	}

--- a/pkg/splunk/enterprise/standalone_test.go
+++ b/pkg/splunk/enterprise/standalone_test.go
@@ -124,7 +124,7 @@ func TestApplyStandaloneWithSmartstore(t *testing.T) {
 			Replicas: 1,
 			SmartStore: enterprisev1.SmartStoreSpec{
 				VolList: []enterprisev1.VolumeSpec{
-					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "splunk-test-secret"},
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "splunk-test-secret", Type: "s3", Provider: "aws"},
 				},
 				IndexList: []enterprisev1.IndexSpec{
 					{Name: "salesdata1", RemotePath: "remotepath1",
@@ -246,7 +246,7 @@ func TestApplyStandaloneSmartstoreKeyChangeDetection(t *testing.T) {
 			Replicas: 1,
 			SmartStore: enterprisev1.SmartStoreSpec{
 				VolList: []enterprisev1.VolumeSpec{
-					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "splunk-test-secret"},
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "splunk-test-secret", Type: "s3", Provider: "aws"},
 				},
 				IndexList: []enterprisev1.IndexSpec{
 					{Name: "salesdata1", RemotePath: "remotepath1",
@@ -303,7 +303,7 @@ func TestAppFrameworkApplyStandaloneShouldNotFail(t *testing.T) {
 			Replicas: 1,
 			AppFrameworkConfig: enterprisev1.AppFrameworkSpec{
 				VolList: []enterprisev1.VolumeSpec{
-					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret"},
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
 				},
 				AppSources: []enterprisev1.AppSourceSpec{
 					{Name: "adminApps",
@@ -325,6 +325,11 @@ func TestAppFrameworkApplyStandaloneShouldNotFail(t *testing.T) {
 							Scope:   "local"},
 					},
 				},
+			},
+			// TODO gaurav: Remove this dependency on mock setting and try to use
+			// mock client for S3 responses.
+			CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
+				Mock: true,
 			},
 		},
 	}


### PR DESCRIPTION
1. This PR targets framework, which will be used by operator to connect to remote storage(typically s3) to get the list of apps as specified in the CRs and which can be used later on to deploy and install the apps from remote storage.

2. This PR is the first part of the changes. Second part/PR will target UTs and code coverage for the related code.