### PR TITLE
CSPL-1321 C3 Automation for MC with App Framework

### DIFF
--- a/test/c3/appframework/appframework_test.go
+++ b/test/c3/appframework/appframework_test.go
@@ -61,9 +61,24 @@ var _ = Describe("c3appfw test", func() {
 	})
 
 	Context("Single Site Indexer Cluster with SHC (C3) with App Framework", func() {
-		It("integration, c3, appframework: can deploy a C3 SVA with App Framework enabled", func() {
+		It("integration, c3, appframework: can deploy a C3 SVA with App Framework enabled, install apps and upgrade them", func() {
 
-			// Create App framework Spec
+			/* Test Steps
+			   ################## SETUP ####################
+			   * Create 2 App Sources for MC and C3 SVA (CM and SHC Deployer)
+			   * Prepare C3 CRD with MC and App config
+			   * Apply C3 CRD and wait for pod to be ready
+			   * Prepare MC CRD with App Config
+			   * Wait for MC to be READY
+			   ################## VERIFICATIONS #############
+			   * Verify apps are copied, installed on MC AND SH,Indexers pods
+			   ############ UPGRADE APPS #############################
+			   * Upgrade apps in app sources
+			   * Wait for MC and C3 are READY
+			   * Verify apps are copied, installed and upgraded on MC AND SH,Indexers pods
+			*/
+
+			// Create App framework Spec for C3
 			volumeName := "appframework-test-volume-" + testenv.RandomDNSName(3)
 			volumeSpec := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volumeName, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
 
@@ -91,7 +106,7 @@ var _ = Describe("c3appfw test", func() {
 			err := deployment.DeploySingleSiteClusterWithGivenAppFrameworkSpec(deployment.GetName(), indexerReplicas, true, appFrameworkSpec, 10)
 			Expect(err).To(Succeed(), "Unable to deploy Single Site Indexer Cluster with App framework")
 
-			// Ensure that the cluster-master goes to Ready phase
+			// Ensure that the CM goes to Ready phase
 			testenv.ClusterMasterReady(deployment, testenvInstance)
 
 			// Ensure indexers go to Ready phase
@@ -100,52 +115,206 @@ var _ = Describe("c3appfw test", func() {
 			// Ensure search head cluster go to Ready phase
 			testenv.SearchHeadClusterReady(deployment, testenvInstance)
 
-			// Verify MC Pod is Ready
-			//testenv.MCPodReady(testenvInstance.GetName(), deployment)
-
 			// Verify RF SF is met
 			testenv.VerifyRFSFMet(deployment, testenvInstance)
 
-			// Verify Apps are downloaded by init-container
-			initContDownloadLocation := "/init-apps/" + appSourceName
-			podNames := []string{fmt.Sprintf(testenv.ClusterMasterPod, deployment.GetName()), fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
+			mcName := deployment.GetName()
+
+			// Upload Apps to S3 for MC
+			s3TestDirMC := "c3appfw-mc-" + testenv.RandomDNSName(4)
 			appFileList := testenv.GetAppFileList(appListV1, 1)
+			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDirMC, appFileList, downloadDirV1)
+			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+
+			// Create App framework Spec for MC
+			volumeNameMC := "appframework-test-volume-mc-" + testenv.RandomDNSName(3)
+			volumeSpecMC := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volumeNameMC, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+
+			// AppSourceDefaultSpec: Remote Storage volume name and Scope of App deployment
+			appSourceDefaultSpecMC := enterpriseApi.AppSourceDefaultSpec{
+				VolName: volumeNameMC,
+				Scope:   enterpriseApi.ScopeLocal,
+			}
+
+			// appSourceSpec: App source name, location and volume name and scope from appSourceDefaultSpec
+			appSourceNameMC := "appframework-mc-" + testenv.RandomDNSName(3)
+			appSourceSpecMC := []enterpriseApi.AppSourceSpec{testenv.GenerateAppSourceSpec(appSourceNameMC, s3TestDirMC, appSourceDefaultSpecMC)}
+
+			// appFrameworkSpec: AppSource settings, Poll Interval, volumes, appSources on volumes
+			appFrameworkSpecMC := enterpriseApi.AppFrameworkSpec{
+				Defaults:             appSourceDefaultSpecMC,
+				AppsRepoPollInterval: 60,
+				VolList:              volumeSpecMC,
+				AppSources:           appSourceSpecMC,
+			}
+
+			// MC AppFramework Spec
+			mcSpec := enterpriseApi.MonitoringConsoleSpec{
+				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
+					Spec: splcommon.Spec{
+						ImagePullPolicy: "IfNotPresent",
+					},
+					Volumes: []corev1.Volume{},
+				},
+				AppFrameworkConfig: appFrameworkSpecMC,
+			}
+
+			// Deploy MC CRD
+			mc, err := deployment.DeployMonitoringConsoleWithGivenSpec(testenvInstance.GetName(), mcName, mcSpec)
+			Expect(err).To(Succeed(), "Unable to deploy Monitoring Console One instance")
+
+			// Verify MC is Ready and stays in ready state
+			testenv.VerifyMonitoringConsoleReady(deployment, deployment.GetName(), mc, testenvInstance)
+
+			// Verify Apps are downloaded by init-container on CM, Deployer and MC
+			initContDownloadLocation := "/init-apps/" + appSourceName
+			initContDownloadLocationMCPod := "/init-apps/" + appSourceNameMC
+			mcPodName := fmt.Sprintf(testenv.MonitoringConsolePod, mcName, 0)
+			podNames := []string{fmt.Sprintf(testenv.ClusterMasterPod, deployment.GetName()), fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
+			appFileList = testenv.GetAppFileList(appListV1, 1)
 			appVersion := "V1"
 			testenvInstance.Log.Info("Verify Apps are downloaded by init container for apps", "version", appVersion)
 			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), podNames, appFileList, initContDownloadLocation)
+			testenvInstance.Log.Info("Verify Apps are downloaded by init container for apps", "POD", mcPodName, "version", appVersion)
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), []string{mcPodName}, appFileList, initContDownloadLocationMCPod)
 
-			//Verify Apps are copied to location
+			// Verify Apps are copied to location
 			allPodNames := testenv.DumpGetPods(testenvInstance.GetName())
 			testenvInstance.Log.Info("Verify Apps are copied to correct location based on Pod KIND for app", "version", appVersion)
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, true)
 
 			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
-			testenvInstance.Log.Info("Verify Apps are NOT copied to /etc/apps on CM and Deployer for app", "verison", appVersion, "App List", appFileList)
+			testenvInstance.Log.Info("Verify Apps are NOT copied to /etc/apps on CM and Deployer for app", "version", appVersion, "App List", appFileList)
 			masterPodNames := []string{fmt.Sprintf(testenv.ClusterMasterPod, deployment.GetName()), fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV1, false, false)
 
-			//Verify Apps are installed
+			// Verify Apps are installed
 			testenvInstance.Log.Info("Verify Apps are installed on the pods by running Splunk CLI commands for app", "version", appVersion)
 			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, "enabled", false, true)
 
-			//Delete apps on S3 for new Apps
+			// Delete apps on S3 for new Apps
 			testenvInstance.Log.Info("Delete Apps on S3 for", "Version", appVersion)
 			testenv.DeleteFilesOnS3(testS3Bucket, uploadedApps)
 			uploadedApps = nil
 			testenvInstance.Log.Info("Testing upgrade scenario")
 
-			//Upload new Versioned Apps to S3
+			// Upload new Versioned Apps to S3
 			appFileList = testenv.GetAppFileList(appListV2, 2)
 			appVersion = "V2"
-			testenvInstance.Log.Info("Uploading apps S3 for", "verison", appVersion)
-			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV2)
+			testenvInstance.Log.Info("Uploading apps S3 for", "version", appVersion)
+			uploadedFiles, err = testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV2)
+			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+			uploadedFiles, err = testenv.UploadFilesToS3(testS3Bucket, s3TestDirMC, appFileList, downloadDirV2)
 			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
 			// Wait for the poll period for the apps to be downloaded
 			time.Sleep(2 * time.Minute)
 
-			// Ensure that the cluster-master goes to Ready phase
+			// Ensure that the CM goes to Ready phase
+			testenv.ClusterMasterReady(deployment, testenvInstance)
+
+			// Ensure indexers go to Ready phase
+			testenv.SingleSiteIndexersReady(deployment, testenvInstance)
+
+			// Ensure SHC go to Ready phase
+			testenv.SearchHeadClusterReady(deployment, testenvInstance)
+
+			// Verify RF SF is met
+			testenv.VerifyRFSFMet(deployment, testenvInstance)
+
+			// Verify MC is Ready and stays in ready state
+			testenv.VerifyMonitoringConsoleReady(deployment, deployment.GetName(), mc, testenvInstance)
+
+			// Verify Apps are downloaded by init-container
+			testenvInstance.Log.Info("Verify Apps are downloaded by init container for apps", "version", appVersion)
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), podNames, appFileList, initContDownloadLocation)
+			testenvInstance.Log.Info("Verify Apps are downloaded by init container for apps", "POD", mcPodName, "version", appVersion)
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), []string{mcPodName}, appFileList, initContDownloadLocationMCPod)
+
+			// Verify Apps are copied to location
+			testenvInstance.Log.Info("Verify Apps are copied to correct location based on Pod KIND for app", "version", appVersion)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, true)
+
+			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
+			testenvInstance.Log.Info("Verify Apps are NOT copied to /etc/apps on CM and Deployer for app", "version", appVersion)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV2, false, false)
+
+			// Verify Apps are updated
+			testenvInstance.Log.Info("Verify Apps are installed on the pods by running Splunk CLI commands for app", "version", appVersion)
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, "enabled", true, true)
+		})
+	})
+
+	Context("Single Site Indexer Cluster with SHC (C3) with App Framework", func() {
+		It("integration, c3, appframework: can deploy a C3 SVA with App Framework enabled, install apps and downgrade them", func() {
+
+			/* Test Steps
+			   ################## SETUP ####################
+			   * Create 2 App Sources for MC and C3 SVA (CM and SHC Deployer)
+			   * Prepare C3 CRD with MC and App config
+			   * Apply C3 CRD and wait for pod to be ready
+			   * Prepare MC CRD with App Config
+			   * Wait for MC to be READY
+			   ################## VERIFICATIONS #############
+			   * Verify apps are copied, installed on MC AND SH,Indexers pods
+			   ##########  SCALE UP SHC and Indexers ###########
+			   * Wait for SHC, indexers and MC to be ready
+			   * Verify apps are copied, installed on MC AND SH,Indexers pods
+			   ############ DOWNGRADE APPS #############################
+			   * Downgrade apps in app sources
+			   * Wait for MC and C3 to be READY
+			   * Verify apps are copied, installed and downgraded on MC AND SH,Indexers pods
+			*/
+
+			// Delete pre-installed apps on S3
+			testenv.DeleteFilesOnS3(testS3Bucket, uploadedApps)
+			uploadedApps = nil
+			testenvInstance.Log.Info("Testing downgrade scenario")
+
+			// Upload newer version of apps to S3
+			s3TestDir = "c3appfw-" + testenv.RandomDNSName(4)
+			appFileList := testenv.GetAppFileList(appListV2, 2)
+			appVersion := "V2"
+			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV2)
+			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+			s3TestDirMC := "c3appfw-mc-" + testenv.RandomDNSName(4)
+			uploadedFiles, err = testenv.UploadFilesToS3(testS3Bucket, s3TestDirMC, appFileList, downloadDirV2)
+			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+
+			// Create App framework Spec for C3
+			volumeName := "appframework-test-volume-" + testenv.RandomDNSName(3)
+			volumeSpec := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volumeName, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+
+			// AppSourceDefaultSpec: Remote Storage volume name and Scope of App deployment
+			appSourceDefaultSpec := enterpriseApi.AppSourceDefaultSpec{
+				VolName: volumeName,
+				Scope:   enterpriseApi.ScopeCluster,
+			}
+
+			// appSourceSpec: App source name, location and volume name and scope from appSourceDefaultSpec
+			appSourceName := "appframework" + testenv.RandomDNSName(3)
+			appSourceSpec := []enterpriseApi.AppSourceSpec{testenv.GenerateAppSourceSpec(appSourceName, s3TestDir, appSourceDefaultSpec)}
+
+			// appFrameworkSpec: AppSource settings, Poll Interval, volumes, appSources on volumes
+			appFrameworkSpec := enterpriseApi.AppFrameworkSpec{
+				Defaults:             appSourceDefaultSpec,
+				AppsRepoPollInterval: 60,
+				VolList:              volumeSpec,
+				AppSources:           appSourceSpec,
+			}
+
+			indexerReplicas := 3
+
+			testenvInstance.Log.Info("Deploy Single Site Indexer Cluster")
+			err = deployment.DeploySingleSiteClusterWithGivenAppFrameworkSpec(deployment.GetName(), indexerReplicas, true, appFrameworkSpec, 10)
+			Expect(err).To(Succeed(), "Unable to deploy Single Site Indexer Cluster with App framework")
+
+			// Ensure that the CM goes to Ready phase
 			testenv.ClusterMasterReady(deployment, testenvInstance)
 
 			// Ensure indexers go to Ready phase
@@ -154,25 +323,72 @@ var _ = Describe("c3appfw test", func() {
 			// Ensure search head cluster go to Ready phase
 			testenv.SearchHeadClusterReady(deployment, testenvInstance)
 
-			// Verify MC Pod is Ready
-			//testenv.MCPodReady(testenvInstance.GetName(), deployment)
-
 			// Verify RF SF is met
 			testenv.VerifyRFSFMet(deployment, testenvInstance)
 
-			// Verify Apps are downloaded by init-container
+			// Create App framework Spec for MC
+			mcName := deployment.GetName()
+			volumeNameMC := "appframework-test-volume-mc-" + testenv.RandomDNSName(3)
+			volumeSpecMC := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volumeNameMC, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+
+			// AppSourceDefaultSpec: Remote Storage volume name and Scope of App deployment
+			appSourceDefaultSpecMC := enterpriseApi.AppSourceDefaultSpec{
+				VolName: volumeNameMC,
+				Scope:   enterpriseApi.ScopeLocal,
+			}
+
+			// appSourceSpec: App source name, location and volume name and scope from appSourceDefaultSpec
+			appSourceNameMC := "appframework-mc-" + testenv.RandomDNSName(3)
+			appSourceSpecMC := []enterpriseApi.AppSourceSpec{testenv.GenerateAppSourceSpec(appSourceNameMC, s3TestDirMC, appSourceDefaultSpecMC)}
+
+			// appFrameworkSpec: AppSource settings, Poll Interval, volumes, appSources on volumes
+			appFrameworkSpecMC := enterpriseApi.AppFrameworkSpec{
+				Defaults:             appSourceDefaultSpecMC,
+				AppsRepoPollInterval: 60,
+				VolList:              volumeSpecMC,
+				AppSources:           appSourceSpecMC,
+			}
+
+			// MC AppFramework Spec
+			mcSpec := enterpriseApi.MonitoringConsoleSpec{
+				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
+					Spec: splcommon.Spec{
+						ImagePullPolicy: "IfNotPresent",
+					},
+					Volumes: []corev1.Volume{},
+				},
+				AppFrameworkConfig: appFrameworkSpecMC,
+			}
+
+			// Deploy MC CRD
+			mc, err := deployment.DeployMonitoringConsoleWithGivenSpec(testenvInstance.GetName(), mcName, mcSpec)
+			Expect(err).To(Succeed(), "Unable to deploy Monitoring Console One instance")
+
+			// Verify MC is Ready and stays in ready state
+			testenv.VerifyMonitoringConsoleReady(deployment, deployment.GetName(), mc, testenvInstance)
+
+			// Verify Apps are downloaded by init-container on CM, Deployer and MC
+			initContDownloadLocation := "/init-apps/" + appSourceName
+			initContDownloadLocationMCPod := "/init-apps/" + appSourceNameMC
+			mcPodName := fmt.Sprintf(testenv.MonitoringConsolePod, mcName, 0)
+			podNames := []string{fmt.Sprintf(testenv.ClusterMasterPod, deployment.GetName()), fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
+			appFileList = testenv.GetAppFileList(appListV2, 2)
 			testenvInstance.Log.Info("Verify Apps are downloaded by init container for apps", "version", appVersion)
 			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), podNames, appFileList, initContDownloadLocation)
+			testenvInstance.Log.Info("Verify Apps are downloaded by init container for apps", "POD", mcPodName, "version", appVersion)
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), []string{mcPodName}, appFileList, initContDownloadLocationMCPod)
 
-			//Verify Apps are copied to location
+			// Verify Apps are copied to location
+			allPodNames := testenv.DumpGetPods(testenvInstance.GetName())
 			testenvInstance.Log.Info("Verify Apps are copied to correct location based on Pod KIND for app", "version", appVersion)
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, true)
 
 			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
-			testenvInstance.Log.Info("Verify Apps are NOT copied to /etc/apps on CM and Deployer for app", "verison", appVersion)
+			testenvInstance.Log.Info("Verify Apps are NOT copied to /etc/apps on CM and Deployer for app", "version", appVersion, "App List", appFileList)
+			masterPodNames := []string{fmt.Sprintf(testenv.ClusterMasterPod, deployment.GetName()), fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV2, false, false)
 
-			//Verify Apps are updated
+			// Verify Apps are installed
 			testenvInstance.Log.Info("Verify Apps are installed on the pods by running Splunk CLI commands for app", "version", appVersion)
 			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, "enabled", true, true)
 
@@ -182,7 +398,7 @@ var _ = Describe("c3appfw test", func() {
 			err = deployment.GetInstance(shcName, shc)
 			Expect(err).To(Succeed(), "Failed to get instance of Search Head Cluster")
 
-			// Scale Search Head Cluster
+			// Scale SHC
 			defaultSHReplicas := shc.Spec.Replicas
 			scaledSHReplicas := defaultSHReplicas + 1
 			testenvInstance.Log.Info("Scaling up Search Head Cluster", "Current Replicas", defaultSHReplicas, "New Replicas", scaledSHReplicas)
@@ -192,7 +408,7 @@ var _ = Describe("c3appfw test", func() {
 			err = deployment.UpdateCR(shc)
 			Expect(err).To(Succeed(), "Failed to scale Search Head Cluster")
 
-			// Ensure Search Head cluster scales up and go to ScalingUp phase
+			// Ensure SHC scales up and go to ScalingUp phase
 			testenv.VerifySearchHeadClusterPhase(deployment, testenvInstance, splcommon.PhaseScalingUp)
 
 			// Get instance of current Indexer CR with latest config
@@ -222,44 +438,47 @@ var _ = Describe("c3appfw test", func() {
 			testenvInstance.Log.Info("Checking for New Indexer On Cluster Master", "Indexer Name", indexerName)
 			Expect(testenv.CheckIndexerOnCM(deployment, indexerName)).To(Equal(true))
 
-			// Ensure search head cluster go to Ready phase
+			// Ensure SHC go to Ready phase
 			testenv.SearchHeadClusterReady(deployment, testenvInstance)
 
-			// Verify MC Pod is Ready
-			//testenv.MCPodReady(testenvInstance.GetName(), deployment)
+			// Verify MC is Ready and stays in ready state
+			testenv.VerifyMonitoringConsoleReady(deployment, deployment.GetName(), mc, testenvInstance)
 
 			// Verify RF SF is met
 			testenv.VerifyRFSFMet(deployment, testenvInstance)
 
-			// Verify Apps are copied to location
+			// Verify apps are copied to location
 			allPodNames = testenv.DumpGetPods(testenvInstance.GetName())
 			testenvInstance.Log.Info("Verify Apps are copied to correct location based on Pod KIND for app", "version", appVersion)
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, true)
 
 			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
-			testenvInstance.Log.Info("Verify Apps are NOT copied to /etc/apps on CM and Deployer for app", "verison", appVersion)
+			testenvInstance.Log.Info("Verify Apps are NOT copied to /etc/apps on CM and Deployer for app", "version", appVersion)
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV2, false, false)
 
-			// Verify Apps install status and version
+			// Verify apps install status and version
 			testenvInstance.Log.Info("Verify Apps are installed on the pods by running Splunk CLI commands for app", "version", appVersion)
 			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, "enabled", true, true)
 
-			//Delete apps on S3 for new Apps
+			// Delete apps on S3 for new Apps
 			testenv.DeleteFilesOnS3(testS3Bucket, uploadedApps)
 			uploadedApps = nil
 			testenvInstance.Log.Info("Testing downgrade scenario")
 
-			//Upload new Versioned Apps to S3
+			// Upload older version of apps to S3
 			appFileList = testenv.GetAppFileList(appListV1, 1)
 			appVersion = "V1"
 			uploadedFiles, err = testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV1)
+			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+			uploadedFiles, err = testenv.UploadFilesToS3(testS3Bucket, s3TestDirMC, appFileList, downloadDirV1)
 			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
 			// Wait for the poll period for the apps to be downloaded
 			time.Sleep(2 * time.Minute)
 
-			// Ensure that the cluster-master goes to Ready phase
+			// Ensure that the CM goes to Ready phase
 			testenv.ClusterMasterReady(deployment, testenvInstance)
 
 			// Ensure indexers go to Ready phase
@@ -268,28 +487,27 @@ var _ = Describe("c3appfw test", func() {
 			// Ensure search head cluster go to Ready phase
 			testenv.SearchHeadClusterReady(deployment, testenvInstance)
 
-			// Verify MC Pod is Ready
-			testenv.MCPodReady(testenvInstance.GetName(), deployment)
+			// Verify Monitoring Console is Ready and stays in ready state
+			testenv.VerifyMonitoringConsoleReady(deployment, deployment.GetName(), mc, testenvInstance)
 
 			// Verify RF SF is met
 			testenv.VerifyRFSFMet(deployment, testenvInstance)
 
-			// Verify Apps are downloaded by init-container
+			// Verify apps are downloaded by init-container
 			testenvInstance.Log.Info("Verify Apps are downloaded by init container for apps", " version", appVersion)
 			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), podNames, appFileList, initContDownloadLocation)
 
-			//Verify Apps are copied to location
+			// Verify apps are copied to location
 			testenvInstance.Log.Info("Verify Apps are copied to correct location based on Pod KIND for app", " version", appVersion)
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, true)
 
 			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
-			testenvInstance.Log.Info("Verify Apps are NOT copied to /etc/apps on CM and Deployer for app", " verison", appVersion)
+			testenvInstance.Log.Info("Verify Apps are NOT copied to /etc/apps on CM and Deployer for app", " version", appVersion)
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV1, false, false)
 
-			//Verify Apps are updated
+			// Verify apps are installed cluster-wide
 			testenvInstance.Log.Info("Verify Apps are installed on the pods by running Splunk CLI commands for app", " version", appVersion)
 			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, "enabled", false, true)
-
 		})
 	})
 
@@ -354,7 +572,7 @@ var _ = Describe("c3appfw test", func() {
 			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), podNames, appListV1, false, "enabled", false, false)
 
 			// Verify apps are not copied in /etc/master-apps/ on CM and /etc/shcluster/ on Deployer (therefore not installed on peers and on SH)
-			testenvInstance.Log.Info("Verify Apps are NOT copied to /etc/master-apps/ on CM and /etc/shcluster/ on Deployer for app", "verison", appVersion, "App List", appFileList)
+			testenvInstance.Log.Info("Verify Apps are NOT copied to /etc/master-apps/ on CM and /etc/shcluster/ on Deployer for app", "version", appVersion, "App List", appFileList)
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), podNames, appListV1, false, true)
 
 			//Delete apps on S3 for new Apps
@@ -365,7 +583,7 @@ var _ = Describe("c3appfw test", func() {
 
 			//Upload new Versioned Apps to S3
 			appVersion = "V2"
-			testenvInstance.Log.Info("Uploading apps S3 for", "verison", appVersion)
+			testenvInstance.Log.Info("Uploading apps S3 for", "version", appVersion)
 			appFileList = testenv.GetAppFileList(appListV2, 2)
 			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV2)
 			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
@@ -399,7 +617,7 @@ var _ = Describe("c3appfw test", func() {
 			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), podNames, appListV2, true, "enabled", true, false)
 
 			// Verify apps are not copied in /etc/master-apps/ on CM and /etc/shcluster/ on Deployer (therefore not installed on peers and on SH)
-			testenvInstance.Log.Info("Verify Apps are NOT copied to /etc/master-apps/ on CM and /etc/shcluster/ on Deployer for app", "verison", appVersion, "App List", appFileList)
+			testenvInstance.Log.Info("Verify Apps are NOT copied to /etc/master-apps/ on CM and /etc/shcluster/ on Deployer for app", "version", appVersion, "App List", appFileList)
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), podNames, appListV2, false, true)
 		})
 	})


### PR DESCRIPTION
Adding testing of App framework for MC CRD.
Previous test got added steps and is also separated in 2 tests as its execution time was too long.

Original test actions:
- Create app framework
- Deploy C3
- Download V1 apps, install them cluster wide
- Download V2 apps, upgrade
- Download V1 apps, downgrade
- Scale up indexers, verify apps


1st test:
- Setup up App sources for MC and C3
- Download V1 apps, install them cluster wide and on MC
- Download V2 apps, upgrade
- Verify apps

2nd test:
- Setup up App sources for MC and C3
- Download V2 apps, install them cluster wide and on MC
- Scale up indexers
- Download V1 apps, downgrade
- Verify apps


Test runs:
Test1:
```
[2] • [SLOW TEST:1400.570 seconds]
[2] c3appfw test
[2] /Users/jambrosiano/splunk-operator/CSPL-1321/splunk-operator/test/c3/appframework/appframework_test.go:29
[2]   Single Site Indexer Cluster with SHC (C3) with App Framework
[2]   /Users/jambrosiano/splunk-operator/CSPL-1321/splunk-operator/test/c3/appframework/appframework_test.go:63
[2]     integration, c3, appframework: can deploy a C3 SVA with App Framework enabled, install apps and upgrade them
[2]     /Users/jambrosiano/splunk-operator/CSPL-1321/splunk-operator/test/c3/appframework/appframework_test.go:64
[2] ------------------------------
[2] {"level":"info","ts":1632868759.555271,"msg":"testenv deleted.\n","testenv":"c3appfw-e9x"}
[2] {"level":"info","ts":1632868759.5553012,"msg":"testenv deleted.\n","testenv":"c3appfw-e9x"}
[2]
[2] JUnit report was created: /Users/jambrosiano/splunk-operator/CSPL-1321/splunk-operator/test/c3/appframework/c3appfw-e9x_junit.xml
[2]
[2] Ran 1 of 1 Specs in 1415.249 seconds
[2] SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[2] PASS
```

Test 2:
```
[1] • [SLOW TEST:2356.711 seconds]
[1] c3appfw test
[1] /Users/jambrosiano/splunk-operator/CSPL-1321/splunk-operator/test/c3/appframework/appframework_test.go:29
[1]   Single Site Indexer Cluster with SHC (C3) with App Framework
[1]   /Users/jambrosiano/splunk-operator/CSPL-1321/splunk-operator/test/c3/appframework/appframework_test.go:251
[1]     integration, c3, appframework: can deploy a C3 SVA with App Framework enabled, install apps and downgrade them
[1]     /Users/jambrosiano/splunk-operator/CSPL-1321/splunk-operator/test/c3/appframework/appframework_test.go:252
[1] ------------------------------
[1] {"level":"info","ts":1632880115.388144,"msg":"testenv deleted.\n","testenv":"c3appfw-vrf"}
[1] {"level":"info","ts":1632880115.3881652,"msg":"testenv deleted.\n","testenv":"c3appfw-vrf"}
[1]
[1] JUnit report was created: /Users/jambrosiano/splunk-operator/CSPL-1321/splunk-operator/test/c3/appframework/c3appfw-vrf_junit.xml
[1]
[1] Ran 1 of 2 Specs in 2371.904 seconds
[1] SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 0 Skipped
[1] PASS

```