### PR TITLE
Adding automation of ES app installation

### DIFF
--- a/test/c3/appframework/appframework_test.go
+++ b/test/c3/appframework/appframework_test.go
@@ -20,9 +20,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	testenv "github.com/splunk/splunk-operator/test/testenv"
-
 	enterprisev1 "github.com/splunk/splunk-operator/pkg/apis/enterprise/v1"
+	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
+	testenv "github.com/splunk/splunk-operator/test/testenv"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var _ = Describe("c3appfw test", func() {
@@ -209,6 +210,104 @@ var _ = Describe("c3appfw test", func() {
 
 			// Verify apps are not copied in /etc/master-apps/ on CM and /etc/shcluster/ on Deployer (therefore not installed on peers and on SH)
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), podNames, appListV1, false, true)
+		})
+	})
+
+	Context("Clustered deployment (C3 - clustered indexer, search head cluster)", func() {
+		It("c3, appframework: can deploy a C3 SVA and have ES app installed on SHC", func() {
+
+			// ES is a huge file, we configure it here rather than in BeforeSuite/BeforeEach to save time for other tests
+			// Upload ES app to S3
+			appList := []string{"SplunkEnterpriseSecuritySuite"}
+			appFileList := testenv.GetAppFileList(appList, 1)
+
+			// Download ES App from S3
+			err := testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV1, downloadDirV1, appFileList)
+			Expect(err).To(Succeed(), "Unable to download ES app file")
+
+			// Upload ES app to S3
+			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV1)
+			Expect(err).To(Succeed(), "Unable to upload ES app to S3 test directory")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+
+			// Create App framework Spec
+			volumeName := "appframework-test-volume-" + testenv.RandomDNSName(3)
+			volumeSpec := []enterprisev1.VolumeSpec{testenv.GenerateIndexVolumeSpec(volumeName, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+
+			appSourceDefaultSpec := enterprisev1.AppSourceDefaultSpec{
+				VolName: volumeName,
+				Scope:   "cluster",
+			}
+			appSourceName := "appframework-" + testenv.RandomDNSName(3)
+			appSourceSpec := []enterprisev1.AppSourceSpec{testenv.GenerateAppSourceSpec(appSourceName, s3TestDir, appSourceDefaultSpec)}
+			appFrameworkSpec := enterprisev1.AppFrameworkSpec{
+				Defaults:             appSourceDefaultSpec,
+				AppsRepoPollInterval: 60,
+				VolList:              volumeSpec,
+				AppSources:           appSourceSpec,
+			}
+
+			// Create Single site Cluster and SHC, with App Framework enabled on SHC Deployer
+			// Deploy the CM
+			deployment.DeployClusterMaster(deployment.GetName(), "", "")
+
+			// Deploy the indexer cluster
+			indexerReplicas := 3
+			deployment.DeployIndexerCluster(deployment.GetName()+"-idxc", deployment.GetName(), indexerReplicas, deployment.GetName(), "")
+
+			// Deploy the SHC
+			shSpec := enterprisev1.SearchHeadClusterSpec{
+				CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
+					Spec: splcommon.Spec{
+						ImagePullPolicy: "Always",
+					},
+					ExtraEnv: []corev1.EnvVar{
+						{
+							Name:  "SPLUNK_ES_SSL_ENABLEMENT",
+							Value: "ignore"},
+					},
+					Volumes: []corev1.Volume{},
+					ClusterMasterRef: corev1.ObjectReference{
+						Name: deployment.GetName(),
+					},
+					LivenessInitialDelaySeconds:  1450,
+					ReadinessInitialDelaySeconds: 1450,
+				},
+				Replicas:           3,
+				AppFrameworkConfig: appFrameworkSpec,
+			}
+			_, err = deployment.DeploySearchHeadClusterWithGivenSpec(deployment.GetName()+"-shc", shSpec)
+			Expect(err).To(Succeed(), "Unable to deploy SHC with App framework")
+
+			// Ensure that the CM goes to Ready phase
+			testenv.ClusterMasterReady(deployment, testenvInstance)
+
+			// Ensure Indexers go to Ready phase
+			testenv.SingleSiteIndexersReady(deployment, testenvInstance)
+
+			// Ensure SHC go to Ready phase
+			testenv.SearchHeadClusterReady(deployment, testenvInstance)
+
+			// Verify RF SF is met
+			testenv.VerifyRFSFMet(deployment, testenvInstance)
+
+			// Verify Apps are downloaded by init-container
+			esApp := "splunk-enterprise-security_640.spl"
+			downloadedapps := append(testenv.GetAppFileList(appListV1, 1), esApp)
+			initContDownloadLocation := "/init-apps/" + appSourceName
+			deployerPod := []string{fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), deployerPod, downloadedapps, initContDownloadLocation)
+
+			// Verify ES app is installed locally on SHC Deployer
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), deployerPod, appFileList, false, "disabled", false, false)
+
+			// Verify ES app is installed on SHs
+			podNames := []string{}
+			for i := 0; i < int(shSpec.Replicas); i++ {
+				sh := fmt.Sprintf(testenv.SearchHeadPod, deployment.GetName(), i)
+				podNames = append(podNames, string(sh))
+			}
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), podNames, appFileList, false, "enabled", false, true)
 		})
 	})
 })

--- a/test/s1/appframework/appframework_test.go
+++ b/test/s1/appframework/appframework_test.go
@@ -145,4 +145,71 @@ var _ = Describe("s1appfw test", func() {
 
 		})
 	})
+
+	Context("appframework Standalone deployment (S1) with App Framework", func() {
+		It("s1, appframework: can deploy a Standalone and have ES app installed", func() {
+
+			// ES is a huge file, we configure it here rather than in BeforeSuite/BeforeEach to save time for other tests
+			// Upload ES app to S3
+			appList := []string{"SplunkEnterpriseSecuritySuite"}
+			appFileList := testenv.GetAppFileList(appList, 1)
+
+			// Download ES App from S3
+			err := testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV1, downloadDirV1, appFileList)
+			Expect(err).To(Succeed(), "Unable to download ES app file")
+
+			// Upload ES app to S3
+			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV1)
+			Expect(err).To(Succeed(), "Unable to upload ES app to S3 test directory")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+
+			// Create App framework Spec
+			volumeName := "appframework-test-volume-" + testenv.RandomDNSName(3)
+			volumeSpec := []enterprisev1.VolumeSpec{testenv.GenerateIndexVolumeSpec(volumeName, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+
+			appSourceDefaultSpec := enterprisev1.AppSourceDefaultSpec{
+				VolName: volumeName,
+				Scope:   "local",
+			}
+			appSourceName := "appframework-" + testenv.RandomDNSName(3)
+			appSourceSpec := []enterprisev1.AppSourceSpec{testenv.GenerateAppSourceSpec(appSourceName, s3TestDir, appSourceDefaultSpec)}
+			appFrameworkSpec := enterprisev1.AppFrameworkSpec{
+				Defaults:             appSourceDefaultSpec,
+				AppsRepoPollInterval: 60,
+				VolList:              volumeSpec,
+				AppSources:           appSourceSpec,
+			}
+
+			// Create Standalone spec with App Framework enabled and some extra config to have ES installed correctly
+			spec := enterprisev1.StandaloneSpec{
+				CommonSplunkSpec: enterprisev1.CommonSplunkSpec{
+					Spec: splcommon.Spec{
+						ImagePullPolicy: "Always",
+					},
+					Volumes:                      []corev1.Volume{},
+					LivenessInitialDelaySeconds:  600,
+					ReadinessInitialDelaySeconds: 660,
+				},
+				AppFrameworkConfig: appFrameworkSpec,
+			}
+
+			standalone, err := deployment.DeployStandalonewithGivenSpec(deployment.GetName(), spec)
+			Expect(err).To(Succeed(), "Unable to deploy Standalone with App framework")
+
+			// Ensure Standalone goes to Ready phase
+			testenv.StandaloneReady(deployment, deployment.GetName(), standalone, testenvInstance)
+
+			// Verify Apps are downloaded by init-container
+			esApp := "splunk-enterprise-security_640.spl"
+			downloadedapps := append(testenv.GetAppFileList(appListV1, 1), esApp)
+			initContDownloadLocation := "/init-apps/" + appSourceName
+			podName := fmt.Sprintf(testenv.StandalonePod, deployment.GetName(), 0)
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), []string{podName}, downloadedapps, initContDownloadLocation)
+
+			// Verify ES app is installed locally
+			standalonePod := []string{fmt.Sprintf(testenv.StandalonePod, deployment.GetName(), 0)}
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), standalonePod, appList, false, "enabled", false, false)
+
+		})
+	})
 })

--- a/test/testenv/appframework_utils.go
+++ b/test/testenv/appframework_utils.go
@@ -23,6 +23,7 @@ var AppInfo = map[string]map[string]string{
 	"splunk_app_stream":                 {"V1": "6.0.1", "V2": "6.0.2", "V2filename": "Splunk-app-for-stream_720.tgz", "V1filename": "Splunk-app-for-stream_720.tgz"},
 	"splunk_app_db_connect":             {"V1": "3.5.0", "V2": "3.5.1", "V2filename": "Splunk-db-connect_351.tgz", "V1filename": "Splunk-db-connect_350.tgz"},
 	"Splunk_Security_Essentials":        {"V1": "3.3.2", "V2": "3.3.3", "V2filename": "Splunk-security-essentials_333.tgz", "V1filename": "Splunk-security-essentials_332.tgz"},
+	"SplunkEnterpriseSecuritySuite":     {"V1": "6.4.0", "V2": "6.4.1", "V2filename": "splunk-enterprise-security_641.spl", "V1filename": "splunk-enterprise-security_640.spl"},
 }
 
 //BasicApps Apps that require no restart to be installed


### PR DESCRIPTION
This PR adds the 2 following tests:
- C3 SVA: Installation of ES app from the deployer on the SHC (ES is first installed on the deployer, then in the /shcluster/apps folder and eventually bundle pushed to the SH)
- S1 SVA:  Installation of ES app locally on a standalone.

Note: It takes extra config in the spec to have ES installed correctly:
- Set the environment variable SPLUNK_ES_SSL_ENABLEMENT to 'ignore' to avoid the following error to show up in the logs: "FATAL: Error in 'essinstall' command: Automatic SSL enablement is not permitted on the deployer"
- Raise the values of Liveness and Readiness probes timeouts. ES takes a long time to get installed, default values are not sufficient. Once a timeout is reached, the deployer/standalone pod will restart and test will eventually fail.

Passed runs:
C3:
[1] • [SLOW TEST:1653.412 seconds]
[1] c3appfw test
[1] /Users/jambrosiano/splunk-operator/CSPL-1151/splunk-operator/test/c3/appframework/appframework_test.go:29
[1]   Clustered deployment (C3 - clustered indexer, search head cluster)
[1]   /Users/jambrosiano/splunk-operator/CSPL-1151/splunk-operator/test/c3/appframework/appframework_test.go:216
[1]     c3, appframework: can deploy a C3 SVA and have ES app installed on SHC
[1]     /Users/jambrosiano/splunk-operator/CSPL-1151/splunk-operator/test/c3/appframework/appframework_test.go:217
[1] ------------------------------
[1] {"level":"info","ts":1625857650.310171,"msg":"testenv deleted.\n","testenv":"c3appfw-lzq"}
[1] {"level":"info","ts":1625857650.3102038,"msg":"testenv deleted.\n","testenv":"c3appfw-lzq"}
[1]
[1] JUnit report was created: /Users/jambrosiano/splunk-operator/CSPL-1151/splunk-operator/test/c3/appframework/c3appfw-lzq_junit.xml
[1]
[1] Ran 1 of 3 Specs in 1668.321 seconds
[1] SUCCESS! -- 1 Passed | 0 Failed | 2 Pending | 0 Skipped
[1] PASS


S1:
1] • [SLOW TEST:827.544 seconds]
[1] s1appfw test
[1] /Users/jambrosiano/splunk-operator/CSPL-1151/splunk-operator/test/s1/appframework/appframework_test.go:30
[1]   appframework Standalone deployment (S1) with App Framework
[1]   /Users/jambrosiano/splunk-operator/CSPL-1151/splunk-operator/test/s1/appframework/appframework_test.go:149
[1]     s1, appframework: can deploy a Standalone and have ES app installed
[1]     /Users/jambrosiano/splunk-operator/CSPL-1151/splunk-operator/test/s1/appframework/appframework_test.go:150
[1] ------------------------------
[1] {"level":"info","ts":1625866143.603484,"msg":"testenv deleted.\n","testenv":"s1appfw-n72"}
[1]
[1] JUnit report was created: /Users/jambrosiano/splunk-operator/CSPL-1151/splunk-operator/test/s1/appframework/s1appfw-n72_junit.xml
[1]
[1] Ran 1 of 2 Specs in 842.549 seconds
[1] SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 0 Skipped
[1] PASS
