### PR TITLE
CSPL-1157: Enforce TLS between Operator and AppRep

### DIFF
--- a/pkg/splunk/client/awss3client.go
+++ b/pkg/splunk/client/awss3client.go
@@ -15,10 +15,13 @@
 package client
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"regexp"
+
+	"net/http"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -52,7 +55,10 @@ var regionRegex = ".*.s3[-,.](?P<region>.*).amazonaws.com"
 // GetRegion extracts the region from the endpoint field
 func GetRegion(endpoint string) string {
 	pattern := regexp.MustCompile(regionRegex)
-	return pattern.FindStringSubmatch(endpoint)[1]
+	if len(pattern.FindStringSubmatch(endpoint)) > 0 {
+		return pattern.FindStringSubmatch(endpoint)[1]
+	}
+	return ""
 }
 
 // InitAWSClientWrapper is a wrapper around InitClientSession
@@ -64,6 +70,16 @@ func InitAWSClientWrapper(region, accessKeyID, secretAccessKey string) interface
 func InitAWSClientSession(region, accessKeyID, secretAccessKey string) SplunkAWSS3Client {
 	scopedLog := log.WithName("InitAWSClientSession")
 
+	// Enforcing minimum version TLS1.2
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		},
+	}
+	tr.ForceAttemptHTTP2 = true
+	httpClient := http.Client{Transport: tr}
+	disableSSL := false
+
 	sess, err := session.NewSession(&aws.Config{
 		Region: aws.String(region),
 		Credentials: credentials.NewStaticCredentials(
@@ -71,13 +87,26 @@ func InitAWSClientSession(region, accessKeyID, secretAccessKey string) SplunkAWS
 			secretAccessKey, // secret
 			""),
 		MaxRetries: aws.Int(3),
+		HTTPClient: &httpClient,
+		DisableSSL: &disableSSL,
 	})
 	if err != nil {
 		scopedLog.Error(err, "Failed to initialize an AWS S3 session.")
 		return nil
 	}
 
-	return s3.New(sess)
+	// Create the s3Client
+	s3Client := s3.New(sess)
+
+	// Validate transport
+	tlsVersion := "Unknown"
+	if tr, ok := s3Client.Config.HTTPClient.Transport.(*http.Transport); ok {
+		tlsVersion = GetTLSVersion(tr)
+	}
+
+	scopedLog.Info("AWS Client Session initialization successful.", "region", region, "TLS Version", tlsVersion)
+
+	return s3Client
 }
 
 // NewAWSS3Client returns an AWS S3 client
@@ -109,6 +138,21 @@ func NewAWSS3Client(bucketName string, accessKeyID string, secretAccessKey strin
 func RegisterAWSS3Client() {
 	wrapperObject := GetS3ClientWrapper{GetS3Client: NewAWSS3Client, GetInitFunc: InitAWSClientWrapper}
 	S3Clients["aws"] = wrapperObject
+}
+
+func GetTLSVersion(tr *http.Transport) string {
+	switch tr.TLSClientConfig.MinVersion {
+	case tls.VersionTLS10:
+		return "TLS 1.0"
+	case tls.VersionTLS11:
+		return "TLS 1.1"
+	case tls.VersionTLS12:
+		return "TLS 1.2"
+	case tls.VersionTLS13:
+		return "TLS 1.3"
+	}
+
+	return "Unknown"
 }
 
 // GetAppsList get the list of apps from remote storage

--- a/pkg/splunk/client/awss3client.go
+++ b/pkg/splunk/client/awss3client.go
@@ -78,7 +78,6 @@ func InitAWSClientSession(region, accessKeyID, secretAccessKey string) SplunkAWS
 	}
 	tr.ForceAttemptHTTP2 = true
 	httpClient := http.Client{Transport: tr}
-	disableSSL := false
 
 	sess, err := session.NewSession(&aws.Config{
 		Region: aws.String(region),
@@ -88,7 +87,6 @@ func InitAWSClientSession(region, accessKeyID, secretAccessKey string) SplunkAWS
 			""),
 		MaxRetries: aws.Int(3),
 		HTTPClient: &httpClient,
-		DisableSSL: &disableSSL,
 	})
 	if err != nil {
 		scopedLog.Error(err, "Failed to initialize an AWS S3 session.")

--- a/pkg/splunk/client/awss3client.go
+++ b/pkg/splunk/client/awss3client.go
@@ -101,7 +101,7 @@ func InitAWSClientSession(region, accessKeyID, secretAccessKey string) SplunkAWS
 	// Validate transport
 	tlsVersion := "Unknown"
 	if tr, ok := s3Client.Config.HTTPClient.Transport.(*http.Transport); ok {
-		tlsVersion = GetTLSVersion(tr)
+		tlsVersion = getTLSVersion(tr)
 	}
 
 	scopedLog.Info("AWS Client Session initialization successful.", "region", region, "TLS Version", tlsVersion)
@@ -140,7 +140,7 @@ func RegisterAWSS3Client() {
 	S3Clients["aws"] = wrapperObject
 }
 
-func GetTLSVersion(tr *http.Transport) string {
+func getTLSVersion(tr *http.Transport) string {
 	switch tr.TLSClientConfig.MinVersion {
 	case tls.VersionTLS10:
 		return "TLS 1.0"

--- a/pkg/splunk/client/minioclient.go
+++ b/pkg/splunk/client/minioclient.go
@@ -84,7 +84,9 @@ func InitMinioClientSession(appS3Endpoint string, accessKeyID string, secretAcce
 	// Check if SSL is needed
 	useSSL := true
 	if strings.HasPrefix(appS3Endpoint, "http://") {
-		useSSL = false
+		// We should always use a secure SSL endpoint
+		// useSSL = false
+		scopedLog.Info("Using insecure endpoint, forcing useSSL=true for Minio Client Session", "appS3Endpoint", appS3Endpoint)
 		appS3Endpoint = strings.TrimPrefix(appS3Endpoint, "http://")
 	} else if strings.HasPrefix(appS3Endpoint, "https://") {
 		appS3Endpoint = strings.TrimPrefix(appS3Endpoint, "https://")

--- a/pkg/splunk/client/minioclient.go
+++ b/pkg/splunk/client/minioclient.go
@@ -84,8 +84,7 @@ func InitMinioClientSession(appS3Endpoint string, accessKeyID string, secretAcce
 	// Check if SSL is needed
 	useSSL := true
 	if strings.HasPrefix(appS3Endpoint, "http://") {
-		// We should always use a secure SSL endpoint
-		// useSSL = false
+		// We should always use a secure SSL endpoint, so we won't set useSSL = false
 		scopedLog.Info("Using insecure endpoint, forcing useSSL=true for Minio Client Session", "appS3Endpoint", appS3Endpoint)
 		appS3Endpoint = strings.TrimPrefix(appS3Endpoint, "http://")
 	} else if strings.HasPrefix(appS3Endpoint, "https://") {


### PR DESCRIPTION
### Problem
Make sure that secure connections are used when connection to the AppRepo volumes from the Splunk Operator.

### Solution
Fix crash when using incorrect endpoint for aws client when using AppRepo volume config.
Use the http transport library and useSSL flags for the aws and minio client libraries respectively to enforce use of secure transport to the remote store 

### Testing

#### AWS
Verify no crash on incorrect volume endpoint. 

Validate that apps can be downloaded and installed from remote store using secure transport.  Verify via operator logs:
```
{"level":"info","ts":1625183320.4624453,"logger":"splunk.client.InitAWSClientSession","msg":"AWS Client Session initialization successful.","region":"us-west-2","TLS Version":"TLS 1.2"}
{"level":"info","ts":1625183320.462464,"logger":"splunk.client.GetAppsList","msg":"Getting Apps list","AWS S3 Bucket":"jrybczynski-af-bucket"}
{"level":"info","ts":1625183320.532438,"logger":"splunk.enterprise.initAndCheckAppInfoStatus","msg":"Apps List retrieved from remote storage","name":"s-af-aws","namespace":"default","App Source":"af","Content":[{"Etag":"\"18be9e557115c572dfe4711bae8637c8\"","Key":"apps/af-test/application5.tgz","LastModified":"2021-05-24T17:21:48Z","Size":1154,"StorageClass":"STANDARD"}]}
{"level":"info","ts":1625183320.532465,"logger":"splunk.enterprise.initAndCheckAppInfoStatus","msg":"Apps List retrieved from remote storage","name":"s-af-aws","namespace":"default","App Source":"admin","Content":[{"Etag":"\"c753c78e80b05cc48596b9e79dd4e0e3\"","Key":"apps/admin-apps/application1.tgz","LastModified":"2021-06-28T18:24:57Z","Size":1159,"StorageClass":"STANDARD"},{"Etag":"\"628f3bb977a1efa325d3c83186f55b59\"","Key":"apps/admin-apps/application3.tgz","LastModified":"2021-06-15T07:00:43Z","Size":1167,"StorageClass":"STANDARD"}]}
{"level":"info","ts":1625183320.5324767,"logger":"splunk.enterprise.initAndCheckAppInfoStatus","msg":"Apps List retrieved from remote storage","name":"s-af-aws","namespace":"default","App Source":"default","Content":[{"Etag":"\"36ba50bcfe974906257ddfb977bf72f9\"","Key":"apps/default-test/application4.tgz","LastModified":"2021-06-28T18:15:30Z","Size":1154,"StorageClass":"STANDARD"},{"Etag":"\"00315a3365cd94e0508baae2a6c0f95a-2\"","Key":"apps/default-test/splunk-machine-learning-toolkit_521.tgz","LastModified":"2021-06-28T18:18:30Z","Size":19865458,"StorageClass":"STANDARD"}]}
```

#### Minio

Add code to enforce uses of TLS.  Validate apps can be installed from a secure endpoint and apps are installed:
```
{"level":"info","ts":1626112309.725725,"logger":"splunk.enterprise.GetRemoteStorageClient","msg":"Creating the client","name":"s-af-minio","namespace":"default","volume":"volume_app_repo_minio","bucket":"s7-apps","bucket path":"af-test/"}
{"level":"info","ts":1626112309.725853,"logger":"splunk.client.InitMinioClientSession","msg":"Using insecure endpoint, forcing useSSL=true for Minio Client Session","appS3Endpoint":"http://10.244.0.44:9000"}
{"level":"info","ts":1626112309.725871,"logger":"splunk.client.InitMinioClientSession","msg":"Connecting to Minio S3 for apps","appS3Endpoint":"10.244.0.44:9000"}
{"level":"info","ts":1626112309.7259192,"logger":"splunk.client.GetAppsList","msg":"Getting Apps list"," S3 Bucket":"s7-apps"}
{"level":"info","ts":1626112309.7326882,"logger":"splunk.client.GetAppsList","msg":"Got an object","object":{"etag":"\"c81d9cbf6dcbbf9ee1ee92af883fbf58\"","name":"af-test/application3.tgz","lastModified":"2021-07-12T17:51:35.475Z","size":1169,"contentType":"","expires":"0001-01-01T00:00:00Z","metadata":null,"userMetadata":null,"userTags":null,"UserTagCount":0,"Owner":{"name":"","id":"02d6176db174dc93cb1b899f7c6078f08654445fe8cf1b6ce98d8855f66bdbf4"},"Grant":null,"storageClass":"STANDARD","IsLatest":false,"IsDeleteMarker":false,"VersionID":"","ReplicationStatus":"","Expiration":"0001-01-01T00:00:00Z","ExpirationRuleID":""}}
{"level":"info","ts":1626112309.7330697,"logger":"splunk.enterprise.initAndCheckAppInfoStatus","msg":"Apps List retrieved from remote storage","name":"s-af-minio","namespace":"default","App Source":"s7","Content":[{"Etag":"\"c81d9cbf6dcbbf9ee1ee92af883fbf58\"","Key":"af-test/application3.tgz","LastModified":"2021-07-12T17:51:35.475Z","Size":1169,"StorageClass":"STANDARD"}]}
```

Validate non-TLS connections are rejected:
```
{"level":"info","ts":1625871742.6283402,"logger":"splunk.enterprise.GetRemoteStorageClient","msg":"Creating the client","name":"s-af-mixed","namespace":"default","volume":"volume_app_repo_minio","bucket":"s7-apps","bucket path":"af-test/"}
{"level":"info","ts":1625871742.6284032,"logger":"splunk.client.InitMinioClientSession","msg":"Force useSSL for Minio Client Session ","appS3Endpoint":"http://10.244.0.8:9000"}
{"level":"info","ts":1625871742.628424,"logger":"splunk.client.InitMinioClientSession","msg":"Connecting to Minio S3 for apps","appS3Endpoint":"10.244.0.8:9000"}
{"level":"info","ts":1625871742.640219,"logger":"splunk.reconcile.UpdateStatefulSetPods","msg":"All pods are ready","name":"splunk-s-af-mixed-standalone","namespace":"default"}
{"level":"info","ts":1625871742.640309,"logger":"splunk.enterprise.changeAppSrcDeployInfoStatus","msg":"Complete","Called for AppSource: ":"s7","repoState":1,"oldDeployStatus":1,"newDeployStatus":3}
{"level":"info","ts":1625871742.6403348,"logger":"splunk.enterprise.changeAppSrcDeployInfoStatus","msg":"Complete","Called for AppSource: ":"s7","repoState":2,"oldDeployStatus":1,"newDeployStatus":3}
{"level":"info","ts":1625871742.6403484,"logger":"splunk.enterprise.markAppsStatusToComplete","msg":"Marked the App deployment status to complete"}
```
Apps do not install:
```
[splunk@splunk-s-af-mixed-standalone-0 splunk]$ export SPLUNK_ADMIN_PW=$(cat /mnt/splunk-secrets/password); bin/splunk display app -auth admin:$SPLUNK_ADMIN_PW
alert_logevent                 CONFIGURED          ENABLED             INVISIBLE           
alert_webhook                  CONFIGURED          ENABLED             INVISIBLE           
appsbrowser                    CONFIGURED          ENABLED             INVISIBLE           
introspection_generator_addon  CONFIGURED          ENABLED             INVISIBLE 
```
Validate that non-secure connections are rejected:
```
{"level":"info","ts":1625872672.789413,"logger":"splunk.client.InitMinioClientSession","msg":"Connecting to Minio S3 for apps","appS3Endpoint":"10.244.0.21:443"}
{"level":"info","ts":1625872672.7895179,"logger":"splunk.client.GetAppsList","msg":"Getting Apps list"," S3 Bucket":"s7-apps"}
{"level":"info","ts":1625872672.8005612,"logger":"splunk.client.GetAppsList","msg":"Got an object error","object.Err":"Get \"https://10.244.0.21/s7-apps/?location=\": http: server gave HTTP response to HTTPS client","client.BucketName":"s7-apps"}
```
