### PR TITLE
Fix failures in pipeline run

### DIFF
--- a/test/c3/appframework/appframework_test.go
+++ b/test/c3/appframework/appframework_test.go
@@ -331,18 +331,21 @@ var _ = Describe("c3appfw test", func() {
 	Context("Clustered deployment (C3 - clustered indexer, search head cluster)", func() {
 		It("appfwint, c3, appframework: can deploy a C3 SVA and have ES app installed on SHC", func() {
 
+			//Delete apps on S3 for new Apps
+			testenv.DeleteFilesOnS3(testS3Bucket, uploadedApps)
+			uploadedApps = nil
+
 			// ES is a huge file, we configure it here rather than in BeforeSuite/BeforeEach to save time for other tests
 			// Upload ES app to S3
 			esApp := []string{"SplunkEnterpriseSecuritySuite"}
-			appListV1 = append(appListV1, esApp...)
-			appFileList := testenv.GetAppFileList(appListV1, 1)
+			appFileList := testenv.GetAppFileList(esApp, 1)
 
 			// Download ES App from S3
-			err := testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV1, downloadDirV1, testenv.GetAppFileList(esApp, 1))
+			err := testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV1, downloadDirV1, appFileList)
 			Expect(err).To(Succeed(), "Unable to download ES app file")
 
 			// Upload ES app to S3
-			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, testenv.GetAppFileList(esApp, 1), downloadDirV1)
+			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV1)
 			Expect(err).To(Succeed(), "Unable to upload ES app to S3 test directory")
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
@@ -413,7 +416,7 @@ var _ = Describe("c3appfw test", func() {
 			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), deployerPod, appFileList, initContDownloadLocation)
 
 			// Verify ES app is installed locally on SHC Deployer
-			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), deployerPod, esApp, false, "disabled", false, false)
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), deployerPod, esApp, true, "disabled", false, false)
 
 			// Verify apps are installed on SHs
 			podNames := []string{}
@@ -421,7 +424,7 @@ var _ = Describe("c3appfw test", func() {
 				sh := fmt.Sprintf(testenv.SearchHeadPod, deployment.GetName(), i)
 				podNames = append(podNames, string(sh))
 			}
-			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), podNames, appListV1, false, "enabled", false, true)
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), podNames, esApp, true, "enabled", false, true)
 		})
 	})
 

--- a/test/s1/appframework/appframework_test.go
+++ b/test/s1/appframework/appframework_test.go
@@ -202,7 +202,7 @@ var _ = Describe("s1appfw test", func() {
 
 			appSourceDefaultSpec := enterpriseApi.AppSourceDefaultSpec{
 				VolName: volumeName,
-				Scope:   enterpriseApi.ScopeClusterWithPreConfig,
+				Scope:   enterpriseApi.ScopeLocal,
 			}
 			appSourceName := "appframework-" + testenv.RandomDNSName(3)
 			appSourceSpec := []enterpriseApi.AppSourceSpec{testenv.GenerateAppSourceSpec(appSourceName, s3TestDir, appSourceDefaultSpec)}

--- a/test/testenv/s3utils.go
+++ b/test/testenv/s3utils.go
@@ -124,7 +124,7 @@ func UploadFileToS3(dataBucket string, filename string, path string, file *os.Fi
 		}
 		logf.Log.Info("Uploaded", "filename", file.Name(), "bytes", numBytes)
 	}
-	return file.Name(), err
+	return filepath.Join(path, filename), err
 }
 
 // GetFileListOnS3 lists object in a bucket


### PR DESCRIPTION
Changes:

- Changed scope on standalone to 'local' for ESapp
- Modified C3 Appframework test case to only install ESApp via clusterwithPreConfig Bucket