### PR TITLE
Revert CRD description changes for 1.0.3 release

### DIFF
--- a/pkg/apis/enterprise/v2/clustermaster_types.go
+++ b/pkg/apis/enterprise/v2/clustermaster_types.go
@@ -40,7 +40,7 @@ type ClusterMasterSpec struct {
 
 // ClusterMasterStatus defines the observed state of ClusterMaster
 type ClusterMasterStatus struct {
-	// current phase of the cluster manager
+	// current phase of the cluster master
 	Phase splcommon.Phase `json:"phase"`
 
 	// selector for pods, used by HorizontalPodAutoscaler
@@ -69,7 +69,7 @@ type BundlePushInfo struct {
 
 // ClusterMaster is the Schema for the clustermasters API
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Status of cluster manager"
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Status of cluster master"
 // +kubebuilder:resource:path=clustermasters,scope=Namespaced,shortName=cm-idxc
 // +kubebuilder:storageversion
 type ClusterMaster struct {

--- a/pkg/apis/enterprise/v2/indexercluster_types.go
+++ b/pkg/apis/enterprise/v2/indexercluster_types.go
@@ -62,7 +62,7 @@ type IndexerClusterStatus struct {
 	// current phase of the indexer cluster
 	Phase splcommon.Phase `json:"phase"`
 
-	// current phase of the cluster manager
+	// current phase of the cluster master
 	ClusterMasterPhase splcommon.Phase `json:"clusterMasterPhase"`
 
 	// desired number of indexer peers


### PR DESCRIPTION
Addressing this [comment](https://github.com/splunk/splunk-operator/pull/511#discussion_r708759247) to ensure the Bias-Language efforts do not affect CRDs for the 1.0.3 release.