### PR TITLE
CSPL-1065: Framework for mock client for AWS S3 and related unit tests

### DIFF
--- a/pkg/splunk/client/awss3client.go
+++ b/pkg/splunk/client/awss3client.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2018-2021 Splunk Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package client
 
 import (
@@ -34,22 +48,21 @@ type AWSS3Client struct {
 // regex to extract the region from the s3 endpoint
 var regionRegex = ".*.s3[-,.](?P<region>.*).amazonaws.com"
 
-//getRegion extracts the region from the endpoint field
-func getRegion(endpoint string) string {
+// GetRegion extracts the region from the endpoint field
+func GetRegion(endpoint string) string {
 	pattern := regexp.MustCompile(regionRegex)
 	return pattern.FindStringSubmatch(endpoint)[1]
 }
 
 // InitAWSClientWrapper is a wrapper around InitClientSession
-func InitAWSClientWrapper(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
-	return InitAWSClientSession(region, accessKeyID, secretAccessKey, isNotInTestContext)
+func InitAWSClientWrapper(region, accessKeyID, secretAccessKey string) interface{} {
+	return InitAWSClientSession(region, accessKeyID, secretAccessKey)
 }
 
 // InitAWSClientSession initializes and returns a client session object
-func InitAWSClientSession(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) SplunkAWSS3Client {
+func InitAWSClientSession(region, accessKeyID, secretAccessKey string) SplunkAWSS3Client {
 	scopedLog := log.WithName("InitAWSClientSession")
 
-	*isNotInTestContext = true
 	sess, err := session.NewSession(&aws.Config{
 		Region: aws.String(region),
 		Credentials: credentials.NewStaticCredentials(
@@ -66,21 +79,17 @@ func InitAWSClientSession(region, accessKeyID, secretAccessKey string, isNotInTe
 }
 
 // NewAWSS3Client returns an AWS S3 client
-func NewAWSS3Client(bucketName string, accessKeyID string, secretAccessKey string, prefix string, startAfter string, endpoint string, fn func(string, string, string, *bool) interface{}) (S3Client, error) {
-	var isNotInTestContext bool
+func NewAWSS3Client(bucketName string, accessKeyID string, secretAccessKey string, prefix string, startAfter string, endpoint string, fn GetInitFunc) (S3Client, error) {
 	var s3SplunkClient SplunkAWSS3Client
 	var err error
-	region := getRegion(endpoint)
-	cl := fn(region, accessKeyID, secretAccessKey, &isNotInTestContext)
+	region := GetRegion(endpoint)
+	cl := fn(region, accessKeyID, secretAccessKey)
 	if cl == nil {
 		err = fmt.Errorf("Failed to create an AWS S3 client")
 		return nil, err
 	}
-	if isNotInTestContext == true {
-		s3SplunkClient = cl.(*s3.S3)
-	} else {
-		s3SplunkClient = cl.(SplunkAWSS3Client)
-	}
+
+	s3SplunkClient = cl.(*s3.S3)
 
 	return &AWSS3Client{
 		Region:             region,

--- a/pkg/splunk/client/awss3client.go
+++ b/pkg/splunk/client/awss3client.go
@@ -14,6 +14,11 @@ import (
 // blank assignment to verify that AWSS3Client implements S3Client
 var _ S3Client = &AWSS3Client{}
 
+// SplunkAWSS3Client is an interface to AWS S3 client
+type SplunkAWSS3Client interface {
+	ListObjectsV2(options *s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error)
+}
+
 // AWSS3Client is a client to implement S3 specific APIs
 type AWSS3Client struct {
 	Region             string
@@ -23,6 +28,7 @@ type AWSS3Client struct {
 	Prefix             string
 	StartAfter         string
 	Endpoint           string
+	Client             SplunkAWSS3Client
 }
 
 // regex to extract the region from the s3 endpoint
@@ -34,9 +40,48 @@ func getRegion(endpoint string) string {
 	return pattern.FindStringSubmatch(endpoint)[1]
 }
 
+// InitAWSClientWrapper is a wrapper around InitClientSession
+func InitAWSClientWrapper(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
+	return InitAWSClientSession(region, accessKeyID, secretAccessKey, isNotInTestContext)
+}
+
+// InitAWSClientSession initializes and returns a client session object
+func InitAWSClientSession(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) SplunkAWSS3Client {
+	scopedLog := log.WithName("InitAWSClientSession")
+
+	*isNotInTestContext = true
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(region),
+		Credentials: credentials.NewStaticCredentials(
+			accessKeyID,     // id
+			secretAccessKey, // secret
+			"")},            // token
+	)
+	if err != nil {
+		scopedLog.Error(err, "Failed to initialize an AWS S3 session.")
+		return nil
+	}
+
+	return s3.New(sess)
+}
+
 // NewAWSS3Client returns an AWS S3 client
-func NewAWSS3Client(bucketName string, accessKeyID string, secretAccessKey string, prefix string, startAfter string, endpoint string) S3Client {
+func NewAWSS3Client(bucketName string, accessKeyID string, secretAccessKey string, prefix string, startAfter string, endpoint string, fn func(string, string, string, *bool) interface{}) (S3Client, error) {
+	var isNotInTestContext bool
+	var s3SplunkClient SplunkAWSS3Client
+	var err error
 	region := getRegion(endpoint)
+	cl := fn(region, accessKeyID, secretAccessKey, &isNotInTestContext)
+	if cl == nil {
+		err = fmt.Errorf("Failed to create an AWS S3 client")
+		return nil, err
+	}
+	if isNotInTestContext == true {
+		s3SplunkClient = cl.(*s3.S3)
+	} else {
+		s3SplunkClient = cl.(SplunkAWSS3Client)
+	}
+
 	return &AWSS3Client{
 		Region:             region,
 		BucketName:         bucketName,
@@ -45,12 +90,14 @@ func NewAWSS3Client(bucketName string, accessKeyID string, secretAccessKey strin
 		Prefix:             prefix,
 		StartAfter:         startAfter,
 		Endpoint:           endpoint,
-	}
+		Client:             s3SplunkClient,
+	}, nil
 }
 
-//RegisterAWSS3Client will add the corresponding function pointer to the map
+// RegisterAWSS3Client will add the corresponding function pointer to the map
 func RegisterAWSS3Client() {
-	S3Clients["aws"] = NewAWSS3Client
+	wrapperObject := GetS3ClientWrapper{GetS3Client: NewAWSS3Client, GetInitFunc: InitAWSClientWrapper}
+	S3Clients["aws"] = wrapperObject
 }
 
 // GetAppsList get the list of apps from remote storage
@@ -60,21 +107,6 @@ func (awsclient *AWSS3Client) GetAppsList() (S3Response, error) {
 	scopedLog.Info("Getting Apps list", "AWS S3 Bucket", awsclient.BucketName)
 	s3Resp := S3Response{}
 
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String(awsclient.Region),
-		Credentials: credentials.NewStaticCredentials(
-			awsclient.AWSAccessKeyID,     // id
-			awsclient.AWSSecretAccessKey, // secret
-			"")},                         // token
-	)
-	if err != nil {
-		scopedLog.Error(err, "Unable to create a new aws s3 session", "AWS S3 Bucket", awsclient.BucketName)
-		return s3Resp, err
-	}
-
-	// Create S3 service client
-	svc := s3.New(sess)
-
 	options := &s3.ListObjectsV2Input{
 		Bucket:     aws.String(awsclient.BucketName),
 		Prefix:     aws.String(awsclient.Prefix),
@@ -83,8 +115,8 @@ func (awsclient *AWSS3Client) GetAppsList() (S3Response, error) {
 		Delimiter:  aws.String("/"),                  // limit the listing to 1 level only
 	}
 
-	// List the bucket contents
-	resp, err := svc.ListObjectsV2(options)
+	client := awsclient.Client
+	resp, err := client.ListObjectsV2(options)
 	if err != nil {
 		scopedLog.Error(err, "Unable to list items in bucket", "AWS S3 Bucket", awsclient.BucketName)
 		return s3Resp, err

--- a/pkg/splunk/client/s3client.go
+++ b/pkg/splunk/client/s3client.go
@@ -5,18 +5,32 @@ import (
 	"time"
 )
 
+// GetS3ClientWrapper is a wrapper around init function pointers
+type GetS3ClientWrapper struct {
+	GetS3Client
+	GetInitFunc
+}
+
+// GetInitFunc gets the init func
+type GetInitFunc func(string, string, string, *bool) interface{}
+
 //GetS3Client gets the required S3Client based on the provider
 type GetS3Client func(string /* bucket */, string, /* AWS access key ID */
-	string /* AWS secret access key */, string /* Prefix */, string /* StartAfter */, string /* Endpoint */) S3Client
+	string /* AWS secret access key */, string /* Prefix */, string /* StartAfter */, string /* Endpoint */, func(string, string, string, *bool) interface{}) (S3Client, error)
 
 // S3Clients is a map of provider name to init functions
-var S3Clients = make(map[string]GetS3Client)
+var S3Clients = make(map[string]GetS3ClientWrapper)
 
 // S3Client is an interface to implement different S3 client APIs
 type S3Client interface {
 	GetAppsList() (S3Response, error)
 	GetInitContainerImage() string
 	GetInitContainerCmd(string /* endpoint */, string /* bucket */, string /* path */, string /* app src name */, string /* app mnt */) []string
+}
+
+// SplunkS3Client is a simple object used to connect to S3
+type SplunkS3Client struct {
+	Client S3Client
 }
 
 // S3Response struct contains list of RemoteObject objects as part of S3 response

--- a/pkg/splunk/client/s3client.go
+++ b/pkg/splunk/client/s3client.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2018-2021 Splunk Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package client
 
 import (
@@ -11,12 +25,34 @@ type GetS3ClientWrapper struct {
 	GetInitFunc
 }
 
-// GetInitFunc gets the init func
-type GetInitFunc func(string, string, string, *bool) interface{}
+// SetS3ClientFuncPtr sets the GetS3Client function pointer member of GetS3ClientWrapper struct
+func (c *GetS3ClientWrapper) SetS3ClientFuncPtr(volName string, fn GetS3Client) {
+	c.GetS3Client = fn
+	S3Clients[volName] = *c
+}
+
+// GetS3ClientFuncPtr gets the GetS3Client function pointer member of GetS3ClientWrapper struct
+func (c *GetS3ClientWrapper) GetS3ClientFuncPtr() GetS3Client {
+	return c.GetS3Client
+}
+
+// SetS3ClientInitFuncPtr sets the GetS3Client function pointer member of GetS3ClientWrapper struct
+func (c *GetS3ClientWrapper) SetS3ClientInitFuncPtr(volName string, fn GetInitFunc) {
+	c.GetInitFunc = fn
+	S3Clients[volName] = *c
+}
+
+// GetS3ClientInitFuncPtr gets the GetS3Client function pointer member of GetS3ClientWrapper struct
+func (c *GetS3ClientWrapper) GetS3ClientInitFuncPtr() GetInitFunc {
+	return c.GetInitFunc
+}
+
+// GetInitFunc gets the init function pointer which returns the new S3 session client object
+type GetInitFunc func(string, string, string) interface{}
 
 //GetS3Client gets the required S3Client based on the provider
 type GetS3Client func(string /* bucket */, string, /* AWS access key ID */
-	string /* AWS secret access key */, string /* Prefix */, string /* StartAfter */, string /* Endpoint */, func(string, string, string, *bool) interface{}) (S3Client, error)
+	string /* AWS secret access key */, string /* Prefix */, string /* StartAfter */, string /* Endpoint */, GetInitFunc) (S3Client, error)
 
 // S3Clients is a map of provider name to init functions
 var S3Clients = make(map[string]GetS3ClientWrapper)

--- a/pkg/splunk/enterprise/clustermaster.go
+++ b/pkg/splunk/enterprise/clustermaster.go
@@ -93,9 +93,9 @@ func ApplyClusterMaster(client splcommon.ControllerClient, cr *enterprisev1.Clus
 			}
 		}
 
-		sourceToAppsList = GetAppListFromS3Bucket(client, cr, &cr.Spec.AppFrameworkConfig)
+		sourceToAppsList, err = GetAppListFromS3Bucket(client, cr, &cr.Spec.AppFrameworkConfig)
 		if len(sourceToAppsList) != len(cr.Spec.AppFrameworkConfig.AppSources) {
-			scopedLog.Error(err, "Unable to get apps list for all the app sources from remote storage")
+			scopedLog.Error(err, "Unable to get apps list, will retry in next reconcile...")
 			return result, err
 		}
 
@@ -191,7 +191,7 @@ func validateClusterMasterSpec(cr *enterprisev1.ClusterMaster) error {
 	}
 
 	if !reflect.DeepEqual(cr.Status.AppContext.AppFrameworkConfig, cr.Spec.AppFrameworkConfig) {
-		err := ValidateAppFrameworkSpec(&cr.Spec.AppFrameworkConfig, true)
+		err := ValidateAppFrameworkSpec(&cr.Spec.AppFrameworkConfig, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/splunk/enterprise/clustermaster_test.go
+++ b/pkg/splunk/enterprise/clustermaster_test.go
@@ -538,7 +538,7 @@ func TestClusterMasterGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 
 	splclient.RegisterS3Client("aws")
 
-	Etags := []string{"cc707187b036405f095a8ebb43a782c1", "5055a61b3d1b667a4c3279a381a2e7ae", "19779168370b97d8654424e6c9446dd9"}
+	Etags := []string{"cc707187b036405f095a8ebb43a782c1", "5055a61b3d1b667a4c3279a381a2e7ae", "19779168370b97d8654424e6c9446dd8"}
 	Keys := []string{"admin_app.tgz", "security_app.tgz", "authentication_app.tgz"}
 	Sizes := []int64{10, 20, 30}
 	StorageClass := "STANDARD"

--- a/pkg/splunk/enterprise/clustermaster_test.go
+++ b/pkg/splunk/enterprise/clustermaster_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1"
+	splclient "github.com/splunk/splunk-operator/pkg/splunk/client"
 	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 	splctrl "github.com/splunk/splunk-operator/pkg/splunk/controller"
 	spltest "github.com/splunk/splunk-operator/pkg/splunk/test"
@@ -423,8 +424,8 @@ func TestPushMasterAppsBundle(t *testing.T) {
 	}
 }
 
-func TestAppFrameworkApplyClusterMasterShouldNotFail(t *testing.T) {
-	cr := enterprisev1.ClusterMaster{
+func TestAppFrameworkApplyClusterMasterShouldFail(t *testing.T) {
+	cm := enterprisev1.ClusterMaster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "stack1",
 			Namespace: "test",
@@ -432,7 +433,12 @@ func TestAppFrameworkApplyClusterMasterShouldNotFail(t *testing.T) {
 		Spec: enterprisev1.ClusterMasterSpec{
 			AppFrameworkConfig: enterprisev1.AppFrameworkSpec{
 				VolList: []enterprisev1.VolumeSpec{
-					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
+					{Name: "msos_s2s3_vol",
+						Endpoint:  "https://s3-eu-west-2.amazonaws.com",
+						Path:      "testbucket-rs-london",
+						SecretRef: "s3-secret",
+						Type:      "s3",
+						Provider:  "aws"},
 				},
 				AppSources: []enterprisev1.AppSourceSpec{
 					{Name: "adminApps",
@@ -455,10 +461,216 @@ func TestAppFrameworkApplyClusterMasterShouldNotFail(t *testing.T) {
 					},
 				},
 			},
-			// TODO gaurav: Remove this dependency on mock setting and try to use
-			// mock client for S3 responses.
-			CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
-				Mock: true,
+		},
+	}
+
+	client := spltest.NewMockClient()
+
+	// Create S3 secret
+	s3Secret := spltest.GetMockS3SecretKeys("s3-secret")
+
+	client.AddObject(&s3Secret)
+
+	// Create namespace scoped secret
+	_, err := splutil.ApplyNamespaceScopedSecretObject(client, "test")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	_, err = ApplyClusterMaster(client, &cm)
+	if err == nil {
+		t.Errorf("ApplyClusterMaster should have returned error here.")
+	}
+}
+
+func TestClusterMasterGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
+	cm := enterprisev1.ClusterMaster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stack1",
+			Namespace: "test",
+		},
+		Spec: enterprisev1.ClusterMasterSpec{
+			AppFrameworkConfig: enterprisev1.AppFrameworkSpec{
+				VolList: []enterprisev1.VolumeSpec{
+					{Name: "msos_s2s3_vol",
+						Endpoint:  "https://s3-eu-west-2.amazonaws.com",
+						Path:      "testbucket-rs-london",
+						SecretRef: "s3-secret",
+						Type:      "s3",
+						Provider:  "aws"},
+				},
+				AppSources: []enterprisev1.AppSourceSpec{
+					{Name: "adminApps",
+						Location: "adminAppsRepo",
+						AppSourceDefaultSpec: enterprisev1.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   "local"},
+					},
+					{Name: "securityApps",
+						Location: "securityAppsRepo",
+						AppSourceDefaultSpec: enterprisev1.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   "local"},
+					},
+					{Name: "authenticationApps",
+						Location: "authenticationAppsRepo",
+						AppSourceDefaultSpec: enterprisev1.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   "local"},
+					},
+				},
+			},
+		},
+	}
+
+	client := spltest.NewMockClient()
+
+	// Create S3 secret
+	s3Secret := spltest.GetMockS3SecretKeys("s3-secret")
+
+	client.AddObject(&s3Secret)
+
+	// Create namespace scoped secret
+	_, err := splutil.ApplyNamespaceScopedSecretObject(client, "test")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	splclient.RegisterS3Client("aws")
+
+	Etags := []string{"cc707187b036405f095a8ebb43a782c1", "5055a61b3d1b667a4c3279a381a2e7ae", "19779168370b97d8654424e6c9446dd9"}
+	Keys := []string{"admin_app.tgz", "security_app.tgz", "authentication_app.tgz"}
+	Sizes := []int64{10, 20, 30}
+	StorageClass := "STANDARD"
+	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.Now().Location())
+
+	mockAwsHandler := spltest.MockAWSS3Handler{}
+
+	mockAwsObjects := []spltest.MockAWSS3Client{
+		{
+			Objects: []*spltest.MockAWSS3Object{
+				{
+					Etag:         &Etags[0],
+					Key:          &Keys[0],
+					LastModified: &randomTime,
+					Size:         &Sizes[0],
+					StorageClass: &StorageClass,
+				},
+			},
+		},
+		{
+			Objects: []*spltest.MockAWSS3Object{
+				{
+					Etag:         &Etags[1],
+					Key:          &Keys[1],
+					LastModified: &randomTime,
+					Size:         &Sizes[1],
+					StorageClass: &StorageClass,
+				},
+			},
+		},
+		{
+			Objects: []*spltest.MockAWSS3Object{
+				{
+					Etag:         &Etags[2],
+					Key:          &Keys[2],
+					LastModified: &randomTime,
+					Size:         &Sizes[2],
+					StorageClass: &StorageClass,
+				},
+			},
+		},
+	}
+
+	appFrameworkRef := cm.Spec.AppFrameworkConfig
+
+	mockAwsHandler.AddObjects(appFrameworkRef, mockAwsObjects...)
+
+	var vol enterprisev1.VolumeSpec
+	var allSuccess bool = true
+	for index, appSource := range appFrameworkRef.AppSources {
+
+		vol, err = GetVolume(client, &cm, appSource, &appFrameworkRef)
+		if err != nil {
+			_ = fmt.Errorf("Unable to get Volume")
+			allSuccess = false
+			continue
+		}
+
+		s3ClientMgr := &S3ClientManager{
+			client:          client,
+			cr:              &cm,
+			appFrameworkRef: &cm.Spec.AppFrameworkConfig,
+			vol:             &vol,
+			location:        appSource.Location,
+			initFn: func(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
+				*isNotInTestContext = false
+				cl := spltest.MockAWSS3Client{}
+				cl.Objects = mockAwsObjects[index].Objects
+				return cl
+			},
+			getS3Client: func(client splcommon.ControllerClient, cr splcommon.MetaObject,
+				appFrameworkRef *enterprisev1.AppFrameworkSpec, vol *enterprisev1.VolumeSpec,
+				location string, fn func(string, string, string, *bool) interface{}) (splclient.SplunkS3Client, error) {
+				// Get the mock client
+				c, err := GetRemoteStorageClient(client, cr, appFrameworkRef, vol, location, fn)
+				return c, err
+			},
+		}
+
+		s3Response, err := s3ClientMgr.GetAppsList()
+		if err != nil {
+			_ = fmt.Errorf("Unable to get apps list")
+			allSuccess = false
+			continue
+		}
+
+		var mockResponse spltest.MockAWSS3Client
+		mockResponse, err = ConvertS3Response(s3Response)
+		if err != nil {
+			_ = fmt.Errorf("Unable to convert s3 response")
+			allSuccess = false
+			continue
+		}
+
+		if mockAwsHandler.GotSourceAppListResponseMap == nil {
+			mockAwsHandler.GotSourceAppListResponseMap = make(map[string]spltest.MockAWSS3Client)
+		}
+
+		mockAwsHandler.GotSourceAppListResponseMap[appSource.Name] = mockResponse
+	}
+
+	if allSuccess == false {
+		t.Errorf("Unable to get apps list for all the app sources")
+	}
+	method := "GetAppsList"
+	mockAwsHandler.CheckAwsS3Response(t, method)
+}
+
+func TestClusterMasterGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
+	cm := enterprisev1.ClusterMaster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stack1",
+			Namespace: "test",
+		},
+		Spec: enterprisev1.ClusterMasterSpec{
+			AppFrameworkConfig: enterprisev1.AppFrameworkSpec{
+				VolList: []enterprisev1.VolumeSpec{
+					{Name: "msos_s2s3_vol",
+						Endpoint:  "https://s3-eu-west-2.amazonaws.com",
+						Path:      "testbucket-rs-london",
+						SecretRef: "s3-secret",
+						Type:      "s3",
+						Provider:  "aws"},
+				},
+				AppSources: []enterprisev1.AppSourceSpec{
+					{Name: "adminApps",
+						Location: "adminAppsRepo",
+						AppSourceDefaultSpec: enterprisev1.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   "local"},
+					},
+				},
 			},
 		},
 	}
@@ -471,8 +683,116 @@ func TestAppFrameworkApplyClusterMasterShouldNotFail(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	_, err = ApplyClusterMaster(client, &cr)
+	splclient.RegisterS3Client("aws")
+
+	Etags := []string{"cc707187b036405f095a8ebb43a782c1"}
+	Keys := []string{"admin_app.tgz"}
+	Sizes := []int64{10}
+	StorageClass := "STANDARD"
+	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.Now().Location())
+
+	mockAwsHandler := spltest.MockAWSS3Handler{}
+
+	mockAwsObjects := []spltest.MockAWSS3Client{
+		{
+			Objects: []*spltest.MockAWSS3Object{
+				{
+					Etag:         &Etags[0],
+					Key:          &Keys[0],
+					LastModified: &randomTime,
+					Size:         &Sizes[0],
+					StorageClass: &StorageClass,
+				},
+			},
+		},
+	}
+
+	appFrameworkRef := cm.Spec.AppFrameworkConfig
+
+	mockAwsHandler.AddObjects(appFrameworkRef, mockAwsObjects...)
+
+	var vol enterprisev1.VolumeSpec
+
+	appSource := appFrameworkRef.AppSources[0]
+	vol, err = GetVolume(client, &cm, appSource, &appFrameworkRef)
 	if err != nil {
-		t.Errorf("ApplyClusterMaster with valid App Framework config should be successful, but got error: %v", err)
+		t.Errorf("Unable to get Volume")
+	}
+
+	s3ClientMgr := &S3ClientManager{
+		client:          client,
+		cr:              &cm,
+		appFrameworkRef: &cm.Spec.AppFrameworkConfig,
+		vol:             &vol,
+		location:        appSource.Location,
+		initFn: func(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
+			*isNotInTestContext = false
+			// Purposefully return nil here so that we test the error scenario
+			return nil
+		},
+		getS3Client: func(client splcommon.ControllerClient, cr splcommon.MetaObject,
+			appFrameworkRef *enterprisev1.AppFrameworkSpec, vol *enterprisev1.VolumeSpec,
+			location string, fn func(string, string, string, *bool) interface{}) (splclient.SplunkS3Client, error) {
+			// Get the mock client
+			c, err := GetRemoteStorageClient(client, cr, appFrameworkRef, vol, location, fn)
+			return c, err
+		},
+	}
+
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as there is no S3 secret provided")
+	}
+
+	// Create empty S3 secret
+	s3Secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "s3-secret",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{},
+	}
+
+	client.AddObject(&s3Secret)
+
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as S3 secret has empty keys")
+	}
+
+	accessKey := []byte{'1'}
+	s3Secret.Data = map[string][]byte{"s3_access_key": accessKey}
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as S3 secret has empty s3_secret_key")
+	}
+
+	secretKey := []byte{'2'}
+	s3Secret.Data = map[string][]byte{"s3_secret_key": secretKey}
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as S3 secret has empty s3_access_key")
+	}
+
+	// Create S3 secret
+	s3Secret = spltest.GetMockS3SecretKeys("s3-secret")
+
+	// This should return an error as we have initialized initFn for s3ClientMgr
+	// to return a nil client.
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as we could not get the S3 client")
+	}
+
+	s3ClientMgr.initFn = func(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
+		*isNotInTestContext = false
+		// To test the error scenario, do no set the Objects member yet
+		cl := spltest.MockAWSS3Client{}
+		return cl
+	}
+
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as we have empty objects in MockAWSS3Client")
 	}
 }

--- a/pkg/splunk/enterprise/clustermaster_test.go
+++ b/pkg/splunk/enterprise/clustermaster_test.go
@@ -595,7 +595,6 @@ func TestClusterMasterGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 
 		vol, err = GetVolume(client, &cm, appSource, &appFrameworkRef)
 		if err != nil {
-			_ = fmt.Errorf("Unable to get Volume")
 			allSuccess = false
 			continue
 		}
@@ -626,7 +625,6 @@ func TestClusterMasterGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 
 		s3Response, err := s3ClientMgr.GetAppsList()
 		if err != nil {
-			_ = fmt.Errorf("Unable to get apps list")
 			allSuccess = false
 			continue
 		}
@@ -634,7 +632,6 @@ func TestClusterMasterGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 		var mockResponse spltest.MockAWSS3Client
 		mockResponse, err = ConvertS3Response(s3Response)
 		if err != nil {
-			_ = fmt.Errorf("Unable to convert s3 response")
 			allSuccess = false
 			continue
 		}

--- a/pkg/splunk/enterprise/clustermaster_test.go
+++ b/pkg/splunk/enterprise/clustermaster_test.go
@@ -542,7 +542,7 @@ func TestClusterMasterGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 	Keys := []string{"admin_app.tgz", "security_app.tgz", "authentication_app.tgz"}
 	Sizes := []int64{10, 20, 30}
 	StorageClass := "STANDARD"
-	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.Now().Location())
+	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.UTC)
 
 	mockAwsHandler := spltest.MockAWSS3Handler{}
 
@@ -689,7 +689,7 @@ func TestClusterMasterGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
 	Keys := []string{"admin_app.tgz"}
 	Sizes := []int64{10}
 	StorageClass := "STANDARD"
-	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.Now().Location())
+	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.UTC)
 
 	mockAwsHandler := spltest.MockAWSS3Handler{}
 

--- a/pkg/splunk/enterprise/licensemaster.go
+++ b/pkg/splunk/enterprise/licensemaster.go
@@ -56,9 +56,9 @@ func ApplyLicenseMaster(client splcommon.ControllerClient, cr *enterprisev1.Lice
 			}
 		}
 
-		sourceToAppsList = GetAppListFromS3Bucket(client, cr, &cr.Spec.AppFrameworkConfig)
+		sourceToAppsList, err = GetAppListFromS3Bucket(client, cr, &cr.Spec.AppFrameworkConfig)
 		if len(sourceToAppsList) != len(cr.Spec.AppFrameworkConfig.AppSources) {
-			scopedLog.Error(err, "Unable to get apps list for all the app sources from remote storage")
+			scopedLog.Error(err, "Unable to get apps list, will retry in next reconcile...")
 			return result, err
 		}
 

--- a/pkg/splunk/enterprise/licensemaster_test.go
+++ b/pkg/splunk/enterprise/licensemaster_test.go
@@ -15,7 +15,6 @@
 package enterprise
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -282,7 +281,6 @@ func TestLicenseMasterGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 
 		vol, err = GetVolume(client, &cr, appSource, &appFrameworkRef)
 		if err != nil {
-			_ = fmt.Errorf("Unable to get Volume")
 			allSuccess = false
 			continue
 		}
@@ -308,7 +306,6 @@ func TestLicenseMasterGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 
 		s3Response, err := s3ClientMgr.GetAppsList()
 		if err != nil {
-			_ = fmt.Errorf("Unable to get apps list")
 			allSuccess = false
 			continue
 		}
@@ -316,7 +313,6 @@ func TestLicenseMasterGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 		var mockResponse spltest.MockAWSS3Client
 		mockResponse, err = ConvertS3Response(s3Response)
 		if err != nil {
-			_ = fmt.Errorf("Unable to convert s3 response")
 			allSuccess = false
 			continue
 		}

--- a/pkg/splunk/enterprise/licensemaster_test.go
+++ b/pkg/splunk/enterprise/licensemaster_test.go
@@ -232,7 +232,7 @@ func TestLicenseMasterGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 	Keys := []string{"admin_app.tgz", "security_app.tgz", "authentication_app.tgz"}
 	Sizes := []int64{10, 20, 30}
 	StorageClass := "STANDARD"
-	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.Now().Location())
+	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.UTC)
 
 	mockAwsHandler := spltest.MockAWSS3Handler{}
 
@@ -374,7 +374,7 @@ func TestLicenseMasterGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
 	Keys := []string{"admin_app.tgz"}
 	Sizes := []int64{10}
 	StorageClass := "STANDARD"
-	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.Now().Location())
+	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.UTC)
 
 	mockAwsHandler := spltest.MockAWSS3Handler{}
 

--- a/pkg/splunk/enterprise/licensemaster_test.go
+++ b/pkg/splunk/enterprise/licensemaster_test.go
@@ -15,6 +15,7 @@
 package enterprise
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1"
+	splclient "github.com/splunk/splunk-operator/pkg/splunk/client"
 	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 	spltest "github.com/splunk/splunk-operator/pkg/splunk/test"
 	splutil "github.com/splunk/splunk-operator/pkg/splunk/util"
@@ -122,7 +124,7 @@ func TestGetLicenseMasterStatefulSet(t *testing.T) {
 	test(`{"kind":"StatefulSet","apiVersion":"apps/v1","metadata":{"name":"splunk-stack1-license-master","namespace":"test","creationTimestamp":null,"ownerReferences":[{"apiVersion":"","kind":"","name":"stack1","uid":"","controller":true}]},"spec":{"replicas":1,"selector":{"matchLabels":{"app.kubernetes.io/component":"license-master","app.kubernetes.io/instance":"splunk-stack1-license-master","app.kubernetes.io/managed-by":"splunk-operator","app.kubernetes.io/name":"license-master","app.kubernetes.io/part-of":"splunk-stack1-license-master"}},"template":{"metadata":{"creationTimestamp":null,"labels":{"app.kubernetes.io/component":"license-master","app.kubernetes.io/instance":"splunk-stack1-license-master","app.kubernetes.io/managed-by":"splunk-operator","app.kubernetes.io/name":"license-master","app.kubernetes.io/part-of":"splunk-stack1-license-master"},"annotations":{"traffic.sidecar.istio.io/excludeOutboundPorts":"8089,8191,9997","traffic.sidecar.istio.io/includeInboundPorts":"8000"}},"spec":{"volumes":[{"name":"mnt-splunk-secrets","secret":{"secretName":"splunk-stack1-license-master-secret-v1","defaultMode":420}}],"containers":[{"name":"splunk","image":"splunk/splunk","ports":[{"name":"http-splunkweb","containerPort":8000,"protocol":"TCP"},{"name":"https-splunkd","containerPort":8089,"protocol":"TCP"}],"env":[{"name":"SPLUNK_HOME","value":"/opt/splunk"},{"name":"SPLUNK_START_ARGS","value":"--accept-license"},{"name":"SPLUNK_DEFAULTS_URL","value":"/mnt/apps/apps.yml,/mnt/splunk-secrets/default.yml"},{"name":"SPLUNK_HOME_OWNERSHIP_ENFORCEMENT","value":"false"},{"name":"SPLUNK_ROLE","value":"splunk_license_master"},{"name":"SPLUNK_DECLARATIVE_ADMIN_PASSWORD","value":"true"},{"name":"SPLUNK_LICENSE_URI","value":"/mnt/splunk.lic"}],"resources":{"limits":{"cpu":"4","memory":"8Gi"},"requests":{"cpu":"100m","memory":"512Mi"}},"volumeMounts":[{"name":"pvc-etc","mountPath":"/opt/splunk/etc"},{"name":"pvc-var","mountPath":"/opt/splunk/var"},{"name":"mnt-splunk-secrets","mountPath":"/mnt/splunk-secrets"}],"livenessProbe":{"exec":{"command":["/sbin/checkstate.sh"]},"initialDelaySeconds":300,"timeoutSeconds":30,"periodSeconds":30},"readinessProbe":{"exec":{"command":["/bin/grep","started","/opt/container_artifact/splunk-container.state"]},"initialDelaySeconds":10,"timeoutSeconds":5,"periodSeconds":5},"imagePullPolicy":"IfNotPresent"}],"serviceAccountName":"defaults","securityContext":{"runAsUser":41812,"fsGroup":41812},"affinity":{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"weight":100,"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/instance","operator":"In","values":["splunk-stack1-license-master"]}]},"topologyKey":"kubernetes.io/hostname"}}]}},"schedulerName":"default-scheduler"}},"volumeClaimTemplates":[{"metadata":{"name":"pvc-etc","namespace":"test","creationTimestamp":null,"labels":{"app.kubernetes.io/component":"license-master","app.kubernetes.io/instance":"splunk-stack1-license-master","app.kubernetes.io/managed-by":"splunk-operator","app.kubernetes.io/name":"license-master","app.kubernetes.io/part-of":"splunk-stack1-license-master"}},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"10Gi"}}},"status":{}},{"metadata":{"name":"pvc-var","namespace":"test","creationTimestamp":null,"labels":{"app.kubernetes.io/component":"license-master","app.kubernetes.io/instance":"splunk-stack1-license-master","app.kubernetes.io/managed-by":"splunk-operator","app.kubernetes.io/name":"license-master","app.kubernetes.io/part-of":"splunk-stack1-license-master"}},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"100Gi"}}},"status":{}}],"serviceName":"splunk-stack1-license-master-headless","podManagementPolicy":"Parallel","updateStrategy":{"type":"OnDelete"}},"status":{"replicas":0}}`)
 }
 
-func TestAppFrameworkApplyLicenseMasterShouldNotFail(t *testing.T) {
+func TestAppFrameworkApplyLicenseMasterShouldFail(t *testing.T) {
 	cr := enterprisev1.LicenseMaster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "stack1",
@@ -154,10 +156,206 @@ func TestAppFrameworkApplyLicenseMasterShouldNotFail(t *testing.T) {
 					},
 				},
 			},
-			// TODO gaurav: Remove this dependency on mock setting and try to use
-			// mock client for S3 responses.
-			CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
-				Mock: true,
+		},
+	}
+
+	client := spltest.NewMockClient()
+
+	// Create namespace scoped secret
+	_, err := splutil.ApplyNamespaceScopedSecretObject(client, "test")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	// Create S3 secret
+	s3Secret := spltest.GetMockS3SecretKeys("s3-secret")
+
+	client.AddObject(&s3Secret)
+
+	_, err = ApplyLicenseMaster(client, &cr)
+	if err == nil {
+		t.Errorf("ApplyLicenseMaster should not be successful")
+	}
+}
+
+func TestLicenseMasterGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
+	cr := enterprisev1.LicenseMaster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stack1",
+			Namespace: "test",
+		},
+		Spec: enterprisev1.LicenseMasterSpec{
+			AppFrameworkConfig: enterprisev1.AppFrameworkSpec{
+				VolList: []enterprisev1.VolumeSpec{
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
+				},
+				AppSources: []enterprisev1.AppSourceSpec{
+					{Name: "adminApps",
+						Location: "adminAppsRepo",
+						AppSourceDefaultSpec: enterprisev1.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   "local"},
+					},
+					{Name: "securityApps",
+						Location: "securityAppsRepo",
+						AppSourceDefaultSpec: enterprisev1.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   "local"},
+					},
+					{Name: "authenticationApps",
+						Location: "authenticationAppsRepo",
+						AppSourceDefaultSpec: enterprisev1.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   "local"},
+					},
+				},
+			},
+		},
+	}
+
+	client := spltest.NewMockClient()
+
+	// Create S3 secret
+	s3Secret := spltest.GetMockS3SecretKeys("s3-secret")
+
+	client.AddObject(&s3Secret)
+
+	// Create namespace scoped secret
+	_, err := splutil.ApplyNamespaceScopedSecretObject(client, "test")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	splclient.RegisterS3Client("aws")
+
+	Etags := []string{"cc707187b036405f095a8ebb43a782c1", "5055a61b3d1b667a4c3279a381a2e7ae", "19779168370b97d8654424e6c9446dd9"}
+	Keys := []string{"admin_app.tgz", "security_app.tgz", "authentication_app.tgz"}
+	Sizes := []int64{10, 20, 30}
+	StorageClass := "STANDARD"
+	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.Now().Location())
+
+	mockAwsHandler := spltest.MockAWSS3Handler{}
+
+	mockAwsObjects := []spltest.MockAWSS3Client{
+		{
+			Objects: []*spltest.MockAWSS3Object{
+				{
+					Etag:         &Etags[0],
+					Key:          &Keys[0],
+					LastModified: &randomTime,
+					Size:         &Sizes[0],
+					StorageClass: &StorageClass,
+				},
+			},
+		},
+		{
+			Objects: []*spltest.MockAWSS3Object{
+				{
+					Etag:         &Etags[1],
+					Key:          &Keys[1],
+					LastModified: &randomTime,
+					Size:         &Sizes[1],
+					StorageClass: &StorageClass,
+				},
+			},
+		},
+		{
+			Objects: []*spltest.MockAWSS3Object{
+				{
+					Etag:         &Etags[2],
+					Key:          &Keys[2],
+					LastModified: &randomTime,
+					Size:         &Sizes[2],
+					StorageClass: &StorageClass,
+				},
+			},
+		},
+	}
+
+	appFrameworkRef := cr.Spec.AppFrameworkConfig
+
+	mockAwsHandler.AddObjects(appFrameworkRef, mockAwsObjects...)
+
+	var vol enterprisev1.VolumeSpec
+	var allSuccess bool = true
+	for index, appSource := range appFrameworkRef.AppSources {
+
+		vol, err = GetVolume(client, &cr, appSource, &appFrameworkRef)
+		if err != nil {
+			_ = fmt.Errorf("Unable to get Volume")
+			allSuccess = false
+			continue
+		}
+
+		s3ClientMgr := &S3ClientManager{client: client,
+			cr: &cr, appFrameworkRef: &cr.Spec.AppFrameworkConfig,
+			vol:      &vol,
+			location: appSource.Location,
+			initFn: func(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
+				*isNotInTestContext = false
+				cl := spltest.MockAWSS3Client{}
+				cl.Objects = mockAwsObjects[index].Objects
+				return cl
+			},
+			getS3Client: func(client splcommon.ControllerClient, cr splcommon.MetaObject, appFrameworkRef *enterprisev1.AppFrameworkSpec, vol *enterprisev1.VolumeSpec, location string, fn func(string, string, string, *bool) interface{}) (splclient.SplunkS3Client, error) {
+				c, err := GetRemoteStorageClient(client, cr, appFrameworkRef, vol, location, fn)
+				return c, err
+			},
+		}
+
+		s3Response, err := s3ClientMgr.GetAppsList()
+		if err != nil {
+			_ = fmt.Errorf("Unable to get apps list")
+			allSuccess = false
+			continue
+		}
+
+		var mockResponse spltest.MockAWSS3Client
+		mockResponse, err = ConvertS3Response(s3Response)
+		if err != nil {
+			_ = fmt.Errorf("Unable to convert s3 response")
+			allSuccess = false
+			continue
+		}
+
+		if mockAwsHandler.GotSourceAppListResponseMap == nil {
+			mockAwsHandler.GotSourceAppListResponseMap = make(map[string]spltest.MockAWSS3Client)
+		}
+
+		mockAwsHandler.GotSourceAppListResponseMap[appSource.Name] = mockResponse
+	}
+
+	if allSuccess == false {
+		t.Errorf("Unable to get apps list for all the app sources")
+	}
+	method := "GetAppsList"
+	mockAwsHandler.CheckAwsS3Response(t, method)
+}
+
+func TestLicenseMasterGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
+	lm := enterprisev1.LicenseMaster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stack1",
+			Namespace: "test",
+		},
+		Spec: enterprisev1.LicenseMasterSpec{
+			AppFrameworkConfig: enterprisev1.AppFrameworkSpec{
+				VolList: []enterprisev1.VolumeSpec{
+					{Name: "msos_s2s3_vol",
+						Endpoint:  "https://s3-eu-west-2.amazonaws.com",
+						Path:      "testbucket-rs-london",
+						SecretRef: "s3-secret",
+						Type:      "s3",
+						Provider:  "aws"},
+				},
+				AppSources: []enterprisev1.AppSourceSpec{
+					{Name: "adminApps",
+						Location: "adminAppsRepo",
+						AppSourceDefaultSpec: enterprisev1.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   "local"},
+					},
+				},
 			},
 		},
 	}
@@ -170,8 +368,116 @@ func TestAppFrameworkApplyLicenseMasterShouldNotFail(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	_, err = ApplyLicenseMaster(client, &cr)
+	splclient.RegisterS3Client("aws")
+
+	Etags := []string{"cc707187b036405f095a8ebb43a782c1"}
+	Keys := []string{"admin_app.tgz"}
+	Sizes := []int64{10}
+	StorageClass := "STANDARD"
+	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.Now().Location())
+
+	mockAwsHandler := spltest.MockAWSS3Handler{}
+
+	mockAwsObjects := []spltest.MockAWSS3Client{
+		{
+			Objects: []*spltest.MockAWSS3Object{
+				{
+					Etag:         &Etags[0],
+					Key:          &Keys[0],
+					LastModified: &randomTime,
+					Size:         &Sizes[0],
+					StorageClass: &StorageClass,
+				},
+			},
+		},
+	}
+
+	appFrameworkRef := lm.Spec.AppFrameworkConfig
+
+	mockAwsHandler.AddObjects(appFrameworkRef, mockAwsObjects...)
+
+	var vol enterprisev1.VolumeSpec
+
+	appSource := appFrameworkRef.AppSources[0]
+	vol, err = GetVolume(client, &lm, appSource, &appFrameworkRef)
 	if err != nil {
-		t.Errorf("ApplyLicenseMaster with valid App Framework config should be successful, but got error: %v", err)
+		t.Errorf("Unable to get Volume")
+	}
+
+	s3ClientMgr := &S3ClientManager{
+		client:          client,
+		cr:              &lm,
+		appFrameworkRef: &lm.Spec.AppFrameworkConfig,
+		vol:             &vol,
+		location:        appSource.Location,
+		initFn: func(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
+			*isNotInTestContext = false
+			// Purposefully return nil here so that we test the error scenario
+			return nil
+		},
+		getS3Client: func(client splcommon.ControllerClient, cr splcommon.MetaObject,
+			appFrameworkRef *enterprisev1.AppFrameworkSpec, vol *enterprisev1.VolumeSpec,
+			location string, fn func(string, string, string, *bool) interface{}) (splclient.SplunkS3Client, error) {
+			// Get the mock client
+			c, err := GetRemoteStorageClient(client, cr, appFrameworkRef, vol, location, fn)
+			return c, err
+		},
+	}
+
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as there is no S3 secret provided")
+	}
+
+	// Create empty S3 secret
+	s3Secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "s3-secret",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{},
+	}
+
+	client.AddObject(&s3Secret)
+
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as S3 secret has empty keys")
+	}
+
+	accessKey := []byte{'1'}
+	s3Secret.Data = map[string][]byte{"s3_access_key": accessKey}
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as S3 secret has empty s3_secret_key")
+	}
+
+	secretKey := []byte{'2'}
+	s3Secret.Data = map[string][]byte{"s3_secret_key": secretKey}
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as S3 secret has empty s3_access_key")
+	}
+
+	// Create S3 secret
+	s3Secret = spltest.GetMockS3SecretKeys("s3-secret")
+
+	// This should return an error as we have initialized initFn for s3ClientMgr
+	// to return a nil client.
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as we could not get the S3 client")
+	}
+
+	s3ClientMgr.initFn = func(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
+		*isNotInTestContext = false
+		// To test the error scenario, do no set the Objects member yet
+		cl := spltest.MockAWSS3Client{}
+		return cl
+	}
+
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as we have empty objects in MockAWSS3Client")
 	}
 }

--- a/pkg/splunk/enterprise/searchheadcluster.go
+++ b/pkg/splunk/enterprise/searchheadcluster.go
@@ -56,9 +56,9 @@ func ApplySearchHeadCluster(client splcommon.ControllerClient, cr *enterprisev1.
 			}
 		}
 
-		sourceToAppsList = GetAppListFromS3Bucket(client, cr, &cr.Spec.AppFrameworkConfig)
+		sourceToAppsList, err = GetAppListFromS3Bucket(client, cr, &cr.Spec.AppFrameworkConfig)
 		if len(sourceToAppsList) != len(cr.Spec.AppFrameworkConfig.AppSources) {
-			scopedLog.Error(err, "Unable to get apps list for all the app sources from remote storage")
+			scopedLog.Error(err, "Unable to get apps list, will retry in next reconcile...")
 			return result, err
 		}
 
@@ -557,7 +557,7 @@ func validateSearchHeadClusterSpec(cr *enterprisev1.SearchHeadCluster) error {
 	}
 
 	if !reflect.DeepEqual(cr.Status.AppContext.AppFrameworkConfig, cr.Spec.AppFrameworkConfig) {
-		err := ValidateAppFrameworkSpec(&cr.Spec.AppFrameworkConfig, true)
+		err := ValidateAppFrameworkSpec(&cr.Spec.AppFrameworkConfig, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/splunk/enterprise/searchheadcluster_test.go
+++ b/pkg/splunk/enterprise/searchheadcluster_test.go
@@ -781,17 +781,20 @@ func TestSHCGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 			continue
 		}
 
+		// Update the GetS3Client with our mock call which initializes mock AWS client
+		getClientWrapper := splclient.S3Clients[vol.Provider]
+		getClientWrapper.SetS3ClientFuncPtr(vol.Provider, NewMockAWSS3Client)
+
 		s3ClientMgr := &S3ClientManager{client: client,
 			cr: &cr, appFrameworkRef: &cr.Spec.AppFrameworkConfig,
 			vol:      &vol,
 			location: appSource.Location,
-			initFn: func(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
-				*isNotInTestContext = false
+			initFn: func(region, accessKeyID, secretAccessKey string) interface{} {
 				cl := spltest.MockAWSS3Client{}
 				cl.Objects = mockAwsObjects[index].Objects
 				return cl
 			},
-			getS3Client: func(client splcommon.ControllerClient, cr splcommon.MetaObject, appFrameworkRef *enterprisev1.AppFrameworkSpec, vol *enterprisev1.VolumeSpec, location string, fn func(string, string, string, *bool) interface{}) (splclient.SplunkS3Client, error) {
+			getS3Client: func(client splcommon.ControllerClient, cr splcommon.MetaObject, appFrameworkRef *enterprisev1.AppFrameworkSpec, vol *enterprisev1.VolumeSpec, location string, fn splclient.GetInitFunc) (splclient.SplunkS3Client, error) {
 				c, err := GetRemoteStorageClient(client, cr, appFrameworkRef, vol, location, fn)
 				return c, err
 			},
@@ -822,7 +825,7 @@ func TestSHCGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 		t.Errorf("Unable to get apps list for all the app sources")
 	}
 	method := "GetAppsList"
-	mockAwsHandler.CheckAwsS3Response(t, method)
+	mockAwsHandler.CheckAWSS3Response(t, method)
 }
 
 func TestSHCGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
@@ -894,8 +897,12 @@ func TestSHCGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
 	appSource := appFrameworkRef.AppSources[0]
 	vol, err = GetVolume(client, &cr, appSource, &appFrameworkRef)
 	if err != nil {
-		t.Errorf("Unable to get Volume")
+		t.Errorf("Unable to get Volume due to error=%s", err)
 	}
+
+	// Update the GetS3Client with our mock call which initializes mock AWS client
+	getClientWrapper := splclient.S3Clients[vol.Provider]
+	getClientWrapper.SetS3ClientFuncPtr(vol.Provider, NewMockAWSS3Client)
 
 	s3ClientMgr := &S3ClientManager{
 		client:          client,
@@ -903,14 +910,13 @@ func TestSHCGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
 		appFrameworkRef: &cr.Spec.AppFrameworkConfig,
 		vol:             &vol,
 		location:        appSource.Location,
-		initFn: func(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
-			*isNotInTestContext = false
+		initFn: func(region, accessKeyID, secretAccessKey string) interface{} {
 			// Purposefully return nil here so that we test the error scenario
 			return nil
 		},
 		getS3Client: func(client splcommon.ControllerClient, cr splcommon.MetaObject,
 			appFrameworkRef *enterprisev1.AppFrameworkSpec, vol *enterprisev1.VolumeSpec,
-			location string, fn func(string, string, string, *bool) interface{}) (splclient.SplunkS3Client, error) {
+			location string, fn splclient.GetInitFunc) (splclient.SplunkS3Client, error) {
 			// Get the mock client
 			c, err := GetRemoteStorageClient(client, cr, appFrameworkRef, vol, location, fn)
 			return c, err
@@ -938,15 +944,15 @@ func TestSHCGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
 		t.Errorf("GetAppsList should have returned error as S3 secret has empty keys")
 	}
 
-	accessKey := []byte{'1'}
-	s3Secret.Data = map[string][]byte{"s3_access_key": accessKey}
+	s3AccessKey := []byte{'1'}
+	s3Secret.Data = map[string][]byte{"s3_access_key": s3AccessKey}
 	_, err = s3ClientMgr.GetAppsList()
 	if err == nil {
 		t.Errorf("GetAppsList should have returned error as S3 secret has empty s3_secret_key")
 	}
 
-	secretKey := []byte{'2'}
-	s3Secret.Data = map[string][]byte{"s3_secret_key": secretKey}
+	s3SecretKey := []byte{'2'}
+	s3Secret.Data = map[string][]byte{"s3_secret_key": s3SecretKey}
 	_, err = s3ClientMgr.GetAppsList()
 	if err == nil {
 		t.Errorf("GetAppsList should have returned error as S3 secret has empty s3_access_key")
@@ -962,8 +968,7 @@ func TestSHCGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
 		t.Errorf("GetAppsList should have returned error as we could not get the S3 client")
 	}
 
-	s3ClientMgr.initFn = func(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
-		*isNotInTestContext = false
+	s3ClientMgr.initFn = func(region, accessKeyID, secretAccessKey string) interface{} {
 		// To test the error scenario, do no set the Objects member yet
 		cl := spltest.MockAWSS3Client{}
 		return cl

--- a/pkg/splunk/enterprise/searchheadcluster_test.go
+++ b/pkg/splunk/enterprise/searchheadcluster_test.go
@@ -726,7 +726,7 @@ func TestSHCGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 	Keys := []string{"admin_app.tgz", "security_app.tgz", "authentication_app.tgz"}
 	Sizes := []int64{10, 20, 30}
 	StorageClass := "STANDARD"
-	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.Now().Location())
+	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.UTC)
 
 	mockAwsHandler := spltest.MockAWSS3Handler{}
 
@@ -867,7 +867,7 @@ func TestSHCGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
 	Keys := []string{"admin_app.tgz"}
 	Sizes := []int64{10}
 	StorageClass := "STANDARD"
-	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.Now().Location())
+	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.UTC)
 
 	mockAwsHandler := spltest.MockAWSS3Handler{}
 

--- a/pkg/splunk/enterprise/searchheadcluster_test.go
+++ b/pkg/splunk/enterprise/searchheadcluster_test.go
@@ -616,7 +616,7 @@ func TestGetDeployerStatefulSet(t *testing.T) {
 	test(`{"kind":"StatefulSet","apiVersion":"apps/v1","metadata":{"name":"splunk-stack1-deployer","namespace":"test","creationTimestamp":null,"ownerReferences":[{"apiVersion":"","kind":"","name":"stack1","uid":"","controller":true}]},"spec":{"replicas":1,"selector":{"matchLabels":{"app.kubernetes.io/component":"search-head","app.kubernetes.io/instance":"splunk-stack1-deployer","app.kubernetes.io/managed-by":"splunk-operator","app.kubernetes.io/name":"deployer","app.kubernetes.io/part-of":"splunk-stack1-search-head"}},"template":{"metadata":{"creationTimestamp":null,"labels":{"app.kubernetes.io/component":"search-head","app.kubernetes.io/instance":"splunk-stack1-deployer","app.kubernetes.io/managed-by":"splunk-operator","app.kubernetes.io/name":"deployer","app.kubernetes.io/part-of":"splunk-stack1-search-head"},"annotations":{"traffic.sidecar.istio.io/excludeOutboundPorts":"8089,8191,9997","traffic.sidecar.istio.io/includeInboundPorts":"8000"}},"spec":{"volumes":[{"name":"mnt-splunk-secrets","secret":{"secretName":"splunk-stack1-deployer-secret-v1","defaultMode":420}}],"containers":[{"name":"splunk","image":"splunk/splunk","ports":[{"name":"http-splunkweb","containerPort":8000,"protocol":"TCP"},{"name":"https-splunkd","containerPort":8089,"protocol":"TCP"}],"env":[{"name":"SPLUNK_HOME","value":"/opt/splunk"},{"name":"SPLUNK_START_ARGS","value":"--accept-license"},{"name":"SPLUNK_DEFAULTS_URL","value":"/mnt/apps/apps.yml,/mnt/splunk-secrets/default.yml"},{"name":"SPLUNK_HOME_OWNERSHIP_ENFORCEMENT","value":"false"},{"name":"SPLUNK_ROLE","value":"splunk_deployer"},{"name":"SPLUNK_DECLARATIVE_ADMIN_PASSWORD","value":"true"},{"name":"SPLUNK_SEARCH_HEAD_URL","value":"splunk-stack1-search-head-0.splunk-stack1-search-head-headless.test.svc.cluster.local,splunk-stack1-search-head-1.splunk-stack1-search-head-headless.test.svc.cluster.local,splunk-stack1-search-head-2.splunk-stack1-search-head-headless.test.svc.cluster.local"},{"name":"SPLUNK_SEARCH_HEAD_CAPTAIN_URL","value":"splunk-stack1-search-head-0.splunk-stack1-search-head-headless.test.svc.cluster.local"}],"resources":{"limits":{"cpu":"4","memory":"8Gi"},"requests":{"cpu":"100m","memory":"512Mi"}},"volumeMounts":[{"name":"pvc-etc","mountPath":"/opt/splunk/etc"},{"name":"pvc-var","mountPath":"/opt/splunk/var"},{"name":"mnt-splunk-secrets","mountPath":"/mnt/splunk-secrets"}],"livenessProbe":{"exec":{"command":["/sbin/checkstate.sh"]},"initialDelaySeconds":300,"timeoutSeconds":30,"periodSeconds":30},"readinessProbe":{"exec":{"command":["/bin/grep","started","/opt/container_artifact/splunk-container.state"]},"initialDelaySeconds":10,"timeoutSeconds":5,"periodSeconds":5},"imagePullPolicy":"IfNotPresent"}],"serviceAccountName":"defaults","securityContext":{"runAsUser":41812,"fsGroup":41812},"affinity":{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"weight":100,"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/instance","operator":"In","values":["splunk-stack1-deployer"]}]},"topologyKey":"kubernetes.io/hostname"}}]}},"schedulerName":"default-scheduler"}},"volumeClaimTemplates":[{"metadata":{"name":"pvc-etc","namespace":"test","creationTimestamp":null,"labels":{"app.kubernetes.io/component":"search-head","app.kubernetes.io/instance":"splunk-stack1-deployer","app.kubernetes.io/managed-by":"splunk-operator","app.kubernetes.io/name":"deployer","app.kubernetes.io/part-of":"splunk-stack1-search-head"}},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"10Gi"}}},"status":{}},{"metadata":{"name":"pvc-var","namespace":"test","creationTimestamp":null,"labels":{"app.kubernetes.io/component":"search-head","app.kubernetes.io/instance":"splunk-stack1-deployer","app.kubernetes.io/managed-by":"splunk-operator","app.kubernetes.io/name":"deployer","app.kubernetes.io/part-of":"splunk-stack1-search-head"}},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"100Gi"}}},"status":{}}],"serviceName":"splunk-stack1-deployer-headless","podManagementPolicy":"Parallel","updateStrategy":{"type":"OnDelete"}},"status":{"replicas":0}}`)
 }
 
-func TestAppFrameworkSearchHeadClusterShouldNotFail(t *testing.T) {
+func TestAppFrameworkSearchHeadClusterShouldFail(t *testing.T) {
 	cr := enterprisev1.SearchHeadCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "stack1",
@@ -649,10 +649,206 @@ func TestAppFrameworkSearchHeadClusterShouldNotFail(t *testing.T) {
 					},
 				},
 			},
-			// TODO gaurav: Remove this dependency on mock setting and try to use
-			// mock client for S3 responses.
-			CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
-				Mock: true,
+		},
+	}
+
+	client := spltest.NewMockClient()
+
+	// Create namespace scoped secret
+	_, err := splutil.ApplyNamespaceScopedSecretObject(client, "test")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	// Create S3 secret
+	s3Secret := spltest.GetMockS3SecretKeys("s3-secret")
+
+	client.AddObject(&s3Secret)
+
+	_, err = ApplySearchHeadCluster(client, &cr)
+	if err == nil {
+		t.Errorf("ApplySearchHeadCluster should not be successful")
+	}
+}
+
+func TestSHCGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
+	cr := enterprisev1.SearchHeadCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stack1",
+			Namespace: "test",
+		},
+		Spec: enterprisev1.SearchHeadClusterSpec{
+			Replicas: 3,
+			AppFrameworkConfig: enterprisev1.AppFrameworkSpec{
+				VolList: []enterprisev1.VolumeSpec{
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
+				},
+				AppSources: []enterprisev1.AppSourceSpec{
+					{Name: "adminApps",
+						Location: "adminAppsRepo",
+						AppSourceDefaultSpec: enterprisev1.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   "local"},
+					},
+					{Name: "securityApps",
+						Location: "securityAppsRepo",
+						AppSourceDefaultSpec: enterprisev1.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   "local"},
+					},
+					{Name: "authenticationApps",
+						Location: "authenticationAppsRepo",
+						AppSourceDefaultSpec: enterprisev1.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   "local"},
+					},
+				},
+			},
+		},
+	}
+
+	client := spltest.NewMockClient()
+
+	// Create S3 secret
+	s3Secret := spltest.GetMockS3SecretKeys("s3-secret")
+
+	client.AddObject(&s3Secret)
+
+	// Create namespace scoped secret
+	_, err := splutil.ApplyNamespaceScopedSecretObject(client, "test")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	splclient.RegisterS3Client("aws")
+
+	Etags := []string{"cc707187b036405f095a8ebb43a782c1", "5055a61b3d1b667a4c3279a381a2e7ae", "19779168370b97d8654424e6c9446dd9"}
+	Keys := []string{"admin_app.tgz", "security_app.tgz", "authentication_app.tgz"}
+	Sizes := []int64{10, 20, 30}
+	StorageClass := "STANDARD"
+	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.Now().Location())
+
+	mockAwsHandler := spltest.MockAWSS3Handler{}
+
+	mockAwsObjects := []spltest.MockAWSS3Client{
+		{
+			Objects: []*spltest.MockAWSS3Object{
+				{
+					Etag:         &Etags[0],
+					Key:          &Keys[0],
+					LastModified: &randomTime,
+					Size:         &Sizes[0],
+					StorageClass: &StorageClass,
+				},
+			},
+		},
+		{
+			Objects: []*spltest.MockAWSS3Object{
+				{
+					Etag:         &Etags[1],
+					Key:          &Keys[1],
+					LastModified: &randomTime,
+					Size:         &Sizes[1],
+					StorageClass: &StorageClass,
+				},
+			},
+		},
+		{
+			Objects: []*spltest.MockAWSS3Object{
+				{
+					Etag:         &Etags[2],
+					Key:          &Keys[2],
+					LastModified: &randomTime,
+					Size:         &Sizes[2],
+					StorageClass: &StorageClass,
+				},
+			},
+		},
+	}
+
+	appFrameworkRef := cr.Spec.AppFrameworkConfig
+
+	mockAwsHandler.AddObjects(appFrameworkRef, mockAwsObjects...)
+
+	var vol enterprisev1.VolumeSpec
+	var allSuccess bool = true
+	for index, appSource := range appFrameworkRef.AppSources {
+
+		vol, err = GetVolume(client, &cr, appSource, &appFrameworkRef)
+		if err != nil {
+			_ = fmt.Errorf("Unable to get Volume")
+			allSuccess = false
+			continue
+		}
+
+		s3ClientMgr := &S3ClientManager{client: client,
+			cr: &cr, appFrameworkRef: &cr.Spec.AppFrameworkConfig,
+			vol:      &vol,
+			location: appSource.Location,
+			initFn: func(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
+				*isNotInTestContext = false
+				cl := spltest.MockAWSS3Client{}
+				cl.Objects = mockAwsObjects[index].Objects
+				return cl
+			},
+			getS3Client: func(client splcommon.ControllerClient, cr splcommon.MetaObject, appFrameworkRef *enterprisev1.AppFrameworkSpec, vol *enterprisev1.VolumeSpec, location string, fn func(string, string, string, *bool) interface{}) (splclient.SplunkS3Client, error) {
+				c, err := GetRemoteStorageClient(client, cr, appFrameworkRef, vol, location, fn)
+				return c, err
+			},
+		}
+
+		s3Response, err := s3ClientMgr.GetAppsList()
+		if err != nil {
+			_ = fmt.Errorf("Unable to get apps list")
+			allSuccess = false
+			continue
+		}
+
+		var mockResponse spltest.MockAWSS3Client
+		mockResponse, err = ConvertS3Response(s3Response)
+		if err != nil {
+			_ = fmt.Errorf("Unable to convert s3 response")
+			allSuccess = false
+			continue
+		}
+		if mockAwsHandler.GotSourceAppListResponseMap == nil {
+			mockAwsHandler.GotSourceAppListResponseMap = make(map[string]spltest.MockAWSS3Client)
+		}
+
+		mockAwsHandler.GotSourceAppListResponseMap[appSource.Name] = mockResponse
+	}
+
+	if allSuccess == false {
+		t.Errorf("Unable to get apps list for all the app sources")
+	}
+	method := "GetAppsList"
+	mockAwsHandler.CheckAwsS3Response(t, method)
+}
+
+func TestSHCGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
+	cr := enterprisev1.SearchHeadCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stack1",
+			Namespace: "test",
+		},
+		Spec: enterprisev1.SearchHeadClusterSpec{
+			AppFrameworkConfig: enterprisev1.AppFrameworkSpec{
+				VolList: []enterprisev1.VolumeSpec{
+					{Name: "msos_s2s3_vol",
+						Endpoint:  "https://s3-eu-west-2.amazonaws.com",
+						Path:      "testbucket-rs-london",
+						SecretRef: "s3-secret",
+						Type:      "s3",
+						Provider:  "aws"},
+				},
+				AppSources: []enterprisev1.AppSourceSpec{
+					{Name: "adminApps",
+						Location: "adminAppsRepo",
+						AppSourceDefaultSpec: enterprisev1.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   "local"},
+					},
+				},
 			},
 		},
 	}
@@ -665,8 +861,116 @@ func TestAppFrameworkSearchHeadClusterShouldNotFail(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	_, err = ApplySearchHeadCluster(client, &cr)
+	splclient.RegisterS3Client("aws")
+
+	Etags := []string{"cc707187b036405f095a8ebb43a782c1"}
+	Keys := []string{"admin_app.tgz"}
+	Sizes := []int64{10}
+	StorageClass := "STANDARD"
+	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.Now().Location())
+
+	mockAwsHandler := spltest.MockAWSS3Handler{}
+
+	mockAwsObjects := []spltest.MockAWSS3Client{
+		{
+			Objects: []*spltest.MockAWSS3Object{
+				{
+					Etag:         &Etags[0],
+					Key:          &Keys[0],
+					LastModified: &randomTime,
+					Size:         &Sizes[0],
+					StorageClass: &StorageClass,
+				},
+			},
+		},
+	}
+
+	appFrameworkRef := cr.Spec.AppFrameworkConfig
+
+	mockAwsHandler.AddObjects(appFrameworkRef, mockAwsObjects...)
+
+	var vol enterprisev1.VolumeSpec
+
+	appSource := appFrameworkRef.AppSources[0]
+	vol, err = GetVolume(client, &cr, appSource, &appFrameworkRef)
 	if err != nil {
-		t.Errorf("ApplySearchHeadCluster with valid App Framework config should be successful, but got error: %v", err)
+		t.Errorf("Unable to get Volume")
+	}
+
+	s3ClientMgr := &S3ClientManager{
+		client:          client,
+		cr:              &cr,
+		appFrameworkRef: &cr.Spec.AppFrameworkConfig,
+		vol:             &vol,
+		location:        appSource.Location,
+		initFn: func(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
+			*isNotInTestContext = false
+			// Purposefully return nil here so that we test the error scenario
+			return nil
+		},
+		getS3Client: func(client splcommon.ControllerClient, cr splcommon.MetaObject,
+			appFrameworkRef *enterprisev1.AppFrameworkSpec, vol *enterprisev1.VolumeSpec,
+			location string, fn func(string, string, string, *bool) interface{}) (splclient.SplunkS3Client, error) {
+			// Get the mock client
+			c, err := GetRemoteStorageClient(client, cr, appFrameworkRef, vol, location, fn)
+			return c, err
+		},
+	}
+
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as there is no S3 secret provided")
+	}
+
+	// Create empty S3 secret
+	s3Secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "s3-secret",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{},
+	}
+
+	client.AddObject(&s3Secret)
+
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as S3 secret has empty keys")
+	}
+
+	accessKey := []byte{'1'}
+	s3Secret.Data = map[string][]byte{"s3_access_key": accessKey}
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as S3 secret has empty s3_secret_key")
+	}
+
+	secretKey := []byte{'2'}
+	s3Secret.Data = map[string][]byte{"s3_secret_key": secretKey}
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as S3 secret has empty s3_access_key")
+	}
+
+	// Create S3 secret
+	s3Secret = spltest.GetMockS3SecretKeys("s3-secret")
+
+	// This should return an error as we have initialized initFn for s3ClientMgr
+	// to return a nil client.
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as we could not get the S3 client")
+	}
+
+	s3ClientMgr.initFn = func(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
+		*isNotInTestContext = false
+		// To test the error scenario, do no set the Objects member yet
+		cl := spltest.MockAWSS3Client{}
+		return cl
+	}
+
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as we have empty objects in MockAWSS3Client")
 	}
 }

--- a/pkg/splunk/enterprise/searchheadcluster_test.go
+++ b/pkg/splunk/enterprise/searchheadcluster_test.go
@@ -776,7 +776,6 @@ func TestSHCGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 
 		vol, err = GetVolume(client, &cr, appSource, &appFrameworkRef)
 		if err != nil {
-			_ = fmt.Errorf("Unable to get Volume")
 			allSuccess = false
 			continue
 		}
@@ -802,7 +801,6 @@ func TestSHCGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 
 		s3Response, err := s3ClientMgr.GetAppsList()
 		if err != nil {
-			_ = fmt.Errorf("Unable to get apps list")
 			allSuccess = false
 			continue
 		}
@@ -810,7 +808,6 @@ func TestSHCGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 		var mockResponse spltest.MockAWSS3Client
 		mockResponse, err = ConvertS3Response(s3Response)
 		if err != nil {
-			_ = fmt.Errorf("Unable to convert s3 response")
 			allSuccess = false
 			continue
 		}

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -78,9 +78,9 @@ func ApplyStandalone(client splcommon.ControllerClient, cr *enterprisev1.Standal
 			}
 		}
 
-		sourceToAppsList = GetAppListFromS3Bucket(client, cr, &cr.Spec.AppFrameworkConfig)
+		sourceToAppsList, err = GetAppListFromS3Bucket(client, cr, &cr.Spec.AppFrameworkConfig)
 		if len(sourceToAppsList) != len(cr.Spec.AppFrameworkConfig.AppSources) {
-			scopedLog.Error(err, "Unable to get apps list for all the app sources from remote storage")
+			scopedLog.Error(err, "Unable to get apps list, will retry in next reconcile...")
 			return result, err
 		}
 

--- a/pkg/splunk/enterprise/standalone_test.go
+++ b/pkg/splunk/enterprise/standalone_test.go
@@ -15,7 +15,6 @@
 package enterprise
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -455,7 +454,6 @@ func TestStandaloneGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 
 		vol, err = GetVolume(client, &cr, appSource, &appFrameworkRef)
 		if err != nil {
-			_ = fmt.Errorf("Unable to get Volume")
 			allSuccess = false
 			continue
 		}
@@ -481,7 +479,6 @@ func TestStandaloneGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 
 		s3Response, err := s3ClientMgr.GetAppsList()
 		if err != nil {
-			_ = fmt.Errorf("Unable to get apps list")
 			allSuccess = false
 			continue
 		}
@@ -489,7 +486,6 @@ func TestStandaloneGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 		var mockResponse spltest.MockAWSS3Client
 		mockResponse, err = ConvertS3Response(s3Response)
 		if err != nil {
-			_ = fmt.Errorf("Unable to convert s3 response")
 			allSuccess = false
 			continue
 		}

--- a/pkg/splunk/enterprise/standalone_test.go
+++ b/pkg/splunk/enterprise/standalone_test.go
@@ -460,17 +460,20 @@ func TestStandaloneGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 			continue
 		}
 
+		// Update the GetS3Client with our mock call which initializes mock AWS client
+		getClientWrapper := splclient.S3Clients[vol.Provider]
+		getClientWrapper.SetS3ClientFuncPtr(vol.Provider, NewMockAWSS3Client)
+
 		s3ClientMgr := &S3ClientManager{client: client,
 			cr: &cr, appFrameworkRef: &cr.Spec.AppFrameworkConfig,
 			vol:      &vol,
 			location: appSource.Location,
-			initFn: func(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
-				*isNotInTestContext = false
+			initFn: func(region, accessKeyID, secretAccessKey string) interface{} {
 				cl := spltest.MockAWSS3Client{}
 				cl.Objects = mockAwsObjects[index].Objects
 				return cl
 			},
-			getS3Client: func(client splcommon.ControllerClient, cr splcommon.MetaObject, appFrameworkRef *enterprisev1.AppFrameworkSpec, vol *enterprisev1.VolumeSpec, location string, fn func(string, string, string, *bool) interface{}) (splclient.SplunkS3Client, error) {
+			getS3Client: func(client splcommon.ControllerClient, cr splcommon.MetaObject, appFrameworkRef *enterprisev1.AppFrameworkSpec, vol *enterprisev1.VolumeSpec, location string, fn splclient.GetInitFunc) (splclient.SplunkS3Client, error) {
 				c, err := GetRemoteStorageClient(client, cr, appFrameworkRef, vol, location, fn)
 				return c, err
 			},
@@ -502,7 +505,7 @@ func TestStandaloneGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 		t.Errorf("Unable to get apps list for all the app sources")
 	}
 	method := "GetAppsList"
-	mockAwsHandler.CheckAwsS3Response(t, method)
+	mockAwsHandler.CheckAWSS3Response(t, method)
 }
 
 func TestStandlaoneGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
@@ -574,8 +577,12 @@ func TestStandlaoneGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
 	appSource := appFrameworkRef.AppSources[0]
 	vol, err = GetVolume(client, &cr, appSource, &appFrameworkRef)
 	if err != nil {
-		t.Errorf("Unable to get Volume")
+		t.Errorf("Unable to get Volume due to error=%s", err)
 	}
+
+	// Update the GetS3Client with our mock call which initializes mock AWS client
+	getClientWrapper := splclient.S3Clients[vol.Provider]
+	getClientWrapper.SetS3ClientFuncPtr(vol.Provider, NewMockAWSS3Client)
 
 	s3ClientMgr := &S3ClientManager{
 		client:          client,
@@ -583,14 +590,13 @@ func TestStandlaoneGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
 		appFrameworkRef: &cr.Spec.AppFrameworkConfig,
 		vol:             &vol,
 		location:        appSource.Location,
-		initFn: func(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
-			*isNotInTestContext = false
+		initFn: func(region, accessKeyID, secretAccessKey string) interface{} {
 			// Purposefully return nil here so that we test the error scenario
 			return nil
 		},
 		getS3Client: func(client splcommon.ControllerClient, cr splcommon.MetaObject,
 			appFrameworkRef *enterprisev1.AppFrameworkSpec, vol *enterprisev1.VolumeSpec,
-			location string, fn func(string, string, string, *bool) interface{}) (splclient.SplunkS3Client, error) {
+			location string, fn splclient.GetInitFunc) (splclient.SplunkS3Client, error) {
 			// Get the mock client
 			c, err := GetRemoteStorageClient(client, cr, appFrameworkRef, vol, location, fn)
 			return c, err
@@ -618,15 +624,15 @@ func TestStandlaoneGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
 		t.Errorf("GetAppsList should have returned error as S3 secret has empty keys")
 	}
 
-	accessKey := []byte{'1'}
-	s3Secret.Data = map[string][]byte{"s3_access_key": accessKey}
+	s3AccessKey := []byte{'1'}
+	s3Secret.Data = map[string][]byte{"s3_access_key": s3AccessKey}
 	_, err = s3ClientMgr.GetAppsList()
 	if err == nil {
 		t.Errorf("GetAppsList should have returned error as S3 secret has empty s3_secret_key")
 	}
 
-	secretKey := []byte{'2'}
-	s3Secret.Data = map[string][]byte{"s3_secret_key": secretKey}
+	s3SecretKey := []byte{'2'}
+	s3Secret.Data = map[string][]byte{"s3_secret_key": s3SecretKey}
 	_, err = s3ClientMgr.GetAppsList()
 	if err == nil {
 		t.Errorf("GetAppsList should have returned error as S3 secret has empty s3_access_key")
@@ -642,8 +648,7 @@ func TestStandlaoneGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
 		t.Errorf("GetAppsList should have returned error as we could not get the S3 client")
 	}
 
-	s3ClientMgr.initFn = func(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
-		*isNotInTestContext = false
+	s3ClientMgr.initFn = func(region, accessKeyID, secretAccessKey string) interface{} {
 		// To test the error scenario, do no set the Objects member yet
 		cl := spltest.MockAWSS3Client{}
 		return cl

--- a/pkg/splunk/enterprise/standalone_test.go
+++ b/pkg/splunk/enterprise/standalone_test.go
@@ -15,6 +15,7 @@
 package enterprise
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1"
+	splclient "github.com/splunk/splunk-operator/pkg/splunk/client"
 	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 	splctrl "github.com/splunk/splunk-operator/pkg/splunk/controller"
 	spltest "github.com/splunk/splunk-operator/pkg/splunk/test"
@@ -293,7 +295,7 @@ func TestApplyStandaloneSmartstoreKeyChangeDetection(t *testing.T) {
 	}
 }
 
-func TestAppFrameworkApplyStandaloneShouldNotFail(t *testing.T) {
+func TestAppFrameworkApplyStandaloneShouldFail(t *testing.T) {
 	cr := enterprisev1.Standalone{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "standalone",
@@ -326,10 +328,207 @@ func TestAppFrameworkApplyStandaloneShouldNotFail(t *testing.T) {
 					},
 				},
 			},
-			// TODO gaurav: Remove this dependency on mock setting and try to use
-			// mock client for S3 responses.
-			CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
-				Mock: true,
+		},
+	}
+
+	client := spltest.NewMockClient()
+
+	// Create namespace scoped secret
+	_, err := splutil.ApplyNamespaceScopedSecretObject(client, "test")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	// Create S3 secret
+	s3Secret := spltest.GetMockS3SecretKeys("s3-secret")
+
+	client.AddObject(&s3Secret)
+
+	_, err = ApplyStandalone(client, &cr)
+	if err == nil {
+		t.Errorf("ApplyStandalone should not be successful")
+	}
+}
+
+func TestStandaloneGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
+	cr := enterprisev1.Standalone{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "standalone",
+			Namespace: "test",
+		},
+		Spec: enterprisev1.StandaloneSpec{
+			Replicas: 1,
+			AppFrameworkConfig: enterprisev1.AppFrameworkSpec{
+				VolList: []enterprisev1.VolumeSpec{
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
+				},
+				AppSources: []enterprisev1.AppSourceSpec{
+					{Name: "adminApps",
+						Location: "adminAppsRepo",
+						AppSourceDefaultSpec: enterprisev1.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   "local"},
+					},
+					{Name: "securityApps",
+						Location: "securityAppsRepo",
+						AppSourceDefaultSpec: enterprisev1.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   "local"},
+					},
+					{Name: "authenticationApps",
+						Location: "authenticationAppsRepo",
+						AppSourceDefaultSpec: enterprisev1.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   "local"},
+					},
+				},
+			},
+		},
+	}
+
+	client := spltest.NewMockClient()
+
+	// Create S3 secret
+	s3Secret := spltest.GetMockS3SecretKeys("s3-secret")
+
+	client.AddObject(&s3Secret)
+
+	// Create namespace scoped secret
+	_, err := splutil.ApplyNamespaceScopedSecretObject(client, "test")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	splclient.RegisterS3Client("aws")
+
+	Etags := []string{"cc707187b036405f095a8ebb43a782c1", "5055a61b3d1b667a4c3279a381a2e7ae", "19779168370b97d8654424e6c9446dd9"}
+	Keys := []string{"admin_app.tgz", "security_app.tgz", "authentication_app.tgz"}
+	Sizes := []int64{10, 20, 30}
+	StorageClass := "STANDARD"
+	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.Now().Location())
+
+	mockAwsHandler := spltest.MockAWSS3Handler{}
+
+	mockAwsObjects := []spltest.MockAWSS3Client{
+		{
+			Objects: []*spltest.MockAWSS3Object{
+				{
+					Etag:         &Etags[0],
+					Key:          &Keys[0],
+					LastModified: &randomTime,
+					Size:         &Sizes[0],
+					StorageClass: &StorageClass,
+				},
+			},
+		},
+		{
+			Objects: []*spltest.MockAWSS3Object{
+				{
+					Etag:         &Etags[1],
+					Key:          &Keys[1],
+					LastModified: &randomTime,
+					Size:         &Sizes[1],
+					StorageClass: &StorageClass,
+				},
+			},
+		},
+		{
+			Objects: []*spltest.MockAWSS3Object{
+				{
+					Etag:         &Etags[2],
+					Key:          &Keys[2],
+					LastModified: &randomTime,
+					Size:         &Sizes[2],
+					StorageClass: &StorageClass,
+				},
+			},
+		},
+	}
+
+	appFrameworkRef := cr.Spec.AppFrameworkConfig
+
+	mockAwsHandler.AddObjects(appFrameworkRef, mockAwsObjects...)
+
+	var vol enterprisev1.VolumeSpec
+	var allSuccess bool = true
+	for index, appSource := range appFrameworkRef.AppSources {
+
+		vol, err = GetVolume(client, &cr, appSource, &appFrameworkRef)
+		if err != nil {
+			_ = fmt.Errorf("Unable to get Volume")
+			allSuccess = false
+			continue
+		}
+
+		s3ClientMgr := &S3ClientManager{client: client,
+			cr: &cr, appFrameworkRef: &cr.Spec.AppFrameworkConfig,
+			vol:      &vol,
+			location: appSource.Location,
+			initFn: func(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
+				*isNotInTestContext = false
+				cl := spltest.MockAWSS3Client{}
+				cl.Objects = mockAwsObjects[index].Objects
+				return cl
+			},
+			getS3Client: func(client splcommon.ControllerClient, cr splcommon.MetaObject, appFrameworkRef *enterprisev1.AppFrameworkSpec, vol *enterprisev1.VolumeSpec, location string, fn func(string, string, string, *bool) interface{}) (splclient.SplunkS3Client, error) {
+				c, err := GetRemoteStorageClient(client, cr, appFrameworkRef, vol, location, fn)
+				return c, err
+			},
+		}
+
+		s3Response, err := s3ClientMgr.GetAppsList()
+		if err != nil {
+			_ = fmt.Errorf("Unable to get apps list")
+			allSuccess = false
+			continue
+		}
+
+		var mockResponse spltest.MockAWSS3Client
+		mockResponse, err = ConvertS3Response(s3Response)
+		if err != nil {
+			_ = fmt.Errorf("Unable to convert s3 response")
+			allSuccess = false
+			continue
+		}
+
+		if mockAwsHandler.GotSourceAppListResponseMap == nil {
+			mockAwsHandler.GotSourceAppListResponseMap = make(map[string]spltest.MockAWSS3Client)
+		}
+
+		mockAwsHandler.GotSourceAppListResponseMap[appSource.Name] = mockResponse
+	}
+
+	if allSuccess == false {
+		t.Errorf("Unable to get apps list for all the app sources")
+	}
+	method := "GetAppsList"
+	mockAwsHandler.CheckAwsS3Response(t, method)
+}
+
+func TestStandlaoneGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
+	cr := enterprisev1.Standalone{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stack1",
+			Namespace: "test",
+		},
+		Spec: enterprisev1.StandaloneSpec{
+			AppFrameworkConfig: enterprisev1.AppFrameworkSpec{
+				VolList: []enterprisev1.VolumeSpec{
+					{Name: "msos_s2s3_vol",
+						Endpoint:  "https://s3-eu-west-2.amazonaws.com",
+						Path:      "testbucket-rs-london",
+						SecretRef: "s3-secret",
+						Type:      "s3",
+						Provider:  "aws"},
+				},
+				AppSources: []enterprisev1.AppSourceSpec{
+					{Name: "adminApps",
+						Location: "adminAppsRepo",
+						AppSourceDefaultSpec: enterprisev1.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   "local"},
+					},
+				},
 			},
 		},
 	}
@@ -342,8 +541,116 @@ func TestAppFrameworkApplyStandaloneShouldNotFail(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	_, err = ApplyStandalone(client, &cr)
+	splclient.RegisterS3Client("aws")
+
+	Etags := []string{"cc707187b036405f095a8ebb43a782c1"}
+	Keys := []string{"admin_app.tgz"}
+	Sizes := []int64{10}
+	StorageClass := "STANDARD"
+	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.Now().Location())
+
+	mockAwsHandler := spltest.MockAWSS3Handler{}
+
+	mockAwsObjects := []spltest.MockAWSS3Client{
+		{
+			Objects: []*spltest.MockAWSS3Object{
+				{
+					Etag:         &Etags[0],
+					Key:          &Keys[0],
+					LastModified: &randomTime,
+					Size:         &Sizes[0],
+					StorageClass: &StorageClass,
+				},
+			},
+		},
+	}
+
+	appFrameworkRef := cr.Spec.AppFrameworkConfig
+
+	mockAwsHandler.AddObjects(appFrameworkRef, mockAwsObjects...)
+
+	var vol enterprisev1.VolumeSpec
+
+	appSource := appFrameworkRef.AppSources[0]
+	vol, err = GetVolume(client, &cr, appSource, &appFrameworkRef)
 	if err != nil {
-		t.Errorf("ApplyStandalone with valid App Framework config should be successful, but got error: %v", err)
+		t.Errorf("Unable to get Volume")
+	}
+
+	s3ClientMgr := &S3ClientManager{
+		client:          client,
+		cr:              &cr,
+		appFrameworkRef: &cr.Spec.AppFrameworkConfig,
+		vol:             &vol,
+		location:        appSource.Location,
+		initFn: func(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
+			*isNotInTestContext = false
+			// Purposefully return nil here so that we test the error scenario
+			return nil
+		},
+		getS3Client: func(client splcommon.ControllerClient, cr splcommon.MetaObject,
+			appFrameworkRef *enterprisev1.AppFrameworkSpec, vol *enterprisev1.VolumeSpec,
+			location string, fn func(string, string, string, *bool) interface{}) (splclient.SplunkS3Client, error) {
+			// Get the mock client
+			c, err := GetRemoteStorageClient(client, cr, appFrameworkRef, vol, location, fn)
+			return c, err
+		},
+	}
+
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as there is no S3 secret provided")
+	}
+
+	// Create empty S3 secret
+	s3Secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "s3-secret",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{},
+	}
+
+	client.AddObject(&s3Secret)
+
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as S3 secret has empty keys")
+	}
+
+	accessKey := []byte{'1'}
+	s3Secret.Data = map[string][]byte{"s3_access_key": accessKey}
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as S3 secret has empty s3_secret_key")
+	}
+
+	secretKey := []byte{'2'}
+	s3Secret.Data = map[string][]byte{"s3_secret_key": secretKey}
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as S3 secret has empty s3_access_key")
+	}
+
+	// Create S3 secret
+	s3Secret = spltest.GetMockS3SecretKeys("s3-secret")
+
+	// This should return an error as we have initialized initFn for s3ClientMgr
+	// to return a nil client.
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as we could not get the S3 client")
+	}
+
+	s3ClientMgr.initFn = func(region, accessKeyID, secretAccessKey string, isNotInTestContext *bool) interface{} {
+		*isNotInTestContext = false
+		// To test the error scenario, do no set the Objects member yet
+		cl := spltest.MockAWSS3Client{}
+		return cl
+	}
+
+	_, err = s3ClientMgr.GetAppsList()
+	if err == nil {
+		t.Errorf("GetAppsList should have returned error as we have empty objects in MockAWSS3Client")
 	}
 }

--- a/pkg/splunk/enterprise/standalone_test.go
+++ b/pkg/splunk/enterprise/standalone_test.go
@@ -405,7 +405,7 @@ func TestStandaloneGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 	Keys := []string{"admin_app.tgz", "security_app.tgz", "authentication_app.tgz"}
 	Sizes := []int64{10, 20, 30}
 	StorageClass := "STANDARD"
-	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.Now().Location())
+	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.UTC)
 
 	mockAwsHandler := spltest.MockAWSS3Handler{}
 
@@ -547,7 +547,7 @@ func TestStandlaoneGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
 	Keys := []string{"admin_app.tgz"}
 	Sizes := []int64{10}
 	StorageClass := "STANDARD"
-	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.Now().Location())
+	randomTime := time.Date(2021, time.May, 1, 23, 23, 0, 0, time.UTC)
 
 	mockAwsHandler := spltest.MockAWSS3Handler{}
 

--- a/pkg/splunk/test/awss3client.go
+++ b/pkg/splunk/test/awss3client.go
@@ -57,8 +57,8 @@ func (c *MockAWSS3Handler) AddObjects(appFrameworkRef enterprisev1.AppFrameworkS
 	}
 }
 
-// CheckAwsS3Response checks if the received objects are same as the one we expect
-func (c *MockAWSS3Handler) CheckAwsS3Response(t *testing.T, testMethod string) {
+// CheckAWSS3Response checks if the received objects are same as the one we expect
+func (c *MockAWSS3Handler) CheckAWSS3Response(t *testing.T, testMethod string) {
 	if len(c.WantSourceAppListResponseMap) != len(c.GotSourceAppListResponseMap) {
 		t.Fatalf("%s got %d Responses; want %d", testMethod, len(c.GotSourceAppListResponseMap), len(c.WantSourceAppListResponseMap))
 	}

--- a/pkg/splunk/test/awss3client.go
+++ b/pkg/splunk/test/awss3client.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2018-2021 Splunk Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1"
+)
+
+// MockAWSS3Object struct contains contents returned as part of S3 response
+type MockAWSS3Object struct {
+	Etag         *string
+	Key          *string
+	LastModified *time.Time
+	Size         *int64
+	StorageClass *string
+}
+
+// MockAWSS3Client is used to store all the objects for an app source
+type MockAWSS3Client struct {
+	Objects []*MockAWSS3Object
+}
+
+// MockAWSS3Handler is used for checking response received
+type MockAWSS3Handler struct {
+	WantSourceAppListResponseMap map[string]MockAWSS3Client
+	GotSourceAppListResponseMap  map[string]MockAWSS3Client
+}
+
+// AddObjects adds mock AWS S3 Objects to handler
+func (c *MockAWSS3Handler) AddObjects(appFrameworkRef enterprisev1.AppFrameworkSpec, objects ...MockAWSS3Client) {
+	for n := range objects {
+		mockAWSS3Client := objects[n]
+		appSource := appFrameworkRef.AppSources[n]
+		if c.WantSourceAppListResponseMap == nil {
+			c.WantSourceAppListResponseMap = make(map[string]MockAWSS3Client)
+		}
+		c.WantSourceAppListResponseMap[appSource.Name] = mockAWSS3Client
+	}
+}
+
+// CheckAwsS3Response checks if the received objects are same as the one we expect
+func (c *MockAWSS3Handler) CheckAwsS3Response(t *testing.T, testMethod string) {
+	if len(c.WantSourceAppListResponseMap) != len(c.GotSourceAppListResponseMap) {
+		t.Fatalf("%s got %d Responses; want %d", testMethod, len(c.GotSourceAppListResponseMap), len(c.WantSourceAppListResponseMap))
+	}
+	for appSourceName, gotObjects := range c.GotSourceAppListResponseMap {
+		wantObjects := c.WantSourceAppListResponseMap[appSourceName]
+		if !reflect.DeepEqual(gotObjects.Objects, wantObjects.Objects) {
+			t.Errorf("%s GotResponse[%s]=%v; want %v", testMethod, appSourceName, gotObjects.Objects, wantObjects.Objects)
+		}
+	}
+}
+
+// ListObjectsV2 is a mock call to ListObjectsV2
+func (mockClient MockAWSS3Client) ListObjectsV2(options *s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
+	output := &s3.ListObjectsV2Output{}
+
+	if mockClient.Objects == nil {
+		return nil, fmt.Errorf("Empty Objects")
+	}
+
+	tmp, err := json.Marshal(mockClient.Objects)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(tmp, &output.Contents)
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}

--- a/pkg/splunk/test/awss3client.go
+++ b/pkg/splunk/test/awss3client.go
@@ -65,7 +65,23 @@ func (c *MockAWSS3Handler) CheckAwsS3Response(t *testing.T, testMethod string) {
 	for appSourceName, gotObjects := range c.GotSourceAppListResponseMap {
 		wantObjects := c.WantSourceAppListResponseMap[appSourceName]
 		if !reflect.DeepEqual(gotObjects.Objects, wantObjects.Objects) {
-			t.Errorf("%s GotResponse[%s]=%v; want %v", testMethod, appSourceName, gotObjects.Objects, wantObjects.Objects)
+			for n, gotObject := range gotObjects.Objects {
+				if *gotObject.Etag != *wantObjects.Objects[n].Etag {
+					t.Errorf("%s GotResponse[%s] Etag=%s; want %s", testMethod, appSourceName, *gotObject.Etag, *wantObjects.Objects[n].Etag)
+				}
+				if *gotObject.Key != *wantObjects.Objects[n].Key {
+					t.Errorf("%s GotResponse[%s] Key=%s; want %s", testMethod, appSourceName, *gotObject.Key, *wantObjects.Objects[n].Key)
+				}
+				if *gotObject.StorageClass != *wantObjects.Objects[n].StorageClass {
+					t.Errorf("%s GotResponse[%s] StorageClass=%s; want %s", testMethod, appSourceName, *gotObject.StorageClass, *wantObjects.Objects[n].StorageClass)
+				}
+				if *gotObject.Size != *wantObjects.Objects[n].Size {
+					t.Errorf("%s GotResponse[%s] Size=%d; want %d", testMethod, appSourceName, *gotObject.Size, *wantObjects.Objects[n].Size)
+				}
+				if *gotObject.LastModified != *wantObjects.Objects[n].LastModified {
+					t.Errorf("%s GotResponse[%s] LastModified=%s; want %s", testMethod, appSourceName, gotObject.LastModified.String(), wantObjects.Objects[n].LastModified.String())
+				}
+			}
 		}
 	}
 }

--- a/pkg/splunk/test/util.go
+++ b/pkg/splunk/test/util.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2018-2021 Splunk Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package test includes common code used for testing other modules.
+This package has no depedencies outside of the standard go and kubernetes libraries,
+and the splunk.common package.
+*/
+package test
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetMockS3SecretKeys returns S3 secret keys
+func GetMockS3SecretKeys(name string) corev1.Secret {
+	accessKey := []byte{'1'}
+	secretKey := []byte{'2'}
+
+	// Create S3 secret
+	s3Secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			"s3_access_key": accessKey,
+			"s3_secret_key": secretKey,
+		},
+	}
+	return s3Secret
+}


### PR DESCRIPTION
This is the part-2 PR for the original PR([PR#344](https://github.com/splunk/splunk-operator/pull/344)). It contains the following changes - 
1. A new framework for S3 Client for AWS for UTs.
2. Unit tests covering the mock client.
3. Introduction of `S3ClientMgr` to handle the retrieval of apps list from S3.

Additional changes - 
1. Fix the minio client to adhere to the new framework.
2. Minor fix in clustermaster.go and searchheadcluster.go to allow the scope of apps to be both local and cluster.

**NOTE:**
In future, if anyone wants to write a mock client(like for e.g. for minio client), then they can write a similar client which behaves the same way as MockAWSS3Client.