### PR TITLE
CSPL-1235: Manual poll for app framework Automation

### DIFF
--- a/test/testenv/appframework_utils.go
+++ b/test/testenv/appframework_utils.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	enterpriseApi "github.com/splunk/splunk-operator/pkg/apis/enterprise/v2"
+	corev1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -129,4 +130,17 @@ func GetAppFileList(appList []string, version int) []string {
 		appFileList = append(appFileList, AppInfo[app][fileKey])
 	}
 	return appFileList
+}
+
+// GetAppframeworkManualUpdateConfigMap gets config map for given manual update configmap
+func GetAppframeworkManualUpdateConfigMap(deployment *Deployment, ns string) (*corev1.ConfigMap, error) {
+	ConfigMapName := fmt.Sprintf(AppframeworkManualUpdateConfigMap, ns)
+	logf.Log.Info("Get config map for", "CONFIG MAP NAME", ConfigMapName)
+	ConfigMap, err := GetConfigMap(deployment, ns, ConfigMapName)
+	if err != nil {
+		logf.Log.Error(err, "Failed to get splunk manual poll Config Map")
+		return ConfigMap, err
+	}
+	logf.Log.Info("Config Map contents", "CONFIG MAP NAME", ConfigMapName, "Data", ConfigMap.Data)
+	return ConfigMap, err
 }

--- a/test/testenv/testenv.go
+++ b/test/testenv/testenv.go
@@ -94,6 +94,9 @@ const (
 
 	// VersionedSecretName Versioned Secret object Template
 	VersionedSecretName = "splunk-%s-%s-secret-v%d"
+
+	// AppframeworkManualUpdateConfigMap Config map for App Framework manual update
+	AppframeworkManualUpdateConfigMap = "splunk-%s-manual-app-update"
 )
 
 var (

--- a/test/testenv/util.go
+++ b/test/testenv/util.go
@@ -554,6 +554,16 @@ func ExecuteCommandOnPod(deployment *Deployment, podName string, stdin string) (
 	return stdout, nil
 }
 
+// GetConfigMap Gets the config map for a given k8 config map name
+func GetConfigMap(deployment *Deployment, ns string, configMapName string) (*corev1.ConfigMap, error) {
+	configMap := &corev1.ConfigMap{}
+	err := deployment.GetInstance(configMapName, configMap)
+	if err != nil {
+		deployment.testenv.Log.Error(err, "Unable to get config map", "Config Map Name", configMap, "Namespace", ns)
+	}
+	return configMap, err
+}
+
 // newClusterMasterWithGivenSpec creates and initialize the CR for ClusterMaster Kind
 func newClusterMasterWithGivenSpec(name string, ns string, spec enterpriseApi.ClusterMasterSpec) *enterpriseApi.ClusterMaster {
 	new := enterpriseApi.ClusterMaster{
@@ -642,4 +652,21 @@ func CheckStringInSlice(stringSlice []string, compString string) bool {
 		}
 	}
 	return false
+}
+
+// GeneratePodNameSlice returns slice of PodNames based on given key and count.
+func GeneratePodNameSlice(formatString string, key string, count int, multisite bool, siteCount int) []string {
+	var podNames []string
+	if multisite {
+		for site := 1; site <= siteCount; site++ {
+			for i := 0; i < count; i++ {
+				podNames = append(podNames, fmt.Sprintf(formatString, key, site, i))
+			}
+		}
+	} else {
+		for i := 0; i < count; i++ {
+			podNames = append(podNames, fmt.Sprintf(formatString, key, i))
+		}
+	}
+	return podNames
 }


### PR DESCRIPTION
Added test cases for S1, C3, M4 with manual poll

Test Scenario:

- Setup config with app Framework enabled
- System downloads Initial list of apps and installs them
- Add new apps to  S3
- Set poll interval to 0 to disable polling
- Wait for 2 mins to confirm that no apps were downloaded/installed/updated
- Modify config map to trigger one time manual poll
- Wait for system to be in ready state
- Check pods for app install/update

Successful Run: 
```
[2] • [SLOW TEST:479.969 seconds]
[2] s1appfw test
[2] /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:31
[2]   appframework Standalone deployment (S1) with App Framework
[2]   /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:249
[2]     appfwint, s1, appframework: can deploy a standalone instance with App Framework enabled for manual poll
[2]     /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:250
[2] ------------------------------
[2] {"level":"info","ts":1629740550.3261619,"msg":"testenv deleted.\n","testenv":"s1appfw-fnq"}
[2]
[2] JUnit report was created: /Users/tpereira/Git/splunk-operator/test/s1/appframework/s1appfw-fnq_junit.xml
[2]
[2] Ran 1 of 3 Specs in 503.665 seconds
[2] SUCCESS! -- 1 Passed | 0 Failed | 2 Pending | 0 Skipped
[2] PASS


• [SLOW TEST:1559.642 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:30
  Single Site Indexer Cluster with SHC (C3) with App Framework
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:558
    appfwint, c3, appframework: can deploy a C3 SVA with App Framework enabled for manual update
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:559
------------------------------
{"level":"info","ts":1629928952.621782,"msg":"testenv deleted.\n","testenv":"c3appfw-yik"}
{"level":"info","ts":1629928952.621809,"msg":"testenv deleted.\n","testenv":"c3appfw-yik"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/c3/appframework/c3appfw-yik_junit.xml

Ran 1 of 5 Specs in 1578.291 seconds
SUCCESS! -- 1 Passed | 0 Failed | 4 Pending | 0 Skipped
PASS


• [SLOW TEST:1180.835 seconds]
m4appfw test
/Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:30
  Multi Site Indexer Cluster with SHC (m4) with App Framework
  /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:326
    m4, appframework: can deploy a M4 SVA with App Framework enabled for manual poll
    /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:327
------------------------------
{"level":"info","ts":1629935341.705771,"msg":"testenv deleted.\n","testenv":"m4appfw-lah"}
{"level":"info","ts":1629935341.7058089,"msg":"testenv deleted.\n","testenv":"m4appfw-lah"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/m4/appframework/m4appfw-lah_junit.xml

Ran 1 of 3 Specs in 1205.454 seconds
SUCCESS! -- 1 Passed | 0 Failed | 2 Pending | 0 Skipped
PASS
```