### PR TITLE
add fix for building splunk-operator-cluster.yaml

### DIFF
--- a/build/package.sh
+++ b/build/package.sh
@@ -41,9 +41,9 @@ cat release-${VERSION}/splunk-operator-crds.yaml deploy/namespace.yaml > release
 echo "---" >> release-${VERSION}/splunk-operator-cluster.yaml
 yq w deploy/service_account.yaml metadata.namespace splunk-operator >> release-${VERSION}/splunk-operator-cluster.yaml
 echo "---" >> release-${VERSION}/splunk-operator-cluster.yaml
-yq w deploy/role.yaml metadata.namespace splunk-operator | yq w - kind ClusterRole >> release-${VERSION}/splunk-operator-cluster.yaml
+yq w deploy/role.yaml kind ClusterRole >> release-${VERSION}/splunk-operator-cluster.yaml
 echo "---" >> release-${VERSION}/splunk-operator-cluster.yaml
-yq w deploy/role_binding.yaml metadata.namespace splunk-operator | yq w - roleRef.kind ClusterRole >> release-${VERSION}/splunk-operator-cluster.yaml
+yq w deploy/role_binding.yaml "subjects[0].namespace" splunk-operator | yq w - roleRef.kind ClusterRole | yq w - kind ClusterRoleBinding >> release-${VERSION}/splunk-operator-cluster.yaml
 cat deploy/cluster_role.yaml deploy/cluster_role_binding.yaml >> release-${VERSION}/splunk-operator-cluster.yaml
 echo "---" >> release-${VERSION}/splunk-operator-cluster.yaml
 yq w deploy/operator.yaml metadata.namespace splunk-operator | yq w - "spec.template.spec.containers[0].image" $IMAGE | yq w - "spec.template.spec.containers[0].env[0].value" "" | yq d - "spec.template.spec.containers[0].env[0].valueFrom" >> release-${VERSION}/splunk-operator-cluster.yaml


### PR DESCRIPTION
Change namespaces and use ClusterRoleBinding instead of RoleBinding 

This PR is intended as a fix for #206 

The same error from the issue still occurs when we use splunk-operator-cluster.yaml from 1.0.0:

```
Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:splunk-operator:splunk-operator" cannot list resource "secrets" in API group "" at the cluster scope
```

The changes result in the exact changes in splunk-operator-cluster.yaml we needed to get it to work.

If this is not the desired approach please answer with a fix/solution in the issue.