### PR TITLE
CSPL-1072

### DIFF
--- a/test/licensemaster/lm_c3_test.go
+++ b/test/licensemaster/lm_c3_test.go
@@ -15,16 +15,21 @@ package licensemaster
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
+	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1"
+	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 	"github.com/splunk/splunk-operator/test/testenv"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var _ = Describe("Licensemaster test", func() {
 
 	var deployment *testenv.Deployment
+	var s3TestDir string
 
 	BeforeEach(func() {
 		var err error
@@ -85,6 +90,105 @@ var _ = Describe("Licensemaster test", func() {
 			testenv.VerifyLMConfiguredOnPod(deployment, searchHeadPodName)
 			searchHeadPodName = fmt.Sprintf(testenv.SearchHeadPod, deployment.GetName(), 2)
 			testenv.VerifyLMConfiguredOnPod(deployment, searchHeadPodName)
+		})
+	})
+
+	Context("Clustered deployment (C3 - clustered indexer, search head cluster)", func() {
+		It("licensemaster: Splunk Operator can configure a C3 SVA and have apps installed locally on LM", func() {
+
+			var (
+				appListV1        []string
+				testS3Bucket     = os.Getenv("TEST_INDEXES_S3_BUCKET")
+				testDataS3Bucket = os.Getenv("TEST_BUCKET")
+				s3AppDirV1       = "appframework/regressionappsv1/"
+				currDir, _       = os.Getwd()
+				downloadDirV1    = filepath.Join(currDir, "lmV1-"+testenv.RandomDNSName(4))
+				uploadedApps     []string
+			)
+
+			appListV1 = testenv.BasicApps
+
+			// Download V1 Apps from S3
+			err := testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV1, downloadDirV1, appListV1)
+			Expect(err).To(Succeed(), "Unable to download V1 app files")
+
+			// Upload V1 apps to S3
+			s3TestDir = "lm-" + testenv.RandomDNSName(4)
+			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appListV1, downloadDirV1)
+			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+
+			// Download License File
+			licenseFilePath, err := testenv.DownloadLicenseFromS3Bucket()
+			Expect(err).To(Succeed(), "Unable to download license file")
+
+			// Create License Config Map
+			testenvInstance.CreateLicenseConfigMap(licenseFilePath)
+
+			// Create App framework Spec
+			volumeName := "lm-test-volume-" + testenv.RandomDNSName(3)
+			volumeSpec := []enterprisev1.VolumeSpec{testenv.GenerateIndexVolumeSpec(volumeName, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+
+			// AppSourceDefaultSpec: Remote Storage volume name and Scope of App deployment
+			appSourceDefaultSpec := enterprisev1.AppSourceDefaultSpec{
+				VolName: volumeName,
+				Scope:   "local",
+			}
+
+			// appSourceSpec: App source name, location and volume name and scope from appSourceDefaultSpec
+			appSourceName := "lm-" + testenv.RandomDNSName(3)
+			appSourceSpec := []enterprisev1.AppSourceSpec{testenv.GenerateAppSourceSpec(appSourceName, s3TestDir, appSourceDefaultSpec)}
+
+			// appFrameworkSpec: AppSource settings, Poll Interval, volumes, appSources on volumes
+			appFrameworkSpec := enterprisev1.AppFrameworkSpec{
+				Defaults:             appSourceDefaultSpec,
+				AppsRepoPollInterval: 60,
+				VolList:              volumeSpec,
+				AppSources:           appSourceSpec,
+			}
+
+			spec := enterprisev1.LicenseMasterSpec{
+				CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "licenses",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: testenvInstance.GetLMConfigMap(),
+									},
+								},
+							},
+						},
+					},
+					LicenseURL: "/mnt/licenses/enterprise.lic",
+					Spec: splcommon.Spec{
+						ImagePullPolicy: "Always",
+					},
+				},
+				AppFrameworkConfig: appFrameworkSpec,
+			}
+
+			// Deploy the LM with App Framework
+			_, err = deployment.DeployLicenseMasterWithGivenSpec(deployment.GetName(), spec)
+			Expect(err).To(Succeed(), "Unable to deploy LM with App framework")
+
+			// Wait for LM to be in READY status
+			testenv.LicenseMasterReady(deployment, testenvInstance)
+
+			// Verify apps are copied at the correct location on LM (/etc/apps/)
+			podName := []string{fmt.Sprintf(testenv.LicenseMasterPod, deployment.GetName(), 0)}
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), podName, appListV1, true, false)
+
+			// Verify apps are installed on LM
+			lmPodName := []string{fmt.Sprintf(testenv.LicenseMasterPod, deployment.GetName(), 0)}
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), lmPodName, appListV1, false, "enabled", false, false)
+
+			// Delete files uploaded to S3
+			testenv.DeleteFilesOnS3(testS3Bucket, uploadedApps)
+
+			// Delete locally downloaded app files
+			os.RemoveAll(downloadDirV1)
 		})
 	})
 })

--- a/test/testenv/deployment.go
+++ b/test/testenv/deployment.go
@@ -553,7 +553,7 @@ func (d *Deployment) DeploySearchHeadClusterWithGivenSpec(name string, spec ente
 }
 
 // DeployLicenseMasterWithGivenSpec deploys the license master with given SPEC
-func (d *Deployment) DeployLicenseMasterWithGivenSpec(name, licenseMasterName string, ansibleConfig string, spec enterprisev1.LicenseMasterSpec) (*enterprisev1.LicenseMaster, error) {
+func (d *Deployment) DeployLicenseMasterWithGivenSpec(name string, spec enterprisev1.LicenseMasterSpec) (*enterprisev1.LicenseMaster, error) {
 	d.testenv.Log.Info("Deploying license-master", "name", name)
 	lm := newLicenseMasterWithGivenSpec(name, d.testenv.namespace, spec)
 	deployed, err := d.deployCR(name, lm)

--- a/test/testenv/testenv.go
+++ b/test/testenv/testenv.go
@@ -613,3 +613,8 @@ func (testenv *TestEnv) NewDeployment(name string) (*Deployment, error) {
 
 	return &d, nil
 }
+
+// GetLMConfigMap Return name of license config map
+func (testenv *TestEnv) GetLMConfigMap() string {
+	return testenv.licenseCMName
+}

--- a/test/testenv/verificationutils.go
+++ b/test/testenv/verificationutils.go
@@ -620,7 +620,7 @@ func VerifyAppsCopied(deployment *Deployment, testenvInstance *TestEnv, ns strin
 
 // VerifyAppsInFolder verify that apps are present in folder
 func VerifyAppsInFolder(deployment *Deployment, testenvInstance *TestEnv, ns string, podName string, apps []string, path string, checkAppDirectory bool) {
-	appList, err := GetDirsOrFilesInPath(deployment, podName, path, true)
+	appList, err := GetDirsOrFilesInPath(deployment, podName, path, checkAppDirectory)
 	gomega.Expect(err).To(gomega.Succeed(), "Unable to get apps on pod", "Pod", podName)
 	for _, app := range apps {
 		folderName := AppInfo[app]["App-name"] + "/"


### PR DESCRIPTION
Add tests to verify app installation with scope=local  on CM, LM, Deployer on C3, M4 SVA


Added tests:
C3 and M4: Verify apps are installed locally on CM, Deployer and not installed on Indexer Cluster and SH.
LM:  Verify apps are installed locally on LM. This test is added in the licensemaster folder.

Test results:
C3:

[2]
[2] • [SLOW TEST:486.154 seconds]
[2] c3appfw test
[2] /Users/jambrosiano/splunk-operator/CSPL-1072/splunk-operator/test/c3/appframework/appframework_test.go:28
[2]   Clustered deployment (C3 - clustered indexer, search head cluster)
[2]   /Users/jambrosiano/splunk-operator/CSPL-1072/splunk-operator/test/c3/appframework/appframework_test.go:141
[2]     c3, appframework: can deploy a C3 SVA and have apps installed locally on CM and SHC Deployer
[2]     /Users/jambrosiano/splunk-operator/CSPL-1072/splunk-operator/test/c3/appframework/appframework_test.go:142
[2] ------------------------------
[2] {"level":"info","ts":1624039461.7944598,"msg":"testenv deleted.\n","testenv":"c3appfw-en5"}
[2] {"level":"info","ts":1624039461.79449,"msg":"testenv deleted.\n","testenv":"c3appfw-en5"}
[2]
[2] JUnit report was created: /Users/jambrosiano/splunk-operator/CSPL-1072/splunk-operator/test/c3/appframework/c3appfw-en5_junit.xml
[2]
[2] Ran 1 of 2 Specs in 501.906 seconds
[2] SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 0 Skipped
[2] PASS


M4:
[1]
[1] • [SLOW TEST:492.732 seconds]
[1] m4appfw test
[1] /Users/jambrosiano/splunk-operator/CSPL-1072/splunk-operator/test/m4/appframework/appframework_test.go:28
[1]   Clustered deployment (M4 - clustered indexer, search head cluster)
[1]   /Users/jambrosiano/splunk-operator/CSPL-1072/splunk-operator/test/m4/appframework/appframework_test.go:142
[1]     m4, appframework: can deploy a M4 SVA and have apps installed locally on CM and SHC Deployer
[1]     /Users/jambrosiano/splunk-operator/CSPL-1072/splunk-operator/test/m4/appframework/appframework_test.go:143
[1] ------------------------------
[1] {"level":"info","ts":1624040367.88337,"msg":"testenv deleted.\n","testenv":"m4appfw-hcw"}
[1] {"level":"info","ts":1624040367.88341,"msg":"testenv deleted.\n","testenv":"m4appfw-hcw"}
[1]
[1] JUnit report was created: /Users/jambrosiano/splunk-operator/CSPL-1072/splunk-operator/test/m4/appframework/m4appfw-hcw_junit.xml
[1]
[1] Ran 1 of 2 Specs in 508.066 seconds
[1] SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 0 Skipped
[1] PASS


LM:
[1]
[1] • [SLOW TEST:122.862 seconds]
[1] Licensemaster test
[1] /Users/jambrosiano/splunk-operator/CSPL-1072/splunk-operator/test/licensemaster/lm_c3_test.go:26
[1]   Clustered deployment (C3 - clustered indexer, search head cluster)
[1]   /Users/jambrosiano/splunk-operator/CSPL-1072/splunk-operator/test/licensemaster/lm_c3_test.go:92
[1]     licensemaster: Splunk Operator can configure a C3 SVA and have apps installed locally on LM
[1]     /Users/jambrosiano/splunk-operator/CSPL-1072/splunk-operator/test/licensemaster/lm_c3_test.go:93
[1] ------------------------------
[1] {"level":"info","ts":1624040917.403751,"msg":"testenv deleted.\n","testenv":"lm-vpc"}
[1]
[1] JUnit report was created: /Users/jambrosiano/splunk-operator/CSPL-1072/splunk-operator/test/licensemaster/lm-vpc_junit.xml
[1]
[1] Ran 1 of 3 Specs in 129.863 seconds
[1] SUCCESS! -- 1 Passed | 0 Failed | 2 Pending | 0 Skipped
[1] PASS

