### PR TITLE
CSPL-1207: Remove liveness and readiness from App spec

### DIFF
--- a/test/c3/appframework/appframework_test.go
+++ b/test/c3/appframework/appframework_test.go
@@ -328,7 +328,7 @@ var _ = Describe("c3appfw test", func() {
 	})
 
 	// Commenting this test for now as ES app is not installed locally on Deployer anymore before bundle push due to change from CSPL-1167
-	XContext("Clustered deployment (C3 - clustered indexer, search head cluster)", func() {
+	Context("Clustered deployment (C3 - clustered indexer, search head cluster)", func() {
 		It("appfwint, c3, appframework: can deploy a C3 SVA and have ES app installed on SHC", func() {
 
 			// ES is a huge file, we configure it here rather than in BeforeSuite/BeforeEach to save time for other tests
@@ -352,7 +352,7 @@ var _ = Describe("c3appfw test", func() {
 
 			appSourceDefaultSpec := enterpriseApi.AppSourceDefaultSpec{
 				VolName: volumeName,
-				Scope:   enterpriseApi.ScopeCluster,
+				Scope:   enterpriseApi.ScopeClusterWithPreConfig,
 			}
 			appSourceName := "appframework-" + testenv.RandomDNSName(3)
 			appSourceSpec := []enterpriseApi.AppSourceSpec{testenv.GenerateAppSourceSpec(appSourceName, s3TestDir, appSourceDefaultSpec)}
@@ -386,8 +386,8 @@ var _ = Describe("c3appfw test", func() {
 					ClusterMasterRef: corev1.ObjectReference{
 						Name: deployment.GetName(),
 					},
-					LivenessInitialDelaySeconds:  1450,
-					ReadinessInitialDelaySeconds: 1450,
+					// LivenessInitialDelaySeconds:  1450,
+					// ReadinessInitialDelaySeconds: 1450,
 				},
 				Replicas:           3,
 				AppFrameworkConfig: appFrameworkSpec,

--- a/test/s1/appframework/appframework_test.go
+++ b/test/s1/appframework/appframework_test.go
@@ -202,7 +202,7 @@ var _ = Describe("s1appfw test", func() {
 
 			appSourceDefaultSpec := enterpriseApi.AppSourceDefaultSpec{
 				VolName: volumeName,
-				Scope:   enterpriseApi.ScopeLocal,
+				Scope:   enterpriseApi.ScopeClusterWithPreConfig,
 			}
 			appSourceName := "appframework-" + testenv.RandomDNSName(3)
 			appSourceSpec := []enterpriseApi.AppSourceSpec{testenv.GenerateAppSourceSpec(appSourceName, s3TestDir, appSourceDefaultSpec)}
@@ -219,9 +219,9 @@ var _ = Describe("s1appfw test", func() {
 					Spec: splcommon.Spec{
 						ImagePullPolicy: "Always",
 					},
-					Volumes:                      []corev1.Volume{},
-					LivenessInitialDelaySeconds:  600,
-					ReadinessInitialDelaySeconds: 660,
+					Volumes: []corev1.Volume{},
+					// LivenessInitialDelaySeconds:  600,
+					// ReadinessInitialDelaySeconds: 660,
 				},
 				AppFrameworkConfig: appFrameworkSpec,
 			}

--- a/test/testenv/deployment.go
+++ b/test/testenv/deployment.go
@@ -589,8 +589,8 @@ func (d *Deployment) DeploySingleSiteClusterWithGivenAppFrameworkSpec(name strin
 			LicenseMasterRef: corev1.ObjectReference{
 				Name: licenseMaster,
 			},
-			LivenessInitialDelaySeconds:  int32(delaySeconds),
-			ReadinessInitialDelaySeconds: int32(delaySeconds),
+			// LivenessInitialDelaySeconds:  int32(delaySeconds),
+			// ReadinessInitialDelaySeconds: int32(delaySeconds),
 		},
 		AppFrameworkConfig: appFrameworkSpec,
 	}
@@ -617,8 +617,8 @@ func (d *Deployment) DeploySingleSiteClusterWithGivenAppFrameworkSpec(name strin
 			LicenseMasterRef: corev1.ObjectReference{
 				Name: licenseMaster,
 			},
-			LivenessInitialDelaySeconds:  int32(delaySeconds),
-			ReadinessInitialDelaySeconds: int32(delaySeconds),
+			// LivenessInitialDelaySeconds:  int32(delaySeconds),
+			// ReadinessInitialDelaySeconds: int32(delaySeconds),
 		},
 		Replicas:           3,
 		AppFrameworkConfig: appFrameworkSpec,
@@ -673,9 +673,9 @@ func (d *Deployment) DeployMultisiteClusterWithSearchHeadAndAppFramework(name st
 			LicenseMasterRef: corev1.ObjectReference{
 				Name: licenseMaster,
 			},
-			Defaults:                     defaults,
-			LivenessInitialDelaySeconds:  int32(delaySeconds),
-			ReadinessInitialDelaySeconds: int32(delaySeconds),
+			Defaults: defaults,
+			// LivenessInitialDelaySeconds:  int32(delaySeconds),
+			// ReadinessInitialDelaySeconds: int32(delaySeconds),
 		},
 		AppFrameworkConfig: appFrameworkSpec,
 	}
@@ -715,9 +715,9 @@ func (d *Deployment) DeployMultisiteClusterWithSearchHeadAndAppFramework(name st
 			LicenseMasterRef: corev1.ObjectReference{
 				Name: licenseMaster,
 			},
-			Defaults:                     siteDefaults,
-			LivenessInitialDelaySeconds:  int32(delaySeconds),
-			ReadinessInitialDelaySeconds: int32(delaySeconds),
+			Defaults: siteDefaults,
+			// LivenessInitialDelaySeconds:  int32(delaySeconds),
+			// ReadinessInitialDelaySeconds: int32(delaySeconds),
 		},
 		Replicas:           3,
 		AppFrameworkConfig: appFrameworkSpec,


### PR DESCRIPTION
Changes include:

- Commenting out liveness and Readiness from all app-framework test cases
- Uncomment out ESApp test case and set Install scope to 'clusterWithPreConfig' 