### PR TITLE
CSPL-1327 App framework: App installation isn't triggered if 1 appsource is empty.

### DIFF
--- a/pkg/splunk/client/awss3client.go
+++ b/pkg/splunk/client/awss3client.go
@@ -185,8 +185,8 @@ func (awsclient *AWSS3Client) GetAppsList() (S3Response, error) {
 	}
 
 	if resp.Contents == nil {
-		err = fmt.Errorf("Empty objects list in the bucket: %s", awsclient.BucketName)
-		return s3Resp, err
+		scopedLog.Info("Empty objects list in bucket. No apps to install", "bucketName", awsclient.BucketName)
+		return s3Resp, nil
 	}
 
 	tmp, err := json.Marshal(resp.Contents)


### PR DESCRIPTION
### Problem
Apps defined in any defined `appSources` fail to install when one of the `appSources` is empty.

### Solution
An empty `appSource` is not necessarily an error. Treat it as a no-op and throw a log message.

### Testing

Verify the issue using an empty `appSource`.
```
apiVersion: enterprise.splunk.com/v2
kind: Standalone
metadata:
  name: s-af-aws
  finalizers:
  - enterprise.splunk.com/delete-pvc
spec:
  replicas: 1
  appRepo:
    appsRepoPollIntervalSeconds: 60
    volumes:
      - name: volume_app_repo1
        path: my-bucket/apps
        endpoint: https://generic-endpoint
        secretRef: my-secret
        storageType: s3
        provider: aws
    appSources:
      - name: empty
        location: empty_dir/
        volumeName: volume_app_repo1
        scope: local
      - name: admin
        location: admin-apps/
        volumeName: volume_app_repo1
        scope: local
      - name: default
        location: default-test/
        volumeName: volume_app_repo1
        scope: local
```

Operator logs:
```
{"level":"info","ts":1632341576.0336561,"logger":"splunk.enterprise.GetRemoteStorageClient","msg":"Creating the client","name":"s-af-aws","namespace":"default","volume":"volume_app_repo1","bucket":"jrybczynski-af-bucket","bucket path":"apps/admin-apps/"}
{"level":"info","ts":1632341576.0337934,"logger":"splunk.client.InitAWSClientSession","msg":"AWS Client Session initialization successful.","region":"us-west-2","TLS Version":"TLS 1.2"}
{"level":"info","ts":1632341576.0338306,"logger":"splunk.client.GetAppsList","msg":"Getting Apps list","AWS S3 Bucket":"jrybczynski-af-bucket"}
{"level":"info","ts":1632341576.0751379,"logger":"splunk.enterprise.GetRemoteStorageClient","msg":"Creating the client","name":"s-af-aws","namespace":"default","volume":"volume_app_repo1","bucket":"jrybczynski-af-bucket","bucket path":"apps/default-test/"}
{"level":"info","ts":1632341576.0752254,"logger":"splunk.client.InitAWSClientSession","msg":"AWS Client Session initialization successful.","region":"us-west-2","TLS Version":"TLS 1.2"}
{"level":"info","ts":1632341576.0752347,"logger":"splunk.client.GetAppsList","msg":"Getting Apps list","AWS S3 Bucket":"jrybczynski-af-bucket"}
{"level":"error","ts":1632341576.1195133,"logger":"splunk.enterprise.initAndCheckAppInfoStatus","msg":"Unable to get apps list, will retry in next reconcile...","name":"s-af-aws","namespace":"default","error":"Unable to get apps list from remote storage list for all the apps","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tsplunk-operator/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/splunk/splunk-operator/pkg/splunk/enterprise.initAndCheckAppInfoStatus\n\tsplunk-operator/pkg/splunk/enterprise/util.go:989\ngithub.com/splunk/splunk-operator/pkg/splunk/enterprise.ApplyStandalone\n\tsplunk-operator/pkg/splunk/enterprise/standalone.go:76\ngithub.com/splunk/splunk-operator/pkg/controller.StandaloneController.Reconcile\n\tsplunk-operator/pkg/controller/add_standalone.go:59\ngithub.com/splunk/splunk-operator/pkg/splunk/controller.splunkReconciler.Reconcile\n\tsplunk-operator/pkg/splunk/controller/controller.go:121\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tsplunk-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:256\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tsplunk-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\tsplunk-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\tsplunk-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\tsplunk-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\tsplunk-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\tsplunk-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
```

From standalone we see apps are downloaded but nothing installed:
```
[splunk@splunk-s-af-aws-standalone-0 splunk]$ ls -Rl /init-apps/
/init-apps/:
total 0
drwxr-sr-x 2 splunk splunk 54 Sep 22 20:13 admin
drwxr-sr-x 2 splunk splunk 77 Sep 22 20:13 default
drwxr-sr-x 2 splunk splunk  6 Sep 22 20:13 empty

/init-apps/admin:
total 8
-rw-r--r-- 1 splunk splunk 1159 Jun 28 18:24 application1.tgz
-rw-r--r-- 1 splunk splunk 1167 Jun 15 07:00 application3.tgz

/init-apps/default:
total 19404
-rw-r--r-- 1 splunk splunk     1154 Jun 28 18:15 application4.tgz
-rw-r--r-- 1 splunk splunk 19865458 Jun 28 18:18 splunk-machine-learning-toolkit_521.tgz

/init-apps/empty:
total 0
[splunk@splunk-s-af-aws-standalone-0 splunk]$ export SPLUNK_ADMIN_PW=$(cat /mnt/splunk-secrets/password); bin/splunk display app -auth admin:$SPLUNK_ADMIN_PW
alert_logevent                 CONFIGURED          ENABLED             INVISIBLE           
alert_webhook                  CONFIGURED          ENABLED             INVISIBLE           
appsbrowser                    CONFIGURED          ENABLED             INVISIBLE           
introspection_generator_addon  CONFIGURED          ENABLED             INVISIBLE           
journald_input                 UNCONFIGURED        ENABLED             INVISIBLE           
launcher                       CONFIGURED          ENABLED             VISIBLE             
learned                        UNCONFIGURED        ENABLED             INVISIBLE           
legacy                         UNCONFIGURED        DISABLED            INVISIBLE           
python_upgrade_readiness_app   UNCONFIGURED        ENABLED             VISIBLE             
sample_app                     UNCONFIGURED        DISABLED            INVISIBLE           
search                         CONFIGURED          ENABLED             VISIBLE             
splunk-dashboard-studio        CONFIGURED          ENABLED             VISIBLE             
splunk_archiver                CONFIGURED          ENABLED             INVISIBLE           
splunk_enterprise_on_docker    CONFIGURED          ENABLED             INVISIBLE           
splunk_essentials_8_2          CONFIGURED          ENABLED             VISIBLE             
splunk_gdi                     UNCONFIGURED        ENABLED             INVISIBLE           
splunk_httpinput               UNCONFIGURED        ENABLED             INVISIBLE           
splunk_instrumentation         UNCONFIGURED        ENABLED             VISIBLE             
splunk_internal_metrics        UNCONFIGURED        ENABLED             INVISIBLE           
splunk_metrics_workspace       UNCONFIGURED        ENABLED             VISIBLE             
splunk_monitoring_console      UNCONFIGURED        ENABLED             VISIBLE             
splunk_rapid_diag              UNCONFIGURED        ENABLED             VISIBLE             
splunk_secure_gateway          UNCONFIGURED        ENABLED             VISIBLE             
SplunkForwarder                UNCONFIGURED        DISABLED            INVISIBLE           
SplunkLightForwarder           UNCONFIGURED        DISABLED            INVISIBLE   
```

Validate fix allowing empty `appSources`:

Operator logs:
```
{"level":"info","ts":1632344519.4163465,"logger":"splunk.enterprise.ValidateAppFrameworkSpec","msg":"App framework configuration is valid"}
{"level":"info","ts":1632344519.4163713,"logger":"splunk.enterprise.HasAppRepoCheckTimerExpired","msg":"App repo polling interval timer has expired","LastAppInfoCheckTime":"0","current epoch time":"1632344519"}
{"level":"info","ts":1632344519.4163775,"logger":"splunk.enterprise.initAndCheckAppInfoStatus","msg":"Checking status of apps on remote storage...","name":"s-af-aws","namespace":"default"}
{"level":"info","ts":1632344519.416385,"logger":"splunk.enterprise.GetAppListFromS3Bucket","msg":"Getting the list of apps from remote storage...","name":"s-af-aws","namespace":"default"}
{"level":"info","ts":1632344519.4199648,"logger":"splunk.enterprise.GetRemoteStorageClient","msg":"Creating the client","name":"s-af-aws","namespace":"default","volume":"volume_app_repo1","bucket":"jrybczynski-af-bucket","bucket path":"apps/empty_dir/"}
{"level":"info","ts":1632344519.4201217,"logger":"splunk.client.InitAWSClientSession","msg":"AWS Client Session initialization successful.","region":"us-west-2","TLS Version":"TLS 1.2"}
{"level":"info","ts":1632344519.420136,"logger":"splunk.client.GetAppsList","msg":"Getting Apps list","AWS S3 Bucket":"jrybczynski-af-bucket"}
{"level":"info","ts":1632344519.5071642,"logger":"splunk.client.GetAppsList","msg":"Empty objects list in bucket. No apps to install","bucketName":"jrybczynski-af-bucket"}
{"level":"info","ts":1632344519.5137684,"logger":"splunk.enterprise.GetRemoteStorageClient","msg":"Creating the client","name":"s-af-aws","namespace":"default","volume":"volume_app_repo1","bucket":"jrybczynski-af-bucket","bucket path":"apps/admin-apps/"}
{"level":"info","ts":1632344519.5138931,"logger":"splunk.client.InitAWSClientSession","msg":"AWS Client Session initialization successful.","region":"us-west-2","TLS Version":"TLS 1.2"}
{"level":"info","ts":1632344519.5139046,"logger":"splunk.client.GetAppsList","msg":"Getting Apps list","AWS S3 Bucket":"jrybczynski-af-bucket"}
{"level":"info","ts":1632344519.5427518,"logger":"splunk.enterprise.GetRemoteStorageClient","msg":"Creating the client","name":"s-af-aws","namespace":"default","volume":"volume_app_repo1","bucket":"jrybczynski-af-bucket","bucket path":"apps/default-test/"}
{"level":"info","ts":1632344519.542925,"logger":"splunk.client.InitAWSClientSession","msg":"AWS Client Session initialization successful.","region":"us-west-2","TLS Version":"TLS 1.2"}
{"level":"info","ts":1632344519.5429375,"logger":"splunk.client.GetAppsList","msg":"Getting Apps list","AWS S3 Bucket":"jrybczynski-af-bucket"}
{"level":"info","ts":1632344519.5731559,"logger":"splunk.enterprise.initAndCheckAppInfoStatus","msg":"Apps List retrieved from remote storage","name":"s-af-aws","namespace":"default","App Source":"empty","Content":null}
{"level":"info","ts":1632344519.5732002,"logger":"splunk.enterprise.initAndCheckAppInfoStatus","msg":"Apps List retrieved from remote storage","name":"s-af-aws","namespace":"default","App Source":"admin","Content":[{"Etag":"\"c753c78e80b05cc48596b9e79dd4e0e3\"","Key":"apps/admin-apps/application1.tgz","LastModified":"2021-06-28T18:24:57Z","Size":1159,"StorageClass":"STANDARD"},{"Etag":"\"628f3bb977a1efa325d3c83186f55b59\"","Key":"apps/admin-apps/application3.tgz","LastModified":"2021-06-15T07:00:43Z","Size":1167,"StorageClass":"STANDARD"}]}
{"level":"info","ts":1632344519.5732126,"logger":"splunk.enterprise.initAndCheckAppInfoStatus","msg":"Apps List retrieved from remote storage","name":"s-af-aws","namespace":"default","App Source":"default","Content":[{"Etag":"\"36ba50bcfe974906257ddfb977bf72f9\"","Key":"apps/default-test/application4.tgz","LastModified":"2021-06-28T18:15:30Z","Size":1154,"StorageClass":"STANDARD"},{"Etag":"\"00315a3365cd94e0508baae2a6c0f95a-2\"","Key":"apps/default-test/splunk-machine-learning-toolkit_521.tgz","LastModified":"2021-06-28T18:18:30Z","Size":19865458,"StorageClass":"STANDARD"}]}
{"level":"info","ts":1632344519.573232,"logger":"splunk.enterprise.handleAppRepoChanges","msg":"received App listing","kind":"Standalone","name":"s-af-aws","namespace":"default","for App sources":3}

```

From standalone showing apps downloaded and installed:
```
[splunk@splunk-s-af-aws-standalone-0 splunk]$ ls -Rl /init-apps/
/init-apps/:
total 0
drwxr-sr-x 2 splunk splunk 54 Sep 22 21:02 admin
drwxr-sr-x 2 splunk splunk 77 Sep 22 21:02 default
drwxr-sr-x 2 splunk splunk  6 Sep 22 21:02 empty

/init-apps/admin:
total 8
-rw-r--r-- 1 splunk splunk 1159 Jun 28 18:24 application1.tgz
-rw-r--r-- 1 splunk splunk 1167 Jun 15 07:00 application3.tgz

/init-apps/default:
total 19404
-rw-r--r-- 1 splunk splunk     1154 Jun 28 18:15 application4.tgz
-rw-r--r-- 1 splunk splunk 19865458 Jun 28 18:18 splunk-machine-learning-toolkit_521.tgz

/init-apps/empty:
total 0
[splunk@splunk-s-af-aws-standalone-0 splunk]$ export SPLUNK_ADMIN_PW=$(cat /mnt/splunk-secrets/password); bin/splunk display app -auth admin:$SPLUNK_ADMIN_PW
alert_logevent                 CONFIGURED          ENABLED             INVISIBLE           
alert_webhook                  CONFIGURED          ENABLED             INVISIBLE           
application1                   UNCONFIGURED        ENABLED             VISIBLE             
application3                   UNCONFIGURED        ENABLED             VISIBLE             
application4                   UNCONFIGURED        ENABLED             VISIBLE             
appsbrowser                    CONFIGURED          ENABLED             INVISIBLE           
introspection_generator_addon  CONFIGURED          ENABLED             INVISIBLE           
journald_input                 UNCONFIGURED        ENABLED             INVISIBLE           
launcher                       CONFIGURED          ENABLED             VISIBLE             
learned                        UNCONFIGURED        ENABLED             INVISIBLE           
legacy                         UNCONFIGURED        DISABLED            INVISIBLE           
python_upgrade_readiness_app   UNCONFIGURED        ENABLED             VISIBLE             
sample_app                     UNCONFIGURED        DISABLED            INVISIBLE           
search                         CONFIGURED          ENABLED             VISIBLE             
splunk-dashboard-studio        CONFIGURED          ENABLED             VISIBLE             
splunk_archiver                CONFIGURED          ENABLED             INVISIBLE           
splunk_enterprise_on_docker    CONFIGURED          ENABLED             INVISIBLE           
splunk_essentials_8_2          CONFIGURED          ENABLED             VISIBLE             
splunk_gdi                     UNCONFIGURED        ENABLED             INVISIBLE           
splunk_httpinput               UNCONFIGURED        ENABLED             INVISIBLE           
splunk_instrumentation         UNCONFIGURED        ENABLED             VISIBLE             
splunk_internal_metrics        UNCONFIGURED        ENABLED             INVISIBLE           
splunk_metrics_workspace       UNCONFIGURED        ENABLED             VISIBLE             
Splunk_ML_Toolkit              UNCONFIGURED        ENABLED             VISIBLE             
splunk_monitoring_console      UNCONFIGURED        ENABLED             VISIBLE             
splunk_rapid_diag              UNCONFIGURED        ENABLED             VISIBLE             
splunk_secure_gateway          UNCONFIGURED        ENABLED             VISIBLE             
SplunkForwarder                UNCONFIGURED        DISABLED            INVISIBLE           
SplunkLightForwarder           UNCONFIGURED        DISABLED            INVISIBLE           
```

Validate that standalone comes up with only empty `appSource`.

```
NAME                                  READY   STATUS    RESTARTS   AGE
splunk-default-monitoring-console-0   0/1     Running   0          58s
splunk-operator-65c846679d-h6ktc      1/1     Running   0          7m47s
splunk-s-af-aws-standalone-0          1/1     Running   0          2m5s
```