### PR TITLE
CSPL:1387 Modify app upload logic to selectively upload apps within test case

### DIFF
--- a/test/s1/appframework/appframework_test.go
+++ b/test/s1/appframework/appframework_test.go
@@ -37,14 +37,6 @@ var _ = Describe("s1appfw test", func() {
 		var err error
 		deployment, err = testenvInstance.NewDeployment(testenv.RandomDNSName(3))
 		Expect(err).To(Succeed(), "Unable to create deployment")
-
-		// Upload V1 apps to S3
-		s3TestDir = "s1appfw-" + testenv.RandomDNSName(4)
-		appFileList := testenv.GetAppFileList(appListV1, 1)
-		uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV1)
-		Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
-		uploadedApps = append(uploadedApps, uploadedFiles...)
-
 	})
 
 	AfterEach(func() {
@@ -86,6 +78,13 @@ var _ = Describe("s1appfw test", func() {
 			*/
 
 			mcName := deployment.GetName()
+
+			// Upload V1 apps to S3
+			s3TestDir = "s1appfw-" + testenv.RandomDNSName(4)
+			appFileList := testenv.GetAppFileList(appListV1, 1)
+			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDir, appFileList, downloadDirV1)
+			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
 
 			// Create App framework Spec for Standalone
 			volumeName := "appframework-test-volume-" + testenv.RandomDNSName(3)
@@ -131,8 +130,8 @@ var _ = Describe("s1appfw test", func() {
 
 			// Upload Apps to S3 for MC
 			s3TestDirMC := "s1appfw-mc-" + testenv.RandomDNSName(4)
-			appFileList := testenv.GetAppFileList(appListV1, 1)
-			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDirMC, appFileList, downloadDirV1)
+			appFileList = testenv.GetAppFileList(appListV1, 1)
+			uploadedFiles, err = testenv.UploadFilesToS3(testS3Bucket, s3TestDirMC, appFileList, downloadDirV1)
 			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory")
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
@@ -321,16 +320,12 @@ var _ = Describe("s1appfw test", func() {
 		})
 	})
 
-	// Removing test from Nightly and Smoke runs due to consistent failure.
 	Context("appframework Standalone deployment (S1) with App Framework", func() {
 		It("s1, integration, appframework: can deploy a Standalone and have ES app installed", func() {
 
-			//Delete apps on S3 for new Apps
-			testenvInstance.Log.Info("Delete Apps on S3 before upload ES")
-			testenv.DeleteFilesOnS3(testS3Bucket, uploadedApps)
-			uploadedApps = nil
+			// Create local app Directory
+			s3TestDir = "s1appfw-" + testenv.RandomDNSName(4)
 
-			// ES is a huge file, we configure it here rather than in BeforeSuite/BeforeEach to save time for other tests
 			// Upload ES app to S3
 			esApp := []string{"SplunkEnterpriseSecuritySuite"}
 			appFileList := testenv.GetAppFileList(esApp, 1)
@@ -392,12 +387,14 @@ var _ = Describe("s1appfw test", func() {
 	Context("appframework Standalone deployment (S1) with App Framework", func() {
 		It("smoke, s1, appframework: can deploy a standalone instance with App Framework enabled and install around 350MB of apps at once", func() {
 
+			// Create local app Directory
+			s3TestDir = "s1appfw-" + testenv.RandomDNSName(4)
+
 			// Creating a bigger list of apps to be installed than the default one
 			appList := append(appListV1, testenv.RestartNeededApps...)
-			appFileList := testenv.GetAppFileList(appList, 1)
 
 			// Download apps from S3
-			err := testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV1, downloadDirV1, testenv.GetAppFileList(appList, 1))
+			err := testenv.DownloadFilesFromS3(testDataS3Bucket, s3AppDirV1, downloadDirV1, testenv.GetAppFileList(testenv.RestartNeededApps, 1))
 			Expect(err).To(Succeed(), "Unable to download apps files")
 
 			// Upload apps to S3
@@ -444,7 +441,7 @@ var _ = Describe("s1appfw test", func() {
 			// Verify apps are downloaded by init-container
 			initContDownloadLocation := "/init-apps/" + appSourceName
 			podName := fmt.Sprintf(testenv.StandalonePod, deployment.GetName(), 0)
-			appFileList = testenv.GetAppFileList(appListV1, 1)
+			appFileList := testenv.GetAppFileList(appListV1, 1)
 			testenv.VerifyAppsDownloadedByInitContainer(deployment, testenvInstance, testenvInstance.GetName(), []string{podName}, appFileList, initContDownloadLocation)
 
 			// Verify apps are copied to location

--- a/test/testenv/cmutil.go
+++ b/test/testenv/cmutil.go
@@ -207,8 +207,12 @@ func RollHotBuckets(deployment *Deployment) bool {
 type ClusterMasterInfoEndpointResponse struct {
 	Entry []struct {
 		Content struct {
-			RollingRestartFlag bool              `json:"rolling_restart_flag"`
-			ActiveBundle       map[string]string `json:"active_bundle"`
+			RollingRestartFlag bool `json:"rolling_restart_flag"`
+			ActiveBundle       struct {
+				BundlePath string `json:"bundle_path"`
+				Checksum   string `json:"checksum"`
+				Timestamp  int    `json:"timestamp"`
+			} `json:"active_bundle"`
 		} `json:"content"`
 	} `json:"entry"`
 }
@@ -281,7 +285,7 @@ func GetClusterManagerBundleHash(deployment *Deployment) string {
 	podName := fmt.Sprintf(ClusterManagerPod, deployment.GetName())
 	restResponse := ClusterMasterInfoResponse(deployment, podName)
 
-	bundleHash := restResponse.Entry[0].Content.ActiveBundle["checksum"]
+	bundleHash := restResponse.Entry[0].Content.ActiveBundle.Checksum
 	logf.Log.Info("Bundle Hash on Cluster Manager Found", "Hash", bundleHash)
 	return bundleHash
 }


### PR DESCRIPTION
- Modified app upload logic to upload apps within each test case

- Added bundle push validation to missing c3 test case

Results
```
• [SLOW TEST:469.748 seconds]
s1appfw test
/Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:30
  appframework Standalone deployment (S1) with App Framework
  /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:326
    smoke, s1, appframework: can deploy a standalone instance with App Framework enabled and install around 350MB of apps at once
    /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:327
------------------------------
{"level":"info","ts":1634763939.235208,"msg":"testenv deleted.\n","testenv":"s1appfw-wep"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/s1/appframework/s1appfw-wep_junit.xml

Ran 3 of 3 Specs in 2482.378 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS




• [SLOW TEST:3489.669 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:29
  Single Site Indexer Cluster with SHC (C3) with App Framework
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:270
    smoke, c3, appframework: can deploy a C3 SVA with App Framework enabled, install apps and downgrade them
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:271
------------------------------
• [SLOW TEST:834.511 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:29
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:556
    smoke, c3, appframework: can deploy a C3 SVA and have apps installed locally on CM and SHC Deployer
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:557
------------------------------
• [SLOW TEST:1751.116 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:29
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:673
    integration, c3, appframework: can deploy a C3 SVA and have ES app installed on SHC
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:674
------------------------------
• [SLOW TEST:1619.152 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:29
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:780
    c3, integration, appframework: can deploy a C3 SVA with apps installed locally on CM and SHC Deployer, and cluster-wide on Peers and SHs
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:781
------------------------------
• [SLOW TEST:1020.234 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:29
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:1010
    smoke, c3, appframework: can deploy a C3 SVA instance with App Framework enabled and install above 200MB of apps at once
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:1011
------------------------------
{"level":"info","ts":1635292555.407289,"msg":"testenv deleted.\n","testenv":"c3appfw-cdt"}
{"level":"info","ts":1635292555.407319,"msg":"testenv deleted.\n","testenv":"c3appfw-cdt"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/c3/appframework/c3appfw-cdt_junit.xml



Ran 6 of 6 Specs in 7291.286 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```