### PR TITLE
cspl-1136: Storage type and provider config should be optional for Smartstore

### DIFF
--- a/deploy/crds/enterprise.splunk.com_clustermasters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_clustermasters_crd.yaml
@@ -699,15 +699,14 @@ spec:
                           description: Remote volume path
                           type: string
                         provider:
-                          description: App Package Remote Store provider. For e.g.
-                            aws, azure, minio, etc. Currently we are only supporting
-                            aws.
+                          description: 'App Package Remote Store provider. Supported
+                            values: aws, minio'
                           type: string
                         secretRef:
                           description: Secret object name
                           type: string
                         storageType:
-                          description: Remote Storage type.
+                          description: 'Remote Storage type. Supported values: s3'
                           type: string
                       type: object
                     type: array
@@ -1353,15 +1352,14 @@ spec:
                           description: Remote volume path
                           type: string
                         provider:
-                          description: App Package Remote Store provider. For e.g.
-                            aws, azure, minio, etc. Currently we are only supporting
-                            aws.
+                          description: 'App Package Remote Store provider. Supported
+                            values: aws, minio'
                           type: string
                         secretRef:
                           description: Secret object name
                           type: string
                         storageType:
-                          description: Remote Storage type.
+                          description: 'Remote Storage type. Supported values: s3'
                           type: string
                       type: object
                     type: array
@@ -2705,15 +2703,15 @@ spec:
                               description: Remote volume path
                               type: string
                             provider:
-                              description: App Package Remote Store provider. For
-                                e.g. aws, azure, minio, etc. Currently we are only
-                                supporting aws.
+                              description: 'App Package Remote Store provider. Supported
+                                values: aws, minio'
                               type: string
                             secretRef:
                               description: Secret object name
                               type: string
                             storageType:
-                              description: Remote Storage type.
+                              description: 'Remote Storage type. Supported values:
+                                s3'
                               type: string
                           type: object
                         type: array
@@ -2896,15 +2894,14 @@ spec:
                           description: Remote volume path
                           type: string
                         provider:
-                          description: App Package Remote Store provider. For e.g.
-                            aws, azure, minio, etc. Currently we are only supporting
-                            aws.
+                          description: 'App Package Remote Store provider. Supported
+                            values: aws, minio'
                           type: string
                         secretRef:
                           description: Secret object name
                           type: string
                         storageType:
-                          description: Remote Storage type.
+                          description: 'Remote Storage type. Supported values: s3'
                           type: string
                       type: object
                     type: array

--- a/deploy/crds/enterprise.splunk.com_licensemasters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_licensemasters_crd.yaml
@@ -704,15 +704,14 @@ spec:
                           description: Remote volume path
                           type: string
                         provider:
-                          description: App Package Remote Store provider. For e.g.
-                            aws, azure, minio, etc. Currently we are only supporting
-                            aws.
+                          description: 'App Package Remote Store provider. Supported
+                            values: aws, minio'
                           type: string
                         secretRef:
                           description: Secret object name
                           type: string
                         storageType:
-                          description: Remote Storage type.
+                          description: 'Remote Storage type. Supported values: s3'
                           type: string
                       type: object
                     type: array
@@ -2600,15 +2599,15 @@ spec:
                               description: Remote volume path
                               type: string
                             provider:
-                              description: App Package Remote Store provider. For
-                                e.g. aws, azure, minio, etc. Currently we are only
-                                supporting aws.
+                              description: 'App Package Remote Store provider. Supported
+                                values: aws, minio'
                               type: string
                             secretRef:
                               description: Secret object name
                               type: string
                             storageType:
-                              description: Remote Storage type.
+                              description: 'Remote Storage type. Supported values:
+                                s3'
                               type: string
                           type: object
                         type: array

--- a/deploy/crds/enterprise.splunk.com_searchheadclusters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_searchheadclusters_crd.yaml
@@ -717,15 +717,14 @@ spec:
                           description: Remote volume path
                           type: string
                         provider:
-                          description: App Package Remote Store provider. For e.g.
-                            aws, azure, minio, etc. Currently we are only supporting
-                            aws.
+                          description: 'App Package Remote Store provider. Supported
+                            values: aws, minio'
                           type: string
                         secretRef:
                           description: Secret object name
                           type: string
                         storageType:
-                          description: Remote Storage type.
+                          description: 'Remote Storage type. Supported values: s3'
                           type: string
                       type: object
                     type: array
@@ -2629,15 +2628,15 @@ spec:
                               description: Remote volume path
                               type: string
                             provider:
-                              description: App Package Remote Store provider. For
-                                e.g. aws, azure, minio, etc. Currently we are only
-                                supporting aws.
+                              description: 'App Package Remote Store provider. Supported
+                                values: aws, minio'
                               type: string
                             secretRef:
                               description: Secret object name
                               type: string
                             storageType:
-                              description: Remote Storage type.
+                              description: 'Remote Storage type. Supported values:
+                                s3'
                               type: string
                           type: object
                         type: array

--- a/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
@@ -712,15 +712,14 @@ spec:
                           description: Remote volume path
                           type: string
                         provider:
-                          description: App Package Remote Store provider. For e.g.
-                            aws, azure, minio, etc. Currently we are only supporting
-                            aws.
+                          description: 'App Package Remote Store provider. Supported
+                            values: aws, minio'
                           type: string
                         secretRef:
                           description: Secret object name
                           type: string
                         storageType:
-                          description: Remote Storage type.
+                          description: 'Remote Storage type. Supported values: s3'
                           type: string
                       type: object
                     type: array
@@ -1370,15 +1369,14 @@ spec:
                           description: Remote volume path
                           type: string
                         provider:
-                          description: App Package Remote Store provider. For e.g.
-                            aws, azure, minio, etc. Currently we are only supporting
-                            aws.
+                          description: 'App Package Remote Store provider. Supported
+                            values: aws, minio'
                           type: string
                         secretRef:
                           description: Secret object name
                           type: string
                         storageType:
-                          description: Remote Storage type.
+                          description: 'Remote Storage type. Supported values: s3'
                           type: string
                       type: object
                     type: array
@@ -2723,15 +2721,15 @@ spec:
                               description: Remote volume path
                               type: string
                             provider:
-                              description: App Package Remote Store provider. For
-                                e.g. aws, azure, minio, etc. Currently we are only
-                                supporting aws.
+                              description: 'App Package Remote Store provider. Supported
+                                values: aws, minio'
                               type: string
                             secretRef:
                               description: Secret object name
                               type: string
                             storageType:
-                              description: Remote Storage type.
+                              description: 'Remote Storage type. Supported values:
+                                s3'
                               type: string
                           type: object
                         type: array
@@ -2913,15 +2911,14 @@ spec:
                           description: Remote volume path
                           type: string
                         provider:
-                          description: App Package Remote Store provider. For e.g.
-                            aws, azure, minio, etc. Currently we are only supporting
-                            aws.
+                          description: 'App Package Remote Store provider. Supported
+                            values: aws, minio'
                           type: string
                         secretRef:
                           description: Secret object name
                           type: string
                         storageType:
-                          description: Remote Storage type.
+                          description: 'Remote Storage type. Supported values: s3'
                           type: string
                       type: object
                     type: array

--- a/deploy/olm-catalog/splunk/1.0.1/enterprise.splunk.com_clustermasters_crd.yaml
+++ b/deploy/olm-catalog/splunk/1.0.1/enterprise.splunk.com_clustermasters_crd.yaml
@@ -699,15 +699,14 @@ spec:
                           description: Remote volume path
                           type: string
                         provider:
-                          description: App Package Remote Store provider. For e.g.
-                            aws, azure, minio, etc. Currently we are only supporting
-                            aws.
+                          description: 'App Package Remote Store provider. Supported
+                            values: aws, minio'
                           type: string
                         secretRef:
                           description: Secret object name
                           type: string
                         storageType:
-                          description: Remote Storage type.
+                          description: 'Remote Storage type. Supported values: s3'
                           type: string
                       type: object
                     type: array
@@ -1352,15 +1351,14 @@ spec:
                           description: Remote volume path
                           type: string
                         provider:
-                          description: App Package Remote Store provider. For e.g.
-                            aws, azure, minio, etc. Currently we are only supporting
-                            aws.
+                          description: 'App Package Remote Store provider. Supported
+                            values: aws, minio'
                           type: string
                         secretRef:
                           description: Secret object name
                           type: string
                         storageType:
-                          description: Remote Storage type.
+                          description: 'Remote Storage type. Supported values: s3'
                           type: string
                       type: object
                     type: array
@@ -2704,15 +2702,15 @@ spec:
                               description: Remote volume path
                               type: string
                             provider:
-                              description: App Package Remote Store provider. For
-                                e.g. aws, azure, minio, etc. Currently we are only
-                                supporting aws.
+                              description: 'App Package Remote Store provider. Supported
+                                values: aws, minio'
                               type: string
                             secretRef:
                               description: Secret object name
                               type: string
                             storageType:
-                              description: Remote Storage type.
+                              description: 'Remote Storage type. Supported values:
+                                s3'
                               type: string
                           type: object
                         type: array
@@ -2895,15 +2893,14 @@ spec:
                           description: Remote volume path
                           type: string
                         provider:
-                          description: App Package Remote Store provider. For e.g.
-                            aws, azure, minio, etc. Currently we are only supporting
-                            aws.
+                          description: 'App Package Remote Store provider. Supported
+                            values: aws, minio'
                           type: string
                         secretRef:
                           description: Secret object name
                           type: string
                         storageType:
-                          description: Remote Storage type.
+                          description: 'Remote Storage type. Supported values: s3'
                           type: string
                       type: object
                     type: array

--- a/deploy/olm-catalog/splunk/1.0.1/enterprise.splunk.com_licensemasters_crd.yaml
+++ b/deploy/olm-catalog/splunk/1.0.1/enterprise.splunk.com_licensemasters_crd.yaml
@@ -704,15 +704,14 @@ spec:
                           description: Remote volume path
                           type: string
                         provider:
-                          description: App Package Remote Store provider. For e.g.
-                            aws, azure, minio, etc. Currently we are only supporting
-                            aws.
+                          description: 'App Package Remote Store provider. Supported
+                            values: aws, minio'
                           type: string
                         secretRef:
                           description: Secret object name
                           type: string
                         storageType:
-                          description: Remote Storage type.
+                          description: 'Remote Storage type. Supported values: s3'
                           type: string
                       type: object
                     type: array
@@ -2599,15 +2598,15 @@ spec:
                               description: Remote volume path
                               type: string
                             provider:
-                              description: App Package Remote Store provider. For
-                                e.g. aws, azure, minio, etc. Currently we are only
-                                supporting aws.
+                              description: 'App Package Remote Store provider. Supported
+                                values: aws, minio'
                               type: string
                             secretRef:
                               description: Secret object name
                               type: string
                             storageType:
-                              description: Remote Storage type.
+                              description: 'Remote Storage type. Supported values:
+                                s3'
                               type: string
                           type: object
                         type: array

--- a/deploy/olm-catalog/splunk/1.0.1/enterprise.splunk.com_searchheadclusters_crd.yaml
+++ b/deploy/olm-catalog/splunk/1.0.1/enterprise.splunk.com_searchheadclusters_crd.yaml
@@ -717,15 +717,14 @@ spec:
                           description: Remote volume path
                           type: string
                         provider:
-                          description: App Package Remote Store provider. For e.g.
-                            aws, azure, minio, etc. Currently we are only supporting
-                            aws.
+                          description: 'App Package Remote Store provider. Supported
+                            values: aws, minio'
                           type: string
                         secretRef:
                           description: Secret object name
                           type: string
                         storageType:
-                          description: Remote Storage type.
+                          description: 'Remote Storage type. Supported values: s3'
                           type: string
                       type: object
                     type: array
@@ -2628,15 +2627,15 @@ spec:
                               description: Remote volume path
                               type: string
                             provider:
-                              description: App Package Remote Store provider. For
-                                e.g. aws, azure, minio, etc. Currently we are only
-                                supporting aws.
+                              description: 'App Package Remote Store provider. Supported
+                                values: aws, minio'
                               type: string
                             secretRef:
                               description: Secret object name
                               type: string
                             storageType:
-                              description: Remote Storage type.
+                              description: 'Remote Storage type. Supported values:
+                                s3'
                               type: string
                           type: object
                         type: array

--- a/deploy/olm-catalog/splunk/1.0.1/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/olm-catalog/splunk/1.0.1/enterprise.splunk.com_standalones_crd.yaml
@@ -712,15 +712,14 @@ spec:
                           description: Remote volume path
                           type: string
                         provider:
-                          description: App Package Remote Store provider. For e.g.
-                            aws, azure, minio, etc. Currently we are only supporting
-                            aws.
+                          description: 'App Package Remote Store provider. Supported
+                            values: aws, minio'
                           type: string
                         secretRef:
                           description: Secret object name
                           type: string
                         storageType:
-                          description: Remote Storage type.
+                          description: 'Remote Storage type. Supported values: s3'
                           type: string
                       type: object
                     type: array
@@ -1369,15 +1368,14 @@ spec:
                           description: Remote volume path
                           type: string
                         provider:
-                          description: App Package Remote Store provider. For e.g.
-                            aws, azure, minio, etc. Currently we are only supporting
-                            aws.
+                          description: 'App Package Remote Store provider. Supported
+                            values: aws, minio'
                           type: string
                         secretRef:
                           description: Secret object name
                           type: string
                         storageType:
-                          description: Remote Storage type.
+                          description: 'Remote Storage type. Supported values: s3'
                           type: string
                       type: object
                     type: array
@@ -2722,15 +2720,15 @@ spec:
                               description: Remote volume path
                               type: string
                             provider:
-                              description: App Package Remote Store provider. For
-                                e.g. aws, azure, minio, etc. Currently we are only
-                                supporting aws.
+                              description: 'App Package Remote Store provider. Supported
+                                values: aws, minio'
                               type: string
                             secretRef:
                               description: Secret object name
                               type: string
                             storageType:
-                              description: Remote Storage type.
+                              description: 'Remote Storage type. Supported values:
+                                s3'
                               type: string
                           type: object
                         type: array
@@ -2912,15 +2910,14 @@ spec:
                           description: Remote volume path
                           type: string
                         provider:
-                          description: App Package Remote Store provider. For e.g.
-                            aws, azure, minio, etc. Currently we are only supporting
-                            aws.
+                          description: 'App Package Remote Store provider. Supported
+                            values: aws, minio'
                           type: string
                         secretRef:
                           description: Secret object name
                           type: string
                         storageType:
-                          description: Remote Storage type.
+                          description: 'Remote Storage type. Supported values: s3'
                           type: string
                       type: object
                     type: array

--- a/pkg/apis/enterprise/v1/common_types.go
+++ b/pkg/apis/enterprise/v1/common_types.go
@@ -184,12 +184,10 @@ type VolumeSpec struct {
 	// Secret object name
 	SecretRef string `json:"secretRef"`
 
-	// Remote Storage type.
+	// Remote Storage type. Supported values: s3
 	Type string `json:"storageType"`
 
-	// App Package Remote Store provider.
-	// For e.g. aws, azure, minio, etc.
-	// Currently we are only supporting aws.
+	// App Package Remote Store provider. Supported values: aws, minio
 	Provider string `json:"provider"`
 }
 

--- a/pkg/splunk/enterprise/clustermaster_test.go
+++ b/pkg/splunk/enterprise/clustermaster_test.go
@@ -201,7 +201,7 @@ func TestApplyClusterMasterWithSmartstore(t *testing.T) {
 		Spec: enterprisev1.ClusterMasterSpec{
 			SmartStore: enterprisev1.SmartStoreSpec{
 				VolList: []enterprisev1.VolumeSpec{
-					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "splunk-test-secret", Type: "s3", Provider: "aws"},
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "splunk-test-secret"},
 				},
 
 				IndexList: []enterprisev1.IndexSpec{

--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -1003,7 +1003,7 @@ func ValidateAppFrameworkSpec(appFramework *enterprisev1.AppFrameworkSpec, appCo
 		appContext.AppsRepoStatusPollInterval = splcommon.MaxAppsRepoPollInterval
 	}
 
-	err = validateRemoteVolumeSpec(appFramework.VolList)
+	err = validateRemoteVolumeSpec(appFramework.VolList, true)
 	if err != nil {
 		return err
 	}
@@ -1017,7 +1017,7 @@ func ValidateAppFrameworkSpec(appFramework *enterprisev1.AppFrameworkSpec, appCo
 }
 
 // validateRemoteVolumeSpec validates the Remote storage volume spec
-func validateRemoteVolumeSpec(volList []enterprisev1.VolumeSpec) error {
+func validateRemoteVolumeSpec(volList []enterprisev1.VolumeSpec, isAppFramework bool) error {
 
 	duplicateChecker := make(map[string]bool)
 
@@ -1040,11 +1040,16 @@ func validateRemoteVolumeSpec(volList []enterprisev1.VolumeSpec) error {
 		if volume.SecretRef == "" {
 			return fmt.Errorf("Volume SecretRef is missing")
 		}
-		if volume.Type == "" {
-			return fmt.Errorf("Remote volume Type is missing")
-		}
-		if volume.Provider == "" {
-			return fmt.Errorf("S3 Provider is missing")
+
+		// provider is used in App framework to pick the S3 client(aws, minio), and is not applicable to Smartstore
+		// For now, Smartstore supports only S3, which is by default.
+		if isAppFramework {
+			if volume.Type == "" {
+				return fmt.Errorf("Remote volume Type is missing")
+			}
+			if volume.Provider == "" {
+				return fmt.Errorf("S3 Provider is missing")
+			}
 		}
 	}
 	return nil
@@ -1095,7 +1100,7 @@ func ValidateSplunkSmartstoreSpec(smartstore *enterprisev1.SmartStoreSpec) error
 		return fmt.Errorf("Volume configuration is missing. Num. of indexes = %d. Num. of Volumes = %d", numIndexes, numVolumes)
 	}
 
-	err = validateRemoteVolumeSpec(smartstore.VolList)
+	err = validateRemoteVolumeSpec(smartstore.VolList, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/splunk/enterprise/configuration_test.go
+++ b/pkg/splunk/enterprise/configuration_test.go
@@ -269,7 +269,7 @@ func TestSmartStoreConfigDoesNotFailOnClusterMasterCR(t *testing.T) {
 		Spec: enterprisev1.ClusterMasterSpec{
 			SmartStore: enterprisev1.SmartStoreSpec{
 				VolList: []enterprisev1.VolumeSpec{
-					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret"},
 				},
 
 				IndexList: []enterprisev1.IndexSpec{
@@ -300,7 +300,7 @@ func TestValidateSplunkSmartstoreSpec(t *testing.T) {
 	// Valid smartstore config
 	SmartStore := enterprisev1.SmartStoreSpec{
 		VolList: []enterprisev1.VolumeSpec{
-			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
+			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret"},
 		},
 		IndexList: []enterprisev1.IndexSpec{
 			{Name: "salesdata1", RemotePath: "remotepath1",
@@ -415,7 +415,7 @@ func TestValidateSplunkSmartstoreSpec(t *testing.T) {
 	//Smartstore config Index with VolName, but missing RemotePath errors out
 	SmartStoreWithMissingIndexLocation := enterprisev1.SmartStoreSpec{
 		VolList: []enterprisev1.VolumeSpec{
-			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
+			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret"},
 		},
 		IndexList: []enterprisev1.IndexSpec{
 			{Name: "salesdata1",
@@ -445,7 +445,7 @@ func TestValidateSplunkSmartstoreSpec(t *testing.T) {
 				VolName: "msos_s2s3_vol"},
 		},
 		VolList: []enterprisev1.VolumeSpec{
-			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
+			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret"},
 		},
 		IndexList: []enterprisev1.IndexSpec{
 			{Name: "salesdata1"},

--- a/pkg/splunk/enterprise/standalone_test.go
+++ b/pkg/splunk/enterprise/standalone_test.go
@@ -127,7 +127,7 @@ func TestApplyStandaloneWithSmartstore(t *testing.T) {
 			Replicas: 1,
 			SmartStore: enterprisev1.SmartStoreSpec{
 				VolList: []enterprisev1.VolumeSpec{
-					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "splunk-test-secret", Type: "s3", Provider: "aws"},
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "splunk-test-secret"},
 				},
 				IndexList: []enterprisev1.IndexSpec{
 					{Name: "salesdata1", RemotePath: "remotepath1",
@@ -259,7 +259,7 @@ func TestApplyStandaloneSmartstoreKeyChangeDetection(t *testing.T) {
 			Replicas: 1,
 			SmartStore: enterprisev1.SmartStoreSpec{
 				VolList: []enterprisev1.VolumeSpec{
-					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "splunk-test-secret", Type: "s3", Provider: "aws"},
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "splunk-test-secret"},
 				},
 				IndexList: []enterprisev1.IndexSpec{
 					{Name: "salesdata1", RemotePath: "remotepath1",


### PR DESCRIPTION
Do not enforce the checks for volume  'storageType' and 'provider', if the volume is used for Smartstore.