### PR TITLE
Fixes for pipeline failures

### DIFF
--- a/test/c3/appframework/appframework_test.go
+++ b/test/c3/appframework/appframework_test.go
@@ -201,8 +201,7 @@ var _ = Describe("c3appfw test", func() {
 
 			// Verify apps are copied at the correct location on CM and on Deployer (/etc/apps/)
 			podNames := []string{fmt.Sprintf(testenv.ClusterMasterPod, deployment.GetName()), fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
-			appFileList := testenv.GetAppFileList(appListV1, 1)
-			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), podNames, appFileList, true, false)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), podNames, appListV1, true, false)
 
 			// Verify apps are installed locally on CM and on SHC Deployer
 			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), podNames, appListV1, false, "enabled", false, false)

--- a/test/licensemaster/lm_c3_test.go
+++ b/test/licensemaster/lm_c3_test.go
@@ -180,7 +180,7 @@ var _ = Describe("Licensemaster test", func() {
 
 			// Verify apps are copied at the correct location on LM (/etc/apps/)
 			podName := []string{fmt.Sprintf(testenv.LicenseMasterPod, deployment.GetName(), 0)}
-			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), podName, appFileList, true, false)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), podName, appListV1, true, false)
 
 			// Verify apps are installed on LM
 			lmPodName := []string{fmt.Sprintf(testenv.LicenseMasterPod, deployment.GetName(), 0)}

--- a/test/m4/appframework/appframework_test.go
+++ b/test/m4/appframework/appframework_test.go
@@ -200,8 +200,7 @@ var _ = Describe("m4appfw test", func() {
 
 			// Verify apps are copied at the correct location on CM and on Deployer (/etc/apps/)
 			podNames := []string{fmt.Sprintf(testenv.ClusterMasterPod, deployment.GetName()), fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
-			appFileList := testenv.GetAppFileList(appListV1, 1)
-			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), podNames, appFileList, true, false)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), podNames, appListV1, true, false)
 
 			// Verify apps are installed locally on CM and on SHC Deployer
 			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), podNames, appListV1, false, "enabled", false, false)

--- a/test/testenv/appframework_utils.go
+++ b/test/testenv/appframework_utils.go
@@ -44,23 +44,26 @@ func GenerateAppSourceSpec(appSourceName string, appSourceLocation string, appSo
 }
 
 // GetPodAppStatus Get the app install status and version number
-func GetPodAppStatus(deployment *Deployment, podName string, ns string, appname string) (string, string, error) {
+func GetPodAppStatus(deployment *Deployment, podName string, ns string, appname string, clusterWideInstall bool) (string, string, error) {
 	output, _ := GetPodAppInstallStatus(deployment, podName, ns, appname)
 	status := strings.Fields(output)[2]
-	version, err := GetPodInstalledAppVersion(deployment, podName, ns, appname)
+	version, err := GetPodInstalledAppVersion(deployment, podName, ns, appname, clusterWideInstall)
 	return status, version, err
 
 }
 
 // GetPodInstalledAppVersion Get the version of the app installed on pod
-func GetPodInstalledAppVersion(deployment *Deployment, podName string, ns string, appname string) (string, error) {
+func GetPodInstalledAppVersion(deployment *Deployment, podName string, ns string, appname string, clusterWideInstall bool) (string, error) {
 	path := "etc/apps"
-	if strings.Contains(podName, "-indexer-") {
-		path = "etc/slave-apps"
-	} else if strings.Contains(podName, "cluster-master") {
-		path = "etc/master-apps"
-	} else if strings.Contains(podName, "-deployer-") {
-		path = "etc/shcluster/apps"
+	//For cluster-wide install the apps are extracted to different locations
+	if clusterWideInstall {
+		if strings.Contains(podName, "-indexer-") {
+			path = "etc/slave-apps"
+		} else if strings.Contains(podName, "cluster-master") {
+			path = "etc/master-apps"
+		} else if strings.Contains(podName, "-deployer-") {
+			path = "etc/shcluster/apps"
+		}
 	}
 	filePath := fmt.Sprintf("/opt/splunk/%s/%s/default/app.conf", path, appname)
 	logf.Log.Info("Check Version for app", "AppName", appname, "config", filePath)


### PR DESCRIPTION
Fixed error in local install.

Added an Eventually check into app Folder check. 

Issue seen: 

1. Even after all pods are checked to be in ready state sometimes app install via bundle push lags behind by a few seconds.

Possible solutions:
- Check that bundle push is competed on all pods and then check app install state
- Loop for certain time to account for bundle push, to check that app is not installed(Implemented)

2.  Wrong variable  was passed to local app install check. Fixed


Passing runs:

```
• [SLOW TEST:2048.302 seconds]
m4appfw test
/Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:28
  Multi Site Indexer Cluster with SHC (m4) with App Framework
  /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:62
    integration, m4, appframework: can deploy a M4 SVA with App Framework enabled
    /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:63
------------------------------
• [SLOW TEST:1459.426 seconds]
m4appfw test
/Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:28
  Clustered deployment (M4 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:160
    m4, appframework: can deploy a M4 SVA and have apps installed locally on CM and SHC Deployer
    /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:161
------------------------------
{"level":"info","ts":1625790659.05328,"msg":"testenv deleted.\n","testenv":"m4appfw-kik"}
{"level":"info","ts":1625790659.0533319,"msg":"testenv deleted.\n","testenv":"m4appfw-kik"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/m4/appframework/m4appfw-kik_junit.xml

Ran 2 of 2 Specs in 2073.265 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS





• [SLOW TEST:1948.675 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:28
  Single Site Indexer Cluster with SHC (C3) with App Framework
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:62
    integration, c3, appframework: can deploy a C3 SVA with App Framework enabled
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:63
------------------------------
• [SLOW TEST:859.426 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:28
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:159
    c3, appframework: can deploy a C3 SVA and have apps installed locally on CM and SHC Deployer
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:160
------------------------------
{"level":"info","ts":1625793077.599648,"msg":"testenv deleted.\n","testenv":"c3appfw-yol"}
{"level":"info","ts":1625793077.599684,"msg":"testenv deleted.\n","testenv":"c3appfw-yol"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/c3/appframework/c3appfw-yol_junit.xml

Ran 2 of 2 Specs in 1973.171 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS



• [SLOW TEST:530.620 seconds]
s1appfw test
/Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:30
  appframework Standalone deployment (S1) with App Framework
  /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:64
    s1, appframework: can deploy a standalone instance with App Framework enabled
    /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:65
------------------------------
{"level":"info","ts":1625798548.061236,"msg":"testenv deleted.\n","testenv":"s1appfw-rh8"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/s1/appframework/s1appfw-rh8_junit.xml

Ran 1 of 1 Specs in 547.554 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS


• [SLOW TEST:280.294 seconds]
Licensemaster test
/Users/tpereira/Git/splunk-operator/test/licensemaster/lm_c3_test.go:29
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/licensemaster/lm_c3_test.go:96
    licensemaster: Splunk Operator can configure a C3 SVA and have apps installed locally on LM
    /Users/tpereira/Git/splunk-operator/test/licensemaster/lm_c3_test.go:97
------------------------------
{"level":"info","ts":1625858321.043654,"msg":"testenv deleted.\n","testenv":"lm-arv"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/licensemaster/lm-arv_junit.xml

Ran 4 of 4 Specs in 3207.595 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```