### PR TITLE
CSPL-1221: Manual trigger for app update

### DIFF
--- a/deploy/olm-catalog/splunk/1.0.2/splunk.v1.0.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/splunk/1.0.2/splunk.v1.0.2.clusterserviceversion.yaml
@@ -258,7 +258,7 @@ spec:
                 - name: OPERATOR_NAME
                   value: splunk-operator
                 - name: RELATED_IMAGE_SPLUNK_ENTERPRISE
-                  value: docker.io/splunk/splunk:8.2.1-a1
+                  value: docker.io/splunk/splunk:8.2.1-a2
                 image: docker.io/splunk/splunk-operator:1.0.2
                 imagePullPolicy: IfNotPresent
                 name: splunk-operator

--- a/docs/AppFramework.md
+++ b/docs/AppFramework.md
@@ -314,11 +314,11 @@ Here is a typical App framework configuration in a Custom resource definition:
 
 ### appsRepoPollIntervalSeconds
 
-The App Framework uses the polling interval `appsRepoPollIntervalSeconds` to check for additional apps, or modified apps on the remote object storage.  If app framework is enabled, the Splunk Operator creates a namespace scoped configMap named **splunk-manual-app-update**, which is used to manually trigger the app updates. When `appsRepoPollIntervalSeconds` is set to '0' for a CR, the App Framework will not perform a check until the configMap `status` field is updated manually. See [Manual initiation of app management](#manaul_initiation_of_app_management).
+The App Framework uses the polling interval `appsRepoPollIntervalSeconds` to check for additional apps, or modified apps on the remote object storage.  If app framework is enabled, the Splunk Operator creates a namespace scoped configMap named **splunk-\<namespace\>-manual-app-update**, which is used to manually trigger the app updates. When `appsRepoPollIntervalSeconds` is set to `0` for a CR, the App Framework will not perform a check until the configMap `status` field is updated manually. See [Manual initiation of app management](#manual_initiation_of_app_management).
 
 
 ## Manual initiation of app management
-You can prevent the App Framework from automatically polling the remote storage for changes. By setting the CR setting `appsRepoPollIntervalSeconds` to '0', the App Framework polling is disabled, and the configMap is updated with a new `status` field.
+You can prevent the App Framework from automatically polling the remote storage for changes. By setting the CR setting `appsRepoPollIntervalSeconds` to `0`, the App Framework polling is disabled, and the configMap is updated with a new `status` field. The App Framework always performs an initial poll of the remote storage, even when the CR is initialized with polling disabled.
 
 The 'status' field defaults to 'off'. When you're ready to initiate an app check using the App Framework, manually update the `status` field in the configMap for that CR type to `on`. 
 For example, you deployed one Standalone CR with app framework enabled. 
@@ -328,7 +328,7 @@ kubectl get standalone
 NAME   PHASE   DESIRED   READY   AGE
 s1     Ready   1         1       13h
 ```
-As mentioned above, Splunk Operator will create the configMap `splunk-manual-app-update` with an entry for Standalone CR as below -
+As mentioned above, Splunk Operator will create the configMap(assuming `default` namespace) `splunk-default-manual-app-update` with an entry for Standalone CR as below -
 
 ```yaml
 apiVersion: v1
@@ -352,15 +352,15 @@ metadata:
   uid: 413c6053-af4f-4cb3-97e0-6dbe7cd17721
   ```
 
-To trigger manual checking of app/s, update the configMap and set the `status` field to 'on' for the Standalone CR as below:
+To trigger manual checking of app/s, update the configMap and set the `status` field to `on` for the Standalone CR as below:
 
-```kubectl patch cm/splunk-manual-app-update --type merge -p '{"data":{"Standalone":"status: on\nrefCount: 1"}}'```
+```kubectl patch cm/splunk-default-manual-app-update --type merge -p '{"data":{"Standalone":"status: on\nrefCount: 1"}}'```
 
-The App Framework will perform its checks and updates, and reset the 'status' to 'off' when it has completed its tasks.
+The App Framework will perform its checks and updates, and reset the `status` to `off` when it has completed its tasks.
 
 To re-enable the polling, update the CR `appsRepoPollIntervalSeconds` setting to a value greater than 0.
 
-NOTE: all CR's of the same type must have polling enabled, or disabled. For example, if `appsRepoPollIntervalSeconds` is set to '0' for one Standalone CR, all other Standalone CRs must also have polling disabled. Use the `kubectl` command to identify all CR's of the same type before updating the polling interval.
+NOTE: All CR's of the same type must have polling enabled, or disabled. For example, if `appsRepoPollIntervalSeconds` is set to '0' for one Standalone CR, all other Standalone CRs must also have polling disabled. Use the `kubectl` command to identify all CR's of the same type before updating the polling interval. We can have unexpected behavior of polling if we have CRs with a mix of polling enabled and disabled.
 
 ## Impact of livenessInitialDelaySeconds and readinessInitialDelaySeconds
 

--- a/pkg/controller/add_clustermaster.go
+++ b/pkg/controller/add_clustermaster.go
@@ -49,7 +49,7 @@ func (ctrl ClusterMasterController) GetInstance() splcommon.MetaObject {
 
 // GetWatchTypes returns a list of types owned by the controller that it would like to receive watch events for
 func (ctrl ClusterMasterController) GetWatchTypes() []runtime.Object {
-	return []runtime.Object{&appsv1.StatefulSet{}, &corev1.Secret{}}
+	return []runtime.Object{&appsv1.StatefulSet{}, &corev1.Secret{}, &corev1.ConfigMap{}}
 }
 
 // Reconcile is used to perform an idempotent reconciliation of the custom resource managed by this controller

--- a/pkg/controller/add_licensemaster.go
+++ b/pkg/controller/add_licensemaster.go
@@ -50,7 +50,7 @@ func (ctrl LicenseMasterController) GetInstance() splcommon.MetaObject {
 
 // GetWatchTypes returns a list of types owned by the controller that it would like to receive watch events for
 func (ctrl LicenseMasterController) GetWatchTypes() []runtime.Object {
-	return []runtime.Object{&appsv1.StatefulSet{}, &corev1.Secret{}}
+	return []runtime.Object{&appsv1.StatefulSet{}, &corev1.Secret{}, &corev1.ConfigMap{}}
 }
 
 // Reconcile is used to perform an idempotent reconciliation of the custom resource managed by this controller

--- a/pkg/controller/add_searchheadcluster.go
+++ b/pkg/controller/add_searchheadcluster.go
@@ -50,7 +50,7 @@ func (ctrl SearchHeadClusterController) GetInstance() splcommon.MetaObject {
 
 // GetWatchTypes returns a list of types owned by the controller that it would like to receive watch events for
 func (ctrl SearchHeadClusterController) GetWatchTypes() []runtime.Object {
-	return []runtime.Object{&appsv1.StatefulSet{}, &corev1.Secret{}}
+	return []runtime.Object{&appsv1.StatefulSet{}, &corev1.Secret{}, &corev1.ConfigMap{}}
 }
 
 // Reconcile is used to perform an idempotent reconciliation of the custom resource managed by this controller

--- a/pkg/controller/add_standalone.go
+++ b/pkg/controller/add_standalone.go
@@ -50,7 +50,7 @@ func (ctrl StandaloneController) GetInstance() splcommon.MetaObject {
 
 // GetWatchTypes returns a list of types owned by the controller that it would like to receive watch events for
 func (ctrl StandaloneController) GetWatchTypes() []runtime.Object {
-	return []runtime.Object{&appsv1.StatefulSet{}, &corev1.Secret{}}
+	return []runtime.Object{&appsv1.StatefulSet{}, &corev1.Secret{}, &corev1.ConfigMap{}}
 }
 
 // Reconcile is used to perform an idempotent reconciliation of the custom resource managed by this controller

--- a/pkg/splunk/controller/statefulset.go
+++ b/pkg/splunk/controller/statefulset.go
@@ -33,7 +33,9 @@ type DefaultStatefulSetPodManager struct{}
 
 // Update for DefaultStatefulSetPodManager handles all updates for a statefulset of standard pods
 func (mgr *DefaultStatefulSetPodManager) Update(client splcommon.ControllerClient, statefulSet *appsv1.StatefulSet, desiredReplicas int32) (splcommon.Phase, error) {
+
 	phase, err := ApplyStatefulSet(client, statefulSet)
+
 	if err == nil && phase == splcommon.PhaseReady {
 		phase, err = UpdateStatefulSetPods(client, statefulSet, mgr, desiredReplicas)
 	}

--- a/pkg/splunk/enterprise/clustermaster.go
+++ b/pkg/splunk/enterprise/clustermaster.go
@@ -321,7 +321,7 @@ func getClusterMasterList(c splcommon.ControllerClient, cr splcommon.MetaObject,
 	err := c.List(context.TODO(), &objectList, listOpts...)
 	numOfObjects := len(objectList.Items)
 
-	if err != nil || numOfObjects == 0 {
+	if err != nil {
 		scopedLog.Error(err, "ClusterMaster types not found in namespace", "namsespace", cr.GetNamespace())
 		return numOfObjects, err
 	}

--- a/pkg/splunk/enterprise/clustermaster.go
+++ b/pkg/splunk/enterprise/clustermaster.go
@@ -22,6 +22,7 @@ import (
 
 	enterpriseApi "github.com/splunk/splunk-operator/pkg/apis/enterprise/v2"
 	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	splclient "github.com/splunk/splunk-operator/pkg/splunk/client"
@@ -104,6 +105,15 @@ func ApplyClusterMaster(client splcommon.ControllerClient, cr *enterpriseApi.Clu
 		err = ApplyMonitoringConsole(client, cr, cr.Spec.CommonSplunkSpec, getClusterMasterExtraEnv(cr, &cr.Spec.CommonSplunkSpec))
 		if err != nil {
 			return result, err
+		}
+
+		// If this is the last of its kind getting deleted,
+		// remove the entry for this CR type from configMap
+		if len(cr.Spec.AppFrameworkConfig.AppSources) != 0 {
+			err = UpdateOrRemoveEntryFromConfigMap(client, cr, SplunkClusterMaster)
+			if err != nil {
+				return result, err
+			}
 		}
 
 		DeleteOwnerReferencesForResources(client, cr, &cr.Spec.SmartStore)
@@ -300,4 +310,25 @@ func PushMasterAppsBundle(c splcommon.ControllerClient, cr *enterpriseApi.Cluste
 	splunkClient := splclient.NewSplunkClient(fmt.Sprintf("https://%s:8089", fqdnName), "admin", string(adminPwd))
 
 	return splunkClient.BundlePush(true)
+}
+
+// helper function to get the list of ClusterMaster types in the current namespace
+func getClusterMasterList(c splcommon.ControllerClient, cr splcommon.MetaObject, listOpts []client.ListOption) (int, error) {
+	scopedLog := log.WithName("getClusterMasterList").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
+
+	objectList := enterpriseApi.ClusterMasterList{}
+
+	err := c.List(context.TODO(), &objectList, listOpts...)
+	numOfObjects := len(objectList.Items)
+
+	if err != nil || numOfObjects == 0 {
+		scopedLog.Error(err, "ClusterMaster types not found in namespace", "namsespace", cr.GetNamespace())
+		return numOfObjects, err
+	}
+	if numOfObjects == 0 {
+		scopedLog.Error(err, "No ClusterMaster types found in namespace %s", cr.GetNamespace())
+		return numOfObjects, nil
+	}
+
+	return numOfObjects, nil
 }

--- a/pkg/splunk/enterprise/clustermaster.go
+++ b/pkg/splunk/enterprise/clustermaster.go
@@ -108,7 +108,8 @@ func ApplyClusterMaster(client splcommon.ControllerClient, cr *enterpriseApi.Clu
 		}
 
 		// If this is the last of its kind getting deleted,
-		// remove the entry for this CR type from configMap
+		// remove the entry for this CR type from configMap or else
+		// just decrement the refCount for this CR type.
 		if len(cr.Spec.AppFrameworkConfig.AppSources) != 0 {
 			err = UpdateOrRemoveEntryFromConfigMap(client, cr, SplunkClusterMaster)
 			if err != nil {

--- a/pkg/splunk/enterprise/clustermaster.go
+++ b/pkg/splunk/enterprise/clustermaster.go
@@ -325,10 +325,6 @@ func getClusterMasterList(c splcommon.ControllerClient, cr splcommon.MetaObject,
 		scopedLog.Error(err, "ClusterMaster types not found in namespace", "namsespace", cr.GetNamespace())
 		return numOfObjects, err
 	}
-	if numOfObjects == 0 {
-		scopedLog.Error(err, "No ClusterMaster types found in namespace %s", cr.GetNamespace())
-		return numOfObjects, nil
-	}
 
 	return numOfObjects, nil
 }

--- a/pkg/splunk/enterprise/clustermaster_test.go
+++ b/pkg/splunk/enterprise/clustermaster_test.go
@@ -918,7 +918,7 @@ func TestGetClusterMasterList(t *testing.T) {
 	client := spltest.NewMockClient()
 
 	// Invalid scenario since we haven't added clustermaster to the list yet
-	numOfObjects, err := getStandaloneList(client, &cm, listOpts)
+	numOfObjects, err := getClusterMasterList(client, &cm, listOpts)
 	if err == nil {
 		t.Errorf("getNumOfObjects should have returned error as we haven't added standalone to the list yet")
 	}

--- a/pkg/splunk/enterprise/clustermaster_test.go
+++ b/pkg/splunk/enterprise/clustermaster_test.go
@@ -441,8 +441,12 @@ func TestAppFrameworkApplyClusterMasterShouldNotFail(t *testing.T) {
 			Name:      "stack1",
 			Namespace: "test",
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ClusterMaster",
+		},
 		Spec: enterpriseApi.ClusterMasterSpec{
 			AppFrameworkConfig: enterpriseApi.AppFrameworkSpec{
+				AppsRepoPollInterval: 60,
 				VolList: []enterpriseApi.VolumeSpec{
 					{Name: "msos_s2s3_vol",
 						Endpoint:  "https://s3-eu-west-2.amazonaws.com",
@@ -819,5 +823,29 @@ func TestClusterMasterGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
 	_, err = s3ClientMgr.GetAppsList()
 	if err == nil {
 		t.Errorf("GetAppsList should have returned error as we have empty objects in MockAWSS3Client")
+	}
+}
+
+func TestGetClusterMasterList(t *testing.T) {
+	cm := enterpriseApi.ClusterMaster{}
+
+	listOpts := []client.ListOption{
+		client.InNamespace("test"),
+	}
+
+	client := spltest.NewMockClient()
+
+	cmList := &enterpriseApi.ClusterMasterList{}
+	cmList.Items = append(cmList.Items, cm)
+
+	client.ListObj = cmList
+
+	numOfObjects, err := getClusterMasterList(client, &cm, listOpts)
+	if err != nil {
+		t.Errorf("getNumOfObjects should not have returned error=%v", err)
+	}
+
+	if numOfObjects != 1 {
+		t.Errorf("Got wrong number of ClusterMaster objects. Expected=%d, Got=%d", 1, numOfObjects)
 	}
 }

--- a/pkg/splunk/enterprise/clustermaster_test.go
+++ b/pkg/splunk/enterprise/clustermaster_test.go
@@ -498,6 +498,88 @@ func TestAppFrameworkApplyClusterMasterShouldNotFail(t *testing.T) {
 	}
 }
 
+func TestApplyCLusterMasterDeletion(t *testing.T) {
+	cm := enterpriseApi.ClusterMaster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stack1",
+			Namespace: "test",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ClusterMaster",
+		},
+		Spec: enterpriseApi.ClusterMasterSpec{
+			AppFrameworkConfig: enterpriseApi.AppFrameworkSpec{
+				AppsRepoPollInterval: 0,
+				VolList: []enterpriseApi.VolumeSpec{
+					{Name: "msos_s2s3_vol",
+						Endpoint:  "https://s3-eu-west-2.amazonaws.com",
+						Path:      "testbucket-rs-london",
+						SecretRef: "s3-secret",
+						Type:      "s3",
+						Provider:  "aws"},
+				},
+				AppSources: []enterpriseApi.AppSourceSpec{
+					{Name: "adminApps",
+						Location: "adminAppsRepo",
+						AppSourceDefaultSpec: enterpriseApi.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   enterpriseApi.ScopeLocal},
+					},
+					{Name: "securityApps",
+						Location: "securityAppsRepo",
+						AppSourceDefaultSpec: enterpriseApi.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   enterpriseApi.ScopeLocal},
+					},
+					{Name: "authenticationApps",
+						Location: "authenticationAppsRepo",
+						AppSourceDefaultSpec: enterpriseApi.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   enterpriseApi.ScopeLocal},
+					},
+				},
+			},
+			CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
+				Mock: true,
+			},
+		},
+	}
+
+	c := spltest.NewMockClient()
+
+	// Create S3 secret
+	s3Secret := spltest.GetMockS3SecretKeys("s3-secret")
+
+	c.AddObject(&s3Secret)
+
+	// Create namespace scoped secret
+	_, err := splutil.ApplyNamespaceScopedSecretObject(c, "test")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	// test deletion
+	currentTime := metav1.NewTime(time.Now())
+	cm.ObjectMeta.DeletionTimestamp = &currentTime
+	cm.ObjectMeta.Finalizers = []string{"enterprise.splunk.com/delete-pvc"}
+
+	pvclist := corev1.PersistentVolumeClaimList{
+		Items: []corev1.PersistentVolumeClaim{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "splunk-pvc-stack1-var",
+					Namespace: "test",
+				},
+			},
+		},
+	}
+	c.ListObj = &pvclist
+
+	_, err = ApplyClusterMaster(c, &cm)
+	if err != nil {
+		t.Errorf("ApplyClusterMaster should not have returned error here.")
+	}
+}
 func TestClusterMasterGetAppsListForAWSS3ClientShouldNotFail(t *testing.T) {
 	cm := enterpriseApi.ClusterMaster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -835,12 +917,18 @@ func TestGetClusterMasterList(t *testing.T) {
 
 	client := spltest.NewMockClient()
 
+	// Invalid scenario since we haven't added clustermaster to the list yet
+	numOfObjects, err := getStandaloneList(client, &cm, listOpts)
+	if err == nil {
+		t.Errorf("getNumOfObjects should have returned error as we haven't added standalone to the list yet")
+	}
+
 	cmList := &enterpriseApi.ClusterMasterList{}
 	cmList.Items = append(cmList.Items, cm)
 
 	client.ListObj = cmList
 
-	numOfObjects, err := getClusterMasterList(client, &cm, listOpts)
+	numOfObjects, err = getClusterMasterList(client, &cm, listOpts)
 	if err != nil {
 		t.Errorf("getNumOfObjects should not have returned error=%v", err)
 	}

--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -888,7 +889,7 @@ func ApplyManualAppUpdateConfigMap(client splcommon.ControllerClient, cr splcomm
 	configMap := splctrl.PrepareConfigMap(configMapName, cr.GetNamespace(), crKindMap)
 
 	// Owner ref doesn't exist, update configMap with owner references
-	if getManualUpdateRefCount(crKindMap[cr.GetObjectKind().GroupVersionKind().Kind]) == "1" {
+	if getManualUpdateRefCount(crKindMap[cr.GetObjectKind().GroupVersionKind().Kind]) == 1 {
 		configMap.SetOwnerReferences(append(configMap.GetOwnerReferences(), splcommon.AsOwner(cr, false)))
 	}
 
@@ -912,13 +913,14 @@ func getManualUpdateStatus(data string) string {
 }
 
 // getManualUpdateRefCount extracts the refCount field from the configMap data
-func getManualUpdateRefCount(data string) string {
+func getManualUpdateRefCount(data string) int {
+	var refCount int
 	refCountRegex := ".*refCount: (?P<refCount>.*).*"
 	pattern := regexp.MustCompile(refCountRegex)
 	if len(pattern.FindStringSubmatch(data)) > 0 {
-		return pattern.FindStringSubmatch(data)[1]
+		refCount, _ = strconv.Atoi(pattern.FindStringSubmatch(data)[1])
 	}
-	return ""
+	return refCount
 }
 
 // createOrUpdateAppUpdateConfigMap creates or updates the manual app update configMap

--- a/pkg/splunk/enterprise/configuration_test.go
+++ b/pkg/splunk/enterprise/configuration_test.go
@@ -823,30 +823,28 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 		t.Errorf("defaultAppsRepoPollInterval should be within the range [%d - %d]", splcommon.MinAppsRepoPollInterval, splcommon.MaxAppsRepoPollInterval)
 	}
 
-	appFrameworkContext.AppsRepoStatusPollInterval = 0
+	AppFramework.AppsRepoPollInterval = 0
 	err = ValidateAppFrameworkSpec(&AppFramework, &appFrameworkContext, false)
 	if err != nil {
 		t.Errorf("Got error on valid App Framework configuration. Error: %v", err)
-	} else if appFrameworkContext.AppsRepoStatusPollInterval != splcommon.DefaultAppsRepoPollInterval {
-		t.Errorf("Spec validation failed to set the Repo poll interval to the default value: %d", splcommon.DefaultAppsRepoPollInterval)
 	}
 
 	// Check for minAppsRepoPollInterval
-	appFrameworkContext.AppsRepoStatusPollInterval = splcommon.MinAppsRepoPollInterval - 1
+	AppFramework.AppsRepoPollInterval = splcommon.MinAppsRepoPollInterval - 1
 	err = ValidateAppFrameworkSpec(&AppFramework, &appFrameworkContext, false)
 	if err != nil {
 		t.Errorf("Got error on valid App Framework configuration. Error: %v", err)
-	} else if appFrameworkContext.AppsRepoStatusPollInterval < splcommon.MinAppsRepoPollInterval {
-		t.Errorf("Spec validation is not able to set the the AppsRepoPollInterval to minAppsRepoPollInterval")
+	} else if appFrameworkContext.AppsRepoStatusPollInterval != splcommon.MinAppsRepoPollInterval {
+		t.Errorf("Spec validation is not able to set the the AppsRepoPollInterval to minAppsRepoPollInterval. AppsRepoStatusPollInterval=%d, expected=%d", appFrameworkContext.AppsRepoStatusPollInterval, splcommon.MinAppsRepoPollInterval)
 	}
 
 	// Check for maxAppsRepoPollInterval
-	appFrameworkContext.AppsRepoStatusPollInterval = splcommon.MaxAppsRepoPollInterval + 1
+	AppFramework.AppsRepoPollInterval = splcommon.MaxAppsRepoPollInterval + 1
 	err = ValidateAppFrameworkSpec(&AppFramework, &appFrameworkContext, false)
 	if err != nil {
 		t.Errorf("Got error on valid App Framework configuration. Error: %v", err)
-	} else if appFrameworkContext.AppsRepoStatusPollInterval > splcommon.MaxAppsRepoPollInterval {
-		t.Errorf("Spec validation is not able to set the the AppsRepoPollInterval to maxAppsRepoPollInterval")
+	} else if appFrameworkContext.AppsRepoStatusPollInterval != splcommon.MaxAppsRepoPollInterval {
+		t.Errorf("Spec validation is not able to set the the AppsRepoPollInterval to maxAppsRepoPollInterval. AppsRepoStatusPollInterval=%d, expected=%d", appFrameworkContext.AppsRepoStatusPollInterval, splcommon.MaxAppsRepoPollInterval)
 	}
 
 	// Invalid volume name in defaults should return an error
@@ -1311,4 +1309,74 @@ func TestGetProbe(t *testing.T) {
 	}
 
 	test(command, 100, 10, 10, `{"exec":{"command":["grep","ready","file.txt"]},"initialDelaySeconds":100,"timeoutSeconds":10,"periodSeconds":10}`)
+}
+
+func TestCreateOrUpdateAppUpdateConfigMapShouldNotFail(t *testing.T) {
+	cr := enterpriseApi.Standalone{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "standalone",
+			Namespace: "test",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Standalone",
+		},
+		Spec: enterpriseApi.StandaloneSpec{
+			Replicas: 1,
+			AppFrameworkConfig: enterpriseApi.AppFrameworkSpec{
+				VolList: []enterpriseApi.VolumeSpec{
+					{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
+				},
+				AppSources: []enterpriseApi.AppSourceSpec{
+					{Name: "adminApps",
+						Location: "adminAppsRepo",
+						AppSourceDefaultSpec: enterpriseApi.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   enterpriseApi.ScopeLocal},
+					},
+					{Name: "securityApps",
+						Location: "securityAppsRepo",
+						AppSourceDefaultSpec: enterpriseApi.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   enterpriseApi.ScopeLocal},
+					},
+					{Name: "authenticationApps",
+						Location: "authenticationAppsRepo",
+						AppSourceDefaultSpec: enterpriseApi.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   enterpriseApi.ScopeLocal},
+					},
+				},
+			},
+		},
+	}
+
+	client := spltest.NewMockClient()
+
+	// now create another standalone type
+	revised := cr
+	revised.ObjectMeta.Name = "standalone2"
+
+	kind := cr.GetObjectKind().GroupVersionKind().Kind
+
+	// Create the configMap
+	configMap, err := createOrUpdateAppUpdateConfigMap(client, &cr)
+	if err != nil {
+		t.Errorf("manual app update configMap should have been created successfully")
+	}
+
+	// check the status and refCount
+	if getManualUpdateRefCount(configMap.Data[kind]) != "1" || getManualUpdateStatus(configMap.Data[kind]) != "off" {
+		t.Errorf("Got wrong status or/and refCount")
+	}
+
+	// update the configMap
+	configMap, err = createOrUpdateAppUpdateConfigMap(client, &revised)
+	if err != nil {
+		t.Errorf("manual app update configMap should have been created successfully")
+	}
+
+	// check the status and refCount
+	if getManualUpdateRefCount(configMap.Data[kind]) != "2" || getManualUpdateStatus(configMap.Data[kind]) != "off" {
+		t.Errorf("Got wrong status or/and refCount")
+	}
 }

--- a/pkg/splunk/enterprise/configuration_test.go
+++ b/pkg/splunk/enterprise/configuration_test.go
@@ -1365,7 +1365,7 @@ func TestCreateOrUpdateAppUpdateConfigMapShouldNotFail(t *testing.T) {
 	}
 
 	// check the status and refCount
-	if getManualUpdateRefCount(configMap.Data[kind]) != "1" || getManualUpdateStatus(configMap.Data[kind]) != "off" {
+	if getManualUpdateRefCount(configMap.Data[kind]) != 1 || getManualUpdateStatus(configMap.Data[kind]) != "off" {
 		t.Errorf("Got wrong status or/and refCount")
 	}
 
@@ -1376,7 +1376,7 @@ func TestCreateOrUpdateAppUpdateConfigMapShouldNotFail(t *testing.T) {
 	}
 
 	// check the status and refCount
-	if getManualUpdateRefCount(configMap.Data[kind]) != "2" || getManualUpdateStatus(configMap.Data[kind]) != "off" {
+	if getManualUpdateRefCount(configMap.Data[kind]) != 2 || getManualUpdateStatus(configMap.Data[kind]) != "off" {
 		t.Errorf("Got wrong status or/and refCount")
 	}
 }

--- a/pkg/splunk/enterprise/configuration_test.go
+++ b/pkg/splunk/enterprise/configuration_test.go
@@ -1356,17 +1356,18 @@ func TestCreateOrUpdateAppUpdateConfigMapShouldNotFail(t *testing.T) {
 	revised := cr
 	revised.ObjectMeta.Name = "standalone2"
 
-	kind := cr.GetObjectKind().GroupVersionKind().Kind
-
 	// Create the configMap
 	configMap, err := createOrUpdateAppUpdateConfigMap(client, &cr)
 	if err != nil {
 		t.Errorf("manual app update configMap should have been created successfully")
 	}
 
+	configMapName := configMap.Name
 	// check the status and refCount
-	if getManualUpdateRefCount(configMap.Data[kind]) != 1 || getManualUpdateStatus(configMap.Data[kind]) != "off" {
-		t.Errorf("Got wrong status or/and refCount")
+	refCount := getManualUpdateRefCount(client, &cr, configMapName)
+	status := getManualUpdateStatus(client, &cr, configMapName)
+	if refCount != 1 || status != "off" {
+		t.Errorf("Got wrong status or/and refCount. Expected status=off, Got=%s. Expected refCount=1, Got=%d", status, refCount)
 	}
 
 	// update the configMap
@@ -1376,7 +1377,9 @@ func TestCreateOrUpdateAppUpdateConfigMapShouldNotFail(t *testing.T) {
 	}
 
 	// check the status and refCount
-	if getManualUpdateRefCount(configMap.Data[kind]) != 2 || getManualUpdateStatus(configMap.Data[kind]) != "off" {
-		t.Errorf("Got wrong status or/and refCount")
+	refCount = getManualUpdateRefCount(client, &revised, configMapName)
+	status = getManualUpdateStatus(client, &revised, configMapName)
+	if refCount != 2 || status != "off" {
+		t.Errorf("Got wrong status or/and refCount. Expected status=off, Got=%s. Expected refCount=2, Got=%d", status, refCount)
 	}
 }

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -614,14 +614,14 @@ func validateIndexerClusterSpec(cr *enterpriseApi.IndexerCluster) error {
 
 // helper function to get the list of IndexerCluster types in the current namespace
 func getIndexerClusterList(c splcommon.ControllerClient, cr splcommon.MetaObject, listOpts []client.ListOption) (int, error) {
-	scopedLog := log.WithName("getStandaloneList").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
+	scopedLog := log.WithName("getIndexerClusterList").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
 
 	objectList := enterpriseApi.IndexerClusterList{}
 
 	err := c.List(context.TODO(), &objectList, listOpts...)
 	numOfObjects := len(objectList.Items)
 
-	if err != nil || numOfObjects == 0 {
+	if err != nil {
 		scopedLog.Error(err, "IndexerCluster types not found in namespace", "namsespace", cr.GetNamespace())
 		return numOfObjects, err
 	}

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -621,13 +621,9 @@ func getIndexerClusterList(c splcommon.ControllerClient, cr splcommon.MetaObject
 	err := c.List(context.TODO(), &objectList, listOpts...)
 	numOfObjects := len(objectList.Items)
 
-	if err != nil {
+	if err != nil || numOfObjects == 0 {
 		scopedLog.Error(err, "IndexerCluster types not found in namespace", "namsespace", cr.GetNamespace())
 		return numOfObjects, err
-	}
-	if numOfObjects == 0 {
-		scopedLog.Error(err, "No IndexerCluster types found in namespace %s", cr.GetNamespace())
-		return numOfObjects, nil
 	}
 
 	return numOfObjects, nil

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -25,6 +25,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/go-logr/logr"
@@ -609,4 +610,25 @@ func validateIndexerClusterSpec(cr *enterpriseApi.IndexerCluster) error {
 		return fmt.Errorf("Multisite cluster does not support cluster master to be located in a different namespace")
 	}
 	return validateCommonSplunkSpec(&cr.Spec.CommonSplunkSpec)
+}
+
+// helper function to get the list of IndexerCluster types in the current namespace
+func getIndexerClusterList(c splcommon.ControllerClient, cr splcommon.MetaObject, listOpts []client.ListOption) (int, error) {
+	scopedLog := log.WithName("getStandaloneList").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
+
+	objectList := enterpriseApi.IndexerClusterList{}
+
+	err := c.List(context.TODO(), &objectList, listOpts...)
+	numOfObjects := len(objectList.Items)
+
+	if err != nil {
+		scopedLog.Error(err, "IndexerCluster types not found in namespace", "namsespace", cr.GetNamespace())
+		return numOfObjects, err
+	}
+	if numOfObjects == 0 {
+		scopedLog.Error(err, "No IndexerCluster types found in namespace %s", cr.GetNamespace())
+		return numOfObjects, nil
+	}
+
+	return numOfObjects, nil
 }

--- a/pkg/splunk/enterprise/indexercluster_test.go
+++ b/pkg/splunk/enterprise/indexercluster_test.go
@@ -1062,3 +1062,27 @@ func TestGetIndexerStatefulSet(t *testing.T) {
 		t.Errorf("validateIndexerClusterSpec() error expected on multisite IndexerCluster referencing a cluster master located in a different namespace")
 	}
 }
+
+func TestGetIndexerClusterList(t *testing.T) {
+	idxc := enterpriseApi.IndexerCluster{}
+
+	listOpts := []client.ListOption{
+		client.InNamespace("test"),
+	}
+
+	client := spltest.NewMockClient()
+
+	idxcList := &enterpriseApi.IndexerClusterList{}
+	idxcList.Items = append(idxcList.Items, idxc)
+
+	client.ListObj = idxcList
+
+	numOfObjects, err := getIndexerClusterList(client, &idxc, listOpts)
+	if err != nil {
+		t.Errorf("getNumOfObjects should not have returned error=%v", err)
+	}
+
+	if numOfObjects != 1 {
+		t.Errorf("Got wrong number of IndexerCluster objects. Expected=%d, Got=%d", 1, numOfObjects)
+	}
+}

--- a/pkg/splunk/enterprise/licensemaster.go
+++ b/pkg/splunk/enterprise/licensemaster.go
@@ -173,10 +173,6 @@ func getLicenseMasterList(c splcommon.ControllerClient, cr splcommon.MetaObject,
 		scopedLog.Error(err, "LicenseMaster types not found in namespace", "namsespace", cr.GetNamespace())
 		return numOfObjects, err
 	}
-	if numOfObjects == 0 {
-		scopedLog.Error(err, "No LicenseMaster types found in namespace %s", cr.GetNamespace())
-		return numOfObjects, nil
-	}
 
 	return numOfObjects, nil
 }

--- a/pkg/splunk/enterprise/licensemaster.go
+++ b/pkg/splunk/enterprise/licensemaster.go
@@ -77,7 +77,8 @@ func ApplyLicenseMaster(client splcommon.ControllerClient, cr *enterpriseApi.Lic
 		}
 
 		// If this is the last of its kind getting deleted,
-		// remove the entry for this CR type from configMap
+		// remove the entry for this CR type from configMap or else
+		// just decrement the refCount for this CR type.
 		if len(cr.Spec.AppFrameworkConfig.AppSources) != 0 {
 			err = UpdateOrRemoveEntryFromConfigMap(client, cr, SplunkLicenseMaster)
 			if err != nil {

--- a/pkg/splunk/enterprise/licensemaster.go
+++ b/pkg/splunk/enterprise/licensemaster.go
@@ -169,7 +169,7 @@ func getLicenseMasterList(c splcommon.ControllerClient, cr splcommon.MetaObject,
 	err := c.List(context.TODO(), &objectList, listOpts...)
 	numOfObjects := len(objectList.Items)
 
-	if err != nil || numOfObjects == 0 {
+	if err != nil {
 		scopedLog.Error(err, "LicenseMaster types not found in namespace", "namsespace", cr.GetNamespace())
 		return numOfObjects, err
 	}

--- a/pkg/splunk/enterprise/licensemaster.go
+++ b/pkg/splunk/enterprise/licensemaster.go
@@ -21,6 +21,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	enterpriseApi "github.com/splunk/splunk-operator/pkg/apis/enterprise/v2"
@@ -74,6 +75,16 @@ func ApplyLicenseMaster(client splcommon.ControllerClient, cr *enterpriseApi.Lic
 		if err != nil {
 			return result, err
 		}
+
+		// If this is the last of its kind getting deleted,
+		// remove the entry for this CR type from configMap
+		if len(cr.Spec.AppFrameworkConfig.AppSources) != 0 {
+			err = UpdateOrRemoveEntryFromConfigMap(client, cr, SplunkLicenseMaster)
+			if err != nil {
+				return result, err
+			}
+		}
+
 		DeleteOwnerReferencesForResources(client, cr, nil)
 		terminating, err := splctrl.CheckForDeletion(cr, client)
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after
@@ -147,4 +158,25 @@ func validateLicenseMasterSpec(cr *enterpriseApi.LicenseMaster) error {
 	}
 
 	return validateCommonSplunkSpec(&cr.Spec.CommonSplunkSpec)
+}
+
+// helper function to get the list of LicenseMaster types in the current namespace
+func getLicenseMasterList(c splcommon.ControllerClient, cr splcommon.MetaObject, listOpts []client.ListOption) (int, error) {
+	scopedLog := log.WithName("getLicenseMasterList").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
+
+	objectList := enterpriseApi.LicenseMasterList{}
+
+	err := c.List(context.TODO(), &objectList, listOpts...)
+	numOfObjects := len(objectList.Items)
+
+	if err != nil || numOfObjects == 0 {
+		scopedLog.Error(err, "LicenseMaster types not found in namespace", "namsespace", cr.GetNamespace())
+		return numOfObjects, err
+	}
+	if numOfObjects == 0 {
+		scopedLog.Error(err, "No LicenseMaster types found in namespace %s", cr.GetNamespace())
+		return numOfObjects, nil
+	}
+
+	return numOfObjects, nil
 }

--- a/pkg/splunk/enterprise/licensemaster_test.go
+++ b/pkg/splunk/enterprise/licensemaster_test.go
@@ -518,6 +518,89 @@ func TestLicenseMasterGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
 	}
 }
 
+func TestApplyLicenseMasterDeletion(t *testing.T) {
+	lm := enterpriseApi.LicenseMaster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stack1",
+			Namespace: "test",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "LicenseMaster",
+		},
+		Spec: enterpriseApi.LicenseMasterSpec{
+			AppFrameworkConfig: enterpriseApi.AppFrameworkSpec{
+				AppsRepoPollInterval: 0,
+				VolList: []enterpriseApi.VolumeSpec{
+					{Name: "msos_s2s3_vol",
+						Endpoint:  "https://s3-eu-west-2.amazonaws.com",
+						Path:      "testbucket-rs-london",
+						SecretRef: "s3-secret",
+						Type:      "s3",
+						Provider:  "aws"},
+				},
+				AppSources: []enterpriseApi.AppSourceSpec{
+					{Name: "adminApps",
+						Location: "adminAppsRepo",
+						AppSourceDefaultSpec: enterpriseApi.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   enterpriseApi.ScopeLocal},
+					},
+					{Name: "securityApps",
+						Location: "securityAppsRepo",
+						AppSourceDefaultSpec: enterpriseApi.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   enterpriseApi.ScopeLocal},
+					},
+					{Name: "authenticationApps",
+						Location: "authenticationAppsRepo",
+						AppSourceDefaultSpec: enterpriseApi.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   enterpriseApi.ScopeLocal},
+					},
+				},
+			},
+			CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
+				Mock: true,
+			},
+		},
+	}
+
+	c := spltest.NewMockClient()
+
+	// Create S3 secret
+	s3Secret := spltest.GetMockS3SecretKeys("s3-secret")
+
+	c.AddObject(&s3Secret)
+
+	// Create namespace scoped secret
+	_, err := splutil.ApplyNamespaceScopedSecretObject(c, "test")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	// test deletion
+	currentTime := metav1.NewTime(time.Now())
+	lm.ObjectMeta.DeletionTimestamp = &currentTime
+	lm.ObjectMeta.Finalizers = []string{"enterprise.splunk.com/delete-pvc"}
+
+	pvclist := corev1.PersistentVolumeClaimList{
+		Items: []corev1.PersistentVolumeClaim{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "splunk-pvc-stack1-var",
+					Namespace: "test",
+				},
+			},
+		},
+	}
+	c.ListObj = &pvclist
+
+	_, err = ApplyLicenseMaster(c, &lm)
+	if err != nil {
+		t.Errorf("ApplyLicenseMaster should not have returned error here.")
+	}
+}
+
 func TestGetLicenseMasterList(t *testing.T) {
 	lm := enterpriseApi.LicenseMaster{}
 
@@ -527,12 +610,18 @@ func TestGetLicenseMasterList(t *testing.T) {
 
 	client := spltest.NewMockClient()
 
+	// Invalid scenario since we haven't added license master to the list yet
+	numOfObjects, err := getStandaloneList(client, &lm, listOpts)
+	if err == nil {
+		t.Errorf("getNumOfObjects should have returned error as we haven't added standalone to the list yet")
+	}
+
 	lmList := &enterpriseApi.LicenseMasterList{}
 	lmList.Items = append(lmList.Items, lm)
 
 	client.ListObj = lmList
 
-	numOfObjects, err := getLicenseMasterList(client, &lm, listOpts)
+	numOfObjects, err = getLicenseMasterList(client, &lm, listOpts)
 	if err != nil {
 		t.Errorf("getNumOfObjects should not have returned error=%v", err)
 	}

--- a/pkg/splunk/enterprise/licensemaster_test.go
+++ b/pkg/splunk/enterprise/licensemaster_test.go
@@ -611,7 +611,7 @@ func TestGetLicenseMasterList(t *testing.T) {
 	client := spltest.NewMockClient()
 
 	// Invalid scenario since we haven't added license master to the list yet
-	numOfObjects, err := getStandaloneList(client, &lm, listOpts)
+	numOfObjects, err := getLicenseMasterList(client, &lm, listOpts)
 	if err == nil {
 		t.Errorf("getNumOfObjects should have returned error as we haven't added standalone to the list yet")
 	}

--- a/pkg/splunk/enterprise/licensemaster_test.go
+++ b/pkg/splunk/enterprise/licensemaster_test.go
@@ -140,6 +140,9 @@ func TestAppFrameworkApplyLicenseMasterShouldNotFail(t *testing.T) {
 			Name:      "stack1",
 			Namespace: "test",
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "LicenseMaster",
+		},
 		Spec: enterpriseApi.LicenseMasterSpec{
 			AppFrameworkConfig: enterpriseApi.AppFrameworkSpec{
 				VolList: []enterpriseApi.VolumeSpec{
@@ -512,5 +515,29 @@ func TestLicenseMasterGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
 	_, err = s3ClientMgr.GetAppsList()
 	if err == nil {
 		t.Errorf("GetAppsList should have returned error as we have empty objects in MockAWSS3Client")
+	}
+}
+
+func TestGetLicenseMasterList(t *testing.T) {
+	lm := enterpriseApi.LicenseMaster{}
+
+	listOpts := []client.ListOption{
+		client.InNamespace("test"),
+	}
+
+	client := spltest.NewMockClient()
+
+	lmList := &enterpriseApi.LicenseMasterList{}
+	lmList.Items = append(lmList.Items, lm)
+
+	client.ListObj = lmList
+
+	numOfObjects, err := getLicenseMasterList(client, &lm, listOpts)
+	if err != nil {
+		t.Errorf("getNumOfObjects should not have returned error=%v", err)
+	}
+
+	if numOfObjects != 1 {
+		t.Errorf("Got wrong number of LicenseMaster objects. Expected=%d, Got=%d", 1, numOfObjects)
 	}
 }

--- a/pkg/splunk/enterprise/names.go
+++ b/pkg/splunk/enterprise/names.go
@@ -68,6 +68,10 @@ const (
 	// Pod location for app related config
 	appConfLocationOnPod = "/mnt/app-listing/"
 
+	manualAppUpdateCM = "splunk-manual-app-update"
+
+	manualAppUpdateRev = "manualAppUpdateRev"
+
 	// command merger
 	commandMerger = " && "
 
@@ -165,6 +169,11 @@ func GetSplunkSmartstoreConfigMapName(identifier string, crKind string) string {
 // GetSplunkAppsConfigMapName uses a template to name a Kubernetes ConfigMap for a SplunkEnterprise resource.
 func GetSplunkAppsConfigMapName(identifier string, crKind string) string {
 	return fmt.Sprintf(appListingTemplateStr, identifier, strings.ToLower(crKind))
+}
+
+// GetSplunkManualAppUpdateConfigMapName returns the manual app update configMap name
+func GetSplunkManualAppUpdateConfigMapName() string {
+	return manualAppUpdateCM
 }
 
 // GetSplunkStatefulsetUrls returns a list of fully qualified domain names for all pods within a Splunk StatefulSet.

--- a/pkg/splunk/enterprise/names.go
+++ b/pkg/splunk/enterprise/names.go
@@ -68,7 +68,7 @@ const (
 	// Pod location for app related config
 	appConfLocationOnPod = "/mnt/app-listing/"
 
-	manualAppUpdateCM = "splunk-manual-app-update"
+	manualAppUpdateCMStr = "splunk-%s-manual-app-update"
 
 	// command merger
 	commandMerger = " && "
@@ -169,9 +169,9 @@ func GetSplunkAppsConfigMapName(identifier string, crKind string) string {
 	return fmt.Sprintf(appListingTemplateStr, identifier, strings.ToLower(crKind))
 }
 
-// GetSplunkManualAppUpdateConfigMapName returns the manual app update configMap name
-func GetSplunkManualAppUpdateConfigMapName() string {
-	return manualAppUpdateCM
+// GetSplunkManualAppUpdateConfigMapName returns the manual app update configMap name for that namespace
+func GetSplunkManualAppUpdateConfigMapName(namespace string) string {
+	return fmt.Sprintf(manualAppUpdateCMStr, namespace)
 }
 
 // GetSplunkStatefulsetUrls returns a list of fully qualified domain names for all pods within a Splunk StatefulSet.

--- a/pkg/splunk/enterprise/names.go
+++ b/pkg/splunk/enterprise/names.go
@@ -70,8 +70,6 @@ const (
 
 	manualAppUpdateCM = "splunk-manual-app-update"
 
-	manualAppUpdateRev = "manualAppUpdateRev"
-
 	// command merger
 	commandMerger = " && "
 

--- a/pkg/splunk/enterprise/searchheadcluster.go
+++ b/pkg/splunk/enterprise/searchheadcluster.go
@@ -579,7 +579,7 @@ func getSearchHeadClusterList(c splcommon.ControllerClient, cr splcommon.MetaObj
 	err := c.List(context.TODO(), &objectList, listOpts...)
 	numOfObjects := len(objectList.Items)
 
-	if err != nil || numOfObjects == 0 {
+	if err != nil {
 		scopedLog.Error(err, "SearchHeadCluster types not found in namespace", "namsespace", cr.GetNamespace())
 		return numOfObjects, err
 	}

--- a/pkg/splunk/enterprise/searchheadcluster.go
+++ b/pkg/splunk/enterprise/searchheadcluster.go
@@ -98,7 +98,8 @@ func ApplySearchHeadCluster(client splcommon.ControllerClient, cr *enterpriseApi
 		}
 
 		// If this is the last of its kind getting deleted,
-		// remove the entry for this CR type from configMap
+		// remove the entry for this CR type from configMap or else
+		// just decrement the refCount for this CR type.
 		if len(cr.Spec.AppFrameworkConfig.AppSources) != 0 {
 			err = UpdateOrRemoveEntryFromConfigMap(client, cr, SplunkSearchHead)
 			if err != nil {

--- a/pkg/splunk/enterprise/searchheadcluster.go
+++ b/pkg/splunk/enterprise/searchheadcluster.go
@@ -583,10 +583,6 @@ func getSearchHeadClusterList(c splcommon.ControllerClient, cr splcommon.MetaObj
 		scopedLog.Error(err, "SearchHeadCluster types not found in namespace", "namsespace", cr.GetNamespace())
 		return numOfObjects, err
 	}
-	if numOfObjects == 0 {
-		scopedLog.Error(err, "No SearchHeadCluster types found in namespace %s", cr.GetNamespace())
-		return numOfObjects, nil
-	}
 
 	return numOfObjects, nil
 }

--- a/pkg/splunk/enterprise/searchheadcluster_test.go
+++ b/pkg/splunk/enterprise/searchheadcluster_test.go
@@ -1104,7 +1104,7 @@ func TestGetSearchHeadClusterList(t *testing.T) {
 	client := spltest.NewMockClient()
 
 	// Invalid scenario since we haven't added shc to the list yet
-	numOfObjects, err := getStandaloneList(client, &shc, listOpts)
+	numOfObjects, err := getSearchHeadClusterList(client, &shc, listOpts)
 	if err == nil {
 		t.Errorf("getNumOfObjects should have returned error as we haven't added shc to the list yet")
 	}

--- a/pkg/splunk/enterprise/searchheadcluster_test.go
+++ b/pkg/splunk/enterprise/searchheadcluster_test.go
@@ -632,6 +632,9 @@ func TestAppFrameworkSearchHeadClusterShouldNotFail(t *testing.T) {
 			Name:      "stack1",
 			Namespace: "test",
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "SearchHeadCluster",
+		},
 		Spec: enterpriseApi.SearchHeadClusterSpec{
 			Replicas: 3,
 			AppFrameworkConfig: enterpriseApi.AppFrameworkSpec{
@@ -1005,5 +1008,29 @@ func TestSHCGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
 	_, err = s3ClientMgr.GetAppsList()
 	if err == nil {
 		t.Errorf("GetAppsList should have returned error as we have empty objects in MockAWSS3Client")
+	}
+}
+
+func TestGetSearchHeadClusterList(t *testing.T) {
+	shc := enterpriseApi.SearchHeadCluster{}
+
+	listOpts := []client.ListOption{
+		client.InNamespace("test"),
+	}
+
+	client := spltest.NewMockClient()
+
+	shcList := &enterpriseApi.SearchHeadClusterList{}
+	shcList.Items = append(shcList.Items, shc)
+
+	client.ListObj = shcList
+
+	numOfObjects, err := getSearchHeadClusterList(client, &shc, listOpts)
+	if err != nil {
+		t.Errorf("getNumOfObjects should not have returned error=%v", err)
+	}
+
+	if numOfObjects != 1 {
+		t.Errorf("Got wrong number of SearchHeadCluster objects. Expected=%d, Got=%d", 1, numOfObjects)
 	}
 }

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -22,6 +22,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	enterpriseApi "github.com/splunk/splunk-operator/pkg/apis/enterprise/v2"
@@ -99,6 +100,15 @@ func ApplyStandalone(client splcommon.ControllerClient, cr *enterpriseApi.Standa
 		err = ApplyMonitoringConsole(client, cr, cr.Spec.CommonSplunkSpec, getStandaloneExtraEnv(cr, cr.Spec.Replicas))
 		if err != nil {
 			return result, err
+		}
+
+		// If this is the last of its kind getting deleted,
+		// remove the entry for this CR type from configMap
+		if len(cr.Spec.AppFrameworkConfig.AppSources) != 0 {
+			err = UpdateOrRemoveEntryFromConfigMap(client, cr, SplunkStandalone)
+			if err != nil {
+				return result, err
+			}
 		}
 
 		DeleteOwnerReferencesForResources(client, cr, &cr.Spec.SmartStore)
@@ -228,4 +238,25 @@ func validateStandaloneSpec(cr *enterpriseApi.Standalone) error {
 	}
 
 	return validateCommonSplunkSpec(&cr.Spec.CommonSplunkSpec)
+}
+
+// helper function to get the list of Standalone types in the current namespace
+func getStandaloneList(c splcommon.ControllerClient, cr splcommon.MetaObject, listOpts []client.ListOption) (int, error) {
+	scopedLog := log.WithName("getStandaloneList").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
+
+	objectList := enterpriseApi.StandaloneList{}
+
+	err := c.List(context.TODO(), &objectList, listOpts...)
+	numOfObjects := len(objectList.Items)
+
+	if err != nil {
+		scopedLog.Error(err, "Standalone types not found in namespace", "namsespace", cr.GetNamespace())
+		return numOfObjects, err
+	}
+	if numOfObjects == 0 {
+		scopedLog.Error(err, "No Standalone types found in namespace %s", cr.GetNamespace())
+		return numOfObjects, nil
+	}
+
+	return numOfObjects, nil
 }

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -249,7 +249,7 @@ func getStandaloneList(c splcommon.ControllerClient, cr splcommon.MetaObject, li
 	err := c.List(context.TODO(), &objectList, listOpts...)
 	numOfObjects := len(objectList.Items)
 
-	if err != nil || numOfObjects == 0 {
+	if err != nil {
 		scopedLog.Error(err, "Standalone types not found in namespace", "namsespace", cr.GetNamespace())
 		return numOfObjects, err
 	}

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -103,7 +103,8 @@ func ApplyStandalone(client splcommon.ControllerClient, cr *enterpriseApi.Standa
 		}
 
 		// If this is the last of its kind getting deleted,
-		// remove the entry for this CR type from configMap
+		// remove the entry for this CR type from configMap or else
+		// just decrement the refCount for this CR type.
 		if len(cr.Spec.AppFrameworkConfig.AppSources) != 0 {
 			err = UpdateOrRemoveEntryFromConfigMap(client, cr, SplunkStandalone)
 			if err != nil {

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -249,13 +249,9 @@ func getStandaloneList(c splcommon.ControllerClient, cr splcommon.MetaObject, li
 	err := c.List(context.TODO(), &objectList, listOpts...)
 	numOfObjects := len(objectList.Items)
 
-	if err != nil {
+	if err != nil || numOfObjects == 0 {
 		scopedLog.Error(err, "Standalone types not found in namespace", "namsespace", cr.GetNamespace())
 		return numOfObjects, err
-	}
-	if numOfObjects == 0 {
-		scopedLog.Error(err, "No Standalone types found in namespace %s", cr.GetNamespace())
-		return numOfObjects, nil
 	}
 
 	return numOfObjects, nil

--- a/pkg/splunk/enterprise/standalone_test.go
+++ b/pkg/splunk/enterprise/standalone_test.go
@@ -312,6 +312,9 @@ func TestAppFrameworkApplyStandaloneShouldNotFail(t *testing.T) {
 			Name:      "standalone",
 			Namespace: "test",
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Standalone",
+		},
 		Spec: enterpriseApi.StandaloneSpec{
 			Replicas: 1,
 			AppFrameworkConfig: enterpriseApi.AppFrameworkSpec{
@@ -366,6 +369,9 @@ func TestAppFrameworkApplyStandaloneScalingUpShouldNotFail(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "standalone",
 			Namespace: "test",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Standalone",
 		},
 		Spec: enterpriseApi.StandaloneSpec{
 			Replicas: 1,
@@ -743,5 +749,29 @@ func TestStandlaoneGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
 	_, err = s3ClientMgr.GetAppsList()
 	if err == nil {
 		t.Errorf("GetAppsList should have returned error as we have empty objects in MockAWSS3Client")
+	}
+}
+
+func TestGetStandaloneList(t *testing.T) {
+	standalone := enterpriseApi.Standalone{}
+
+	listOpts := []client.ListOption{
+		client.InNamespace("test"),
+	}
+
+	client := spltest.NewMockClient()
+
+	standaloneList := &enterpriseApi.StandaloneList{}
+	standaloneList.Items = append(standaloneList.Items, standalone)
+
+	client.ListObj = standaloneList
+
+	numOfObjects, err := getStandaloneList(client, &standalone, listOpts)
+	if err != nil {
+		t.Errorf("getNumOfObjects should not have returned error=%v", err)
+	}
+
+	if numOfObjects != 1 {
+		t.Errorf("Got wrong number of standalone objects. Expected=%d, Got=%d", 1, numOfObjects)
 	}
 }

--- a/pkg/splunk/enterprise/standalone_test.go
+++ b/pkg/splunk/enterprise/standalone_test.go
@@ -752,6 +752,89 @@ func TestStandlaoneGetAppsListForAWSS3ClientShouldFail(t *testing.T) {
 	}
 }
 
+func TestApplyStandaloneDeletion(t *testing.T) {
+	stand1 := enterpriseApi.Standalone{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stack1",
+			Namespace: "test",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Standalone",
+		},
+		Spec: enterpriseApi.StandaloneSpec{
+			AppFrameworkConfig: enterpriseApi.AppFrameworkSpec{
+				AppsRepoPollInterval: 0,
+				VolList: []enterpriseApi.VolumeSpec{
+					{Name: "msos_s2s3_vol",
+						Endpoint:  "https://s3-eu-west-2.amazonaws.com",
+						Path:      "testbucket-rs-london",
+						SecretRef: "s3-secret",
+						Type:      "s3",
+						Provider:  "aws"},
+				},
+				AppSources: []enterpriseApi.AppSourceSpec{
+					{Name: "adminApps",
+						Location: "adminAppsRepo",
+						AppSourceDefaultSpec: enterpriseApi.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   enterpriseApi.ScopeLocal},
+					},
+					{Name: "securityApps",
+						Location: "securityAppsRepo",
+						AppSourceDefaultSpec: enterpriseApi.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   enterpriseApi.ScopeLocal},
+					},
+					{Name: "authenticationApps",
+						Location: "authenticationAppsRepo",
+						AppSourceDefaultSpec: enterpriseApi.AppSourceDefaultSpec{
+							VolName: "msos_s2s3_vol",
+							Scope:   enterpriseApi.ScopeLocal},
+					},
+				},
+			},
+			CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
+				Mock: true,
+			},
+		},
+	}
+
+	c := spltest.NewMockClient()
+
+	// Create S3 secret
+	s3Secret := spltest.GetMockS3SecretKeys("s3-secret")
+
+	c.AddObject(&s3Secret)
+
+	// Create namespace scoped secret
+	_, err := splutil.ApplyNamespaceScopedSecretObject(c, "test")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	// test deletion
+	currentTime := metav1.NewTime(time.Now())
+	stand1.ObjectMeta.DeletionTimestamp = &currentTime
+	stand1.ObjectMeta.Finalizers = []string{"enterprise.splunk.com/delete-pvc"}
+
+	pvclist := corev1.PersistentVolumeClaimList{
+		Items: []corev1.PersistentVolumeClaim{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "splunk-pvc-stack1-var",
+					Namespace: "test",
+				},
+			},
+		},
+	}
+	c.ListObj = &pvclist
+
+	_, err = ApplyStandalone(c, &stand1)
+	if err != nil {
+		t.Errorf("ApplyStandalone should not have returned error here.")
+	}
+}
+
 func TestGetStandaloneList(t *testing.T) {
 	standalone := enterpriseApi.Standalone{}
 
@@ -761,12 +844,18 @@ func TestGetStandaloneList(t *testing.T) {
 
 	client := spltest.NewMockClient()
 
+	// Invalid scenario since we haven't added standalone to the list yet
+	numOfObjects, err := getStandaloneList(client, &standalone, listOpts)
+	if err == nil {
+		t.Errorf("getNumOfObjects should have returned error as we haven't added standalone to the list yet")
+	}
+
 	standaloneList := &enterpriseApi.StandaloneList{}
 	standaloneList.Items = append(standaloneList.Items, standalone)
 
 	client.ListObj = standaloneList
 
-	numOfObjects, err := getStandaloneList(client, &standalone, listOpts)
+	numOfObjects, err = getStandaloneList(client, &standalone, listOpts)
 	if err != nil {
 		t.Errorf("getNumOfObjects should not have returned error=%v", err)
 	}

--- a/pkg/splunk/enterprise/types.go
+++ b/pkg/splunk/enterprise/types.go
@@ -88,3 +88,21 @@ func (instanceType InstanceType) ToKind() string {
 	}
 	return kind
 }
+
+// ToInstanceType returns instanceType based on kind
+func ToInstanceType(kind string) InstanceType {
+	var instanceType InstanceType
+	switch kind {
+	case "Standalone":
+		instanceType = SplunkStandalone
+	case "ClusterMaster":
+		instanceType = SplunkClusterMaster
+	case "LicenseMaster":
+		instanceType = SplunkLicenseMaster
+	case "IndexerCluster":
+		instanceType = SplunkIndexer
+	case "SearchHeadCluster":
+		instanceType = SplunkSearchHead
+	}
+	return instanceType
+}

--- a/pkg/splunk/enterprise/types.go
+++ b/pkg/splunk/enterprise/types.go
@@ -88,21 +88,3 @@ func (instanceType InstanceType) ToKind() string {
 	}
 	return kind
 }
-
-// ToInstanceType returns instanceType based on kind
-func ToInstanceType(kind string) InstanceType {
-	var instanceType InstanceType
-	switch kind {
-	case "Standalone":
-		instanceType = SplunkStandalone
-	case "ClusterMaster":
-		instanceType = SplunkClusterMaster
-	case "LicenseMaster":
-		instanceType = SplunkLicenseMaster
-	case "IndexerCluster":
-		instanceType = SplunkIndexer
-	case "SearchHeadCluster":
-		instanceType = SplunkSearchHead
-	}
-	return instanceType
-}

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -25,6 +25,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	enterpriseApi "github.com/splunk/splunk-operator/pkg/apis/enterprise/v2"
@@ -949,6 +950,39 @@ func GetNextRequeueTime(appRepoPollInterval, lastCheckTime int64) time.Duration 
 	return time.Second * (time.Duration(nextRequeueTimeInSec))
 }
 
+// isAppRepoPollingEnabled checks whether automatic polling for apps repo changes
+// is enabled or not. If the value is 0, then we fallback to on-demand polling of apps
+// repo changes.
+func isAppRepoPollingEnabled(appStatusContext *enterpriseApi.AppDeploymentContext) bool {
+	return appStatusContext.AppsRepoStatusPollInterval != 0
+}
+
+func shouldCheckAppRepoStatus(client splcommon.ControllerClient, cr splcommon.MetaObject, appStatusContext *enterpriseApi.AppDeploymentContext, kind string, turnOffManualChecking *bool) bool {
+	scopedLog := log.WithName("shouldCheckAppRepoStatus").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
+	if !isAppRepoPollingEnabled(appStatusContext) {
+		// check if manual app checking flag is turned on for this CR kind
+		namespacedName := types.NamespacedName{Namespace: cr.GetNamespace(), Name: GetSplunkManualAppUpdateConfigMapName()}
+		configMap, err := splctrl.GetConfigMap(client, namespacedName)
+		if err != nil {
+			scopedLog.Error(err, "Unable to get the configMap", "name", namespacedName.Name)
+			return false
+		}
+
+		// Check if we need to manually check for app updates for this CR kind
+		if getManualUpdateStatus(configMap.Data[kind]) == "on" {
+			// There can be more than 1 CRs of this kind. We should only
+			// turn off the status once all the CRs have finished the reconciles
+			if getManualUpdateRefCount(configMap.Data[kind]) == "1" {
+				*turnOffManualChecking = true
+			}
+			return true
+		}
+	} else {
+		return HasAppRepoCheckTimerExpired(appStatusContext)
+	}
+	return false
+}
+
 // initAndCheckAppInfoStatus initializes the S3Clients and checks the status of apps on remote storage.
 func initAndCheckAppInfoStatus(client splcommon.ControllerClient, cr splcommon.MetaObject, appFrameworkConf *enterpriseApi.AppFrameworkSpec, appStatusContext *enterpriseApi.AppDeploymentContext) error {
 	scopedLog := log.WithName("initAndCheckAppInfoStatus").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
@@ -958,10 +992,16 @@ func initAndCheckAppInfoStatus(client splcommon.ControllerClient, cr splcommon.M
 	// This is done to prevent the null pointer dereference in case when
 	// operator crashes and comes back up and the status of app context was updated
 	// to match the spec in the previous run.
-	initAppFrameWorkContext(appFrameworkConf, appStatusContext)
+	err = initAppFrameWorkContext(client, cr, appFrameworkConf, appStatusContext)
+	if err != nil {
+		scopedLog.Error(err, "Unable initialize app framework")
+		return err
+	}
 
+	var turnOffManualChecking bool
+	kind := cr.GetObjectKind().GroupVersionKind().Kind
 	//check if the apps need to be downloaded from remote storage
-	if HasAppRepoCheckTimerExpired(appStatusContext) || !reflect.DeepEqual(appStatusContext.AppFrameworkConfig, *appFrameworkConf) {
+	if shouldCheckAppRepoStatus(client, cr, appStatusContext, kind, &turnOffManualChecking) || !reflect.DeepEqual(appStatusContext.AppFrameworkConfig, *appFrameworkConf) {
 		var sourceToAppsList map[string]splclient.S3Response
 
 		scopedLog.Info("Checking status of apps on remote storage...")
@@ -993,9 +1033,159 @@ func initAndCheckAppInfoStatus(client splcommon.ControllerClient, cr splcommon.M
 			appStatusContext.AppFrameworkConfig = *appFrameworkConf
 		}
 
-		// set the last check time to current time
-		SetLastAppInfoCheckTime(appStatusContext)
+		// set the last check time to current time only if the polling is enabled
+		if isAppRepoPollingEnabled(appStatusContext) {
+			SetLastAppInfoCheckTime(appStatusContext)
+		} else {
+			var status string
+			namespacedName := types.NamespacedName{Namespace: cr.GetNamespace(), Name: GetSplunkManualAppUpdateConfigMapName()}
+			configMap, err := splctrl.GetConfigMap(client, namespacedName)
+			if err != nil {
+				scopedLog.Error(err, "Unable to get configMap", "name", namespacedName.Name)
+				return err
+			}
+
+			// reset the LastAppInfoCheckTime to 0 so that we don't reconcile again and poll for apps status
+			appStatusContext.LastAppInfoCheckTime = 0
+
+			numOfObjects := getNumOfOwnerRefsKind(configMap, kind)
+
+			// turn off the manual checking for this CR kind in the configMap
+			if turnOffManualChecking == true {
+				scopedLog.Info("Turning off manual checking of apps update", "Kind", kind)
+				status = "off"
+			} else {
+				//just decrement the refCount if the status is "on"
+				status = getManualUpdateStatus(configMap.Data[kind])
+				if status == "on" {
+					numOfObjects--
+				}
+			}
+
+			// prepare the configMapData
+			configMapData := fmt.Sprintf(`status: %s
+refCount: %d`, status, numOfObjects)
+
+			configMap.Data[kind] = configMapData
+
+			err = splutil.UpdateResource(client, configMap)
+			if err != nil {
+				scopedLog.Error(err, "Could not update the configMap", "name", namespacedName.Name)
+				return err
+			}
+		}
 	}
 
 	return nil
+}
+
+// SetConfigMapOwnerRef sets the owner references for the configMap
+func SetConfigMapOwnerRef(client splcommon.ControllerClient, cr splcommon.MetaObject, configMap *corev1.ConfigMap) error {
+	scopedLog := log.WithName("SetConfigMapOwnerRef").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
+
+	currentOwnerRef := configMap.GetOwnerReferences()
+	// Check if owner ref exists
+	for i := 0; i < len(currentOwnerRef); i++ {
+		if reflect.DeepEqual(currentOwnerRef[i], splcommon.AsOwner(cr, false)) {
+			return nil
+		}
+	}
+
+	// Owner ref doesn't exist, update configMap with owner references
+	configMap.SetOwnerReferences(append(configMap.GetOwnerReferences(), splcommon.AsOwner(cr, false)))
+
+	// Update the configMap now
+	err := splutil.UpdateResource(client, configMap)
+	if err != nil {
+		scopedLog.Error(err, "Unable to update configMap", "name", configMap.Name)
+		return err
+	}
+
+	return nil
+
+}
+
+func getNumOfOwnerRefsKind(configMap *corev1.ConfigMap, kind string) int {
+	var numOfObjects int
+	currentOwnerRefs := configMap.GetOwnerReferences()
+	// Get the nubmer of owners of this kind
+	for i := 0; i < len(currentOwnerRefs); i++ {
+		if currentOwnerRefs[i].Kind == kind {
+			numOfObjects++
+		}
+	}
+	return numOfObjects
+}
+
+// UpdateOrRemoveEntryFromConfigMap removes the entry for the CR type from the manual app update configMap
+func UpdateOrRemoveEntryFromConfigMap(c splcommon.ControllerClient, cr splcommon.MetaObject, instanceType InstanceType) error {
+	scopedLog := log.WithName("UpdateOrRemoveEntryFromConfigMap").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
+
+	namespacedName := types.NamespacedName{Namespace: cr.GetNamespace(), Name: GetSplunkManualAppUpdateConfigMapName()}
+	configMap, err := splctrl.GetConfigMap(c, namespacedName)
+	if err != nil {
+		scopedLog.Error(err, "Unable to get config map", "name", namespacedName.Name)
+		return err
+	}
+
+	kind := cr.GetObjectKind().GroupVersionKind().Kind
+
+	numOfObjects := getNumOfOwnerRefsKind(configMap, kind)
+	if numOfObjects == 0 {
+		err = fmt.Errorf("Error getting objects for this type: %s", instanceType.ToString())
+		return err
+	}
+
+	// if this is the last of its kind, remove its entry from the config map
+	if numOfObjects == 1 {
+		delete(configMap.Data, kind)
+	} else {
+		// just decrement the refCount in the configMap
+		numOfObjects--
+
+		configMapData := fmt.Sprintf(`status: %s
+refCount: %d`, getManualUpdateStatus(configMap.Data[kind]), numOfObjects)
+
+		configMap.Data[kind] = configMapData
+	}
+
+	// Update configMap now
+	err = splutil.UpdateResource(c, configMap)
+	if err != nil {
+		scopedLog.Error(err, "Unable to update configMap", "name", namespacedName.Name)
+		return err
+	}
+
+	return nil
+}
+
+// RemoveConfigMapOwnerRef removes the owner references for the configMap
+func RemoveConfigMapOwnerRef(client splcommon.ControllerClient, cr splcommon.MetaObject, configMapName string) (uint, error) {
+	var err error
+	var refCount uint = 0
+
+	namespacedName := types.NamespacedName{Namespace: cr.GetNamespace(), Name: configMapName}
+	configMap, err := splctrl.GetConfigMap(client, namespacedName)
+	if err != nil {
+		return 0, err
+	}
+
+	ownerRef := configMap.GetOwnerReferences()
+	for i := 0; i < len(ownerRef); i++ {
+		if reflect.DeepEqual(ownerRef[i], splcommon.AsOwner(cr, false)) {
+			ownerRef = append(ownerRef[:i], ownerRef[i+1:]...)
+			refCount++
+		}
+	}
+
+	// Update the modified owner reference list
+	if refCount > 0 {
+		configMap.SetOwnerReferences(ownerRef)
+		err = splutil.UpdateResource(client, configMap)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	return refCount, nil
 }

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -1000,6 +1000,7 @@ func initAndCheckAppInfoStatus(client splcommon.ControllerClient, cr splcommon.M
 
 	var turnOffManualChecking bool
 	kind := cr.GetObjectKind().GroupVersionKind().Kind
+
 	//check if the apps need to be downloaded from remote storage
 	if shouldCheckAppRepoStatus(client, cr, appStatusContext, kind, &turnOffManualChecking) || !reflect.DeepEqual(appStatusContext.AppFrameworkConfig, *appFrameworkConf) {
 		var sourceToAppsList map[string]splclient.S3Response

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -972,7 +972,7 @@ func shouldCheckAppRepoStatus(client splcommon.ControllerClient, cr splcommon.Me
 		if getManualUpdateStatus(configMap.Data[kind]) == "on" {
 			// There can be more than 1 CRs of this kind. We should only
 			// turn off the status once all the CRs have finished the reconciles
-			if getManualUpdateRefCount(configMap.Data[kind]) == "1" {
+			if getManualUpdateRefCount(configMap.Data[kind]) == 1 {
 				*turnOffManualChecking = true
 			}
 			return true
@@ -1049,12 +1049,15 @@ func initAndCheckAppInfoStatus(client splcommon.ControllerClient, cr splcommon.M
 			// reset the LastAppInfoCheckTime to 0 so that we don't reconcile again and poll for apps status
 			appStatusContext.LastAppInfoCheckTime = 0
 
-			numOfObjects := getNumOfOwnerRefsKind(configMap, kind)
+			numOfObjects := getManualUpdateRefCount(configMap.Data[kind])
 
 			// turn off the manual checking for this CR kind in the configMap
 			if turnOffManualChecking == true {
 				scopedLog.Info("Turning off manual checking of apps update", "Kind", kind)
+				// reset the status back to "off" and
+				// refCount to original count
 				status = "off"
+				numOfObjects = getNumOfOwnerRefsKind(configMap, kind)
 			} else {
 				//just decrement the refCount if the status is "on"
 				status = getManualUpdateStatus(configMap.Data[kind])

--- a/pkg/splunk/enterprise/util_test.go
+++ b/pkg/splunk/enterprise/util_test.go
@@ -530,7 +530,7 @@ func TestInitAndCheckAppInfoStatusShouldNotFail(t *testing.T) {
 	kind := cr.GetObjectKind().GroupVersionKind().Kind
 
 	// check the status and refCount first time
-	if getManualUpdateRefCount(configMap.Data[kind]) != "1" || getManualUpdateStatus(configMap.Data[kind]) != "off" {
+	if getManualUpdateRefCount(configMap.Data[kind]) != 1 || getManualUpdateStatus(configMap.Data[kind]) != "off" {
 		t.Errorf("Got wrong status or/and refCount")
 	}
 
@@ -547,7 +547,7 @@ func TestInitAndCheckAppInfoStatusShouldNotFail(t *testing.T) {
 	}
 
 	// check the status and refCount second time. We should have turned off manual update now.
-	if getManualUpdateRefCount(configMap.Data[kind]) != "2" || getManualUpdateStatus(configMap.Data[kind]) != "off" {
+	if getManualUpdateRefCount(configMap.Data[kind]) != 2 || getManualUpdateStatus(configMap.Data[kind]) != "off" {
 		t.Errorf("Got wrong status or/and refCount")
 	}
 
@@ -583,7 +583,7 @@ func TestInitAndCheckAppInfoStatusShouldNotFail(t *testing.T) {
 	}
 
 	// check the status and refCount second time. We should have turned off manual update now.
-	if getManualUpdateRefCount(configMap.Data[kind]) != "1" || getManualUpdateStatus(configMap.Data[kind]) != "on" {
+	if getManualUpdateRefCount(configMap.Data[kind]) != 1 || getManualUpdateStatus(configMap.Data[kind]) != "on" {
 		t.Errorf("Got wrong status or/and refCount")
 	}
 
@@ -593,7 +593,7 @@ func TestInitAndCheckAppInfoStatusShouldNotFail(t *testing.T) {
 	}
 
 	// check the status and refCount second time. We should have turned off manual update now.
-	if getManualUpdateRefCount(configMap.Data[kind]) != "2" || getManualUpdateStatus(configMap.Data[kind]) != "off" {
+	if getManualUpdateRefCount(configMap.Data[kind]) != 2 || getManualUpdateStatus(configMap.Data[kind]) != "off" {
 		t.Errorf("Got wrong status or/and refCount")
 	}
 
@@ -1126,8 +1126,8 @@ refCount: 1`)
 	}
 
 	refCount := getManualUpdateRefCount(configMap.Data[kind])
-	if refCount != "1" {
-		t.Errorf("Got wrong refCount. Expected=%d, Got=%s", 1, refCount)
+	if refCount != 1 {
+		t.Errorf("Got wrong refCount. Expected=%d, Got=%d", 1, refCount)
 	}
 
 	// remove stand2 as the configMap owner reference

--- a/pkg/splunk/enterprise/util_test.go
+++ b/pkg/splunk/enterprise/util_test.go
@@ -522,7 +522,7 @@ func TestInitAndCheckAppInfoStatusShouldNotFail(t *testing.T) {
 	}
 
 	var configMap *corev1.ConfigMap
-	configMapName := GetSplunkManualAppUpdateConfigMapName()
+	configMapName := GetSplunkManualAppUpdateConfigMapName(cr.GetNamespace())
 	namespacedName := types.NamespacedName{Namespace: cr.GetNamespace(), Name: configMapName}
 	configMap, err = splctrl.GetConfigMap(client, namespacedName)
 	if err != nil {
@@ -1024,7 +1024,7 @@ func TestShouldCheckAppRepoStatus(t *testing.T) {
 	var appStatusContext enterpriseApi.AppDeploymentContext
 	appStatusContext.AppsRepoStatusPollInterval = 0
 	var turnOffManualChecking bool
-	shouldCheck := shouldCheckAppRepoStatus(c, &cr, &cr.Spec.AppFrameworkConfig, &appStatusContext, cr.GetObjectKind().GroupVersionKind().Kind, &turnOffManualChecking)
+	shouldCheck := shouldCheckAppRepoStatus(c, &cr, &appStatusContext, cr.GetObjectKind().GroupVersionKind().Kind, &turnOffManualChecking)
 	if shouldCheck == true {
 		t.Errorf("shouldCheckAppRepoStatus should have returned false as there is no configMap yet.")
 	}
@@ -1034,9 +1034,9 @@ func TestShouldCheckAppRepoStatus(t *testing.T) {
 refCount: 1`)
 	crKindMap[cr.GetObjectKind().GroupVersionKind().Kind] = configMapData
 
-	configMap := splctrl.PrepareConfigMap(GetSplunkManualAppUpdateConfigMapName(), cr.GetNamespace(), crKindMap)
+	configMap := splctrl.PrepareConfigMap(GetSplunkManualAppUpdateConfigMapName(cr.GetNamespace()), cr.GetNamespace(), crKindMap)
 	c.AddObject(configMap)
-	shouldCheck = shouldCheckAppRepoStatus(c, &cr, &cr.Spec.AppFrameworkConfig, &appStatusContext, cr.GetObjectKind().GroupVersionKind().Kind, &turnOffManualChecking)
+	shouldCheck = shouldCheckAppRepoStatus(c, &cr, &appStatusContext, cr.GetObjectKind().GroupVersionKind().Kind, &turnOffManualChecking)
 	if shouldCheck != true {
 		t.Errorf("shouldCheckAppRepoStatus should have returned true.")
 	}
@@ -1098,7 +1098,7 @@ func TestUpdateOrRemoveEntryFromConfigMap(t *testing.T) {
 refCount: 1`)
 
 	crKindMap[kind] = configMapData
-	configMapName := GetSplunkManualAppUpdateConfigMapName()
+	configMapName := GetSplunkManualAppUpdateConfigMapName(stand1.GetNamespace())
 
 	configMap := splctrl.PrepareConfigMap(configMapName, stand1.GetNamespace(), crKindMap)
 

--- a/pkg/splunk/test/controller.go
+++ b/pkg/splunk/test/controller.go
@@ -49,14 +49,24 @@ func enterpriseObjCopier(dst, src *runtime.Object) bool {
 	switch srcP.(type) {
 	case *enterpriseApi.ClusterMaster:
 		*dstP.(*enterpriseApi.ClusterMaster) = *srcP.(*enterpriseApi.ClusterMaster)
+	case *enterpriseApi.ClusterMasterList:
+		*dstP.(*enterpriseApi.ClusterMasterList) = *srcP.(*enterpriseApi.ClusterMasterList)
 	case *enterpriseApi.IndexerCluster:
 		*dstP.(*enterpriseApi.IndexerCluster) = *srcP.(*enterpriseApi.IndexerCluster)
+	case *enterpriseApi.IndexerClusterList:
+		*dstP.(*enterpriseApi.IndexerClusterList) = *srcP.(*enterpriseApi.IndexerClusterList)
 	case *enterpriseApi.LicenseMaster:
 		*dstP.(*enterpriseApi.LicenseMaster) = *srcP.(*enterpriseApi.LicenseMaster)
+	case *enterpriseApi.LicenseMasterList:
+		*dstP.(*enterpriseApi.LicenseMasterList) = *srcP.(*enterpriseApi.LicenseMasterList)
 	case *enterpriseApi.SearchHeadCluster:
 		*dstP.(*enterpriseApi.SearchHeadCluster) = *srcP.(*enterpriseApi.SearchHeadCluster)
+	case *enterpriseApi.SearchHeadClusterList:
+		*dstP.(*enterpriseApi.SearchHeadClusterList) = *srcP.(*enterpriseApi.SearchHeadClusterList)
 	case *enterpriseApi.Standalone:
 		*dstP.(*enterpriseApi.Standalone) = *srcP.(*enterpriseApi.Standalone)
+	case *enterpriseApi.StandaloneList:
+		*dstP.(*enterpriseApi.StandaloneList) = *srcP.(*enterpriseApi.StandaloneList)
 	default:
 		return false
 	}


### PR DESCRIPTION
This PR targets the manual trigger for app update. Here are the key changes - 
1. Polling of app updates can be disabled by setting `appsRepoPollInterval=0`.
2. Now, all the CRs, with appFramework enabled, in the initial reconcile will either create a configMap(if not created) or will update the already existing configMap with the manual app update status for that CR and the refCount(i.e. the total number of CRs of that kind in the cluster in that namespace).
3. We can enable manual trigger for one time by editing the configMap and setting the `status` to `on` for that CR.
4. Once the checking for app update is done, we reset the status for that CR back to `off` again.

Here is how the configMap looks like for a ClusterMaster and a Standalone CR type - 
```
apiVersion: v1
data:
  ClusterMaster: |-
    status: off
    refCount: 1
  Standalone: |-
    status: off
    refCount: 1
kind: ConfigMap
metadata:
  creationTimestamp: "2021-08-16T23:40:06Z"
  name: splunk-manual-app-update
  namespace: default
  ownerReferences:
  - apiVersion: enterprise.splunk.com/v2
    controller: false
    kind: Standalone
    name: stand1
    uid: b1c5646b-ab53-499f-bf37-fef55118325a
  - apiVersion: enterprise.splunk.com/v2
    controller: false
    kind: ClusterMaster
    name: cm
    uid: 2f3a2671-d872-492b-9b52-9b7538d28a44
  resourceVersion: "73859037"
  selfLink: /api/v1/namespaces/default/configmaps/splunk-manual-app-update
  uid: c25d86b1-746b-47c0-b5f2-8319e2ad6e46
```

Current Limitation:
All the CRs of the same type with app framework enabled should be either using the manual app update or should be using the polling interval. We might target the mixed behavior in coming releases as an improvement.
