### PR TITLE
Cspl 1055 test for mc crd

### DIFF
--- a/test/monitoring_console/monitoring_console_test.go
+++ b/test/monitoring_console/monitoring_console_test.go
@@ -42,12 +42,20 @@ var _ = Describe("Monitoring Console test", func() {
 		if CurrentGinkgoTestDescription().Failed {
 			testenvInstance.SkipTeardown = true
 		}
-		if !testenvInstance.SkipTeardown {
-			testenv.DeleteMCPod(testenvInstance.GetName())
-		}
+
 		if deployment != nil {
 			deployment.Teardown()
 		}
+	})
+
+	Context("Deploy Monitoring Console", func() {
+		It("smoke, monitoring_console: can deploy MC CR", func() {
+			mc, err := deployment.DeployMonitoringConsole(deployment.GetName(), "")
+			Expect(err).To(Succeed(), "Unable to deploy Monitoring Console instance")
+
+			// Verify MC is Ready and stays in ready state
+			testenv.VerifyMonitoringConsoleReady(deployment, deployment.GetName(), mc, testenvInstance)
+		})
 	})
 
 	XContext("Standalone deployment (S1)", func() {

--- a/test/testenv/deployment.go
+++ b/test/testenv/deployment.go
@@ -100,6 +100,17 @@ func (d *Deployment) DeployStandalone(name string) (*enterprisev1.Standalone, er
 	return deployed.(*enterprisev1.Standalone), err
 }
 
+// DeployMonitoringConsole deploys MC instance on specified testenv,
+// licenseMasterRef is optional, pass empty string if MC should not be attached to a LM
+func (d *Deployment) DeployMonitoringConsole(name string, licenseMasterRef string) (*enterprisev1.MonitoringConsole, error) {
+	mc := newMonitoringConsoleSpec(name, d.testenv.namespace, licenseMasterRef)
+	deployed, err := d.deployCR(name, mc)
+	if err != nil {
+		return nil, err
+	}
+	return deployed.(*enterprisev1.MonitoringConsole), err
+}
+
 // GetInstance retrieves the standalone, indexer, searchhead, licensemaster instance
 func (d *Deployment) GetInstance(name string, instance runtime.Object) error {
 	key := client.ObjectKey{Name: name, Namespace: d.testenv.namespace}

--- a/test/testenv/util.go
+++ b/test/testenv/util.go
@@ -464,6 +464,33 @@ func newStandaloneWithSpec(name, ns string, spec enterprisev1.StandaloneSpec) *e
 	return &new
 }
 
+// newMonitoringConsoleSpec returns MC Spec with given name, namespace and license master Ref
+func newMonitoringConsoleSpec(name string, ns string, LicenseMasterRef string) *enterprisev1.MonitoringConsole {
+	mcSpec := enterprisev1.MonitoringConsole{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "MonitoringConsole",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  ns,
+			Finalizers: []string{"enterprise.splunk.com/delete-pvc"},
+		},
+
+		Spec: enterprisev1.MonitoringConsoleSpec{
+			CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
+				Spec: splcommon.Spec{
+					ImagePullPolicy: "IfNotPresent",
+				},
+				LicenseMasterRef: corev1.ObjectReference{
+					Name: LicenseMasterRef,
+				},
+				Volumes: []corev1.Volume{},
+			},
+		},
+	}
+	return &mcSpec
+}
+
 // DumpGetPods prints and returns list of pods in the namespace
 func DumpGetPods(ns string) []string {
 	output, err := exec.Command("kubectl", "get", "pods", "-n", ns).Output()


### PR DESCRIPTION
Added test to verify MC Pod comes up when MC CRD is applied.

Test Run
```
• [SLOW TEST:213.434 seconds]
Monitoring Console test
/Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:30
  Deploy Monitoring Console
  /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:53
    smoke, monitoring_console: can deploy MC CR
    /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:54
```