### PR TITLE
CSPL-1322: Add MC+AppFramework automation for M4

### DIFF
--- a/test/m4/appframework/appframework_test.go
+++ b/test/m4/appframework/appframework_test.go
@@ -24,6 +24,7 @@ import (
 
 	enterpriseApi "github.com/splunk/splunk-operator/pkg/apis/enterprise/v3"
 	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var _ = Describe("m4appfw test", func() {
@@ -60,24 +61,73 @@ var _ = Describe("m4appfw test", func() {
 		}
 	})
 
-	Context("Multi Site Indexer Cluster with SHC (M4) with App Framework", func() {
+	Context("Multi Site Indexer Cluster with SHC (m4) with App Framework", func() {
 		It("integration, m4, appframework: can deploy a M4 SVA with App Framework enabled, install apps and upgrade them", func() {
 
-			// Create App framework Spec
+			/* Test Steps
+			   ################## SETUP ##################
+			   * Create 2 App Sources for MC (Monitoring Console) and M4 SVA (CM and SHC Deployer)
+			   * Prepare and deploy MC CRD with app framework and wait for pod to be ready
+			   * Prepare and deploy M4 CRD with app framework and wait for pods to be ready
+			   ############### VERIFICATION ##############
+			   * Verify apps are copied and installed on MC and on SH and Indexers pods
+			   ############### UPGRADE APPS ##############
+			   * Upgrade apps in app sources
+			   * Wait for MC and M4 pod to be ready
+			   ############### VERIFICATION ##############
+			   * Verify apps are copied and upgraded on MC and on SH and Indexers pods
+			*/
+
+			// Upload apps to S3 for MC
+			s3TestDirMC := "m4appfw-mc-" + testenv.RandomDNSName(4)
+			appFileList := testenv.GetAppFileList(appListV1, 1)
+			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDirMC, appFileList, downloadDirV1)
+			Expect(err).To(Succeed(), "Unable to upload apps for MC to S3 test directory")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+
+			// Create App framework Spec for MC
+			volumeNameMC := "appframework-test-volume-mc-" + testenv.RandomDNSName(3)
+			volumeSpecMC := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volumeNameMC, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+			appSourceDefaultSpecMC := enterpriseApi.AppSourceDefaultSpec{
+				VolName: volumeNameMC,
+				Scope:   enterpriseApi.ScopeLocal,
+			}
+			appSourceNameMC := "appframework-mc-" + testenv.RandomDNSName(3)
+			appSourceSpecMC := []enterpriseApi.AppSourceSpec{testenv.GenerateAppSourceSpec(appSourceNameMC, s3TestDirMC, appSourceDefaultSpecMC)}
+			appFrameworkSpecMC := enterpriseApi.AppFrameworkSpec{
+				Defaults:             appSourceDefaultSpecMC,
+				AppsRepoPollInterval: 60,
+				VolList:              volumeSpecMC,
+				AppSources:           appSourceSpecMC,
+			}
+			mcSpec := enterpriseApi.MonitoringConsoleSpec{
+				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
+					Spec: splcommon.Spec{
+						ImagePullPolicy: "IfNotPresent",
+					},
+					Volumes: []corev1.Volume{},
+				},
+				AppFrameworkConfig: appFrameworkSpecMC,
+			}
+
+			// Deploy MC CRD
+			testenvInstance.Log.Info("Deploy Monitoring Console")
+			mcName := deployment.GetName()
+			mc, err := deployment.DeployMonitoringConsoleWithGivenSpec(testenvInstance.GetName(), mcName, mcSpec)
+			Expect(err).To(Succeed(), "Unable to deploy Monitoring Console instance")
+
+			// Verify MC is ready and stays in ready state
+			testenv.VerifyMonitoringConsoleReady(deployment, deployment.GetName(), mc, testenvInstance)
+
+			// Create App framework Spec for M4
 			volumeName := "appframework-test-volume-" + testenv.RandomDNSName(3)
 			volumeSpec := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volumeName, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
-
-			// appSourceDefaultSpec: Remote Storage volume name and Scope of App deployment
 			appSourceDefaultSpec := enterpriseApi.AppSourceDefaultSpec{
 				VolName: volumeName,
 				Scope:   enterpriseApi.ScopeCluster,
 			}
-
-			// appSourceSpec: App source name, location and volume name and scope from appSourceDefaultSpec
 			appSourceName := "appframework" + testenv.RandomDNSName(3)
 			appSourceSpec := []enterpriseApi.AppSourceSpec{testenv.GenerateAppSourceSpec(appSourceName, s3TestDir, appSourceDefaultSpec)}
-
-			// appFrameworkSpec: AppSource settings, Poll Interval, volumes, appSources on volumes
 			appFrameworkSpec := enterpriseApi.AppFrameworkSpec{
 				Defaults:             appSourceDefaultSpec,
 				AppsRepoPollInterval: 60,
@@ -85,11 +135,390 @@ var _ = Describe("m4appfw test", func() {
 				AppSources:           appSourceSpec,
 			}
 
+			// Deploy M4 CRD
+			testenvInstance.Log.Info("Deploy Multisite Indexer Cluster with SHC")
 			siteCount := 3
 			indexersPerSite := 1
+			err = deployment.DeployMultisiteClusterWithSearchHeadAndAppFramework(deployment.GetName(), indexersPerSite, siteCount, appFrameworkSpec, true, 10, mcName, "")
+			Expect(err).To(Succeed(), "Unable to deploy Multi Site Indexer Cluster and SHC with App framework")
 
-			testenvInstance.Log.Info("Deploy Multisite Indexer Cluster")
-			err := deployment.DeployMultisiteClusterWithSearchHeadAndAppFramework(deployment.GetName(), indexersPerSite, siteCount, appFrameworkSpec, true, 10)
+			// Ensure that the CM goes to Ready phase
+			testenv.ClusterMasterReady(deployment, testenvInstance)
+
+			// Ensure the indexers of all sites go to Ready phase
+			testenv.IndexersReady(deployment, testenvInstance, siteCount)
+
+			// Ensure cluster configured as multisite
+			testenv.IndexerClusterMultisiteStatus(deployment, testenvInstance, siteCount)
+
+			// Ensure SHC go to Ready phase
+			testenv.SearchHeadClusterReady(deployment, testenvInstance)
+
+			// Verify RF SF is met
+			testenv.VerifyRFSFMet(deployment, testenvInstance)
+
+			// Verify MC is Ready and stays in ready state
+			testenv.VerifyMonitoringConsoleReady(deployment, deployment.GetName(), mc, testenvInstance)
+
+			// Verify apps are downloaded by init-container on CM, Deployer and MC
+			appVersion := "V1"
+			initContDownloadLocation := "/init-apps/" + appSourceName
+			initContDownloadLocationMCPod := "/init-apps/" + appSourceNameMC
+			mcPodName := fmt.Sprintf(testenv.MonitoringConsolePod, mcName, 0)
+			podNames := []string{fmt.Sprintf(testenv.ClusterMasterPod, deployment.GetName()), fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
+			appFileList = testenv.GetAppFileList(appListV1, 1)
+			testenvInstance.Log.Info("Verify Apps are downloaded by init container for apps", "version", appVersion)
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), podNames, appFileList, initContDownloadLocation)
+			testenvInstance.Log.Info("Verify Apps are downloaded by init container on MC for apps", "POD", mcPodName, "version", appVersion)
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), []string{mcPodName}, appFileList, initContDownloadLocationMCPod)
+
+			// Verify apps are copied to correct location
+			allPodNames := testenv.DumpGetPods(testenvInstance.GetName())
+			testenvInstance.Log.Info("Verify apps are copied to correct location based on Pod KIND for app", "version", appVersion)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, true)
+
+			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
+			masterPodNames := []string{fmt.Sprintf(testenv.ClusterMasterPod, deployment.GetName()), fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
+			testenvInstance.Log.Info("Verify Apps are NOT copied to /etc/apps on CM and Deployer for app", "version", appVersion, "App List", appFileList)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV1, false, false)
+
+			// Verify apps are installed on MC and M4(cluster-wide)
+			testenvInstance.Log.Info("Verify Apps are installed on the pods by running Splunk CLI commands for app", "version", appVersion)
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, "enabled", false, true)
+
+			// Delete apps on S3
+			testenvInstance.Log.Info("Delete Apps on S3 for", "Version", appVersion)
+			testenv.DeleteFilesOnS3(testS3Bucket, uploadedApps)
+			uploadedApps = nil
+			testenvInstance.Log.Info("Testing upgrade scenario")
+
+			// Upload newer version of apps to S3 for M4 and MC
+			appFileList = testenv.GetAppFileList(appListV2, 2)
+			appVersion = "V2"
+			testenvInstance.Log.Info("Uploading apps S3 for", "version", appVersion)
+			uploadedFiles, err = testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV2)
+			Expect(err).To(Succeed(), "Unable to upload newer version of apps for M4 to S3 test directory")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+			uploadedFiles, err = testenv.UploadFilesToS3(testS3Bucket, s3TestDirMC, appFileList, downloadDirV2)
+			Expect(err).To(Succeed(), "Unable to upload newer version of apps for MC to S3 test directory")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+
+			// Wait for the poll period for the apps to be downloaded
+			time.Sleep(2 * time.Minute)
+
+			// Ensure that the CM goes to Ready phase
+			testenv.ClusterMasterReady(deployment, testenvInstance)
+
+			// Ensure the indexers of all sites go to Ready phase
+			testenv.IndexersReady(deployment, testenvInstance, siteCount)
+
+			// Ensure cluster configured as multisite
+			testenv.IndexerClusterMultisiteStatus(deployment, testenvInstance, siteCount)
+
+			// Ensure SHC go to Ready phase
+			testenv.SearchHeadClusterReady(deployment, testenvInstance)
+
+			// Verify RF SF is met
+			testenv.VerifyRFSFMet(deployment, testenvInstance)
+
+			// Verify MC is Ready and stays in ready state
+			testenv.VerifyMonitoringConsoleReady(deployment, deployment.GetName(), mc, testenvInstance)
+
+			// Verify apps are downloaded by init-container
+			testenvInstance.Log.Info("Verify apps are downloaded by init container for M4 for apps", "version", appVersion)
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), podNames, appFileList, initContDownloadLocation)
+			testenvInstance.Log.Info("Verify apps are downloaded by init container for MC for apps", "POD", mcPodName, "version", appVersion)
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), []string{mcPodName}, appFileList, initContDownloadLocationMCPod)
+
+			// Verify apps are copied to location
+			testenvInstance.Log.Info("Verify apps are copied to correct location based on Pod KIND for app", "version", appVersion)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, true)
+
+			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
+			testenvInstance.Log.Info("Verify apps are NOT copied to /etc/apps on CM and Deployer for app", "version", appVersion)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV2, false, false)
+
+			// Verify apps are updated on MC and M4(cluster-wide)
+			testenvInstance.Log.Info("Verify apps are updated on the MC and M4 pods for app", "version", appVersion)
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, "enabled", true, true)
+		})
+	})
+
+	Context("Multi Site Indexer Cluster with SHC (m4) with App Framework", func() {
+		It("integration, m4, appframework: can deploy a M4 SVA with App Framework enabled, install apps and downgrade them", func() {
+
+			/* Test Steps
+			   ################## SETUP ##################
+			   * Create 2 App Sources for MC and M4 SVA (CM and SHC Deployer)
+			   * Prepare and deploy MC CRD with app config and wait for pod to be ready
+			   * Prepare and deploy M4 CRD with app config and wait for pods to be ready
+			   ############### VERIFICATION ##############
+			   * Verify apps are copied and installed on MC and on SH and Indexers pods
+			   ############### DOWNGRADE APPS ############
+			   * Downgrade apps in app sources
+			   * Wait for MC and M4 to be ready
+			   ############### VERIFICATION ##############
+			   * Verify apps are copied and downgraded on MC and on SH and Indexers pods
+			*/
+
+			// Delete pre-installed apps on S3
+			testenv.DeleteFilesOnS3(testS3Bucket, uploadedApps)
+			uploadedApps = nil
+			testenvInstance.Log.Info("Testing downgrade scenario")
+
+			// Upload newer version of apps to S3
+			s3TestDir = "m4appfw-" + testenv.RandomDNSName(4)
+			appFileList := testenv.GetAppFileList(appListV2, 2)
+			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV2)
+			Expect(err).To(Succeed(), "Unable to upload newer version of apps for M4 to S3 test directory")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+			s3TestDirMC := "m4appfw-mc-" + testenv.RandomDNSName(4)
+			uploadedFiles, err = testenv.UploadFilesToS3(testS3Bucket, s3TestDirMC, appFileList, downloadDirV2)
+			Expect(err).To(Succeed(), "Unable to upload newer version of apps for MC to S3 test directory")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+
+			// Create App framework Spec for MC
+			volumeNameMC := "appframework-test-volume-mc-" + testenv.RandomDNSName(3)
+			volumeSpecMC := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volumeNameMC, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+			appSourceDefaultSpecMC := enterpriseApi.AppSourceDefaultSpec{
+				VolName: volumeNameMC,
+				Scope:   enterpriseApi.ScopeLocal,
+			}
+			appSourceNameMC := "appframework-mc-" + testenv.RandomDNSName(3)
+			appSourceSpecMC := []enterpriseApi.AppSourceSpec{testenv.GenerateAppSourceSpec(appSourceNameMC, s3TestDirMC, appSourceDefaultSpecMC)}
+			appFrameworkSpecMC := enterpriseApi.AppFrameworkSpec{
+				Defaults:             appSourceDefaultSpecMC,
+				AppsRepoPollInterval: 60,
+				VolList:              volumeSpecMC,
+				AppSources:           appSourceSpecMC,
+			}
+			mcSpec := enterpriseApi.MonitoringConsoleSpec{
+				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
+					Spec: splcommon.Spec{
+						ImagePullPolicy: "IfNotPresent",
+					},
+					Volumes: []corev1.Volume{},
+				},
+				AppFrameworkConfig: appFrameworkSpecMC,
+			}
+
+			// Deploy MC CRD
+			testenvInstance.Log.Info("Deploy Monitoring Console")
+			mcName := deployment.GetName()
+			mc, err := deployment.DeployMonitoringConsoleWithGivenSpec(testenvInstance.GetName(), mcName, mcSpec)
+			Expect(err).To(Succeed(), "Unable to deploy Monitoring Console instance")
+
+			// Verify MC is ready and stays in ready state
+			testenv.VerifyMonitoringConsoleReady(deployment, deployment.GetName(), mc, testenvInstance)
+
+			// Create App framework Spec for M4
+			volumeName := "appframework-test-volume-" + testenv.RandomDNSName(3)
+			volumeSpec := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volumeName, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+			appSourceDefaultSpec := enterpriseApi.AppSourceDefaultSpec{
+				VolName: volumeName,
+				Scope:   enterpriseApi.ScopeCluster,
+			}
+			appSourceName := "appframework" + testenv.RandomDNSName(3)
+			appSourceSpec := []enterpriseApi.AppSourceSpec{testenv.GenerateAppSourceSpec(appSourceName, s3TestDir, appSourceDefaultSpec)}
+			appFrameworkSpec := enterpriseApi.AppFrameworkSpec{
+				Defaults:             appSourceDefaultSpec,
+				AppsRepoPollInterval: 60,
+				VolList:              volumeSpec,
+				AppSources:           appSourceSpec,
+			}
+
+			// Deploy M4 CRD
+			testenvInstance.Log.Info("Deploy Multisite Indexer Cluster with SHC")
+			siteCount := 3
+			indexersPerSite := 1
+			err = deployment.DeployMultisiteClusterWithSearchHeadAndAppFramework(deployment.GetName(), indexersPerSite, siteCount, appFrameworkSpec, true, 10, mcName, "")
+			Expect(err).To(Succeed(), "Unable to deploy Multi Site Indexer Cluster and SHC with App framework")
+
+			// Ensure that the CM goes to Ready phase
+			testenv.ClusterMasterReady(deployment, testenvInstance)
+
+			// Ensure the indexers of all sites go to Ready phase
+			testenv.IndexersReady(deployment, testenvInstance, siteCount)
+
+			// Ensure cluster configured as multisite
+			testenv.IndexerClusterMultisiteStatus(deployment, testenvInstance, siteCount)
+
+			// Ensure SHC go to Ready phase
+			testenv.SearchHeadClusterReady(deployment, testenvInstance)
+
+			// Verify RF SF is met
+			testenv.VerifyRFSFMet(deployment, testenvInstance)
+
+			// Verify MC is Ready and stays in ready state
+			testenv.VerifyMonitoringConsoleReady(deployment, deployment.GetName(), mc, testenvInstance)
+
+			// Verify apps are downloaded by init-container on CM, Deployer and MC
+			appVersion := "V2"
+			initContDownloadLocation := "/init-apps/" + appSourceName
+			initContDownloadLocationMCPod := "/init-apps/" + appSourceNameMC
+			mcPodName := fmt.Sprintf(testenv.MonitoringConsolePod, mcName, 0)
+			podNames := []string{fmt.Sprintf(testenv.ClusterMasterPod, deployment.GetName()), fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
+			appFileList = testenv.GetAppFileList(appListV2, 2)
+			testenvInstance.Log.Info("Verify Apps are downloaded by init container for apps", "version", appVersion)
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), podNames, appFileList, initContDownloadLocation)
+			testenvInstance.Log.Info("Verify Apps are downloaded by init container on MC pod for apps", "POD", mcPodName, "version", appVersion)
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), []string{mcPodName}, appFileList, initContDownloadLocationMCPod)
+
+			// Verify apps are copied to correct location
+			allPodNames := testenv.DumpGetPods(testenvInstance.GetName())
+			testenvInstance.Log.Info("Verify Apps are copied to correct location based on Pod KIND for app", "version", appVersion)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, true)
+
+			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
+			testenvInstance.Log.Info("Verify apps are NOT copied to /etc/apps on CM and Deployer for app", "version", appVersion, "App List", appFileList)
+			masterPodNames := []string{fmt.Sprintf(testenv.ClusterMasterPod, deployment.GetName()), fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV2, false, false)
+
+			// Verify apps are installed on MC and M4(cluster-wide)
+			testenvInstance.Log.Info("Verify newer version of apps are installed on the pods", "version", appVersion)
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, "enabled", true, true)
+
+			// Delete apps on S3
+			testenvInstance.Log.Info("Delete Apps on S3 for", "Version", appVersion)
+			testenv.DeleteFilesOnS3(testS3Bucket, uploadedApps)
+			uploadedApps = nil
+
+			// Upload older version of apps to S3 for M4 and MC
+			appFileList = testenv.GetAppFileList(appListV1, 1)
+			appVersion = "V1"
+			testenvInstance.Log.Info("Uploading apps S3 for", "version", appVersion)
+			uploadedFiles, err = testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV1)
+			Expect(err).To(Succeed(), "Unable to upload older version of apps to S3 test directory")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+			uploadedFiles, err = testenv.UploadFilesToS3(testS3Bucket, s3TestDirMC, appFileList, downloadDirV1)
+			Expect(err).To(Succeed(), "Unable to upload older version of apps to S3 test directory")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+
+			// Wait for the poll period for the apps to be downloaded
+			time.Sleep(2 * time.Minute)
+
+			// Ensure that the CM goes to Ready phase
+			testenv.ClusterMasterReady(deployment, testenvInstance)
+
+			// Ensure the indexers of all sites go to Ready phase
+			testenv.IndexersReady(deployment, testenvInstance, siteCount)
+
+			// Ensure cluster configured as multisite
+			testenv.IndexerClusterMultisiteStatus(deployment, testenvInstance, siteCount)
+
+			// Ensure SHC go to Ready phase
+			testenv.SearchHeadClusterReady(deployment, testenvInstance)
+
+			// Verify RF SF is met
+			testenv.VerifyRFSFMet(deployment, testenvInstance)
+
+			// Verify MC is Ready and stays in ready state
+			testenv.VerifyMonitoringConsoleReady(deployment, deployment.GetName(), mc, testenvInstance)
+
+			// Verify apps are downloaded by init-container
+			testenvInstance.Log.Info("Verify apps are downloaded by init container for apps", " version", appVersion)
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), podNames, appFileList, initContDownloadLocation)
+			testenvInstance.Log.Info("Verify Apps are downloaded by init container on MC pod for apps", "POD", mcPodName, "version", appVersion)
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), []string{mcPodName}, appFileList, initContDownloadLocationMCPod)
+
+			// Verify apps are copied to location
+			testenvInstance.Log.Info("Verify apps are copied to correct location based on Pod KIND for app", " version", appVersion)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, true)
+
+			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
+			testenvInstance.Log.Info("Verify apps are NOT copied to /etc/apps on CM and Deployer for app", " version", appVersion)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV1, false, false)
+
+			// Verify apps are downgraded on MC and M4(cluster-wide)
+			testenvInstance.Log.Info("Verify apps are downgraded on the pods by running Splunk CLI commands for app", " version", appVersion)
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, "enabled", false, true)
+		})
+	})
+
+	XContext("Multi Site Indexer Cluster with SHC (m4) with App Framework", func() {
+		It("integration, m4, appframework: can deploy a M4 SVA with App Framework enabled, install apps, scale up IDXC and SHC, install app on new pods", func() {
+
+			/* Test Steps
+			   ################## SETUP ##################
+			   * Create 2 App Sources for MC and M4 SVA (CM and SHC Deployer)
+			   * Prepare and deploy MC CRD with app config and wait for pod to be ready
+			   * Prepare and deploy M4 CRD with app config and wait for pods to be ready
+			   ############### VERIFICATION ##############
+			   * Verify apps are copied and installed on MC and also on SH and Indexers pods
+			   ############### SCALING UP ################
+			   * Scale up indexers and SHC
+			   * Wait for MC and M4 to be ready
+			   ############### VERIFICATION ##############
+			   * Verify apps are copied and installed on new SH and Indexers pods
+			   ############### SCALING DOWN ################
+			   * Scale down indexers and SHC
+			   * Wait for MC and M4 to be ready
+			   ############### VERIFICATION ##############
+			   * Verify apps are still copied and installed on all SH and Indexers pods
+			*/
+
+			// Upload apps to S3 for MC
+			s3TestDirMC := "m4appfw-mc-" + testenv.RandomDNSName(4)
+			appFileList := testenv.GetAppFileList(appListV1, 1)
+			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDirMC, appFileList, downloadDirV1)
+			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+
+			// Create App framework Spec for MC
+			volumeNameMC := "appframework-test-volume-mc-" + testenv.RandomDNSName(3)
+			volumeSpecMC := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volumeNameMC, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+			appSourceDefaultSpecMC := enterpriseApi.AppSourceDefaultSpec{
+				VolName: volumeNameMC,
+				Scope:   enterpriseApi.ScopeLocal,
+			}
+			appSourceNameMC := "appframework-mc-" + testenv.RandomDNSName(3)
+			appSourceSpecMC := []enterpriseApi.AppSourceSpec{testenv.GenerateAppSourceSpec(appSourceNameMC, s3TestDirMC, appSourceDefaultSpecMC)}
+			appFrameworkSpecMC := enterpriseApi.AppFrameworkSpec{
+				Defaults:             appSourceDefaultSpecMC,
+				AppsRepoPollInterval: 60,
+				VolList:              volumeSpecMC,
+				AppSources:           appSourceSpecMC,
+			}
+			mcSpec := enterpriseApi.MonitoringConsoleSpec{
+				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
+					Spec: splcommon.Spec{
+						ImagePullPolicy: "IfNotPresent",
+					},
+					Volumes: []corev1.Volume{},
+				},
+				AppFrameworkConfig: appFrameworkSpecMC,
+			}
+
+			// Deploy MC CRD
+			testenvInstance.Log.Info("Deploy Monitoring Console")
+			mcName := deployment.GetName()
+			mc, err := deployment.DeployMonitoringConsoleWithGivenSpec(testenvInstance.GetName(), mcName, mcSpec)
+			Expect(err).To(Succeed(), "Unable to deploy Monitoring Console instance")
+
+			// Verify MC is ready and stays in ready state
+			testenv.VerifyMonitoringConsoleReady(deployment, deployment.GetName(), mc, testenvInstance)
+
+			// Create App framework Spec for M4
+			volumeName := "appframework-test-volume-" + testenv.RandomDNSName(3)
+			volumeSpec := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volumeName, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+			appSourceDefaultSpec := enterpriseApi.AppSourceDefaultSpec{
+				VolName: volumeName,
+				Scope:   enterpriseApi.ScopeCluster,
+			}
+			appSourceName := "appframework" + testenv.RandomDNSName(3)
+			appSourceSpec := []enterpriseApi.AppSourceSpec{testenv.GenerateAppSourceSpec(appSourceName, s3TestDir, appSourceDefaultSpec)}
+			appFrameworkSpec := enterpriseApi.AppFrameworkSpec{
+				Defaults:             appSourceDefaultSpec,
+				AppsRepoPollInterval: 60,
+				VolList:              volumeSpec,
+				AppSources:           appSourceSpec,
+			}
+
+			// Deploy M4 CRD
+			testenvInstance.Log.Info("Deploy Multisite Indexer Cluster with SHC")
+			siteCount := 3
+			indexersPerSite := 1
+			err = deployment.DeployMultisiteClusterWithSearchHeadAndAppFramework(deployment.GetName(), indexersPerSite, siteCount, appFrameworkSpec, true, 10, mcName, "")
 			Expect(err).To(Succeed(), "Unable to deploy Multi Site Indexer Cluster with App framework")
 
 			// Ensure that the CM goes to Ready phase
@@ -101,23 +530,30 @@ var _ = Describe("m4appfw test", func() {
 			// Ensure cluster configured as multisite
 			testenv.IndexerClusterMultisiteStatus(deployment, testenvInstance, siteCount)
 
-			// Ensure search head cluster go to Ready phase
+			// Ensure SHC go to Ready phase
 			testenv.SearchHeadClusterReady(deployment, testenvInstance)
 
 			// Verify RF SF is met
 			testenv.VerifyRFSFMet(deployment, testenvInstance)
 
-			// Verify apps are downloaded by init-container
+			// Verify MC is ready and stays in ready state
+			testenv.VerifyMonitoringConsoleReady(deployment, deployment.GetName(), mc, testenvInstance)
+
+			// Verify apps are downloaded by init-container on CM, Deployer and MC
 			appVersion := "V1"
 			initContDownloadLocation := "/init-apps/" + appSourceName
+			initContDownloadLocationMCPod := "/init-apps/" + appSourceNameMC
+			mcPodName := fmt.Sprintf(testenv.MonitoringConsolePod, mcName, 0)
 			podNames := []string{fmt.Sprintf(testenv.ClusterMasterPod, deployment.GetName()), fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
-			appFileList := testenv.GetAppFileList(appListV1, 1)
+			appFileList = testenv.GetAppFileList(appListV1, 1)
 			testenvInstance.Log.Info("Verify Apps are downloaded by init container for apps", "version", appVersion)
 			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), podNames, appFileList, initContDownloadLocation)
+			testenvInstance.Log.Info("Verify Apps are downloaded by init container on MC for apps", "POD", mcPodName, "version", appVersion)
+			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), []string{mcPodName}, appFileList, initContDownloadLocationMCPod)
 
-			// Verify apps are copied to location
+			// Verify apps are copied to correct location
 			allPodNames := testenv.DumpGetPods(testenvInstance.GetName())
-			testenvInstance.Log.Info("Verify Apps are copied to correct location based on Pod KIND for app", "version", appVersion)
+			testenvInstance.Log.Info("Verify apps are copied to correct location based on Pod KIND for app", "version", appVersion)
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, true)
 
 			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
@@ -125,139 +561,28 @@ var _ = Describe("m4appfw test", func() {
 			testenvInstance.Log.Info("Verify Apps are NOT copied to /etc/apps on CM and Deployer for app", "version", appVersion, "App List", appFileList)
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV1, false, false)
 
-			// Verify apps are installed cluster-wide
+			// Verify apps are installed on MC and M4(cluster-wide)
 			testenvInstance.Log.Info("Verify Apps are installed on the pods by running Splunk CLI commands for app", "version", appVersion)
 			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, "enabled", false, true)
 
-			// Delete apps on S3 for new Apps
-			testenvInstance.Log.Info("Delete Apps on S3 for", "Version", appVersion)
-			testenv.DeleteFilesOnS3(testS3Bucket, uploadedApps)
-			uploadedApps = nil
-			testenvInstance.Log.Info("Testing upgrade scenario")
+			// Get instance of current SHC CR with latest config
+			shcName := deployment.GetName() + "-shc"
+			shc := &enterpriseApi.SearchHeadCluster{}
+			err = deployment.GetInstance(shcName, shc)
+			Expect(err).To(Succeed(), "Failed to get instance of Search Head Cluster")
 
-			// Upload newer version of apps to S3
-			appFileList = testenv.GetAppFileList(appListV2, 2)
-			appVersion = "V2"
-			testenvInstance.Log.Info("Uploading apps S3 for", "version", appVersion)
-			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV2)
-			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
-			uploadedApps = append(uploadedApps, uploadedFiles...)
+			// Scale up SHC
+			defaultSHReplicas := shc.Spec.Replicas
+			scaledSHReplicas := defaultSHReplicas + 1
+			testenvInstance.Log.Info("Scaling up Search Head Cluster", "Current Replicas", defaultSHReplicas, "New Replicas", scaledSHReplicas)
 
-			// Wait for the poll period for the apps to be downloaded
-			time.Sleep(2 * time.Minute)
+			// Update Replicas of SHC
+			shc.Spec.Replicas = int32(scaledSHReplicas)
+			err = deployment.UpdateCR(shc)
+			Expect(err).To(Succeed(), "Failed to scale up Search Head Cluster")
 
-			// Ensure that the cluster-manager goes to Ready phase
-			testenv.ClusterMasterReady(deployment, testenvInstance)
-
-			// Ensure the indexers of all sites go to Ready phase
-			testenv.IndexersReady(deployment, testenvInstance, siteCount)
-
-			// Ensure cluster configured as multisite
-			testenv.IndexerClusterMultisiteStatus(deployment, testenvInstance, siteCount)
-
-			// Ensure search head cluster go to Ready phase
-			testenv.SearchHeadClusterReady(deployment, testenvInstance)
-
-			// Verify RF SF is met
-			testenv.VerifyRFSFMet(deployment, testenvInstance)
-
-			// Verify apps are downloaded by init-container
-			testenvInstance.Log.Info("Verify apps are downloaded by init container for apps", "version", appVersion)
-			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), podNames, appFileList, initContDownloadLocation)
-
-			// Verify apps are copied to location
-			testenvInstance.Log.Info("Verify apps are copied to correct location based on Pod KIND for app after upgrade", "version", appVersion)
-			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, true)
-
-			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
-			testenvInstance.Log.Info("Verify apps are NOT copied to /etc/apps on CM and Deployer for app after upgrade", "version", appVersion)
-			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV2, false, false)
-
-			// Verify Apps are installed cluster-wide
-			testenvInstance.Log.Info("Verify apps are installed on the pods by running Splunk CLI commands for app after upgrade", "version", appVersion)
-			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, "enabled", true, true)
-		})
-	})
-
-	Context("Multi Site Indexer Cluster with SHC (M4) with App Framework", func() {
-		It("integration, m4, appframework: can deploy a M4 SVA with App Framework enabled, install apps and downgrade them", func() {
-
-			// Delete pre-installed apps on S3
-			testenv.DeleteFilesOnS3(testS3Bucket, uploadedApps)
-			uploadedApps = nil
-			testenvInstance.Log.Info("Testing downgrade scenario")
-
-			// Upload newer version of apps to S3
-			s3TestDir = "m4appfw-" + testenv.RandomDNSName(4)
-			appFileList := testenv.GetAppFileList(appListV2, 2)
-			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV2)
-			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
-			uploadedApps = append(uploadedApps, uploadedFiles...)
-
-			// Create App framework Spec
-			volumeName := "appframework-test-volume-" + testenv.RandomDNSName(3)
-			volumeSpec := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volumeName, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
-
-			// appSourceDefaultSpec: Remote Storage volume name and Scope of App deployment
-			appSourceDefaultSpec := enterpriseApi.AppSourceDefaultSpec{
-				VolName: volumeName,
-				Scope:   enterpriseApi.ScopeCluster,
-			}
-
-			// appSourceSpec: App source name, location and volume name and scope from appSourceDefaultSpec
-			appSourceName := "appframework" + testenv.RandomDNSName(3)
-			appSourceSpec := []enterpriseApi.AppSourceSpec{testenv.GenerateAppSourceSpec(appSourceName, s3TestDir, appSourceDefaultSpec)}
-
-			// appFrameworkSpec: AppSource settings, Poll Interval, volumes, appSources on volumes
-			appFrameworkSpec := enterpriseApi.AppFrameworkSpec{
-				Defaults:             appSourceDefaultSpec,
-				AppsRepoPollInterval: 60,
-				VolList:              volumeSpec,
-				AppSources:           appSourceSpec,
-			}
-
-			siteCount := 3
-			indexersPerSite := 1
-
-			testenvInstance.Log.Info("Deploy Multisite Indexer Cluster")
-			err = deployment.DeployMultisiteClusterWithSearchHeadAndAppFramework(deployment.GetName(), indexersPerSite, siteCount, appFrameworkSpec, true, 10)
-			Expect(err).To(Succeed(), "Unable to deploy Multi Site Indexer Cluster with App framework")
-
-			// Ensure that the cluster-manager goes to Ready phase
-			testenv.ClusterMasterReady(deployment, testenvInstance)
-
-			// Ensure the indexers of all sites go to Ready phase
-			testenv.IndexersReady(deployment, testenvInstance, siteCount)
-
-			// Ensure cluster configured as multisite
-			testenv.IndexerClusterMultisiteStatus(deployment, testenvInstance, siteCount)
-
-			// Ensure search head cluster go to Ready phase
-			testenv.SearchHeadClusterReady(deployment, testenvInstance)
-
-			// Verify RF SF is met
-			testenv.VerifyRFSFMet(deployment, testenvInstance)
-
-			// Verify apps are downloaded by init-container
-			appVersion := "V2"
-			initContDownloadLocation := "/init-apps/" + appSourceName
-			podNames := []string{fmt.Sprintf(testenv.ClusterMasterPod, deployment.GetName()), fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
-			testenvInstance.Log.Info("Verify Apps are downloaded by init container for apps", "version", appVersion)
-			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), podNames, appFileList, initContDownloadLocation)
-
-			// Verify apps are copied to location
-			allPodNames := testenv.DumpGetPods(testenvInstance.GetName())
-			testenvInstance.Log.Info("Verify Apps are copied to correct location based on Pod KIND for app before downgrade", "version", appVersion)
-			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, true)
-
-			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
-			masterPodNames := []string{fmt.Sprintf(testenv.ClusterMasterPod, deployment.GetName()), fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
-			testenvInstance.Log.Info("Verify Apps are NOT copied to /etc/apps on CM and Deployer for app before downgrade", "version", appVersion, "App List", appFileList)
-			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV2, false, false)
-
-			// Verify apps are installed cluster-wide
-			testenvInstance.Log.Info("Verify Apps are installed on the pods by running Splunk CLI commands for app before downgrade", "version", appVersion)
-			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, "enabled", true, true)
+			// Ensure SHC scales up and go to ScalingUp phase
+			testenv.VerifySearchHeadClusterPhase(deployment, testenvInstance, splcommon.PhaseScalingUp)
 
 			// Get instance of current Indexer CR with latest config
 			idxcName := deployment.GetName() + "-" + "site1"
@@ -276,70 +601,83 @@ var _ = Describe("m4appfw test", func() {
 			// Ensure Indexer cluster scales up and go to ScalingUp phase
 			testenv.VerifyIndexerClusterPhase(deployment, testenvInstance, splcommon.PhaseScalingUp, idxcName)
 
+			// Ensure SHC go to Ready phase
+			testenv.SearchHeadClusterReady(deployment, testenvInstance)
+
 			// Ensure Indexer cluster go to Ready phase
 			testenv.IndexersReady(deployment, testenvInstance, siteCount)
 
 			// Verify RF SF is met
 			testenv.VerifyRFSFMet(deployment, testenvInstance)
 
-			// Verify Apps are copied to correct location
+			// Verify apps are copied to correct location
 			allPodNames = testenv.DumpGetPods(testenvInstance.GetName())
-			testenvInstance.Log.Info("Verify Apps are copied to correct location based on Pod KIND after scaling up of indexers", "version", appVersion)
-			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, true)
+			testenvInstance.Log.Info("Verify apps are copied to correct location based on Pod KIND after scaling up of indexers and SH", "version", appVersion)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, true)
 
 			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
-			testenvInstance.Log.Info("Verify apps are NOT copied to /etc/apps on CM and Deployer after scaling up of indexers", "version", appVersion)
-			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV2, false, false)
+			testenvInstance.Log.Info("Verify apps are NOT copied to /etc/apps on CM and Deployer after scaling up of indexers and SH", "version", appVersion)
+			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV1, false, false)
 
-			// Verify Apps are installed cluster-wide
-			testenvInstance.Log.Info("Verify apps are installed on the pods by running Splunk CLI commands after scaling up of indexers", "version", appVersion)
-			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV2, true, "enabled", true, true)
+			// Verify apps are installed cluster-wide
+			testenvInstance.Log.Info("Verify apps are installed on the pods by running Splunk CLI commands after scaling up of indexers and SH", "version", appVersion)
+			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, "enabled", false, true)
 
-			// Delete apps on S3 for new Apps
-			testenvInstance.Log.Info("Delete Apps on S3 for", "Version", appVersion)
-			testenv.DeleteFilesOnS3(testS3Bucket, uploadedApps)
-			uploadedApps = nil
-			testenvInstance.Log.Info("Testing downgrade scenario")
+			// Get instance of current SHC CR with latest config
+			shc = &enterpriseApi.SearchHeadCluster{}
+			err = deployment.GetInstance(shcName, shc)
+			Expect(err).To(Succeed(), "Failed to get instance of Search Head Cluster")
 
-			// Upload older versions of apps to S3
-			appFileList = testenv.GetAppFileList(appListV1, 1)
-			appVersion = "V1"
-			uploadedFiles, err = testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV1)
-			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
-			uploadedApps = append(uploadedApps, uploadedFiles...)
+			// Scale down SHC
+			defaultSHReplicas = shc.Spec.Replicas
+			scaledSHReplicas = defaultSHReplicas - 1
+			testenvInstance.Log.Info("Scaling down Search Head Cluster", "Current Replicas", defaultSHReplicas, "New Replicas", scaledSHReplicas)
 
-			// Wait for the poll period for the apps to be downloaded
-			time.Sleep(2 * time.Minute)
+			// Update Replicas of SHC
+			shc.Spec.Replicas = int32(scaledSHReplicas)
+			err = deployment.UpdateCR(shc)
+			Expect(err).To(Succeed(), "Failed to scale down Search Head Cluster")
 
-			// Ensure that the cluster-master goes to Ready phase
-			testenv.ClusterMasterReady(deployment, testenvInstance)
+			// Ensure SHC scales down and go to ScalingDown phase
+			testenv.VerifySearchHeadClusterPhase(deployment, testenvInstance, splcommon.PhaseScalingDown)
 
-			// Ensure the indexers of all sites go to Ready phase
-			testenv.IndexersReady(deployment, testenvInstance, siteCount)
+			// Get instance of current Indexer CR with latest config
+			idxcName = deployment.GetName() + "-" + "site1"
+			idxc = &enterpriseApi.IndexerCluster{}
+			err = deployment.GetInstance(idxcName, idxc)
+			Expect(err).To(Succeed(), "Failed to get instance of Indexer Cluster")
+			defaultIndexerReplicas = idxc.Spec.Replicas
+			scaledIndexerReplicas = defaultIndexerReplicas - 1
+			testenvInstance.Log.Info("Scaling down Indexer Cluster", "Current Replicas", defaultIndexerReplicas, "New Replicas", scaledIndexerReplicas)
 
-			// Ensure search head cluster go to Ready phase
+			// Update Replicas of Indexer Cluster
+			idxc.Spec.Replicas = int32(scaledIndexerReplicas)
+			err = deployment.UpdateCR(idxc)
+			Expect(err).To(Succeed(), "Failed to Scale down Indexer Cluster")
+
+			// Ensure Indexer cluster scales down and go to ScalingDown phase
+			testenv.VerifyIndexerClusterPhase(deployment, testenvInstance, splcommon.PhaseScalingDown, idxcName)
+
+			// Ensure SHC go to Ready phase
 			testenv.SearchHeadClusterReady(deployment, testenvInstance)
+
+			// Ensure Indexer cluster go to Ready phase
+			testenv.IndexersReady(deployment, testenvInstance, siteCount)
 
 			// Verify RF SF is met
 			testenv.VerifyRFSFMet(deployment, testenvInstance)
 
-			// Verify older version of apps are downloaded by init-container
-			testenvInstance.Log.Info("Verify older version of apps are downloaded by init container", "version", appVersion)
-			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), podNames, appFileList, initContDownloadLocation)
-
-			// Verify older version of apps are copied to correct location
-			testenvInstance.Log.Info("Verify older version of apps are copied to correct location based on Pod KIND", "version", appVersion)
+			// Verify apps are copied to correct location
+			allPodNames = testenv.DumpGetPods(testenvInstance.GetName())
+			testenvInstance.Log.Info("Verify apps are copied to correct location based on Pod KIND after scaling down of indexers and SH", "version", appVersion)
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, true)
 
-			// Verify older versions of apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
-			testenvInstance.Log.Info("Verify older versions of apps are NOT copied to /etc/apps on CM and Deployer", "version", appVersion)
+			// Verify apps are not copied in /etc/apps/ on CM and on Deployer (therefore not installed on Deployer and on CM)
+			testenvInstance.Log.Info("Verify apps are NOT copied to /etc/apps on CM and Deployer after scaling down of indexers and SH", "version", appVersion)
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), masterPodNames, appListV1, false, false)
 
-			// Wait for the completion of app downgrade as it could take a while on indexers
-			time.Sleep(2 * time.Minute)
-
-			// Verify older versions of apps are installed cluster-wide
-			testenvInstance.Log.Info("Verify older versions of apps are installed on the pods by running Splunk CLI commands", "version", appVersion)
+			// Verify apps are installed cluster-wide
+			testenvInstance.Log.Info("Verify apps are installed on the pods by running Splunk CLI commands after scaling down of indexers and SH", "version", appVersion)
 			testenv.VerifyAppInstalled(deployment, testenvInstance, testenvInstance.GetName(), allPodNames, appListV1, true, "enabled", false, true)
 		})
 	})
@@ -374,7 +712,7 @@ var _ = Describe("m4appfw test", func() {
 			siteCount := 3
 			indexersPerSite := 1
 			testenvInstance.Log.Info("Deploy Multisite Indexer Cluster")
-			err := deployment.DeployMultisiteClusterWithSearchHeadAndAppFramework(deployment.GetName(), indexersPerSite, siteCount, appFrameworkSpec, true, 10)
+			err := deployment.DeployMultisiteClusterWithSearchHeadAndAppFramework(deployment.GetName(), indexersPerSite, siteCount, appFrameworkSpec, true, 10, "", "")
 			Expect(err).To(Succeed(), "Unable to deploy Multi Site Indexer Cluster with App framework")
 
 			// Ensure that the CM goes to Ready phase

--- a/test/testenv/deployment.go
+++ b/test/testenv/deployment.go
@@ -667,10 +667,8 @@ func (d *Deployment) DeploySingleSiteClusterWithGivenAppFrameworkSpec(name strin
 	return nil
 }
 
-// DeployMultisiteClusterWithSearchHeadAndAppFramework deploys cluster-manager, indexers in multiple sites (SHC LM Optional) with app framework spec
-func (d *Deployment) DeployMultisiteClusterWithSearchHeadAndAppFramework(name string, indexerReplicas int, siteCount int, appFrameworkSpec enterpriseApi.AppFrameworkSpec, shc bool, delaySeconds int) error {
-
-	licenseMaster := ""
+// DeployMultisiteClusterWithSearchHeadAndAppFramework deploys cluster-master, indexers in multiple sites (SHC LM Optional) with app framework spec
+func (d *Deployment) DeployMultisiteClusterWithSearchHeadAndAppFramework(name string, indexerReplicas int, siteCount int, appFrameworkSpec enterpriseApi.AppFrameworkSpec, shc bool, delaySeconds int, mcName string, licenseMaster string) error {
 
 	// If license file specified, deploy License Manager
 	if d.testenv.licenseFilePath != "" {
@@ -706,6 +704,9 @@ func (d *Deployment) DeployMultisiteClusterWithSearchHeadAndAppFramework(name st
 			Volumes: []corev1.Volume{},
 			LicenseMasterRef: corev1.ObjectReference{
 				Name: licenseMaster,
+			},
+			MonitoringConsoleRef: corev1.ObjectReference{
+				Name: mcName,
 			},
 			Defaults: defaults,
 			// LivenessInitialDelaySeconds:  int32(delaySeconds),
@@ -748,6 +749,9 @@ func (d *Deployment) DeployMultisiteClusterWithSearchHeadAndAppFramework(name st
 			},
 			LicenseMasterRef: corev1.ObjectReference{
 				Name: licenseMaster,
+			},
+			MonitoringConsoleRef: corev1.ObjectReference{
+				Name: mcName,
 			},
 			Defaults: siteDefaults,
 			// LivenessInitialDelaySeconds:  int32(delaySeconds),


### PR DESCRIPTION
Adding testing of App framework for MC CRD with M4 SVA.

1st test:
Setup up App sources for MC and M4
Download V1 apps, install them cluster wide and on MC
Download V2 apps, upgrade
Verify apps

2nd test:
Setup up App sources for MC and M4
Download V2 apps, install them cluster wide and on MC
Download V1 apps, downgrade
Verify apps

3rd test:
Setup up App sources for MC and M4
Download V1 apps, install them cluster wide and on MC
Scale up SHC and IDXC
Verify apps
Scale down SHC and IDXC
Verify apps

Test runs:
Test1:
`[1] • [SLOW TEST:2021.650 seconds]
[1] m4appfw test
[1] /Users/jambrosiano/splunk-operator/CSPL-1322/splunk-operator/test/m4/appframework/appframework_test.go:30
[1]   Multi Site Indexer Cluster with SHC (m4) with App Framework
[1]   /Users/jambrosiano/splunk-operator/CSPL-1322/splunk-operator/test/m4/appframework/appframework_test.go:64
[1]     smoke, m4, appframework: can deploy a M4 SVA with App Framework enabled, install apps and upgrade them
[1]     /Users/jambrosiano/splunk-operator/CSPL-1322/splunk-operator/test/m4/appframework/appframework_test.go:65
[1] ------------------------------
[1] {"level":"info","ts":1634327150.2414231,"msg":"testenv deleted.\n","testenv":"m4appfw-rif"}
[1] {"level":"info","ts":1634327150.2414641,"msg":"testenv deleted.\n","testenv":"m4appfw-rif"}
[1]
[1] JUnit report was created: /Users/jambrosiano/splunk-operator/CSPL-1322/splunk-operator/test/m4/appframework/m4appfw-rif_junit.xml
[1]
[1] Ran 1 of 1 Specs in 2037.482 seconds
[1] SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[1] PASS`

Test2:
`[1] • [SLOW TEST:1952.466 seconds]
[1] m4appfw test
[1] /Users/jambrosiano/splunk-operator/CSPL-1322/splunk-operator/test/m4/appframework/appframework_test.go:30
[1]   Multi Site Indexer Cluster with SHC (m4) with App Framework
[1]   /Users/jambrosiano/splunk-operator/CSPL-1322/splunk-operator/test/m4/appframework/appframework_test.go:247
[1]     integration, m4, appframework: can deploy a M4 SVA with App Framework enabled, install apps and downgrade them
[1]     /Users/jambrosiano/splunk-operator/CSPL-1322/splunk-operator/test/m4/appframework/appframework_test.go:248
[1] ------------------------------
[1] {"level":"info","ts":1634607265.3955562,"msg":"testenv deleted.\n","testenv":"m4appfw-tac"}
[1] {"level":"info","ts":1634607265.395581,"msg":"testenv deleted.\n","testenv":"m4appfw-tac"}
[1]
[1] JUnit report was created: /Users/jambrosiano/splunk-operator/CSPL-1322/splunk-operator/test/m4/appframework/m4appfw-tac_junit.xml
[1]
[1] Ran 1 of 2 Specs in 1967.950 seconds
[1] SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 0 Skipped
[1] PASS
`

NOTE: Test3 will fail now due to CSPL-1379, we need that bug fix to be merged before running this test, so it  is commented out for now.
(To verify the rest of the test I ran it with MC lines commented and it passed, so once the fix is on we should be fine)