### PR TITLE
CSPL-1135: Fix a bug in GetNextRequeueTime where we should provide the polling interval from status

### DIFF
--- a/deploy/olm-catalog/splunk/1.0.1/enterprise.splunk.com_clustermasters_crd.yaml
+++ b/deploy/olm-catalog/splunk/1.0.1/enterprise.splunk.com_clustermasters_crd.yaml
@@ -633,6 +633,85 @@ spec:
                         type: array
                     type: object
                 type: object
+              appRepo:
+                description: Splunk Enterprise App repository. Specifies remote App
+                  location and scope for Splunk App management
+                properties:
+                  appSources:
+                    description: List of App sources on remote storage
+                    items:
+                      description: AppSourceSpec defines list of App package (*.spl,
+                        *.tgz) locations on remote volumes
+                      properties:
+                        location:
+                          description: Location relative to the volume path
+                          type: string
+                        name:
+                          description: Logical name for the set of apps placed in
+                            this location. Logical name must be unique to the appRepo
+                          type: string
+                        scope:
+                          description: 'Scope of the App deployment: cluster, local.
+                            Scope determines whether the App(s) is/are installed locally
+                            or cluster-wide'
+                          type: string
+                        volumeName:
+                          description: Remote Storage Volume name
+                          type: string
+                      type: object
+                    type: array
+                  appsRepoPollIntervalSeconds:
+                    description: Interval in seconds to check the Remote Storage for
+                      App changes. The default value for this config is 1 hour(3600
+                      sec), minimum value is 1 minute(60sec) and maximum value is
+                      1 day(86400 sec). We assign the value based on following conditions
+                      -    1. If no value or 0 is specified then it will be defaulted
+                      to 1 hour.    2. If anything less than min is specified then
+                      we set it to 1 min.    3. If anything more than the max value
+                      is specified then we set it to 1 day.
+                    format: int64
+                    type: integer
+                  defaults:
+                    description: Defines the default configuration settings for App
+                      sources
+                    properties:
+                      scope:
+                        description: 'Scope of the App deployment: cluster, local.
+                          Scope determines whether the App(s) is/are installed locally
+                          or cluster-wide'
+                        type: string
+                      volumeName:
+                        description: Remote Storage Volume name
+                        type: string
+                    type: object
+                  volumes:
+                    description: List of remote storage volumes
+                    items:
+                      description: VolumeSpec defines remote volume config
+                      properties:
+                        endpoint:
+                          description: Remote volume URI
+                          type: string
+                        name:
+                          description: Remote volume name
+                          type: string
+                        path:
+                          description: Remote volume path
+                          type: string
+                        provider:
+                          description: App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws.
+                          type: string
+                        secretRef:
+                          description: Secret object name
+                          type: string
+                        storageType:
+                          description: Remote Storage type.
+                          type: string
+                      type: object
+                    type: array
+                type: object
               clusterMasterRef:
                 description: ClusterMasterRef refers to a Splunk Enterprise indexer
                   cluster managed by the operator within Kubernetes
@@ -1247,8 +1326,7 @@ spec:
                   volumes:
                     description: List of remote storage volumes
                     items:
-                      description: VolumeSpec defines remote volume name and remote
-                        volume URI
+                      description: VolumeSpec defines remote volume config
                       properties:
                         endpoint:
                           description: Remote volume URI
@@ -1259,8 +1337,16 @@ spec:
                         path:
                           description: Remote volume path
                           type: string
+                        provider:
+                          description: App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws.
+                          type: string
                         secretRef:
                           description: Secret object name
+                          type: string
+                        storageType:
+                          description: Remote Storage type.
                           type: string
                       type: object
                     type: array
@@ -2533,6 +2619,142 @@ spec:
           status:
             description: ClusterMasterStatus defines the observed state of ClusterMaster
             properties:
+              appContext:
+                description: App Framework status
+                properties:
+                  appRepo:
+                    description: List of App package (*.spl, *.tgz) locations on remote
+                      volume
+                    properties:
+                      appSources:
+                        description: List of App sources on remote storage
+                        items:
+                          description: AppSourceSpec defines list of App package (*.spl,
+                            *.tgz) locations on remote volumes
+                          properties:
+                            location:
+                              description: Location relative to the volume path
+                              type: string
+                            name:
+                              description: Logical name for the set of apps placed
+                                in this location. Logical name must be unique to the
+                                appRepo
+                              type: string
+                            scope:
+                              description: 'Scope of the App deployment: cluster,
+                                local. Scope determines whether the App(s) is/are
+                                installed locally or cluster-wide'
+                              type: string
+                            volumeName:
+                              description: Remote Storage Volume name
+                              type: string
+                          type: object
+                        type: array
+                      appsRepoPollIntervalSeconds:
+                        description: Interval in seconds to check the Remote Storage
+                          for App changes. The default value for this config is 1
+                          hour(3600 sec), minimum value is 1 minute(60sec) and maximum
+                          value is 1 day(86400 sec). We assign the value based on
+                          following conditions -    1. If no value or 0 is specified
+                          then it will be defaulted to 1 hour.    2. If anything less
+                          than min is specified then we set it to 1 min.    3. If
+                          anything more than the max value is specified then we set
+                          it to 1 day.
+                        format: int64
+                        type: integer
+                      defaults:
+                        description: Defines the default configuration settings for
+                          App sources
+                        properties:
+                          scope:
+                            description: 'Scope of the App deployment: cluster, local.
+                              Scope determines whether the App(s) is/are installed
+                              locally or cluster-wide'
+                            type: string
+                          volumeName:
+                            description: Remote Storage Volume name
+                            type: string
+                        type: object
+                      volumes:
+                        description: List of remote storage volumes
+                        items:
+                          description: VolumeSpec defines remote volume config
+                          properties:
+                            endpoint:
+                              description: Remote volume URI
+                              type: string
+                            name:
+                              description: Remote volume name
+                              type: string
+                            path:
+                              description: Remote volume path
+                              type: string
+                            provider:
+                              description: App Package Remote Store provider. For
+                                e.g. aws, azure, minio, etc. Currently we are only
+                                supporting aws.
+                              type: string
+                            secretRef:
+                              description: Secret object name
+                              type: string
+                            storageType:
+                              description: Remote Storage type.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  appSrcDeployStatus:
+                    additionalProperties:
+                      description: AppSrcDeployInfo represents deployment info for
+                        list of Apps
+                      properties:
+                        appDeploymentInfo:
+                          items:
+                            description: AppDeploymentInfo represents a single App
+                              deployment information
+                            properties:
+                              Size:
+                                format: int64
+                                type: integer
+                              appName:
+                                type: string
+                              deployStatus:
+                                description: AppDeploymentStatus represents the status
+                                  of an App on the Pod
+                                type: integer
+                              lastModifiedTime:
+                                type: string
+                              objectHash:
+                                type: string
+                              repoState:
+                                description: AppRepoState represent the App state
+                                  on remote store
+                                type: integer
+                            type: object
+                          type: array
+                      type: object
+                    description: Represents the Apps deployment status
+                    type: object
+                  appsRepoStatusPollIntervalSeconds:
+                    description: Interval in seconds to check the Remote Storage for
+                      App changes This is introduced here so that we dont do spec
+                      validation in every reconcile just because the spec and status
+                      are different.
+                    format: int64
+                    type: integer
+                  isDeploymentInProgress:
+                    description: IsDeploymentInProgress indicates if the Apps deployment
+                      is in progress
+                    type: boolean
+                  lastAppInfoCheckTime:
+                    description: This is set to the time when we get the list of apps
+                      from remote storage.
+                    format: int64
+                    type: integer
+                  version:
+                    description: App Framework version info for future use
+                    type: integer
+                type: object
               bundlePushInfo:
                 description: Bundle push status tracker
                 properties:
@@ -2647,8 +2869,7 @@ spec:
                   volumes:
                     description: List of remote storage volumes
                     items:
-                      description: VolumeSpec defines remote volume name and remote
-                        volume URI
+                      description: VolumeSpec defines remote volume config
                       properties:
                         endpoint:
                           description: Remote volume URI
@@ -2659,8 +2880,16 @@ spec:
                         path:
                           description: Remote volume path
                           type: string
+                        provider:
+                          description: App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws.
+                          type: string
                         secretRef:
                           description: Secret object name
+                          type: string
+                        storageType:
+                          description: Remote Storage type.
                           type: string
                       type: object
                     type: array

--- a/deploy/olm-catalog/splunk/1.0.1/enterprise.splunk.com_licensemasters_crd.yaml
+++ b/deploy/olm-catalog/splunk/1.0.1/enterprise.splunk.com_licensemasters_crd.yaml
@@ -638,6 +638,85 @@ spec:
                         type: array
                     type: object
                 type: object
+              appRepo:
+                description: Splunk enterprise App repository. Specifies remote App
+                  location and scope for Splunk App management
+                properties:
+                  appSources:
+                    description: List of App sources on remote storage
+                    items:
+                      description: AppSourceSpec defines list of App package (*.spl,
+                        *.tgz) locations on remote volumes
+                      properties:
+                        location:
+                          description: Location relative to the volume path
+                          type: string
+                        name:
+                          description: Logical name for the set of apps placed in
+                            this location. Logical name must be unique to the appRepo
+                          type: string
+                        scope:
+                          description: 'Scope of the App deployment: cluster, local.
+                            Scope determines whether the App(s) is/are installed locally
+                            or cluster-wide'
+                          type: string
+                        volumeName:
+                          description: Remote Storage Volume name
+                          type: string
+                      type: object
+                    type: array
+                  appsRepoPollIntervalSeconds:
+                    description: Interval in seconds to check the Remote Storage for
+                      App changes. The default value for this config is 1 hour(3600
+                      sec), minimum value is 1 minute(60sec) and maximum value is
+                      1 day(86400 sec). We assign the value based on following conditions
+                      -    1. If no value or 0 is specified then it will be defaulted
+                      to 1 hour.    2. If anything less than min is specified then
+                      we set it to 1 min.    3. If anything more than the max value
+                      is specified then we set it to 1 day.
+                    format: int64
+                    type: integer
+                  defaults:
+                    description: Defines the default configuration settings for App
+                      sources
+                    properties:
+                      scope:
+                        description: 'Scope of the App deployment: cluster, local.
+                          Scope determines whether the App(s) is/are installed locally
+                          or cluster-wide'
+                        type: string
+                      volumeName:
+                        description: Remote Storage Volume name
+                        type: string
+                    type: object
+                  volumes:
+                    description: List of remote storage volumes
+                    items:
+                      description: VolumeSpec defines remote volume config
+                      properties:
+                        endpoint:
+                          description: Remote volume URI
+                          type: string
+                        name:
+                          description: Remote volume name
+                          type: string
+                        path:
+                          description: Remote volume path
+                          type: string
+                        provider:
+                          description: App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws.
+                          type: string
+                        secretRef:
+                          description: Secret object name
+                          type: string
+                        storageType:
+                          description: Remote Storage type.
+                          type: string
+                      type: object
+                    type: array
+                type: object
               clusterMasterRef:
                 description: ClusterMasterRef refers to a Splunk Enterprise indexer
                   cluster managed by the operator within Kubernetes
@@ -2435,6 +2514,142 @@ spec:
             description: LicenseMasterStatus defines the observed state of a Splunk
               Enterprise license master.
             properties:
+              appContext:
+                description: App Framework Context
+                properties:
+                  appRepo:
+                    description: List of App package (*.spl, *.tgz) locations on remote
+                      volume
+                    properties:
+                      appSources:
+                        description: List of App sources on remote storage
+                        items:
+                          description: AppSourceSpec defines list of App package (*.spl,
+                            *.tgz) locations on remote volumes
+                          properties:
+                            location:
+                              description: Location relative to the volume path
+                              type: string
+                            name:
+                              description: Logical name for the set of apps placed
+                                in this location. Logical name must be unique to the
+                                appRepo
+                              type: string
+                            scope:
+                              description: 'Scope of the App deployment: cluster,
+                                local. Scope determines whether the App(s) is/are
+                                installed locally or cluster-wide'
+                              type: string
+                            volumeName:
+                              description: Remote Storage Volume name
+                              type: string
+                          type: object
+                        type: array
+                      appsRepoPollIntervalSeconds:
+                        description: Interval in seconds to check the Remote Storage
+                          for App changes. The default value for this config is 1
+                          hour(3600 sec), minimum value is 1 minute(60sec) and maximum
+                          value is 1 day(86400 sec). We assign the value based on
+                          following conditions -    1. If no value or 0 is specified
+                          then it will be defaulted to 1 hour.    2. If anything less
+                          than min is specified then we set it to 1 min.    3. If
+                          anything more than the max value is specified then we set
+                          it to 1 day.
+                        format: int64
+                        type: integer
+                      defaults:
+                        description: Defines the default configuration settings for
+                          App sources
+                        properties:
+                          scope:
+                            description: 'Scope of the App deployment: cluster, local.
+                              Scope determines whether the App(s) is/are installed
+                              locally or cluster-wide'
+                            type: string
+                          volumeName:
+                            description: Remote Storage Volume name
+                            type: string
+                        type: object
+                      volumes:
+                        description: List of remote storage volumes
+                        items:
+                          description: VolumeSpec defines remote volume config
+                          properties:
+                            endpoint:
+                              description: Remote volume URI
+                              type: string
+                            name:
+                              description: Remote volume name
+                              type: string
+                            path:
+                              description: Remote volume path
+                              type: string
+                            provider:
+                              description: App Package Remote Store provider. For
+                                e.g. aws, azure, minio, etc. Currently we are only
+                                supporting aws.
+                              type: string
+                            secretRef:
+                              description: Secret object name
+                              type: string
+                            storageType:
+                              description: Remote Storage type.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  appSrcDeployStatus:
+                    additionalProperties:
+                      description: AppSrcDeployInfo represents deployment info for
+                        list of Apps
+                      properties:
+                        appDeploymentInfo:
+                          items:
+                            description: AppDeploymentInfo represents a single App
+                              deployment information
+                            properties:
+                              Size:
+                                format: int64
+                                type: integer
+                              appName:
+                                type: string
+                              deployStatus:
+                                description: AppDeploymentStatus represents the status
+                                  of an App on the Pod
+                                type: integer
+                              lastModifiedTime:
+                                type: string
+                              objectHash:
+                                type: string
+                              repoState:
+                                description: AppRepoState represent the App state
+                                  on remote store
+                                type: integer
+                            type: object
+                          type: array
+                      type: object
+                    description: Represents the Apps deployment status
+                    type: object
+                  appsRepoStatusPollIntervalSeconds:
+                    description: Interval in seconds to check the Remote Storage for
+                      App changes This is introduced here so that we dont do spec
+                      validation in every reconcile just because the spec and status
+                      are different.
+                    format: int64
+                    type: integer
+                  isDeploymentInProgress:
+                    description: IsDeploymentInProgress indicates if the Apps deployment
+                      is in progress
+                    type: boolean
+                  lastAppInfoCheckTime:
+                    description: This is set to the time when we get the list of apps
+                      from remote storage.
+                    format: int64
+                    type: integer
+                  version:
+                    description: App Framework version info for future use
+                    type: integer
+                type: object
               phase:
                 description: current phase of the license master
                 enum:

--- a/deploy/olm-catalog/splunk/1.0.1/enterprise.splunk.com_searchheadclusters_crd.yaml
+++ b/deploy/olm-catalog/splunk/1.0.1/enterprise.splunk.com_searchheadclusters_crd.yaml
@@ -651,6 +651,85 @@ spec:
                         type: array
                     type: object
                 type: object
+              appRepo:
+                description: Splunk Enterprise App repository. Specifies remote App
+                  location and scope for Splunk App management
+                properties:
+                  appSources:
+                    description: List of App sources on remote storage
+                    items:
+                      description: AppSourceSpec defines list of App package (*.spl,
+                        *.tgz) locations on remote volumes
+                      properties:
+                        location:
+                          description: Location relative to the volume path
+                          type: string
+                        name:
+                          description: Logical name for the set of apps placed in
+                            this location. Logical name must be unique to the appRepo
+                          type: string
+                        scope:
+                          description: 'Scope of the App deployment: cluster, local.
+                            Scope determines whether the App(s) is/are installed locally
+                            or cluster-wide'
+                          type: string
+                        volumeName:
+                          description: Remote Storage Volume name
+                          type: string
+                      type: object
+                    type: array
+                  appsRepoPollIntervalSeconds:
+                    description: Interval in seconds to check the Remote Storage for
+                      App changes. The default value for this config is 1 hour(3600
+                      sec), minimum value is 1 minute(60sec) and maximum value is
+                      1 day(86400 sec). We assign the value based on following conditions
+                      -    1. If no value or 0 is specified then it will be defaulted
+                      to 1 hour.    2. If anything less than min is specified then
+                      we set it to 1 min.    3. If anything more than the max value
+                      is specified then we set it to 1 day.
+                    format: int64
+                    type: integer
+                  defaults:
+                    description: Defines the default configuration settings for App
+                      sources
+                    properties:
+                      scope:
+                        description: 'Scope of the App deployment: cluster, local.
+                          Scope determines whether the App(s) is/are installed locally
+                          or cluster-wide'
+                        type: string
+                      volumeName:
+                        description: Remote Storage Volume name
+                        type: string
+                    type: object
+                  volumes:
+                    description: List of remote storage volumes
+                    items:
+                      description: VolumeSpec defines remote volume config
+                      properties:
+                        endpoint:
+                          description: Remote volume URI
+                          type: string
+                        name:
+                          description: Remote volume name
+                          type: string
+                        path:
+                          description: Remote volume path
+                          type: string
+                        provider:
+                          description: App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws.
+                          type: string
+                        secretRef:
+                          description: Secret object name
+                          type: string
+                        storageType:
+                          description: Remote Storage type.
+                          type: string
+                      type: object
+                    type: array
+                type: object
               clusterMasterRef:
                 description: ClusterMasterRef refers to a Splunk Enterprise indexer
                   cluster managed by the operator within Kubernetes
@@ -2464,6 +2543,142 @@ spec:
                 items:
                   type: boolean
                 type: array
+              appContext:
+                description: App Framework Context
+                properties:
+                  appRepo:
+                    description: List of App package (*.spl, *.tgz) locations on remote
+                      volume
+                    properties:
+                      appSources:
+                        description: List of App sources on remote storage
+                        items:
+                          description: AppSourceSpec defines list of App package (*.spl,
+                            *.tgz) locations on remote volumes
+                          properties:
+                            location:
+                              description: Location relative to the volume path
+                              type: string
+                            name:
+                              description: Logical name for the set of apps placed
+                                in this location. Logical name must be unique to the
+                                appRepo
+                              type: string
+                            scope:
+                              description: 'Scope of the App deployment: cluster,
+                                local. Scope determines whether the App(s) is/are
+                                installed locally or cluster-wide'
+                              type: string
+                            volumeName:
+                              description: Remote Storage Volume name
+                              type: string
+                          type: object
+                        type: array
+                      appsRepoPollIntervalSeconds:
+                        description: Interval in seconds to check the Remote Storage
+                          for App changes. The default value for this config is 1
+                          hour(3600 sec), minimum value is 1 minute(60sec) and maximum
+                          value is 1 day(86400 sec). We assign the value based on
+                          following conditions -    1. If no value or 0 is specified
+                          then it will be defaulted to 1 hour.    2. If anything less
+                          than min is specified then we set it to 1 min.    3. If
+                          anything more than the max value is specified then we set
+                          it to 1 day.
+                        format: int64
+                        type: integer
+                      defaults:
+                        description: Defines the default configuration settings for
+                          App sources
+                        properties:
+                          scope:
+                            description: 'Scope of the App deployment: cluster, local.
+                              Scope determines whether the App(s) is/are installed
+                              locally or cluster-wide'
+                            type: string
+                          volumeName:
+                            description: Remote Storage Volume name
+                            type: string
+                        type: object
+                      volumes:
+                        description: List of remote storage volumes
+                        items:
+                          description: VolumeSpec defines remote volume config
+                          properties:
+                            endpoint:
+                              description: Remote volume URI
+                              type: string
+                            name:
+                              description: Remote volume name
+                              type: string
+                            path:
+                              description: Remote volume path
+                              type: string
+                            provider:
+                              description: App Package Remote Store provider. For
+                                e.g. aws, azure, minio, etc. Currently we are only
+                                supporting aws.
+                              type: string
+                            secretRef:
+                              description: Secret object name
+                              type: string
+                            storageType:
+                              description: Remote Storage type.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  appSrcDeployStatus:
+                    additionalProperties:
+                      description: AppSrcDeployInfo represents deployment info for
+                        list of Apps
+                      properties:
+                        appDeploymentInfo:
+                          items:
+                            description: AppDeploymentInfo represents a single App
+                              deployment information
+                            properties:
+                              Size:
+                                format: int64
+                                type: integer
+                              appName:
+                                type: string
+                              deployStatus:
+                                description: AppDeploymentStatus represents the status
+                                  of an App on the Pod
+                                type: integer
+                              lastModifiedTime:
+                                type: string
+                              objectHash:
+                                type: string
+                              repoState:
+                                description: AppRepoState represent the App state
+                                  on remote store
+                                type: integer
+                            type: object
+                          type: array
+                      type: object
+                    description: Represents the Apps deployment status
+                    type: object
+                  appsRepoStatusPollIntervalSeconds:
+                    description: Interval in seconds to check the Remote Storage for
+                      App changes This is introduced here so that we dont do spec
+                      validation in every reconcile just because the spec and status
+                      are different.
+                    format: int64
+                    type: integer
+                  isDeploymentInProgress:
+                    description: IsDeploymentInProgress indicates if the Apps deployment
+                      is in progress
+                    type: boolean
+                  lastAppInfoCheckTime:
+                    description: This is set to the time when we get the list of apps
+                      from remote storage.
+                    format: int64
+                    type: integer
+                  version:
+                    description: App Framework version info for future use
+                    type: integer
+                type: object
               captain:
                 description: name or label of the search head captain
                 type: string

--- a/deploy/olm-catalog/splunk/1.0.1/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/olm-catalog/splunk/1.0.1/enterprise.splunk.com_standalones_crd.yaml
@@ -646,6 +646,85 @@ spec:
                         type: array
                     type: object
                 type: object
+              appRepo:
+                description: Splunk Enterprise App repository. Specifies remote App
+                  location and scope for Splunk App management
+                properties:
+                  appSources:
+                    description: List of App sources on remote storage
+                    items:
+                      description: AppSourceSpec defines list of App package (*.spl,
+                        *.tgz) locations on remote volumes
+                      properties:
+                        location:
+                          description: Location relative to the volume path
+                          type: string
+                        name:
+                          description: Logical name for the set of apps placed in
+                            this location. Logical name must be unique to the appRepo
+                          type: string
+                        scope:
+                          description: 'Scope of the App deployment: cluster, local.
+                            Scope determines whether the App(s) is/are installed locally
+                            or cluster-wide'
+                          type: string
+                        volumeName:
+                          description: Remote Storage Volume name
+                          type: string
+                      type: object
+                    type: array
+                  appsRepoPollIntervalSeconds:
+                    description: Interval in seconds to check the Remote Storage for
+                      App changes. The default value for this config is 1 hour(3600
+                      sec), minimum value is 1 minute(60sec) and maximum value is
+                      1 day(86400 sec). We assign the value based on following conditions
+                      -    1. If no value or 0 is specified then it will be defaulted
+                      to 1 hour.    2. If anything less than min is specified then
+                      we set it to 1 min.    3. If anything more than the max value
+                      is specified then we set it to 1 day.
+                    format: int64
+                    type: integer
+                  defaults:
+                    description: Defines the default configuration settings for App
+                      sources
+                    properties:
+                      scope:
+                        description: 'Scope of the App deployment: cluster, local.
+                          Scope determines whether the App(s) is/are installed locally
+                          or cluster-wide'
+                        type: string
+                      volumeName:
+                        description: Remote Storage Volume name
+                        type: string
+                    type: object
+                  volumes:
+                    description: List of remote storage volumes
+                    items:
+                      description: VolumeSpec defines remote volume config
+                      properties:
+                        endpoint:
+                          description: Remote volume URI
+                          type: string
+                        name:
+                          description: Remote volume name
+                          type: string
+                        path:
+                          description: Remote volume path
+                          type: string
+                        provider:
+                          description: App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws.
+                          type: string
+                        secretRef:
+                          description: Secret object name
+                          type: string
+                        storageType:
+                          description: Remote Storage type.
+                          type: string
+                      type: object
+                    type: array
+                type: object
               clusterMasterRef:
                 description: ClusterMasterRef refers to a Splunk Enterprise indexer
                   cluster managed by the operator within Kubernetes
@@ -1264,8 +1343,7 @@ spec:
                   volumes:
                     description: List of remote storage volumes
                     items:
-                      description: VolumeSpec defines remote volume name and remote
-                        volume URI
+                      description: VolumeSpec defines remote volume config
                       properties:
                         endpoint:
                           description: Remote volume URI
@@ -1276,8 +1354,16 @@ spec:
                         path:
                           description: Remote volume path
                           type: string
+                        provider:
+                          description: App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws.
+                          type: string
                         secretRef:
                           description: Secret object name
+                          type: string
+                        storageType:
+                          description: Remote Storage type.
                           type: string
                       type: object
                     type: array
@@ -2551,6 +2637,142 @@ spec:
             description: StandaloneStatus defines the observed state of a Splunk Enterprise
               standalone instances.
             properties:
+              appContext:
+                description: App Framework Context
+                properties:
+                  appRepo:
+                    description: List of App package (*.spl, *.tgz) locations on remote
+                      volume
+                    properties:
+                      appSources:
+                        description: List of App sources on remote storage
+                        items:
+                          description: AppSourceSpec defines list of App package (*.spl,
+                            *.tgz) locations on remote volumes
+                          properties:
+                            location:
+                              description: Location relative to the volume path
+                              type: string
+                            name:
+                              description: Logical name for the set of apps placed
+                                in this location. Logical name must be unique to the
+                                appRepo
+                              type: string
+                            scope:
+                              description: 'Scope of the App deployment: cluster,
+                                local. Scope determines whether the App(s) is/are
+                                installed locally or cluster-wide'
+                              type: string
+                            volumeName:
+                              description: Remote Storage Volume name
+                              type: string
+                          type: object
+                        type: array
+                      appsRepoPollIntervalSeconds:
+                        description: Interval in seconds to check the Remote Storage
+                          for App changes. The default value for this config is 1
+                          hour(3600 sec), minimum value is 1 minute(60sec) and maximum
+                          value is 1 day(86400 sec). We assign the value based on
+                          following conditions -    1. If no value or 0 is specified
+                          then it will be defaulted to 1 hour.    2. If anything less
+                          than min is specified then we set it to 1 min.    3. If
+                          anything more than the max value is specified then we set
+                          it to 1 day.
+                        format: int64
+                        type: integer
+                      defaults:
+                        description: Defines the default configuration settings for
+                          App sources
+                        properties:
+                          scope:
+                            description: 'Scope of the App deployment: cluster, local.
+                              Scope determines whether the App(s) is/are installed
+                              locally or cluster-wide'
+                            type: string
+                          volumeName:
+                            description: Remote Storage Volume name
+                            type: string
+                        type: object
+                      volumes:
+                        description: List of remote storage volumes
+                        items:
+                          description: VolumeSpec defines remote volume config
+                          properties:
+                            endpoint:
+                              description: Remote volume URI
+                              type: string
+                            name:
+                              description: Remote volume name
+                              type: string
+                            path:
+                              description: Remote volume path
+                              type: string
+                            provider:
+                              description: App Package Remote Store provider. For
+                                e.g. aws, azure, minio, etc. Currently we are only
+                                supporting aws.
+                              type: string
+                            secretRef:
+                              description: Secret object name
+                              type: string
+                            storageType:
+                              description: Remote Storage type.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  appSrcDeployStatus:
+                    additionalProperties:
+                      description: AppSrcDeployInfo represents deployment info for
+                        list of Apps
+                      properties:
+                        appDeploymentInfo:
+                          items:
+                            description: AppDeploymentInfo represents a single App
+                              deployment information
+                            properties:
+                              Size:
+                                format: int64
+                                type: integer
+                              appName:
+                                type: string
+                              deployStatus:
+                                description: AppDeploymentStatus represents the status
+                                  of an App on the Pod
+                                type: integer
+                              lastModifiedTime:
+                                type: string
+                              objectHash:
+                                type: string
+                              repoState:
+                                description: AppRepoState represent the App state
+                                  on remote store
+                                type: integer
+                            type: object
+                          type: array
+                      type: object
+                    description: Represents the Apps deployment status
+                    type: object
+                  appsRepoStatusPollIntervalSeconds:
+                    description: Interval in seconds to check the Remote Storage for
+                      App changes This is introduced here so that we dont do spec
+                      validation in every reconcile just because the spec and status
+                      are different.
+                    format: int64
+                    type: integer
+                  isDeploymentInProgress:
+                    description: IsDeploymentInProgress indicates if the Apps deployment
+                      is in progress
+                    type: boolean
+                  lastAppInfoCheckTime:
+                    description: This is set to the time when we get the list of apps
+                      from remote storage.
+                    format: int64
+                    type: integer
+                  version:
+                    description: App Framework version info for future use
+                    type: integer
+                type: object
               phase:
                 description: current phase of the standalone instances
                 enum:
@@ -2664,8 +2886,7 @@ spec:
                   volumes:
                     description: List of remote storage volumes
                     items:
-                      description: VolumeSpec defines remote volume name and remote
-                        volume URI
+                      description: VolumeSpec defines remote volume config
                       properties:
                         endpoint:
                           description: Remote volume URI
@@ -2676,8 +2897,16 @@ spec:
                         path:
                           description: Remote volume path
                           type: string
+                        provider:
+                          description: App Package Remote Store provider. For e.g.
+                            aws, azure, minio, etc. Currently we are only supporting
+                            aws.
+                          type: string
                         secretRef:
                           description: Secret object name
+                          type: string
+                        storageType:
+                          description: Remote Storage type.
                           type: string
                       type: object
                     type: array

--- a/pkg/splunk/enterprise/clustermaster.go
+++ b/pkg/splunk/enterprise/clustermaster.go
@@ -161,7 +161,7 @@ func ApplyClusterMaster(client splcommon.ControllerClient, cr *enterprisev1.Clus
 		if cr.Status.BundlePushTracker.NeedToPushMasterApps == false {
 			// Requeue the reconcile after polling interval if we had set the lastAppInfoCheckTime.
 			if cr.Status.AppContext.LastAppInfoCheckTime != 0 {
-				result.RequeueAfter = GetNextRequeueTime(cr.Spec.AppFrameworkConfig.AppsRepoPollInterval, cr.Status.AppContext.LastAppInfoCheckTime)
+				result.RequeueAfter = GetNextRequeueTime(cr.Status.AppContext.AppsRepoStatusPollInterval, cr.Status.AppContext.LastAppInfoCheckTime)
 			} else {
 				result.Requeue = false
 			}

--- a/pkg/splunk/enterprise/licensemaster.go
+++ b/pkg/splunk/enterprise/licensemaster.go
@@ -115,7 +115,7 @@ func ApplyLicenseMaster(client splcommon.ControllerClient, cr *enterprisev1.Lice
 
 		// Requeue the reconcile after polling interval if we had set the lastAppInfoCheckTime.
 		if cr.Status.AppContext.LastAppInfoCheckTime != 0 {
-			result.RequeueAfter = GetNextRequeueTime(cr.Spec.AppFrameworkConfig.AppsRepoPollInterval, cr.Status.AppContext.LastAppInfoCheckTime)
+			result.RequeueAfter = GetNextRequeueTime(cr.Status.AppContext.AppsRepoStatusPollInterval, cr.Status.AppContext.LastAppInfoCheckTime)
 		} else {
 			result.Requeue = false
 		}

--- a/pkg/splunk/enterprise/searchheadcluster.go
+++ b/pkg/splunk/enterprise/searchheadcluster.go
@@ -160,7 +160,7 @@ func ApplySearchHeadCluster(client splcommon.ControllerClient, cr *enterprisev1.
 
 		// Requeue the reconcile after polling interval if we had set the lastAppInfoCheckTime.
 		if cr.Status.AppContext.LastAppInfoCheckTime != 0 {
-			result.RequeueAfter = GetNextRequeueTime(cr.Spec.AppFrameworkConfig.AppsRepoPollInterval, cr.Status.AppContext.LastAppInfoCheckTime)
+			result.RequeueAfter = GetNextRequeueTime(cr.Status.AppContext.AppsRepoStatusPollInterval, cr.Status.AppContext.LastAppInfoCheckTime)
 		} else {
 			result.Requeue = false
 		}

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -150,7 +150,7 @@ func ApplyStandalone(client splcommon.ControllerClient, cr *enterprisev1.Standal
 
 		// Requeue the reconcile after polling interval if we had set the lastAppInfoCheckTime.
 		if cr.Status.AppContext.LastAppInfoCheckTime != 0 {
-			result.RequeueAfter = GetNextRequeueTime(cr.Spec.AppFrameworkConfig.AppsRepoPollInterval, cr.Status.AppContext.LastAppInfoCheckTime)
+			result.RequeueAfter = GetNextRequeueTime(cr.Status.AppContext.AppsRepoStatusPollInterval, cr.Status.AppContext.LastAppInfoCheckTime)
 		} else {
 			result.Requeue = false
 		}

--- a/pkg/splunk/enterprise/util_test.go
+++ b/pkg/splunk/enterprise/util_test.go
@@ -770,9 +770,9 @@ func TestSetLastAppInfoCheckTime(t *testing.T) {
 }
 
 func TestGetNextRequeueTime(t *testing.T) {
-	appFrameworkRef := enterprisev1.AppFrameworkSpec{}
-	appFrameworkRef.AppsRepoPollInterval = 60
-	nextRequeueTime := GetNextRequeueTime(appFrameworkRef.AppsRepoPollInterval, (time.Now().Unix() - int64(40)))
+	appFrameworkContext := enterprisev1.AppDeploymentContext{}
+	appFrameworkContext.AppsRepoStatusPollInterval = 60
+	nextRequeueTime := GetNextRequeueTime(appFrameworkContext.AppsRepoStatusPollInterval, (time.Now().Unix() - int64(40)))
 	if nextRequeueTime > time.Second*20 {
 		t.Errorf("Got wrong next requeue time")
 	}


### PR DESCRIPTION
This PR ensures the `GetNextRequeueTime` is read from the in-memory structure rather than what is specified in the CR. This is to avoid making use of invalid configs in the CR (which would have been validated & stored in memory)