### PR TITLE
CSPL-1114: Automation for Polling updates on App framework

### DIFF
--- a/test/c3/appframework/appframework_suite_test.go
+++ b/test/c3/appframework/appframework_suite_test.go
@@ -63,21 +63,20 @@ var _ = BeforeSuite(func() {
 	testenvInstance, err = testenv.NewDefaultTestEnv(testSuiteName)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Parse Applist1 to create Valid Apps1
+	// Create a list of apps to upload to S3
 	appListV1 = testenv.BasicApps
+	appFileList := testenv.GetAppFileList(appListV1, 1)
 
 	// Download V1 Apps from S3
-	err = testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV1, downloadDirV1, appListV1)
+	err = testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV1, downloadDirV1, appFileList)
 	Expect(err).To(Succeed(), "Unable to download V1 app files")
 
-	// Parse ValidAppsV1 to create Valid Apps2
-	appListV2 = make([]string, 0, len(appListV1))
-	for _, app := range appListV1 {
-		appListV2 = append(appListV2, testenv.AppInfo[app]["V2filename"])
-	}
+	// Create a list of apps to upload to S3 after poll period
+	appListV2 = append(appListV1, testenv.NewAppsAddedBetweenPolls...)
+	appFileList = testenv.GetAppFileList(appListV2, 2)
 
 	// Download V2 Apps from S3
-	err = testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV2, downloadDirV2, appListV2)
+	err = testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV2, downloadDirV2, appFileList)
 	Expect(err).To(Succeed(), "Unable to download V2 app files")
 
 })

--- a/test/licensemaster/lm_c3_test.go
+++ b/test/licensemaster/lm_c3_test.go
@@ -106,15 +106,17 @@ var _ = Describe("Licensemaster test", func() {
 				uploadedApps     []string
 			)
 
+			// Create a list of apps to upload to S3
 			appListV1 = testenv.BasicApps
+			appFileList := testenv.GetAppFileList(appListV1, 1)
 
 			// Download V1 Apps from S3
-			err := testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV1, downloadDirV1, appListV1)
+			err := testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV1, downloadDirV1, appFileList)
 			Expect(err).To(Succeed(), "Unable to download V1 app files")
 
 			// Upload V1 apps to S3
 			s3TestDir = "lm-" + testenv.RandomDNSName(4)
-			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appListV1, downloadDirV1)
+			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV1)
 			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
@@ -178,7 +180,7 @@ var _ = Describe("Licensemaster test", func() {
 
 			// Verify apps are copied at the correct location on LM (/etc/apps/)
 			podName := []string{fmt.Sprintf(testenv.LicenseMasterPod, deployment.GetName(), 0)}
-			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), podName, appListV1, true, false)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), podName, appFileList, true, false)
 
 			// Verify apps are installed on LM
 			lmPodName := []string{fmt.Sprintf(testenv.LicenseMasterPod, deployment.GetName(), 0)}

--- a/test/m4/appframework/appframework_suite_test.go
+++ b/test/m4/appframework/appframework_suite_test.go
@@ -63,21 +63,20 @@ var _ = BeforeSuite(func() {
 	testenvInstance, err = testenv.NewDefaultTestEnv(testSuiteName)
 	Expect(err).ToNot(HaveOccurred())
 
-	// create Valid Apps1
+	// Create a list of apps to upload to S3
 	appListV1 = testenv.BasicApps
+	appFileList := testenv.GetAppFileList(appListV1, 1)
 
 	// Download V1 Apps from S3
-	err = testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV1, downloadDirV1, appListV1)
+	err = testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV1, downloadDirV1, appFileList)
 	Expect(err).To(Succeed(), "Unable to download V1 app files")
 
-	// Parse ValidAppsV1 to create Valid Apps2
-	appListV2 = make([]string, 0, len(appListV1))
-	for _, app := range appListV1 {
-		appListV2 = append(appListV2, testenv.AppInfo[app]["V2filename"])
-	}
+	// Create a list of apps to upload to S3 after poll period
+	appListV2 = append(appListV1, testenv.NewAppsAddedBetweenPolls...)
+	appFileList = testenv.GetAppFileList(appListV2, 2)
 
 	// Download V2 Apps from S3
-	err = testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV2, downloadDirV2, appListV2)
+	err = testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV2, downloadDirV2, appFileList)
 	Expect(err).To(Succeed(), "Unable to download V2 app files")
 
 })

--- a/test/m4/appframework/appframework_test.go
+++ b/test/m4/appframework/appframework_test.go
@@ -38,7 +38,8 @@ var _ = Describe("m4appfw test", func() {
 
 		// Upload V1 apps to S3
 		s3TestDir = "m4appfw-" + testenv.RandomDNSName(4)
-		uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appListV1, downloadDirV1)
+		appFileList := testenv.GetAppFileList(appListV1, 1)
+		uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV1)
 		Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
 		uploadedApps = append(uploadedApps, uploadedFiles...)
 
@@ -107,7 +108,8 @@ var _ = Describe("m4appfw test", func() {
 			// Verify Apps are downloaded by init-container
 			initContDownloadLocation := "/init-apps/" + appSourceName
 			podNames := []string{fmt.Sprintf(testenv.ClusterMasterPod, deployment.GetName()), fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
-			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), podNames, appListV1, initContDownloadLocation)
+			appFileList := testenv.GetAppFileList(appListV1, 1)
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), podNames, appFileList, initContDownloadLocation)
 
 			//Verify Apps are copied to location
 			allPodNames := testenv.DumpGetPods(testenvInstance.GetName())
@@ -121,21 +123,37 @@ var _ = Describe("m4appfw test", func() {
 			uploadedApps = nil
 
 			//Upload new Versioned Apps to S3
-			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appListV2, downloadDirV2)
+			appFileList = testenv.GetAppFileList(appListV2, 2)
+			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV2)
 			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
 			// Wait for the poll period for the apps to be downloaded
 			time.Sleep(2 * time.Minute)
 
+			// Ensure that the cluster-master goes to Ready phase
+			testenv.ClusterMasterReady(deployment, testenvInstance)
+
+			// Ensure the indexers of all sites go to Ready phase
+			testenv.IndexersReady(deployment, testenvInstance, siteCount)
+
+			// Ensure cluster configured as multisite
+			testenv.IndexerClusterMultisiteStatus(deployment, testenvInstance, siteCount)
+
+			// Ensure search head cluster go to Ready phase
+			testenv.SearchHeadClusterReady(deployment, testenvInstance)
+
+			// Verify RF SF is met
+			testenv.VerifyRFSFMet(deployment, testenvInstance)
+
 			// Verify Apps are downloaded by init-container
-			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), podNames, appListV2, initContDownloadLocation)
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), podNames, appFileList, initContDownloadLocation)
 
 			//Verify Apps are copied to location
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, true)
 
 			//Verify Apps are installed cluster-wide
-			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, "enabled", true, true)
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, "enabled", true, true)
 		})
 	})
 
@@ -182,7 +200,8 @@ var _ = Describe("m4appfw test", func() {
 
 			// Verify apps are copied at the correct location on CM and on Deployer (/etc/apps/)
 			podNames := []string{fmt.Sprintf(testenv.ClusterMasterPod, deployment.GetName()), fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
-			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), podNames, appListV1, true, false)
+			appFileList := testenv.GetAppFileList(appListV1, 1)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), podNames, appFileList, true, false)
 
 			// Verify apps are installed locally on CM and on SHC Deployer
 			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), podNames, appListV1, false, "enabled", false, false)

--- a/test/s1/appframework/appframework_suite_test.go
+++ b/test/s1/appframework/appframework_suite_test.go
@@ -63,21 +63,20 @@ var _ = BeforeSuite(func() {
 	testenvInstance, err = testenv.NewDefaultTestEnv(testSuiteName)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Create Valid apps
+	// Create a list of apps to upload to S3
 	appListV1 = testenv.BasicApps
+	appFileList := testenv.GetAppFileList(appListV1, 1)
 
 	// Download V1 Apps from S3
-	err = testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV1, downloadDirV1, appListV1)
+	err = testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV1, downloadDirV1, appFileList)
 	Expect(err).To(Succeed(), "Unable to download V1 app files")
 
-	// Parse ValidAppsV1 to create Valid Apps2
-	appListV2 = make([]string, 0, len(appListV1))
-	for _, app := range appListV1 {
-		appListV2 = append(appListV2, testenv.AppInfo[app]["V2filename"])
-	}
+	// Create a list of apps to upload to S3 after poll period
+	appListV2 = append(appListV1, testenv.NewAppsAddedBetweenPolls...)
+	appFileList = testenv.GetAppFileList(appListV2, 2)
 
 	// Download V2 Apps from S3
-	err = testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV2, downloadDirV2, appListV2)
+	err = testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV2, downloadDirV2, appFileList)
 	Expect(err).To(Succeed(), "Unable to download V2 app files")
 
 })

--- a/test/s1/appframework/appframework_test.go
+++ b/test/s1/appframework/appframework_test.go
@@ -40,7 +40,8 @@ var _ = Describe("s1appfw test", func() {
 
 		// Upload V1 apps to S3
 		s3TestDir = "s1appfw-" + testenv.RandomDNSName(4)
-		uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appListV1, downloadDirV1)
+		appFileList := testenv.GetAppFileList(appListV1, 1)
+		uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV1)
 		Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
 		uploadedApps = append(uploadedApps, uploadedFiles...)
 
@@ -108,7 +109,8 @@ var _ = Describe("s1appfw test", func() {
 			// Verify Apps are downloaded by init-container
 			initContDownloadLocation := "/init-apps/" + appSourceName
 			podName := fmt.Sprintf(testenv.StandalonePod, deployment.GetName(), 0)
-			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), []string{podName}, appListV1, initContDownloadLocation)
+			appFileList := testenv.GetAppFileList(appListV1, 1)
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), []string{podName}, appFileList, initContDownloadLocation)
 
 			//Verify Apps are copied to location
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), []string{podName}, appListV1, true, true)
@@ -121,15 +123,19 @@ var _ = Describe("s1appfw test", func() {
 			uploadedApps = nil
 
 			//Upload new Versioned Apps to S3
-			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appListV2, downloadDirV2)
+			appFileList = testenv.GetAppFileList(appListV2, 2)
+			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV2)
 			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
 			// Wait for the poll period for the apps to be downloaded
 			time.Sleep(2 * time.Minute)
 
+			// Wait for Standalone to be in READY status
+			testenv.StandaloneReady(deployment, deployment.GetName(), standalone, testenvInstance)
+
 			// Verify Apps are downloaded by init-container
-			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), []string{podName}, appListV2, initContDownloadLocation)
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), []string{podName}, appFileList, initContDownloadLocation)
 
 			//Verify Apps are copied to location
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), []string{podName}, appListV2, true, true)

--- a/test/testenv/appframework_utils.go
+++ b/test/testenv/appframework_utils.go
@@ -10,33 +10,29 @@ import (
 
 //AppInfo Installation info on Apps
 var AppInfo = map[string]map[string]string{
-	"splunk-common-information-model-cim_4181.tgz":       {"App-name": "Splunk_SA_CIM", "V1": "4.18.1", "V2": "4.19.0", "V2filename": "splunk-common-information-model-cim_4190.tgz"},
-	"Add-on-for-ldap_400.tgz":                            {"App-name": "TA-LDAP", "V1": "4.0.0", "V2": "4.0.0", "V2filename": "Add-on-for-ldap_400.tgz"},
-	"splunk-es-content-update_3200.tgz":                  {"App-name": "DA-ESS-ContentUpdate", "V1": "3.20.0", "V2": "3.21.0", "V2filename": "splunk-es-content-update_3210.tgz"},
-	"palo-alto-networks-add-on-for-splunk_660.tgz":       {"App-name": "Splunk_TA_paloalto", "V1": "6.6.0", "V2": "7.0.0", "V2filename": "palo-alto-networks-add-on-for-splunk_700.tgz"},
-	"microsoft-azure-add-on-for-splunk_300.tgz":          {"App-name": "TA-MS-AAD", "V1": "3.0.0", "V2": "3.1.1", "V2filename": "microsoft-azure-add-on-for-splunk_311.tgz"},
-	"splunk-add-on-for-unix-and-linux_830.tgz":           {"App-name": "Splunk_TA_nix", "V1": "8.3.0", "V2": "8.3.0", "V2filename": "splunk-add-on-for-unix-and-linux_830.tgz"},
-	"splunk-app-for-microsoft-exchange_401.tgz":          {"App-name": "splunk_app_microsoft_exchange", "V1": "4.0.1", "V2": "4.0.2", "V2filename": "splunk-app-for-microsoft-exchange_402.tgz"},
-	"Splunk-app-for-aws_601.tgz":                         {"App-name": "splunk_app_aws", "V1": "6.0.1", "V2": "6.0.2", "V2filename": "Splunk-app-for-aws_602.tgz"},
-	"splunk-machine-learning-toolkit_520.tgz":            {"App-name": "Splunk_ML_Toolkit", "V1": "5.2.0", "V2": "5.2.1", "V2filename": "splunk-machine-learning-toolkit_521.tgz"},
-	"splunk-add-on-for-microsoft-cloud-services_412.tgz": {"App-name": "Splunk_TA_microsoft-cloudservices", "V1": "4.1.2", "V2": "4.1.3", "V2filename": "splunk-add-on-for-microsoft-cloud-services_413.tgz"},
-	"Splunk-app-for-stream_720.tgz":                      {"App-name": "splunk_app_stream", "V1": "6.0.1", "V2": "6.0.2", "V2filename": "Splunk-app-for-stream_720.tgz"},
-	"Splunk-db-connect_350.tgz":                          {"App-name": "splunk_app_db_connect", "V1": "3.5.0", "V2": "3.5.1", "V2filename": "Splunk-db-connect_351.tgz"},
-	"Splunk-security-essentials_332.tgz":                 {"App-name": "Splunk_Security_Essentials", "V1": "3.3.2", "V2": "3.3.3", "V2filename": "Splunk-security-essentials_333.tgz"},
-	//Need to explore these apps for their app Name and installation steps
-	"splunk-app-for-vmware_401.tgz":          {"App-name": "", "V1": "4.0.1", "V2": "4.0.2", "V2filename": "splunk-app-for-vmware_402.tgz"},
-	"splunk-it-service-intelligence_472.spl": {"App-name": "", "V1": "4.7.2", "V2": "4.9.0", "V2filename": "splunk-it-service-intelligence_490.spl"},
-	"splunk-enterprise-security_640.spl":     {"App-name": "", "V1": "6.4.0", "V2": "6.4.1", "V2filename": "splunk-enterprise-security_641.spl"},
+	"Splunk_SA_CIM":                     {"V1": "4.18.1", "V2": "4.19.0", "V2filename": "splunk-common-information-model-cim_4190.tgz", "V1filename": "splunk-common-information-model-cim_4181.tgz"},
+	"TA-LDAP":                           {"V1": "4.0.0", "V2": "4.0.0", "V2filename": "add-on-for-ldap_400.tgz", "V1filename": "add-on-for-ldap_400.tgz"},
+	"DA-ESS-ContentUpdate":              {"V1": "3.20.0", "V2": "3.21.0", "V2filename": "splunk-es-content-update_3210.tgz", "V1filename": "splunk-es-content-update_3200.tgz"},
+	"Splunk_TA_paloalto":                {"V1": "6.6.0", "V2": "7.0.0", "V2filename": "palo-alto-networks-add-on-for-splunk_700.tgz", "V1filename": "palo-alto-networks-add-on-for-splunk_660.tgz"},
+	"TA-MS-AAD":                         {"V1": "3.0.0", "V2": "3.1.1", "V2filename": "microsoft-azure-add-on-for-splunk_311.tgz", "V1filename": "microsoft-azure-add-on-for-splunk_300.tgz"},
+	"Splunk_TA_nix":                     {"V1": "8.3.0", "V2": "8.3.0", "V2filename": "splunk-add-on-for-unix-and-linux_830.tgz", "V1filename": "splunk-add-on-for-unix-and-linux_830.tgz"},
+	"splunk_app_microsoft_exchange":     {"V1": "4.0.1", "V2": "4.0.2", "V2filename": "splunk-app-for-microsoft-exchange_402.tgz", "V1filename": "splunk-app-for-microsoft-exchange_401.tgz"},
+	"splunk_app_aws":                    {"V1": "6.0.1", "V2": "6.0.2", "V2filename": "Splunk-app-for-aws_602.tgz", "V1filename": "Splunk-app-for-aws_601.tgz"},
+	"Splunk_ML_Toolkit":                 {"V1": "5.2.0", "V2": "5.2.1", "V2filename": "splunk-machine-learning-toolkit_521.tgz", "V1filename": "splunk-machine-learning-toolkit_520.tgz"},
+	"Splunk_TA_microsoft-cloudservices": {"V1": "4.1.2", "V2": "4.1.3", "V2filename": "splunk-add-on-for-microsoft-cloud-services_413.tgz", "V1filename": "splunk-add-on-for-microsoft-cloud-services_412.tgz"},
+	"splunk_app_stream":                 {"V1": "6.0.1", "V2": "6.0.2", "V2filename": "Splunk-app-for-stream_720.tgz", "V1filename": "Splunk-app-for-stream_720.tgz"},
+	"splunk_app_db_connect":             {"V1": "3.5.0", "V2": "3.5.1", "V2filename": "Splunk-db-connect_351.tgz", "V1filename": "Splunk-db-connect_350.tgz"},
+	"Splunk_Security_Essentials":        {"V1": "3.3.2", "V2": "3.3.3", "V2filename": "Splunk-security-essentials_333.tgz", "V1filename": "Splunk-security-essentials_332.tgz"},
 }
 
 //BasicApps Apps that require no restart to be installed
-var BasicApps = []string{"splunk-common-information-model-cim_4181.tgz", "splunk-es-content-update_3200.tgz", "palo-alto-networks-add-on-for-splunk_660.tgz", "microsoft-azure-add-on-for-splunk_300.tgz"}
+var BasicApps = []string{"Splunk_SA_CIM", "DA-ESS-ContentUpdate", "Splunk_TA_paloalto", "TA-MS-AAD"}
 
 //RestartNeededApps Apps that require restart to be installed
-var RestartNeededApps = []string{"splunk-add-on-for-unix-and-linux_830.tgz", "splunk-app-for-microsoft-exchange_401.tgz", "Splunk-app-for-aws_601.tgz", "splunk-machine-learning-toolkit_520.tgz", "splunk-add-on-for-microsoft-cloud-services_412.tgz", "Splunk-app-for-stream_720.tgz", "Splunk-db-connect_350.tgz", "Splunk-security-essentials_332.tgz"}
+var RestartNeededApps = []string{"Splunk_TA_nix", "splunk_app_microsoft_exchange", "splunk_app_aws", "Splunk_ML_Toolkit", "Splunk_TA_microsoft-cloudservices", "splunk_app_stream", "splunk_app_db_connect", "Splunk_Security_Essentials"}
 
-//AdditionalStepsApps Apps that require additional steps to be installed
-var AdditionalStepsApps = []string{"splunk-app-for-vmware_401.tgz", "splunk-it-service-intelligence_472.spl", "splunk-enterprise-security_640.spl"}
+//NewAppsAddedBetweenPolls Apps to be installed as poll after
+var NewAppsAddedBetweenPolls = []string{"TA-LDAP"}
 
 // GenerateAppSourceSpec return AppSourceSpec struct with given values
 func GenerateAppSourceSpec(appSourceName string, appSourceLocation string, appSourceDefaultSpec enterprisev1.AppSourceDefaultSpec) enterprisev1.AppSourceSpec {
@@ -60,7 +56,11 @@ func GetPodAppStatus(deployment *Deployment, podName string, ns string, appname 
 func GetPodInstalledAppVersion(deployment *Deployment, podName string, ns string, appname string) (string, error) {
 	path := "etc/apps"
 	if strings.Contains(podName, "-indexer-") {
-		path = "etc/slave-apps/"
+		path = "etc/slave-apps"
+	} else if strings.Contains(podName, "cluster-master") {
+		path = "etc/master-apps"
+	} else if strings.Contains(podName, "-deployer-") {
+		path = "etc/shcluster/apps"
 	}
 	filePath := fmt.Sprintf("/opt/splunk/%s/%s/default/app.conf", path, appname)
 	logf.Log.Info("Check Version for app", "AppName", appname, "config", filePath)
@@ -77,14 +77,7 @@ func GetPodInstalledAppVersion(deployment *Deployment, podName string, ns string
 
 // GetPodAppInstallStatus Get the app install status
 func GetPodAppInstallStatus(deployment *Deployment, podName string, ns string, appname string) (string, error) {
-	//Get password to via secret object
-	namespaceScopedSecretName := fmt.Sprintf(NamespaceScopedSecretObjectName, ns)
-	secretStruct, _ := GetSecretStruct(deployment, ns, namespaceScopedSecretName)
-	logf.Log.Info("Data in secret object", "data", secretStruct.Data)
-	pwd := DecryptSplunkEncodedSecret(deployment, podName, ns, string(secretStruct.Data["password"]))
-
-	//Use password to access info
-	stdin := fmt.Sprintf("/opt/splunk/bin/splunk display app '%s' -auth admin:%s", appname, pwd)
+	stdin := fmt.Sprintf("/opt/splunk/bin/splunk display app '%s' -auth admin:$(cat /mnt/splunk-secrets/password)", appname)
 	command := []string{"/bin/sh"}
 	stdout, stderr, err := deployment.PodExecCommand(podName, command, stdin, false)
 	if err != nil {
@@ -114,4 +107,14 @@ func GetPodAppbtoolStatus(deployment *Deployment, podName string, ns string, app
 		return "ENABLED", nil
 	}
 	return "", err
+}
+
+// GetAppFileList Get the Versioned App file list for  app Names
+func GetAppFileList(appList []string, version int) []string {
+	fileKey := fmt.Sprintf("V%dfilename", version)
+	appFileList := make([]string, 0, len(appList))
+	for _, app := range appList {
+		appFileList = append(appFileList, AppInfo[app][fileKey])
+	}
+	return appFileList
 }


### PR DESCRIPTION
Automation Covers:

Waiting for the polling interval for new downloads to trigger.

Check that Apps are updated or newer apps are installed

Passing Runs.  Failures not see after builds using https://github.com/splunk/splunk-operator/pull/390 
```
[2] • [SLOW TEST:453.295 seconds]
[2] s1appfw test
[2] /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:30
[2]   appframework Standalone deployment (S1) with App Framework
[2]   /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:63
[2]     s1, appframework: can deploy a standalone instance with App Framework enabled
[2]     /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:64
[2] ------------------------------
[2] {"level":"info","ts":1623963535.669206,"msg":"testenv deleted.\n","testenv":"s1appfw-rv8"}
[2]
[2] JUnit report was created: /Users/tpereira/Git/splunk-operator/test/s1/appframework/s1appfw-rv8_junit.xml
[2]
[2] Ran 1 of 1 Specs in 478.821 seconds
[2] SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[2] PASS

Ginkgo ran 1 suite in 8m5.461280422s


[2] • [SLOW TEST:1051.742 seconds]
[2] c3appfw test
[2] /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:27
[2]   Single Site Indexer Cluster with SHC (C3) with App Framework
[2]   /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:60
[2]     integration, c3, appframework: can deploy a C3 SVA with App Framework enabled
[2]     /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:61
[2] ------------------------------
[2] {"level":"info","ts":1623884000.392606,"msg":"testenv deleted.\n","testenv":"c3appfw-du2"}
[2] {"level":"info","ts":1623884000.392637,"msg":"testenv deleted.\n","testenv":"c3appfw-du2"}
[2]
[2] JUnit report was created: /Users/tpereira/Git/splunk-operator/test/c3/appframework/c3appfw-du2_junit.xml
[2]
[2] Ran 1 of 1 Specs in 1085.279 seconds
[2] SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[2] PASS
```
