### PR TITLE
CSPL-1226 S1 Automation for MC with App Framework

### DIFF
--- a/test/testenv/deployment.go
+++ b/test/testenv/deployment.go
@@ -111,6 +111,16 @@ func (d *Deployment) DeployMonitoringConsole(name string, licenseMasterRef strin
 	return deployed.(*enterpriseApi.MonitoringConsole), err
 }
 
+// DeployMonitoringConsoleWithGivenSpec deploys MC instance on specified testenv with given spec
+func (d *Deployment) DeployMonitoringConsoleWithGivenSpec(ns string, name string, mcSpec enterpriseApi.MonitoringConsoleSpec) (*enterpriseApi.MonitoringConsole, error) {
+	mc := newMonitoringConsoleSpecWithGivenSpec(name, ns, mcSpec)
+	deployed, err := d.deployCR(name, mc)
+	if err != nil {
+		return nil, err
+	}
+	return deployed.(*enterpriseApi.MonitoringConsole), err
+}
+
 // GetInstance retrieves the standalone, indexer, searchhead, licensemaster instance
 func (d *Deployment) GetInstance(name string, instance runtime.Object) error {
 	key := client.ObjectKey{Name: name, Namespace: d.testenv.namespace}

--- a/test/testenv/util.go
+++ b/test/testenv/util.go
@@ -493,6 +493,23 @@ func newMonitoringConsoleSpec(name string, ns string, LicenseMasterRef string) *
 	return &mcSpec
 }
 
+// newMonitoringConsoleSpecWithGivenSpec returns MC Spec with given name, namespace and Spec
+func newMonitoringConsoleSpecWithGivenSpec(name string, ns string, spec enterpriseApi.MonitoringConsoleSpec) *enterpriseApi.MonitoringConsole {
+	mcSpec := enterpriseApi.MonitoringConsole{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "MonitoringConsole",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  ns,
+			Finalizers: []string{"enterprise.splunk.com/delete-pvc"},
+		},
+
+		Spec: spec,
+	}
+	return &mcSpec
+}
+
 // DumpGetPods prints and returns list of pods in the namespace
 func DumpGetPods(ns string) []string {
 	output, err := exec.Command("kubectl", "get", "pods", "-n", ns).Output()


### PR DESCRIPTION
## Test Steps 
#### SETUP 
* Create 2 App Sources for MC and Standalone
* Prepare Standalone CRD with MC and App config
* Apply Standalone CRD and wait for pod to become ready
* Prepare MC CRD with App Config
* Wait for MC to become READY
#### VERIFICATIONS 
* Verify apps are copied, installed on MC AND Standalone Pod
#### UPGRADE APPS 
* Upgrade apps in app sources
* Wait for MC and Standalone are READY
* Verify apps are copied, installed and upgraded on MC AND Standalone Pod
#### SCALE STANDALONE TO TWO REPLICAS
* Wait for Standalone and MC to be ready 
* Verify apps are copied, installed on MC AND Standalone Pod
#### DOWNGRADE APP VERSION
* Wait for Standalone and MC to be ready 
* Verify apps are copied, installed on MC AND Standalone Pod


## TEST RUN
```• [SLOW TEST:1618.402 seconds]
s1appfw test
/Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/s1/appframework/appframework_test.go:30
  appframework Standalone deployment (S1) with App Framework
  /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/s1/appframework/appframework_test.go:64
    smoke, s1, appframework: can deploy a standalone instance with App Framework enabled
    /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/s1/appframework/appframework_test.go:65
------------------------------
P{"level":"info","ts":1631823261.678734,"msg":"testenv deleted.\n","testenv":"s1appfw-u90"}

JUnit report was created: /Users/pdhanoya/splunk-operator-git/automation/splunk-operator/test/s1/appframework/s1appfw-u90_junit.xml

Ran 1 of 2 Specs in 1635.185 seconds
SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 0 Skipped
PASS```