### PR TITLE
CSPL-1240: Fix the bug where during upgrade to latest CRD version, K8s server prunes the CRD fields

### DIFF
--- a/build/make_bundle.sh
+++ b/build/make_bundle.sh
@@ -27,6 +27,7 @@ for v in $OLD_VERSIONS; do
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string

--- a/deploy/crds/enterprise.splunk.com_clustermasters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_clustermasters_crd.yaml
@@ -2918,6 +2918,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2927,6 +2928,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2936,6 +2938,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2945,6 +2948,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string

--- a/deploy/crds/enterprise.splunk.com_indexerclusters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_indexerclusters_crd.yaml
@@ -2575,6 +2575,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2584,6 +2585,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2593,6 +2595,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2602,6 +2605,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string

--- a/deploy/crds/enterprise.splunk.com_licensemasters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_licensemasters_crd.yaml
@@ -2687,6 +2687,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2696,6 +2697,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2705,6 +2707,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2714,6 +2717,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string

--- a/deploy/crds/enterprise.splunk.com_searchheadclusters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_searchheadclusters_crd.yaml
@@ -2796,6 +2796,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2805,6 +2806,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2814,6 +2816,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2823,6 +2826,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string

--- a/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
@@ -2939,6 +2939,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2948,6 +2949,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2957,6 +2959,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2966,6 +2969,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string

--- a/deploy/olm-catalog/splunk/1.0.2/enterprise.splunk.com_clustermasters_crd.yaml
+++ b/deploy/olm-catalog/splunk/1.0.2/enterprise.splunk.com_clustermasters_crd.yaml
@@ -2918,6 +2918,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2927,6 +2928,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2936,6 +2938,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2945,6 +2948,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string

--- a/deploy/olm-catalog/splunk/1.0.2/enterprise.splunk.com_indexerclusters_crd.yaml
+++ b/deploy/olm-catalog/splunk/1.0.2/enterprise.splunk.com_indexerclusters_crd.yaml
@@ -2575,6 +2575,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2584,6 +2585,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2593,6 +2595,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2602,6 +2605,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string

--- a/deploy/olm-catalog/splunk/1.0.2/enterprise.splunk.com_licensemasters_crd.yaml
+++ b/deploy/olm-catalog/splunk/1.0.2/enterprise.splunk.com_licensemasters_crd.yaml
@@ -2687,6 +2687,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2696,6 +2697,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2705,6 +2707,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2714,6 +2717,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string

--- a/deploy/olm-catalog/splunk/1.0.2/enterprise.splunk.com_searchheadclusters_crd.yaml
+++ b/deploy/olm-catalog/splunk/1.0.2/enterprise.splunk.com_searchheadclusters_crd.yaml
@@ -2796,6 +2796,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2805,6 +2806,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2814,6 +2816,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2823,6 +2826,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string

--- a/deploy/olm-catalog/splunk/1.0.2/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/olm-catalog/splunk/1.0.2/enterprise.splunk.com_standalones_crd.yaml
@@ -2939,6 +2939,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2948,6 +2949,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2957,6 +2959,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string
@@ -2966,6 +2969,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
           apiVersion:
             type: string

--- a/deploy/olm-catalog/splunk/1.0.2/splunk.v1.0.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/splunk/1.0.2/splunk.v1.0.2.clusterserviceversion.yaml
@@ -258,7 +258,7 @@ spec:
                 - name: OPERATOR_NAME
                   value: splunk-operator
                 - name: RELATED_IMAGE_SPLUNK_ENTERPRISE
-                  value: docker.io/splunk/splunk:8.2.1-a1
+                  value: docker.io/splunk/splunk:8.2.1-a2
                 image: docker.io/splunk/splunk-operator:1.0.2
                 imagePullPolicy: IfNotPresent
                 name: splunk-operator


### PR DESCRIPTION
**Problem**
If we upgrade the operator from 1.0.1 to 1.0.2, the CRD version is also upgraded from v1 to v2. Now after the upgrade the `spec` section of the CRs(which were still on version v1) was pruned and pods either started crashing or they came up with no spec section at all.

This happened because of the default kubernetes behavior of pruning the unknown fields(fields that are not native to K8s server, such as the spec section of a CRD) of a CRD.

**Solution**
To fix this we had to add the field **x-kubernetes-preserve-unknown-fields: true** to older versions of the CRDs so that when  we upgrade to newer version/s, we still retain all the fields of the older versions.