### PR TITLE
CSPL: Automation to check apps are not installed on deployer and ClusterMaster in ClusterWide Install

### DIFF
--- a/test/c3/appframework/appframework_test.go
+++ b/test/c3/appframework/appframework_test.go
@@ -115,8 +115,12 @@ var _ = Describe("c3appfw test", func() {
 			allPodNames := testenv.DumpGetPods(testenvInstance.GetName())
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, true)
 
+			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
+			masterPodNames := []string{fmt.Sprintf(testenv.ClusterMasterPod, deployment.GetName()), fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV1, false, false)
+
 			//Verify Apps are installed
-			// testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, "enabled", false, true)
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, "enabled", false, true)
 
 			//Delete apps on S3 for new Apps
 			testenv.DeleteFilesOnS3(testS3Bucket, uploadedApps)
@@ -152,8 +156,11 @@ var _ = Describe("c3appfw test", func() {
 			//Verify Apps are copied to location
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, true)
 
+			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV2, false, false)
+
 			//Verify Apps are updated
-			// testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, "enabled", true, true)
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, "enabled", true, true)
 
 			// Get instance of current SHC CR with latest config
 			shcName := deployment.GetName() + "-shc"
@@ -214,8 +221,11 @@ var _ = Describe("c3appfw test", func() {
 			allPodNames = testenv.DumpGetPods(testenvInstance.GetName())
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, true)
 
+			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV2, false, false)
+
 			// Verify Apps are updated
-			// testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, "enabled", true, true)
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, "enabled", true, true)
 
 		})
 	})

--- a/test/m4/appframework/appframework_test.go
+++ b/test/m4/appframework/appframework_test.go
@@ -60,7 +60,7 @@ var _ = Describe("m4appfw test", func() {
 		}
 	})
 
-	XContext("Multi Site Indexer Cluster with SHC (m4) with App Framework", func() {
+	Context("Multi Site Indexer Cluster with SHC (m4) with App Framework", func() {
 		It("smoke, integration, m4, appframework: can deploy a M4 SVA with App Framework enabled", func() {
 
 			// Create App framework Spec
@@ -116,8 +116,12 @@ var _ = Describe("m4appfw test", func() {
 			allPodNames := testenv.DumpGetPods(testenvInstance.GetName())
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, true)
 
+			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
+			masterPodNames := []string{fmt.Sprintf(testenv.ClusterMasterPod, deployment.GetName()), fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV1, false, false)
+
 			//Verify Apps are installed cluster-wide
-			// testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, "enabled", false, true)
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, "enabled", false, true)
 
 			//Delete apps on S3 for new Apps
 			testenv.DeleteFilesOnS3(testS3Bucket, uploadedApps)
@@ -153,8 +157,11 @@ var _ = Describe("m4appfw test", func() {
 			//Verify Apps are copied to location
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, true)
 
+			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV2, false, false)
+
 			//Verify Apps are installed cluster-wide
-			// testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, "enabled", true, true)
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, "enabled", true, true)
 
 			// Get instance of current Indexer CR with latest config
 			idxcName := deployment.GetName() + "-" + "site1"
@@ -185,8 +192,11 @@ var _ = Describe("m4appfw test", func() {
 			//Verify Apps are copied to location
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, true)
 
+			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV2, false, false)
+
 			//Verify Apps are installed cluster-wide
-			// testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, "enabled", true, true)
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, "enabled", true, true)
 
 		})
 	})

--- a/test/testenv/appframework_utils.go
+++ b/test/testenv/appframework_utils.go
@@ -46,7 +46,15 @@ func GenerateAppSourceSpec(appSourceName string, appSourceLocation string, appSo
 
 // GetPodAppStatus Get the app install status and version number
 func GetPodAppStatus(deployment *Deployment, podName string, ns string, appname string, clusterWideInstall bool) (string, string, error) {
-	output, _ := GetPodAppInstallStatus(deployment, podName, ns, appname)
+	// For clusterwide install do not check for versions on deployer and cluster-master as the apps arent installed there
+	if clusterWideInstall && (strings.Contains(podName, "-cluster-master-") || strings.Contains(podName, "-deployer-")) {
+		logf.Log.Info("Pod skipped as install is Cluter-wide", "PodName", podName)
+		return "", "", nil
+	}
+	output, err := GetPodAppInstallStatus(deployment, podName, ns, appname)
+	if err != nil {
+		return "", "", err
+	}
 	status := strings.Fields(output)[2]
 	version, err := GetPodInstalledAppVersion(deployment, podName, ns, appname, clusterWideInstall)
 	return status, version, err

--- a/test/testenv/verificationutils.go
+++ b/test/testenv/verificationutils.go
@@ -587,27 +587,28 @@ func VerifyAppInstalled(deployment *Deployment, testenvInstance *TestEnv, ns str
 				status, versionInstalled, err := GetPodAppStatus(deployment, podName, ns, appName, clusterWideInstall)
 				logf.Log.Info("App info returned for app", "App-name", appName, "status", status, "versionInstalled", versionInstalled, "error", err)
 				gomega.Expect(err).To(gomega.Succeed(), "Unable to get app status on pod ")
-				comparsion := strings.EqualFold(status, statusCheck)
+				comparison := strings.EqualFold(status, statusCheck)
 				//Check the app is installed on specific pods and un-installed on others for cluster-wide install
 				if clusterWideInstall {
 					if strings.Contains(podName, "-indexer-") || strings.Contains(podName, "-search-head-") {
-						gomega.Expect(comparsion).Should(gomega.Equal(true))
-					} else {
-						gomega.Expect(comparsion).Should(gomega.Equal(false))
+						gomega.Expect(comparison).Should(gomega.Equal(true))
 					}
 				} else {
 					// For local install check pods individually
 					if strings.Contains(podName, "-indexer-") || strings.Contains(podName, "-search-head-") {
-						gomega.Expect(comparsion).Should(gomega.Equal(false))
+						gomega.Expect(comparison).Should(gomega.Equal(false))
 					} else {
-						gomega.Expect(comparsion).Should(gomega.Equal(true))
+						gomega.Expect(comparison).Should(gomega.Equal(true))
 					}
 				}
 				if versionCheck {
-					if checkupdated {
-						gomega.Expect(versionInstalled).Should(gomega.Equal(AppInfo[appName]["V2"]))
-					} else {
-						gomega.Expect(versionInstalled).Should(gomega.Equal(AppInfo[appName]["V1"]))
+					// For clusterwide install do not check for versions on deployer and cluster-master as the apps arent installed there
+					if !(clusterWideInstall && (strings.Contains(podName, "-deployer-") || strings.Contains(podName, "-cluster-master-"))) {
+						if checkupdated {
+							gomega.Expect(versionInstalled).Should(gomega.Equal(AppInfo[appName]["V2"]))
+						} else {
+							gomega.Expect(versionInstalled).Should(gomega.Equal(AppInfo[appName]["V1"]))
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Automation Changes

- Removed check for app installation on deployer and ClusterMaster
- Add check to see that apps are not downloaded in etc/apps in deployer and ClusterMaster



Test Results:
```
• [SLOW TEST:2671.113 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:29
  Single Site Indexer Cluster with SHC (C3) with App Framework
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:63
    integration, c3, appframework: can deploy a C3 SVA with App Framework enabled
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:64
------------------------------
P [PENDING]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:29
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:230
    smoke, c3, appframework: can deploy a C3 SVA and have apps installed locally on CM and SHC Deployer
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:231
------------------------------
P [PENDING]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:29
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:319
    integration, c3, appframework: can deploy a C3 SVA and have ES app installed on SHC
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:320
------------------------------
{"level":"info","ts":1626750845.936061,"msg":"testenv deleted.\n","testenv":"c3appfw-l66"}
{"level":"info","ts":1626750845.936094,"msg":"testenv deleted.\n","testenv":"c3appfw-l66"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/c3/appframework/c3appfw-l66_junit.xml

Ran 1 of 3 Specs in 2690.197 seconds
SUCCESS! -- 1 Passed | 0 Failed | 2 Pending | 0 Skipped
PASS


• [SLOW TEST:1283.395 seconds]
m4appfw test
/Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:29
  Multi Site Indexer Cluster with SHC (m4) with App Framework
  /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:63
    smoke, m4, appframework: can deploy a M4 SVA with App Framework enabled
    /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:64
------------------------------
P [PENDING]
m4appfw test
/Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:29
  Clustered deployment (M4 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:201
    integration, m4, appframework: can deploy a M4 SVA and have apps installed locally on CM and SHC Deployer
    /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:202
------------------------------
{"level":"info","ts":1626753126.3124008,"msg":"testenv deleted.\n","testenv":"m4appfw-c3s"}
{"level":"info","ts":1626753126.312433,"msg":"testenv deleted.\n","testenv":"m4appfw-c3s"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/m4/appframework/m4appfw-c3s_junit.xml

Ran 1 of 2 Specs in 1302.727 seconds
SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 0 Skipped
PASS
```


Local Runs passed:
```
• [SLOW TEST:1180.808 seconds]
m4appfw test
/Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:29
  Clustered deployment (M4 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:204
    integration, m4, appframework: can deploy a M4 SVA and have apps installed locally on CM and SHC Deployer
    /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:205
------------------------------
{"level":"info","ts":1626813579.485845,"msg":"testenv deleted.\n","testenv":"m4appfw-umc"}
{"level":"info","ts":1626813579.485899,"msg":"testenv deleted.\n","testenv":"m4appfw-umc"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/m4/appframework/m4appfw-umc_junit.xml

Ran 1 of 2 Specs in 1200.935 seconds
SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 20m6.793815681s
Test Suite Passed
tpereira@C02D15YMMD6R splunk-operator %


• [SLOW TEST:1018.483 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:29
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:230
    smoke, c3, integration, appframework: can deploy a C3 SVA and have apps installed locally on CM and SHC Deployer
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:231
------------------------------
• [SLOW TEST:1218.103 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:29
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:327
    integration, c3, appframework: can deploy a C3 SVA and have ES app installed on SHC
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:328
------------------------------
{"level":"info","ts":1626810193.427284,"msg":"testenv deleted.\n","testenv":"c3appfw-gjq"}
{"level":"info","ts":1626810193.42731,"msg":"testenv deleted.\n","testenv":"c3appfw-gjq"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/c3/appframework/c3appfw-gjq_junit.xml

Ran 2 of 3 Specs in 2254.836 seconds
SUCCESS! -- 2 Passed | 0 Failed | 1 Pending | 0 Skipped
PASS
```