### PR TITLE
CSPL-1316: Avoid app framework flow from re-entrancy

### DIFF
--- a/pkg/splunk/enterprise/searchheadcluster.go
+++ b/pkg/splunk/enterprise/searchheadcluster.go
@@ -53,6 +53,7 @@ func ApplySearchHeadCluster(client splcommon.ControllerClient, cr *enterpriseApi
 	if len(cr.Spec.AppFrameworkConfig.AppSources) != 0 {
 		err := initAndCheckAppInfoStatus(client, cr, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext)
 		if err != nil {
+			cr.Status.AppContext.IsDeploymentInProgress = false
 			return result, err
 		}
 	}
@@ -147,12 +148,17 @@ func ApplySearchHeadCluster(client splcommon.ControllerClient, cr *enterpriseApi
 	}
 	cr.Status.Phase = phase
 
+	if cr.Status.AppContext.AppsSrcDeployStatus != nil && cr.Status.DeployerPhase == splcommon.PhaseReady {
+		markAppsStatusToComplete(client, cr, &cr.Spec.AppFrameworkConfig, cr.Status.AppContext.AppsSrcDeployStatus)
+		// Schedule one more reconcile in next 5 seconds, just to cover any latest app framework config changes
+		if cr.Status.AppContext.IsDeploymentInProgress {
+			cr.Status.AppContext.IsDeploymentInProgress = false
+			return result, nil
+		}
+	}
+
 	// no need to requeue if everything is ready
 	if cr.Status.Phase == splcommon.PhaseReady {
-		if cr.Status.AppContext.AppsSrcDeployStatus != nil {
-			markAppsStatusToComplete(client, cr, &cr.Spec.AppFrameworkConfig, cr.Status.AppContext.AppsSrcDeployStatus)
-		}
-
 		err = ApplyMonitoringConsole(client, cr, cr.Spec.CommonSplunkSpec, getSearchHeadEnv(cr))
 		if err != nil {
 			return result, err

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -667,7 +667,6 @@ func handleAppRepoChanges(client splcommon.ControllerClient, cr splcommon.MetaOb
 			modified, appSrcDeploymentInfo.AppDeploymentInfoList = setStateAndStatusForAppDeployInfoList(curAppDeployList, enterpriseApi.RepoStateDeleted, enterpriseApi.DeployStatusPending)
 
 			if modified {
-				appDeployContext.IsDeploymentInProgress = true
 				// Finally update the Map entry with latest info
 				appDeployContext.AppsSrcDeployStatus[appSrc] = appSrcDeploymentInfo
 			}
@@ -685,14 +684,12 @@ func handleAppRepoChanges(client splcommon.ControllerClient, cr splcommon.MetaOb
 				if !checkIfAnAppIsActiveOnRemoteStore(currentList[appIdx].AppName, s3Response.Objects) {
 					scopedLog.Info("App change", "deleting/disabling the App: ", currentList[appIdx].AppName, "as it is missing in the remote listing", nil)
 					setStateAndStatusForAppDeployInfo(&currentList[appIdx], enterpriseApi.RepoStateDeleted, enterpriseApi.DeployStatusPending)
-					appDeployContext.IsDeploymentInProgress = true
 				}
 			}
 		}
 
 		// 2.2 Check for any App changes(Ex. A new App source, a new App added/updated)
 		if AddOrUpdateAppSrcDeploymentInfoList(&appSrcDeploymentInfo, s3Response.Objects) {
-			appDeployContext.IsDeploymentInProgress = true
 			appsModified = true
 		}
 
@@ -950,13 +947,16 @@ func HasAppRepoCheckTimerExpired(appInfoContext *enterpriseApi.AppDeploymentCont
 // GetNextRequeueTime gets the next reconcile requeue time based on the appRepoPollInterval.
 // There can be some time elapsed between when we first set lastAppInfoCheckTime and when the CR is in Ready state.
 // Hence we need to subtract the delta time elapsed from the actual polling interval,
-// so that the next reconile would happen at the right time.
+// so that the next reconcile would happen at the right time.
 func GetNextRequeueTime(appRepoPollInterval, lastCheckTime int64) time.Duration {
 	scopedLog := log.WithName("GetNextRequeueTime")
 	currentEpoch := time.Now().Unix()
 
 	var nextRequeueTimeInSec int64
 	nextRequeueTimeInSec = appRepoPollInterval - (currentEpoch - lastCheckTime)
+	if nextRequeueTimeInSec < 0 {
+		nextRequeueTimeInSec = 5
+	}
 
 	scopedLog.Info("Getting next requeue time", "LastAppInfoCheckTime", lastCheckTime, "Current Epoch time", currentEpoch, "nextRequeueTimeInSec", nextRequeueTimeInSec)
 
@@ -976,6 +976,12 @@ func initAndCheckAppInfoStatus(client splcommon.ControllerClient, cr splcommon.M
 
 	//check if the apps need to be downloaded from remote storage
 	if HasAppRepoCheckTimerExpired(appStatusContext) || !reflect.DeepEqual(appStatusContext.AppFrameworkConfig, *appFrameworkConf) {
+		if appStatusContext.IsDeploymentInProgress {
+			scopedLog.Info("App installation is already in progress. Not checking for any latest app repo changes")
+			return nil
+		}
+
+		appStatusContext.IsDeploymentInProgress = true
 		var sourceToAppsList map[string]splclient.S3Response
 		appsModified := false
 


### PR DESCRIPTION
When the App framework flow is in execution, re-entring the flow can cause the following issues:
1. For SHC, CR phase `Ready` doesn’t include the deployer, so, we should not mark the app deployment as complete. Right now, once the SHC becomes ready, we are marking the apps are deployed. So, if the AppSources are changing in between while the app installation is in progress, as the config Map is changing, we are marking all the apps as deployed, when some of them are not even installed: which needs to be fixed.

2. Even after the above case is fixed, still, the re-entrance is a problem, as the deployer Pod is ready, we are going to mark all the apps as deployed. On follow-up Pod reset if any app installation fails, our CR says all the apps are deployed, but that is not fully correct. This is the same problem for all the deployments. 

Code changes mentioned here addresses: 
1. Avoid the app framework flow re-entering during the reconciles
2. For SHC, use the deployer phase for marking the app installation status to complete.