### PR TITLE
Image Update to 8.2.1-a1

### DIFF
--- a/deploy/olm-catalog/splunk/1.0.2/splunk.v1.0.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/splunk/1.0.2/splunk.v1.0.2.clusterserviceversion.yaml
@@ -251,7 +251,7 @@ spec:
                 - name: OPERATOR_NAME
                   value: splunk-operator
                 - name: RELATED_IMAGE_SPLUNK_ENTERPRISE
-                  value: docker.io/splunk/splunk:8.2.1
+                  value: docker.io/splunk/splunk:8.2.1-a1
                 image: docker.io/splunk/splunk-operator:1.0.2
                 imagePullPolicy: IfNotPresent
                 name: splunk-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -30,4 +30,4 @@ spec:
         - name: OPERATOR_NAME
           value: "splunk-operator"
         - name: RELATED_IMAGE_SPLUNK_ENTERPRISE
-          value: "docker.io/splunk/splunk:8.2.1"
+          value: "docker.io/splunk/splunk:8.2.1-a1"

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -3,7 +3,7 @@
 ## 1.0.1 (2021-06-09)
 * This is the 1.0.1 release. The Splunk Operator for Kubernetes is a supported platform for deploying Splunk Enterprise with the prerequisites and constraints laid out [here](https://github.com/splunk/splunk-operator/blob/develop/docs/README.md#prerequisites-for-the-splunk-operator)
 
-* This release depends upon changes made concurrently in the Splunk Enterprise container images. You should use the splunk/splunk:8.2.1 image with it
+* This release depends upon changes made concurrently in the Splunk Enterprise container images. You should use the splunk/splunk:8.2.1-a1 image with it
 
 * Upgraded operator-sdk version from v0.15.1 to v0.18.2
 

--- a/docs/Images.md
+++ b/docs/Images.md
@@ -3,7 +3,7 @@
 The Splunk Operator requires these docker images to be present or available to your Kubernetes cluster:
 
 * `splunk/splunk-operator`: The Splunk Operator image built by this repository or the [official release](https://hub.docker.com/r/splunk/splunk-operator) (1.0.2 or later)
-* `splunk/splunk:<version>`: The [Splunk Enterprise image](https://github.com/splunk/docker-splunk) (8.2.1 or later)
+* `splunk/splunk:<version>`: The [Splunk Enterprise image](https://github.com/splunk/docker-splunk) (8.2.1-a1 or later)
 
 All of these images are publicly available, and published on [Docker Hub](https://hub.docker.com/).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ Apps and add-ons can be installed using the Splunk Operator by following the ins
 The Splunk Operator requires these docker images to be present or available to your Kubernetes cluster:
 
 * `splunk/splunk-operator`: The Splunk Operator image built by this repository or the [official release](https://hub.docker.com/r/splunk/splunk-operator) (1.0.2 or later)
-* `splunk/splunk:<version>`: The [Splunk Enterprise image](https://github.com/splunk/docker-splunk) (8.2.1 or later)
+* `splunk/splunk:<version>`: The [Splunk Enterprise image](https://github.com/splunk/docker-splunk) (8.2.1-a1 or later)
 
 All of the Splunk Enterprise images are publicly available on [Docker Hub](https://hub.docker.com/). If your cluster does not have access to pull from Docker Hub, see the [Required Images Documentation](Images.md) page.
 


### PR DESCRIPTION
Update to Splunk Docker image 8.2.1-a1 which will contain the latest ansible changes needed by the 1.0.2 release