### PR TITLE
MC Re-config Test Case

### DIFF
--- a/test/testenv/mcutil.go
+++ b/test/testenv/mcutil.go
@@ -76,8 +76,8 @@ func CheckMCPodReady(ns string) bool {
 }
 
 // GetConfiguredPeers get list of Peers Configured on Montioring Console
-func GetConfiguredPeers(ns string, deploymentName string) []string {
-	podName := fmt.Sprintf(MonitoringConsolePod, deploymentName, 0)
+func GetConfiguredPeers(ns string, mcName string) []string {
+	podName := fmt.Sprintf(MonitoringConsolePod, mcName, 0)
 	var peerList []string
 	if len(podName) > 0 {
 		peerFile := "/opt/splunk/etc/apps/splunk_monitoring_console/local/splunk_monitoring_console_assets.conf"
@@ -100,6 +100,7 @@ func GetConfiguredPeers(ns string, deploymentName string) []string {
 			}
 		}
 	}
+	logf.Log.Info("Peer List found on MC Pod", "MC POD", podName, "Configured Peers", peerList)
 	return peerList
 }
 
@@ -134,10 +135,10 @@ func MCPodReady(ns string, deployment *Deployment) {
 	}, ConsistentDuration, ConsistentPollInterval).Should(gomega.Equal(true))
 }
 
-// CheckPodNameOnMC Check Standalone Pod configured on MC
-func CheckPodNameOnMC(ns string, deploymentName string, podName string) bool {
+// CheckPodNameOnMC Check given pod is configured on Monitoring console pod
+func CheckPodNameOnMC(ns string, mcName string, podName string) bool {
 	// Get Peers configured on Monitoring Console
-	peerList := GetConfiguredPeers(ns, deploymentName)
+	peerList := GetConfiguredPeers(ns, mcName)
 	logf.Log.Info("Peer List", "instance", peerList)
 	found := false
 	for _, peer := range peerList {
@@ -169,13 +170,13 @@ func GetPodIP(ns string, podName string) string {
 
 // GetMCConfigMap gets config map for give Monitoring Console Name
 func GetMCConfigMap(deployment *Deployment, ns string, mcName string) (*corev1.ConfigMap, error) {
-	mcConfigMapName := enterprise.GetSplunkMonitoringconsoleConfigMapName(deployment.GetName(), enterprise.SplunkMonitoringConsole)
+	mcConfigMapName := enterprise.GetSplunkMonitoringconsoleConfigMapName(mcName, enterprise.SplunkMonitoringConsole)
 	mcConfigMap, err := GetConfigMap(deployment, ns, mcConfigMapName)
 	if err != nil {
 		logf.Log.Error(err, "Failed to get Monitoring Console Config Map")
 		return mcConfigMap, err
 	}
-	logf.Log.Info("MC Config Map contents", "Data", mcConfigMap.Data)
+	logf.Log.Info("MC Config Map contents", "MC CONFIG MAP NAME", mcConfigMapName, "Data", mcConfigMap.Data)
 	return mcConfigMap, err
 }
 

--- a/test/testenv/testenv.go
+++ b/test/testenv/testenv.go
@@ -94,6 +94,12 @@ const (
 
 	// VersionedSecretName Versioned Secret object Template
 	VersionedSecretName = "splunk-%s-%s-secret-v%d"
+
+	// ClusterMasterServiceName Cluster Master Service Template String
+	ClusterMasterServiceName = "splunk-%s-cluster-master-service"
+
+	// DeployerServiceName Cluster Master Service Template String
+	DeployerServiceName = "splunk-%s-shc-deployer-service"
 )
 
 var (

--- a/test/testenv/util.go
+++ b/test/testenv/util.go
@@ -680,3 +680,20 @@ func CheckStringInSlice(stringSlice []string, compString string) bool {
 	}
 	return false
 }
+
+// GeneratePodNameSlice returns slice of PodNames based on given key and count.
+func GeneratePodNameSlice(formatString string, key string, count int, multisite bool, siteCount int) []string {
+	var podNames []string
+	if multisite {
+		for site := 1; site <= siteCount; site++ {
+			for i := 0; i < count; i++ {
+				podNames = append(podNames, fmt.Sprintf(formatString, key, site, i))
+			}
+		}
+	} else {
+		for i := 0; i < count; i++ {
+			podNames = append(podNames, fmt.Sprintf(formatString, key, i))
+		}
+	}
+	return podNames
+}


### PR DESCRIPTION
Added Test for S1, C3, M4 test cases. 

#### Test Scenario added for S1 
1. Reconfigure S1 with 2nd Monitoring Console Name
2. Check 2nd Monitoring Console Config Map
3. Deploy 2nd Monitoring Console Pod
4. Verify S1 pod is configured on Monitoring Console Pod
5. Verify 1st Monitoring Console Config Map is not configured with S1
6. Verify 1st Monitoring Console Pod is not configured with S1

#### Test Scenario added for C3 
1. Reconfigure CM with Second MC
2. Verify CM in config map of Second MC
3. Create Second MC Pod
4. Verify Indexers in second MC Pod
5. Verify SHC not in second MC
6. Verify SHC still present in first MC d
7. Verify CM and Indexers not in first MC Pod
8. Configure SHC with Second MC
9. Verify CM, DEPLOYER, Search Heads in config map of seconds MC
10. Verify SHC in second MC pod
11. Verify Indexers in Second MC Pod
12. Verify CM and Deployer not in first MC CONFIG MAP
13. Verify SHC, Indexers not in first MC Pod

#### Test Scenario for M4 
1. Configure Cluster Master to use 2nd Monitoring Console
2. Verify Cluster Master is configured Config Maps of Second MC
3. Deploy 2nd MC pod
4. Verify Indexers in 2nd MC Pod
5. Verify SHC not in 2nd MC CM
6. Verify SHC not in 2nd MC Pod
7. Verify Cluster Master not 1st MC Config Map
8. Verify Indexers not in 1st MC Pod

#### Successful Test Runs + 1 Failure in C3 

```
• [SLOW TEST:656.528 seconds]
[2] Monitoring Console test
[2] /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:29
[2]   Standalone deployment with Scale up
[2]   /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:292
[2]     monitoring_console, integration: can deploy a MC with standalone instance and update MC when standalone is scaled up
[2]     /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:293
[2] ------------------------------
[2] {"level":"info","ts":1629408337.0902631,"msg":"testenv deleted.\n","testenv":"mc-lv2"}
[2]
[2] JUnit report was created: /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/mc-lv2_junit.xml



[3] • [SLOW TEST:671.068 seconds]
[3] Monitoring Console test
[3] /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:29
[3]   Deploy Monitoring Console
[3]   /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:50
[3]     smoke, monitoring_console: can deploy MC CR
[3]     /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:51
[3] ------------------------------
[3] {"level":"info","ts":1629408351.618159,"msg":"testenv deleted.\n","testenv":"mc-qw5"}
[3]
[3] JUnit report was created: /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/mc-qw5_junit.xml


[1] • [SLOW TEST:618.237 seconds]
[1] Monitoring Console test
[1] /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:29
[1]   Standalone deployment (S1)
[1]   /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:149
[1]     monitoring_console, integration: can deploy a MC with standalone instance and update MC with new standalone deployment
[1]     /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:150
[1] ------------------------------
[1] {"level":"info","ts":1629409268.4440908,"msg":"testenv deleted.\n","testenv":"mc-yjx"}
[1]
[1] JUnit report was created: /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/mc-yjx_junit.xml



• [SLOW TEST:1344.581 seconds]
[1] Monitoring Console test
[1] /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:29
[1]   Multisite Clustered deployment (M4 - 3 Site clustered indexer, search head cluster)
[1]   /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:725
[1]     monitoring_console, integration: MC can configure SHC, indexer instances and reconfigure Cluster Master to new Monitoring Console
[1]     /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:726
[1] ------------------------------
[1] {"level":"info","ts":1629412858.785571,"msg":"testenv deleted.\n","testenv":"mc-nhs"}
[1]
[1] JUnit report was created: /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/mc-nhs_junit.xml
[1]
[1] Ran 1 of 6 Specs in 1352.190 seconds
[1] SUCCESS! -- 1 Passed | 0 Failed | 5 Pending | 0 Skipped
[1] PASS


[2] • Failure [1773.007 seconds]
[2] Monitoring Console test
[2] /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:29
[2]   Clustered deployment (C3 - clustered indexer, search head cluster)
[2]   /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:528
[2]     monitoring_console, smoke: MC can configure SHC, indexer instances and reconfigure to new MC [It]
[2]     /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/monitoring_console/monitoring_console_test.go:529
[2]
[2]     Verify Pod in MC Config String. Pod Name splunk-mc-pqy-d92-idxc-indexer-0.
[2]     Expected
[2]         <bool>: false
[2]     to equal
[2]         <bool>: true
[2]
```