### PR TITLE
- Change for LicenseMaster to have additonal livenessProbe intial del…

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -30,4 +30,4 @@ spec:
         - name: OPERATOR_NAME
           value: "splunk-operator"
         - name: RELATED_IMAGE_SPLUNK_ENTERPRISE
-          value: "docker.io/splunk/splunk:8.2.1-a1"
+          value: "docker.io/splunk/splunk:8.2.1-a2"

--- a/docs/AppFramework.md
+++ b/docs/AppFramework.md
@@ -318,9 +318,9 @@ Here is a typical App framework configuration in a Custom resource definition:
 
 ## Impact of livenessInitialDelaySeconds and readinessInitialDelaySeconds
 
-* Splunk Operator CRDs support the configuration of [initialDelaySeconds](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) for both Liveliness (livenessInitialDelaySeconds) and Readiness (readinessInitialDelaySeconds) probes 
-* Default values are 300 seconds for livenessInitialDelaySeconds and 10 seconds for readinessInitialDelaySeconds
-* When Appframework is configured as part of a CR, depending on the number of Apps being configured, Operator can also override the default or configured values for both probes with internally calculated higher values. This is to ensure that optimal values are being used to allow for successful installation or update of Apps especially in large scale deployments. 
+* Splunk Operator CRDs support the configuration of [initialDelaySeconds](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) for both Liveliness (livenessInitialDelaySeconds) and Readiness (readinessInitialDelaySeconds) probes
+* When App Framework is NOT configured, default values are 300 seconds for livenessInitialDelaySeconds and 10 seconds for readinessInitialDelaySeconds (for all CRs)
+* When App Framework is configured, default values are 1800 seconds for livenessInitialDelaySeconds and 10 seconds for readinessInitialDelaySeconds (only for Deployer, Cluster Master, Standalone and License Master CRs). The higher value of livenessInitialDelaySeconds is to ensure sufficient time is allocated for installing most apps. This configuration can further be managed depending on the number & size of Apps to be installed
 
 ## App Framework Limitations
 

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -1,6 +1,6 @@
 # Splunk Operator for Kubernetes Change Log
 
-## 1.0.2 (2021-08-04)
+## 1.0.2 (2021-08-20)
 * This is the 1.0.2 release. The Splunk Operator for Kubernetes is a supported platform for deploying Splunk Enterprise with the prerequisites and constraints laid out [here](https://github.com/splunk/splunk-operator/blob/develop/docs/README.md#prerequisites-for-the-splunk-operator)
 
 * This release depends upon changes made concurrently in the Splunk Enterprise container images. You should use the splunk/splunk:8.2.1-a1 image with it

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ Apps and add-ons can be installed using the Splunk Operator by following the ins
 The Splunk Operator requires these docker images to be present or available to your Kubernetes cluster:
 
 * `splunk/splunk-operator`: The Splunk Operator image built by this repository or the [official release](https://hub.docker.com/r/splunk/splunk-operator) (1.0.2 or later)
-* `splunk/splunk:<version>`: The [Splunk Enterprise image](https://github.com/splunk/docker-splunk) (8.2.1-a1 or later)
+* `splunk/splunk:<version>`: The [Splunk Enterprise image](https://github.com/splunk/docker-splunk) (8.2.1-a2 or later)
 
 All of the Splunk Enterprise images are publicly available on [Docker Hub](https://hub.docker.com/). If your cluster does not have access to pull from Docker Hub, see the [Required Images Documentation](Images.md) page.
 

--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -614,7 +614,7 @@ func updateSplunkPodTemplateWithConfig(client splcommon.ControllerClient, podTem
 		// Always sort the slice, so that map entries are ordered, to avoid pod resets
 		sort.Strings(appListingFiles)
 
-		if instanceType == SplunkDeployer || instanceType == SplunkClusterMaster || instanceType == SplunkStandalone {
+		if instanceType == SplunkDeployer || instanceType == SplunkClusterMaster || instanceType == SplunkStandalone || instanceType == SplunkLicenseMaster {
 			additionalDelayForAppInstallation = int32(maxSplunkAppsInstallationDelaySecs)
 		}
 	}


### PR DESCRIPTION
- Change for LicenseMaster to have additional livenessProbe initial delay of 1500 Sec. when the AppFramework is configured.

- Addressing doc changes to reflect the latest correct Splunk Enterprise image.