### PR TITLE
Modify monitoring console selection name

### DIFF
--- a/.github/workflows/int-test-workflow.yml
+++ b/.github/workflows/int-test-workflow.yml
@@ -8,7 +8,7 @@ jobs:
   int-tests:
     strategy:
       matrix:
-        test: [appframework, secret, smartstore, monitoring_console, scaling]
+        test: [appframework, secret, smartstore, monitoringconsole, scaling]
     runs-on: ubuntu-latest
     env:
       CLUSTER_NODES: 1

--- a/.github/workflows/nightly-int-test-workflow.yml
+++ b/.github/workflows/nightly-int-test-workflow.yml
@@ -6,7 +6,7 @@ jobs:
   int-tests:
     strategy:
       matrix:
-        test: [appframework, secret, smartstore, monitoring_console, scaling]
+        test: [appframework, secret, smartstore, monitoringconsole, scaling]
     runs-on: ubuntu-latest
     env:
       CLUSTER_NODES: 1

--- a/test/monitoring_console/monitoring_console_test.go
+++ b/test/monitoring_console/monitoring_console_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Monitoring Console test", func() {
 	})
 
 	Context("Standalone deployment (S1)", func() {
-		It("monitoring_console, integration: can deploy a MC with standalone instance and update MC with new standalone deployment", func() {
+		It("monitoringconsole, integration: can deploy a MC with standalone instance and update MC with new standalone deployment", func() {
 
 			standaloneOneName := deployment.GetName()
 			standaloneOne, err := deployment.DeployStandalone(standaloneOneName)
@@ -144,7 +144,7 @@ var _ = Describe("Monitoring Console test", func() {
 	})
 
 	Context("Standalone deployment with Scale up", func() {
-		It("monitoring_console: can deploy a MC with standalone instance and update MC when standalone is scaled up", func() {
+		It("monitoringconsole, integration: can deploy a MC with standalone instance and update MC when standalone is scaled up", func() {
 
 			standalone, err := deployment.DeployStandalone(deployment.GetName())
 			Expect(err).To(Succeed(), "Unable to deploy standalone instance ")
@@ -203,7 +203,7 @@ var _ = Describe("Monitoring Console test", func() {
 	})
 
 	Context("Clustered deployment (C3 - clustered indexer, search head cluster)", func() {
-		It("monitoring_console, integration: MC can configure SHC, indexer instances after scale up and standalone in a namespace", func() {
+		It("monitoringconsole, integration: MC can configure SHC, indexer instances after scale up and standalone in a namespace", func() {
 
 			defaultSHReplicas := 3
 			defaultIndexerReplicas := 3


### PR DESCRIPTION
Modified Monitoring Console test selection keyword to avoid cluster creation error on eks.