### PR TITLE
[CSPL-1283] Fix AWS & minio S3 client code to support App framework on GCS

### DIFF
--- a/pkg/splunk/client/minioclient_test.go
+++ b/pkg/splunk/client/minioclient_test.go
@@ -59,7 +59,7 @@ func TestMinioGetInitContainerImage(t *testing.T) {
 }
 
 func TestGetMinioInitContainerCmd(t *testing.T) {
-	wantCmd := []string{"--endpoint-url=https://s3.us-west-2.amazonaws.com", "s3", "sync", "s3://sample_bucket/admin", "/mnt/apps-local//admin"}
+	wantCmd := []string{"--endpoint-url=https://s3.us-west-2.amazonaws.com", "s3", "sync", "s3://sample_bucket/admin/", "/mnt/apps-local/admin/"}
 
 	minioClient := &MinioClient{}
 	gotCmd := minioClient.GetInitContainerCmd("https://s3.us-west-2.amazonaws.com", "sample_bucket", "admin", "admin", "/mnt/apps-local/")


### PR DESCRIPTION
### Problem
When attempting to access a bucket on GCS (which is S3 compatable) the aws and minio clients both fail.  The aws client fails due to a missing region in the endpoint formatting.  The minio client init container fails to download anything and the app-listing configmap is malformed:
```
[splunk@splunk-gcp-test-standalone-0 splunk]$ cat /mnt/app-listing/app-list-local.yaml 
splunk:
  app_paths_install:
    default:
      - "/init-apps/appframework1/application5.tgz"
      - "/init-apps/appframework1/application5.tgz"
      - "/init-apps/appframework1/application5.tgz"
      - "/init-apps/appframework1/application5.tgz"
      - "/init-apps/appframework1/application5.tgz"
      - "/init-apps/appframework1/application5.tgz"
```

### Solution
Fix the init container command so that there are no "//" in the path.
Fix the List API so that it doesn't use object pointers and get stuck on the last app returned from minio list API.

### Test
Create a bucket on GCS with a secret/access key.  Create a GCS secret object and standalone referring to that remote store with `minio` as the provider:
```
apiVersion: v1
kind: Secret
metadata:
  name: af-gcp-secret
type: Opaque
data:
  s3_access_key: ==SHHHHHHHHHH==
  s3_secret_key: ==SHHHHHHHHHH==
------------
apiVersion: enterprise.splunk.com/v2
kind: Standalone
metadata:
  name: gcp-test
  finalizers:
  - enterprise.splunk.com/delete-pvc
spec:
  replicas: 1
  appRepo:
    appSources:
    - location: apps
      name: appframework1
      scope: local
      volumeName: volname
    appsRepoPollIntervalSeconds: 60
    volumes:
    - endpoint: https://storage.googleapis.com
      name: volname
      path: test-bkt
      provider: minio
      secretRef: af-gcp-secret
      storageType: s3
```
Make sure apps get downloaded and installed onto the standalone:
```
[splunk@splunk-gcp-test-standalone-0 splunk]$ ls -Rl /init-apps/
/init-apps/:
total 0
drwxr-sr-x 2 splunk splunk 126 Sep  2 19:25 appframework1

/init-apps/appframework1:
total 20
-rw-r--r-- 1 splunk splunk 1155 Sep  2 18:17 application1.tgz
-rw-r--r-- 1 splunk splunk 1148 Sep  2 18:17 application2.tgz
-rw-r--r-- 1 splunk splunk 1167 Sep  2 18:17 application3.tgz
-rw-r--r-- 1 splunk splunk 1154 Sep  2 18:17 application4.tgz
-rw-r--r-- 1 splunk splunk 1154 Sep  2 18:17 application5.tgz
[splunk@splunk-gcp-test-standalone-0 splunk]$ ls /mnt/app-listing/
app-list-local.yaml
[splunk@splunk-gcp-test-standalone-0 splunk]$ cat /mnt/app-listing/app-list-local.yaml 
splunk:
  app_paths_install:
    default:
      - "/init-apps/appframework1/application1.tgz"
      - "/init-apps/appframework1/application2.tgz"
      - "/init-apps/appframework1/application3.tgz"
      - "/init-apps/appframework1/application4.tgz"
      - "/init-apps/appframework1/application5.tgz"[splunk@splunk-gcp-test-standalone-0 splunk]$ '//.,mklhjbkghjkb^C////
[splunk@splunk-gcp-test-standalone-0 splunk]$ ls etc/apps/
SplunkForwarder       application5		     sample_app			  splunk_instrumentation
SplunkLightForwarder  appsbrowser		     search			  splunk_internal_metrics
alert_logevent	      introspection_generator_addon  splunk-dashboard-studio	  splunk_metrics_workspace
alert_webhook	      journald_input		     splunk_archiver		  splunk_monitoring_console
application1	      launcher			     splunk_enterprise_on_docker  splunk_rapid_diag
application2	      learned			     splunk_essentials_8_2	  splunk_secure_gateway
application3	      legacy			     splunk_gdi			  user-prefs
application4	      python_upgrade_readiness_app   splunk_httpinput
[splunk@splunk-gcp-test-standalone-0 splunk]$ export SPLUNK_ADMIN_PW=$(cat /mnt/splunk-secrets/password); bin/splunk display app -auth admin:$SPLUNK_ADMIN_PW
alert_logevent                 CONFIGURED          ENABLED             INVISIBLE           
alert_webhook                  CONFIGURED          ENABLED             INVISIBLE           
application1                   UNCONFIGURED        ENABLED             VISIBLE             
application2                   UNCONFIGURED        ENABLED             VISIBLE             
application3                   UNCONFIGURED        ENABLED             VISIBLE             
application4                   UNCONFIGURED        ENABLED             VISIBLE             
application5                   UNCONFIGURED        ENABLED             VISIBLE             
appsbrowser                    CONFIGURED          ENABLED             INVISIBLE           
introspection_generator_addon  CONFIGURED          ENABLED             INVISIBLE           
journald_input                 UNCONFIGURED        ENABLED             INVISIBLE           
launcher                       CONFIGURED          ENABLED             VISIBLE             
learned                        UNCONFIGURED        ENABLED             INVISIBLE           
legacy                         UNCONFIGURED        DISABLED            INVISIBLE           
python_upgrade_readiness_app   UNCONFIGURED        ENABLED             VISIBLE             
sample_app                     UNCONFIGURED        DISABLED            INVISIBLE           
search                         CONFIGURED          ENABLED             VISIBLE             
splunk-dashboard-studio        CONFIGURED          ENABLED             VISIBLE             
splunk_archiver                CONFIGURED          ENABLED             INVISIBLE           
splunk_enterprise_on_docker    CONFIGURED          ENABLED             INVISIBLE           
splunk_essentials_8_2          CONFIGURED          ENABLED             VISIBLE             
splunk_gdi                     UNCONFIGURED        ENABLED             INVISIBLE           
splunk_httpinput               UNCONFIGURED        ENABLED             INVISIBLE           
splunk_instrumentation         UNCONFIGURED        ENABLED             VISIBLE             
splunk_internal_metrics        UNCONFIGURED        ENABLED             INVISIBLE           
splunk_metrics_workspace       UNCONFIGURED        ENABLED             VISIBLE             
splunk_monitoring_console      UNCONFIGURED        ENABLED             VISIBLE             
splunk_rapid_diag              UNCONFIGURED        ENABLED             VISIBLE             
splunk_secure_gateway          UNCONFIGURED        ENABLED             VISIBLE             
SplunkForwarder                UNCONFIGURED        DISABLED            INVISIBLE           
SplunkLightForwarder           UNCONFIGURED        DISABLED            INVISIBLE          
```
```
Every 2.0s: kubectl get pods                                jryb-MBP: Thu Sep  2 15:11:29 2021

NAME                                  READY   STATUS    RESTARTS   AGE
splunk-default-monitoring-console-0   0/1     Running   2          16m
splunk-gcp-test-standalone-0          1/1     Running   0          17m
splunk-operator-65c846679d-v4kjx      1/1     Running   0          21m
```