### PR TITLE
CSPL-1108 Locally scoped app install from CM/Deployer

### DIFF
--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -233,12 +233,20 @@ func ApplyAppListingConfigMap(client splcommon.ControllerClient, cr splcommon.Me
 
 	mapAppListing := make(map[string]string)
 
-	// ToDo: sgontla/Jeff: Adapt to any Ansible changes(if required) for differentiating local vs. cluster scope (?)
+	// Locally scoped apps for CM/Deployer require the latest splunk-ansible with apps_location_local.  Prior to this,
+	// there was no method to install local apps for these roles.  If the apps_location_local variable is not available,
+	// it will be ignored and revert back to no locally scoped apps for CM/Deployer.
 	yamlConfHeader := fmt.Sprintf(`splunk:
   apps_location:`)
+	yamlConfLocalHeader := fmt.Sprintf(`splunk:
+  apps_location_local:`)
 
 	var localAppsConf, clusterAppsConf string
-	localAppsConf = yamlConfHeader
+	if crKind == "ClusterMaster" || crKind == "SearchHeadCluster" {
+		localAppsConf = yamlConfLocalHeader
+	} else {
+		localAppsConf = yamlConfHeader
+	}
 	clusterAppsConf = yamlConfHeader
 
 	for appSrc, appSrcDeployInfo := range appsSrcDeployStatus {


### PR DESCRIPTION
## Problem

As part of the app installation framework for SOK, there is a requirement to install apps locally to CM/SHDeployer instances.  These apps would not be pushed to the SHC/IDC but rather only be installed on the CM.

## Solution

Originally splunk-ansible did not have a method of installing apps locally on CM/Deployer instance.  Any apps specified in `apps_location` we pushed to the cluster and disabled locally.  However with https://github.com/splunk/splunk-ansible/pull/628 the `apps_location_local` allows apps listed here to be installed locally to CM/Deployer instances only.  The operator needs to use this new config for locally scoped apps on CM/Deployer instances.

## Tests

Verify the new functionality of the operator and ansible changes while making sure if old splunk images (without the needed ansbile changes) still work as before.  This means no locally scoped apps of CM/Deployer for old image, however this change should not break any existing use cases.

### Verify on CM and IDC

The TL;DR summary is `appSource` `af` and `default` are cluster scope and contain `application5.tgz` and `application4.tgz` respectivly.  `admin` is scoped to local and contains `application1.tgz` and `application3.tgz`

#### CM CR
```
apiVersion: enterprise.splunk.com/v1beta1
kind: ClusterMaster
metadata:
  name: cm-aws
spec:
  # Added edge splunk image with ansible fix
  image: splunk/splunk:edge
  imagePullPolicy: IfNotPresent

  appRepo:
    appsRepoPollIntervalSeconds: 60
    volumes:
      - name: volume_app_repo1
        path: test-af-bucket/apps
        endpoint: https://s3-us-west-2.amazonaws.com
        secretRef: af-aws-secret
        storageType: s3
        provider: aws
    appSources:
      - name: af
        location: af-test/
        volumeName: volume_app_repo1
        scope: cluster
      - name: admin
        location: admin-apps/
        volumeName: volume_app_repo1
        scope: local
      - name: default
        location: default-test/
        volumeName: volume_app_repo1
        scope: cluster
```

#### IDC CR
```
apiVersion: enterprise.splunk.com/v1beta1
kind: IndexerCluster
metadata:
  name: idc-aws
  finalizers:
  - enterprise.splunk.com/delete-pvc
spec:
  clusterMasterRef:
    name: cm-aws
```

#### Verify app download on CM only
```
[splunk@splunk-cm-aws-cluster-master-0 splunk]$ ls -Rl /init-apps/
/init-apps/:
total 0
drwxr-sr-x 2 splunk splunk 54 Jun 15 07:04 admin
drwxr-sr-x 2 splunk splunk 30 Jun 15 07:04 af
drwxr-sr-x 2 splunk splunk 30 Jun 15 07:05 default

/init-apps/admin:
total 8
-rw-r--r-- 1 splunk splunk 1155 May 24 17:21 application1.tgz
-rw-r--r-- 1 splunk splunk 1167 Jun 15 07:00 application3.tgz

/init-apps/af:
total 4
-rw-r--r-- 1 splunk splunk 1154 May 24 17:21 application5.tgz

/init-apps/default:
total 4
-rw-r--r-- 1 splunk splunk 1154 May 24 17:21 application4.tgz
[splunk@splunk-cm-aws-cluster-master-0 splunk]$
```

#### Verify only local apps are install/enabled locally
```
[splunk@splunk-cm-aws-cluster-master-0 splunk]$ bin/splunk display app
alert_logevent                 CONFIGURED          ENABLED             INVISIBLE           
alert_webhook                  CONFIGURED          ENABLED             INVISIBLE           
application1                   UNCONFIGURED        ENABLED             VISIBLE             
application3                   UNCONFIGURED        ENABLED             VISIBLE             
application4                   UNCONFIGURED        DISABLED            VISIBLE             
application5                   UNCONFIGURED        DISABLED            VISIBLE             
appsbrowser                    CONFIGURED          ENABLED             INVISIBLE           
...       
```

#### Verify master-apps apps are pushed to cluster
```
[splunk@splunk-idc1-indexer-0 splunk]$ bin/splunk display app
Your session is invalid.  Please login.
Splunk username: admin
Password: 
_cluster                       UNCONFIGURED        ENABLED             INVISIBLE           
alert_logevent                 CONFIGURED          ENABLED             INVISIBLE           
alert_webhook                  CONFIGURED          ENABLED             INVISIBLE           
application4                   UNCONFIGURED        ENABLED             VISIBLE             
application5                   UNCONFIGURED        ENABLED             VISIBLE             
appsbrowser                    CONFIGURED          ENABLED             INVISIBLE
...

```


### Verify on SH Deployer and SHC Members

Similar setup to the IDC, `appSource` `af` and `default` are cluster scope and contain `application5.tgz` and `application4.tgz` respectivly.  `admin` is scoped to local and contains `application1.tgz` and `application3.tgz`

#### SHC CR

```
apiVersion: enterprise.splunk.com/v1
kind: SearchHeadCluster
metadata:
  name: shc-aws
  finalizers:
  - enterprise.splunk.com/delete-pvc
spec:
  # Added edge splunk image with ansible fix
  image: splunk/splunk:edge
  imagePullPolicy: IfNotPresent
  clusterMasterRef:
    name: cm-aws
  appRepo:
    appsRepoPollIntervalSeconds: 60
    volumes:
      - name: volume_app_repo1
        path: test-bucket/apps
        endpoint: https://s3-us-west-2.amazonaws.com
        secretRef: af-aws-secret
        storageType: s3
        provider: aws
    appSources:
      - name: af
        location: af-test/
        volumeName: volume_app_repo1
        scope: cluster
      - name: admin
        location: admin-apps/
        volumeName: volume_app_repo1
        scope: local
      - name: default
        location: default-test/
        volumeName: volume_app_repo1
        scope: cluster
```

#### Verify app download on SH Deployer only
```
[splunk@splunk-shc-aws-deployer-0 splunk]$ ls -Rl /init-apps/
/init-apps/:
total 0
drwxr-sr-x 2 splunk splunk 54 Jun 15 15:56 admin
drwxr-sr-x 2 splunk splunk 30 Jun 15 15:56 af
drwxr-sr-x 2 splunk splunk 30 Jun 15 15:56 default

/init-apps/admin:
total 8
-rw-r--r-- 1 splunk splunk 1155 May 24 17:21 application1.tgz
-rw-r--r-- 1 splunk splunk 1167 Jun 15 07:00 application3.tgz

/init-apps/af:
total 4
-rw-r--r-- 1 splunk splunk 1154 May 24 17:21 application5.tgz

/init-apps/default:
total 4
-rw-r--r-- 1 splunk splunk 1154 May 24 17:21 application4.tgz
[splunk@splunk-shc-aws-deployer-0 splunk]$
```

#### Verify only local apps are install/enabled locally
```
[splunk@splunk-shc-aws-deployer-0 splunk]$ bin/splunk display app
alert_logevent                 CONFIGURED          ENABLED             INVISIBLE           
alert_webhook                  CONFIGURED          ENABLED             INVISIBLE           
application1                   UNCONFIGURED        ENABLED             VISIBLE             
application3                   UNCONFIGURED        ENABLED             VISIBLE             
application4                   UNCONFIGURED        DISABLED            VISIBLE             
application5                   UNCONFIGURED        DISABLED            VISIBLE             
appsbrowser                    CONFIGURED          ENABLED             INVISIBLE
...
```

#### Verify shcluster apps are pushed to cluster
```
[splunk@splunk-shc-aws-deployer-0 splunk]$ ls -l etc/shcluster/apps/
total 12
-r--r--r-- 1 splunk splunk  121 May  1 18:22 README
drwx--s--- 6 splunk splunk 4096 Jun 15 16:07 application4
drwx--s--- 6 splunk splunk 4096 Jun 15 16:07 application5
[splunk@splunk-shc-aws-deployer-0 splunk]$
...
[splunk@splunk-shc-aws-search-head-0 splunk]$ bin/splunk display app
alert_logevent                 CONFIGURED          ENABLED             INVISIBLE           
alert_webhook                  CONFIGURED          ENABLED             INVISIBLE           
application4                   UNCONFIGURED        ENABLED             VISIBLE             
application5                   UNCONFIGURED        ENABLED             VISIBLE             
appsbrowser                    CONFIGURED          ENABLED             INVISIBLE         
...
```


### Verify Standalone still works

#### Standalone CR
```
apiVersion: enterprise.splunk.com/v1
kind: Standalone
metadata:
  name: s-af-aws
  finalizers:
  - enterprise.splunk.com/delete-pvc
spec:
  image: splunk/splunk:edge
  imagePullPolicy: IfNotPresent
  replicas: 1
  appRepo:
    appsRepoPollIntervalSeconds: 60
    volumes:
      - name: volume_app_repo1
        path: test-af-bucket/apps
        endpoint: https://s3-us-west-2.amazonaws.com
        secretRef: af-aws-secret
        storageType: s3
        provider: aws
    appSources:
      - name: af
        location: af-test/
        volumeName: volume_app_repo1
        scope: local
      - name: admin
        location: admin-apps/
        volumeName: volume_app_repo1
        scope: local
      - name: default
        location: default-test/
        volumeName: volume_app_repo1
        scope: local
```

#### Verify app install
```
[splunk@splunk-s-af-aws-standalone-0 splunk]$ ls -Rl /init-apps/
/init-apps/:
total 0
drwxr-sr-x 2 splunk splunk 54 Jun 15 17:00 admin
drwxr-sr-x 2 splunk splunk 30 Jun 15 17:00 af
drwxr-sr-x 2 splunk splunk 30 Jun 15 17:00 default

/init-apps/admin:
total 8
-rw-r--r-- 1 splunk splunk 1155 May 24 17:21 application1.tgz
-rw-r--r-- 1 splunk splunk 1167 Jun 15 07:00 application3.tgz

/init-apps/af:
total 4
-rw-r--r-- 1 splunk splunk 1154 May 24 17:21 application5.tgz

/init-apps/default:
total 4
-rw-r--r-- 1 splunk splunk 1154 May 24 17:21 application4.tgz
[splunk@splunk-s-af-aws-standalone-0 splunk]$ bin/splunk display app
Splunk username: admin
Password: 
alert_logevent                 CONFIGURED          ENABLED             INVISIBLE           
alert_webhook                  CONFIGURED          ENABLED             INVISIBLE           
application1                   UNCONFIGURED        ENABLED             VISIBLE             
application3                   UNCONFIGURED        ENABLED             VISIBLE             
application4                   UNCONFIGURED        ENABLED             VISIBLE             
application5                   UNCONFIGURED        ENABLED             VISIBLE             
appsbrowser                    CONFIGURED          ENABLED             INVISIBLE 
...
```

### Verify old splunk/ansible images still work as before (without ansible `apps_location_local` fix)

Verify cluster scoped apps are pushed.  Local apps will not be installed.

#### CM CR
```
kind: ClusterMaster
metadata:
  name: cm-aws
  finalizers:
  - enterprise.splunk.com/delete-pvc
spec:
  appRepo:
    appsRepoPollIntervalSeconds: 60
    volumes:
      - name: volume_app_repo1
        path: test-af-bucket/apps
        endpoint: https://s3-us-west-2.amazonaws.com
        secretRef: af-aws-secret
        storageType: s3
        provider: aws
    appSources:
      - name: af
        location: af-test/
        volumeName: volume_app_repo1
        scope: cluster
      - name: admin
        location: admin-apps/
        volumeName: volume_app_repo1
        scope: local
      - name: default
        location: default-test/
        volumeName: volume_app_repo1
        scope: cluster
```

#### Verify cluster scoped apps are pushed to IDC
```
[splunk@splunk-cm-aws-cluster-master-0 splunk]$ ls -l etc/master-apps/
total 12
drwxr-sr-x 4 splunk splunk 4096 Mar  9 17:09 _cluster
drwx--s--- 6 splunk splunk 4096 Jun 15 17:36 application4
drwx--s--- 6 splunk splunk 4096 Jun 15 17:36 application5
[splunk@splunk-cm-aws-cluster-master-0 splunk]$ ls -Rl /init-apps/
/init-apps/:
total 0
drwxr-sr-x 2 splunk splunk 54 Jun 15 17:35 admin
drwxr-sr-x 2 splunk splunk 30 Jun 15 17:35 af
drwxr-sr-x 2 splunk splunk 30 Jun 15 17:35 default

/init-apps/admin:
total 8
-rw-r--r-- 1 splunk splunk 1155 May 24 17:21 application1.tgz
-rw-r--r-- 1 splunk splunk 1167 Jun 15 07:00 application3.tgz

/init-apps/af:
total 4
-rw-r--r-- 1 splunk splunk 1154 May 24 17:21 application5.tgz

/init-apps/default:
total 4
-rw-r--r-- 1 splunk splunk 1154 May 24 17:21 application4.tgz
[splunk@splunk-cm-aws-cluster-master-0 splunk]$  bin/splunk display app
alert_logevent                 CONFIGURED          ENABLED             INVISIBLE           
alert_webhook                  CONFIGURED          ENABLED             INVISIBLE           
application4                   UNCONFIGURED        DISABLED            VISIBLE             
application5                   UNCONFIGURED        DISABLED            VISIBLE             
appsbrowser                    CONFIGURED          ENABLED             INVISIBLE           
introspection_generator_addon  CONFIGURED          ENABLED             INVISIBLE         
...
```
```
[splunk@splunk-idc-aws-indexer-0 splunk]$ bin/splunk display app
_cluster                       UNCONFIGURED        ENABLED             INVISIBLE           
alert_logevent                 CONFIGURED          ENABLED             INVISIBLE           
alert_webhook                  CONFIGURED          ENABLED             INVISIBLE           
application4                   UNCONFIGURED        ENABLED             VISIBLE             
application5                   UNCONFIGURED        ENABLED             VISIBLE             
appsbrowser                    CONFIGURED          ENABLED             INVISIBLE           
introspection_generator_addon  CONFIGURED          ENABLED             INVISIBLE  
... 
```