### PR TITLE
CSPL-1115: Add a separator in deploy/roles.yaml

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:


### PR DESCRIPTION
Add a separator in deploy/roles.yaml

On applying the Splunk-operator-install.yml it should create the service account for the Splunk operator. Due to these separator lines missing in the roles.yml we saw the below difference Splunk-operator-install.yml due to which, when the Splunk operator is deployed on the fresh instance the service account was not getting created and hence the operator pod was not coming up.
Although the upgrade of the operator would have worked seamlessly as the service account for Splunk operator would pre-exist

Incorrect:
```
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: splunk-operator
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
```

Correct:
```
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: splunk-operator
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
```

