### PR TITLE
App Framework POC for phase 3.5

### DIFF
--- a/pkg/splunk/client/s3client.go
+++ b/pkg/splunk/client/s3client.go
@@ -62,6 +62,7 @@ type S3Client interface {
 	GetAppsList() (S3Response, error)
 	GetInitContainerImage() string
 	GetInitContainerCmd(string /* endpoint */, string /* bucket */, string /* path */, string /* app src name */, string /* app mnt */) []string
+	DownloadFile(string, string) error
 }
 
 // SplunkS3Client is a simple object used to connect to S3

--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -581,7 +581,7 @@ func updateSplunkPodTemplateWithConfig(client splcommon.ControllerClient, podTem
 		// ToDo: sgontla: for Phase-2, to install the new apps, always reset the pod.(need to change the behavior for phase-3)
 		// Once the apps are installed, and on a reconcile entry triggered by polling interval expirty, if there is no new
 		// App changes on remote store, then the config map data is erased. In such case, no need to reset the Pod
-		if len(appListingConfigMap.Data) > 0 {
+		if len(appListingConfigMap.Data) > 0 && 1 == 0 /* TODO jryb: turn this off for now*/ {
 			podTemplateSpec.ObjectMeta.Annotations[appListingRev] = appListingConfigMap.ResourceVersion
 		}
 	}


### PR DESCRIPTION
This code adds download and install capabilities when an app package
is determined to have changed, without the need for any restart.

App packages are downloaded by the operator then pushed to the
cooresponding pod.  Once successfuly they are either a) installed
for local scope, or b) extracted to the bundle directory for cluster
scope.  Once all apps are finished if any were extracted to a
bundle dir, then a bundle push is performed.  All splunk cmds are
handled via the operator and not ansible.

Ansible still handles the initial install of all apps.