### PR TITLE
CSPL-1146: Added polling update scenario for locally installation scenario

### DIFF
--- a/test/m4/appframework/appframework_test.go
+++ b/test/m4/appframework/appframework_test.go
@@ -207,6 +207,37 @@ var _ = Describe("m4appfw test", func() {
 
 			// Verify apps are not copied in /etc/master-apps/ on CM and /etc/shcluster/ on Deployer (therefore not installed on peers and on SH)
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), podNames, appListV1, false, true)
+
+			//Delete apps on S3 for new Apps
+			testenv.DeleteFilesOnS3(testS3Bucket, uploadedApps)
+			uploadedApps = nil
+
+			//Upload new Versioned Apps to S3
+			appFileList := testenv.GetAppFileList(appListV2, 2)
+			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV2)
+			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+
+			// Wait for the poll period for the apps to be downloaded
+			time.Sleep(2 * time.Minute)
+
+			// Ensure that the CM goes to Ready phase
+			testenv.ClusterMasterReady(deployment, testenvInstance)
+
+			// Ensure the indexers of all sites go to Ready phase
+			testenv.IndexersReady(deployment, testenvInstance, siteCount)
+
+			// Ensure SHC go to Ready phase
+			testenv.SearchHeadClusterReady(deployment, testenvInstance)
+
+			// Verify apps are copied at the correct location on CM and on Deployer (/etc/apps/)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), podNames, appListV2, true, false)
+
+			// Verify apps are installed locally on CM and on SHC Deployer
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), podNames, appListV2, true, "enabled", true, false)
+
+			// Verify apps are not copied in /etc/master-apps/ on CM and /etc/shcluster/ on Deployer (therefore not installed on peers and on SH)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), podNames, appListV2, false, true)
 		})
 	})
 })


### PR DESCRIPTION
Added polling update for local app installation scenario.

Passing Runs: 
```
• [SLOW TEST:1406.771 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:28
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:159
    c3, appframework: can deploy a C3 SVA and have apps installed locally on CM and SHC Deployer
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:160
------------------------------
{"level":"info","ts":1626119788.4379241,"msg":"testenv deleted.\n","testenv":"c3appfw-efk"}
{"level":"info","ts":1626119788.437949,"msg":"testenv deleted.\n","testenv":"c3appfw-efk"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/c3/appframework/c3appfw-efk_junit.xml

Ran 2 of 2 Specs in 3433.670 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS


• [SLOW TEST:1185.495 seconds]
m4appfw test
/Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:28
  Clustered deployment (M4 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:160
    m4, appframework: can deploy a M4 SVA and have apps installed locally on CM and SHC Deployer
    /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:161
------------------------------
{"level":"info","ts":1626125200.078602,"msg":"testenv deleted.\n","testenv":"m4appfw-ljo"}
{"level":"info","ts":1626125200.078628,"msg":"testenv deleted.\n","testenv":"m4appfw-ljo"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/m4/appframework/m4appfw-ljo_junit.xml

Ran 2 of 2 Specs in 3203.253 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS


• [SLOW TEST:481.174 seconds]
Licensemaster test
/Users/tpereira/Git/splunk-operator/test/licensemaster/lm_c3_test.go:30
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/licensemaster/lm_c3_test.go:97
    licensemaster: Splunk Operator can configure a C3 SVA and have apps installed locally on LM
    /Users/tpereira/Git/splunk-operator/test/licensemaster/lm_c3_test.go:98
------------------------------
P [PENDING]
Licensemaster test
/Users/tpereira/Git/splunk-operator/test/licensemaster/lm_s1_test.go:25
  Standalone deployment (S1) with LM
  /Users/tpereira/Git/splunk-operator/test/licensemaster/lm_s1_test.go:45
    licensemaster: Splunk Operator can configure License Master with Standalone in S1 SVA
    /Users/tpereira/Git/splunk-operator/test/licensemaster/lm_s1_test.go:46
------------------------------
{"level":"info","ts":1625868242.4389398,"msg":"testenv deleted.\n","testenv":"lm-a6j"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/licensemaster/lm-a6j_junit.xml

Ran 1 of 4 Specs in 489.401 seconds
SUCCESS! -- 1 Passed | 0 Failed | 3 Pending | 0 Skipped
PASS
```