### PR TITLE
Fix unnecessary restarts due to empty app-list configmap after app update

### DIFF
--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -287,7 +287,7 @@ func ApplyAppListingConfigMap(client splcommon.ControllerClient, cr splcommon.Me
 		}
 	}
 
-	if localAppsConf != yamlConfHeader {
+	if localAppsConf != yamlConfHeader && localAppsConf != yamlConfLocalHeader {
 		mapAppListing["app-list-local.yaml"] = localAppsConf
 	}
 


### PR DESCRIPTION
### Problem
The app-list configmap only adds app that have changes since the last app install.  If there are no apps to add, the file is not written to the configmap.

However after https://github.com/splunk/splunk-operator/pull/378 the app_list_local.yml is being written empty due to the following check:

```
func ApplyAppListingConfigMap(client splcommon.ControllerClient, cr splcommon.Me
...
        if localAppsConf != yamlConfHeader {
                mapAppListing["app-list-local.yaml"] = localAppsConf
```

This causes differences in the Pod Volumes and Pod Env (namely SPLUNK_DEFAULTS_URL) which causes an additional (and unnecessary) pod restart after the Pod becomes ready from the initial (necessary) restart to install the app changes:
```
{"level":"info","ts":1624470956.0716994,"logger":"splunk.reconcile.MergePodUpdates","msg":
"Pod Volumes differ","name":"splunk-cm-aws-cluster-master",
"current":[{"name":"init-apps","emptyDir":{}},{"name":"mnt-app-listing","configMap":{"name":"splunk-cm-aws-clustermaster-app-list","items":[{"key":"app-list-local.yaml","path":"app-list-local.yaml","mode":420}],"defaultMode":420}},{"name":"mnt-splunk-secrets","secret":{"secretName":"splunk-cm-aws-cluster-master-secret-v1","defaultMode":420}}],
"revised":[{"name":"init-apps","emptyDir":{}},{"name":"mnt-app-listing","configMap":{"name":"splunk-cm-aws-clustermaster-app-list","items":[{"key":"app-list-cluster.yaml","path":"app-list-cluster.yaml","mode":420},{"key":"app-list-local.yaml","path":"app-list-local.yaml","mode":420}],"defaultMode":420}},{"name":"mnt-splunk-secrets","secret":{"secretName":"splunk-cm-aws-cluster-master-secret-v1","defaultMode":420}}]}
{"level":"info","ts":1624470956.071805,"logger":"splunk.reconcile.MergePodUpdates","msg":
"Pod Container Envs differ","name":"splunk-cm-aws-cluster-master",
"current":[{"name":"SPLUNK_CLUSTER_MASTER_URL","value":"localhost"},{"name":"SPLUNK_DECLARATIVE_ADMIN_PASSWORD","value":"true"},{"name":"SPLUNK_DEFAULTS_URL","value":"/mnt/app-listing/app-list-local.yaml,/mnt/splunk-secrets/default.yml"},{"name":"SPLUNK_HOME","value":"/opt/splunk"},{"name":"SPLUNK_HOME_OWNERSHIP_ENFORCEMENT","value":"false"},{"name":"SPLUNK_ROLE","value":"splunk_cluster_master"},{"name":"SPLUNK_START_ARGS","value":"--accept-license"}],
"revised":[{"name":"SPLUNK_CLUSTER_MASTER_URL","value":"localhost"},{"name":"SPLUNK_DECLARATIVE_ADMIN_PASSWORD","value":"true"},{"name":"SPLUNK_DEFAULTS_URL","value":"/mnt/app-listing/app-list-local.yaml,/mnt/app-listing/app-list-cluster.yaml,/mnt/splunk-secrets/default.yml"},{"name":"SPLUNK_HOME","value":"/opt/splunk"},{"name":"SPLUNK_HOME_OWNERSHIP_ENFORCEMENT","value":"false"},{"name":"SPLUNK_ROLE","value":"splunk_cluster_master"},{"name":"SPLUNK_START_ARGS","value":"--accept-license"}]}
```

Fixing this check removes the unnecessary restart.


### Solution
Since non-clustered instances use `apps_location` for local apps, check for both the `apps_location` and `apps_location_local` when performing the "is empty" check for the app-list-local.yml

### Unit Test

For both Deployer and Cluster Master pods, verify that the Pod is only restarted once when an app is added/changed.

```
NAME                                  READY   STATUS    RESTARTS   AGE
splunk-cm-aws-cluster-master-0        1/1     Running   0          4m5s
splunk-default-monitoring-console-0   1/1     Running   0          9m18s
splunk-idc-aws-indexer-0              1/1     Running   0          8m39s
splunk-idc-aws-indexer-1              1/1     Running   0          8m39s
splunk-idc-aws-indexer-2              1/1     Running   0          8m39s
splunk-operator-7ccfc68749-rqfz6      1/1     Running   0          11m
```