### PR TITLE
CSPL-1068 added common util to support app framework test automation

### DIFF
--- a/test/testenv/util.go
+++ b/test/testenv/util.go
@@ -20,6 +20,8 @@ import (
 	"math/rand"
 	"os/exec"
 	"path"
+	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -616,4 +618,39 @@ func newLicenseMasterWithGivenSpec(name, ns string, spec enterprisev1.LicenseMas
 	}
 
 	return &new
+}
+
+// GetSubDirsOnPod returns subdirectory under given path on the given POD
+func GetSubDirsOnPod(deployment *Deployment, podName string, path string) ([]string, error) {
+	cmd := fmt.Sprintf("cd %s; ls -d */", path)
+	stdout, err := ExecuteCommandOnPod(deployment, podName, cmd)
+	if err != nil {
+		return nil, err
+	}
+	dirList := strings.Fields(stdout)
+	// Directory are returned with trailing /. The below loop removes the trailing /
+	for i, dirName := range dirList {
+		dirList[i] = strings.TrimSuffix(dirName, "/")
+	}
+	return strings.Fields(stdout), err
+}
+
+// CompareStringSlices checks if two string slices are matching
+func CompareStringSlices(stringOne []string, stringTwo []string) bool {
+	if len(stringOne) != len(stringTwo) {
+		return false
+	}
+	sort.Strings(stringOne)
+	sort.Strings(stringTwo)
+	return reflect.DeepEqual(stringOne, stringTwo)
+}
+
+// CheckStringInSlice check if string is present in a slice
+func CheckStringInSlice(stringSlice []string, compString string) bool {
+	for _, item := range stringSlice {
+		if item == compString {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Added common utils details below:

* Util to get directories under given path on a pod
* Util to check if a string exists in a given string slice
* Util to check two string slices match

Original PR with base develop https://github.com/splunk/splunk-operator/pull/353. 