### PR TITLE
CSPL-1339: Fix make_bundle.sh to check for version change

### DIFF
--- a/build/make_bundle.sh
+++ b/build/make_bundle.sh
@@ -137,7 +137,12 @@ cat << EOF >$YAML_SCRIPT_FILE
 EOF
 
 echo Updating $OLM_CATALOG
-operator-sdk generate csv --csv-version $VERSION --operator-name splunk --update-crds --make-manifests=false --verbose --from-version $LAST_RELEASE_VERSION
+VERSION_CHECK=""
+if [[ $VERSION != $LAST_RELEASE_VERSION ]];
+then
+	VERSION_CHECK="--from-version $LAST_RELEASE_VERSION"
+fi
+operator-sdk generate csv --csv-version $VERSION --operator-name splunk --update-crds --make-manifests=false --verbose $VERSION_CHECK
 yq w -i -s $YAML_SCRIPT_FILE $OLM_CATALOG/splunk/$VERSION/splunk.v${VERSION}.clusterserviceversion.yaml
 rm -f $YAML_SCRIPT_FILE
 


### PR DESCRIPTION
**Problem*
The command `make generate` would fail if there was no version change from previous version.

**Solution**
Add a check for version change in the script.