### PR TITLE
fix ES_APP test failure

### DIFF
--- a/test/c3/appframework/appframework_test.go
+++ b/test/c3/appframework/appframework_test.go
@@ -411,9 +411,6 @@ var _ = Describe("c3appfw test", func() {
 			deployerPod := []string{fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
 			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), deployerPod, appFileList, initContDownloadLocation)
 
-			// Verify ES app is installed locally on SHC Deployer
-			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), deployerPod, esApp, false, "disabled", false, false)
-
 			// Verify apps are installed on SHs
 			podNames := []string{}
 			for i := 0; i < int(shSpec.Replicas); i++ {


### PR DESCRIPTION
With the new Ansible changes from  https://github.com/splunk/splunk-operator/pull/420. The app is no longer installed on Deployer. 

Therefore this check is redundant and would cause the test to fail