### PR TITLE
CSPL-1340: App framework - Add APIs to copy and untar app on Splunk pod and prune it on operator pod

### DIFF
--- a/pkg/apis/enterprise/v2/common_types.go
+++ b/pkg/apis/enterprise/v2/common_types.go
@@ -398,6 +398,8 @@ const (
 	AppPkgPodCopyInProgress = 202
 	// AppPkgPodCopyComplete indicates complete
 	AppPkgPodCopyComplete = 203
+	// AppPkgMissingFromOperator indicates the downloaded app package is missing
+	AppPkgMissingFromOperator = 298
 	// AppPkgPodCopyError indicates error after retries
 	AppPkgPodCopyError = 299
 )

--- a/pkg/splunk/common/names.go
+++ b/pkg/splunk/common/names.go
@@ -84,12 +84,13 @@ const (
 	// MaxAppsRepoPollInterval sets the polling interval to one day
 	MaxAppsRepoPollInterval int64 = 60 * 60 * 24
 
-	// AppDownloadVolume is the mount volume on the operator pod to temporarily download apps
-	AppDownloadVolume = "/opt/splunk/appframework/"
-
 	// DefaultMaxConcurrentAppDownloads sets the default value for maximum concurrent app downloads
 	DefaultMaxConcurrentAppDownloads uint64 = 5
 )
+
+// AppDownloadVolume is the mount volume on the operator pod to temporarily download apps
+// sgontla: ToDo: being a constant will be a blocker for the UT to pass. relaxing a bit. Find a better alternative
+var AppDownloadVolume string = "/opt/splunk/appframework/"
 
 // GetVersionedSecretName returns a versioned secret name
 func GetVersionedSecretName(versionedSecretIdentifier string, version string) string {

--- a/pkg/splunk/enterprise/types.go
+++ b/pkg/splunk/enterprise/types.go
@@ -84,9 +84,6 @@ type PipelineWorker struct {
 
 	// waiter reference to inform the caller
 	waiter *sync.WaitGroup
-
-	// mutex to protect shared data
-	workerMutex sync.Mutex
 }
 
 // PipelinePhase represents one phase in the overall installation pipeline
@@ -111,11 +108,11 @@ type AppInstallPipeline struct {
 	// represents the available disk space on operator pod
 	availableDiskSpace uint64
 
-	// Refernce to app deploy context
-	appDeployContext *enterpriseApi.AppDeploymentContext
-
 	// mutex to synchronize shared variables across phases
 	pplnMutex sync.Mutex
+
+	// Refernce to app deploy context
+	appDeployContext *enterpriseApi.AppDeploymentContext
 }
 
 // ToString returns a string for a given InstanceType

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -536,6 +536,11 @@ func ApplyAppListingConfigMap(client splcommon.ControllerClient, cr splcommon.Me
 	return appListingConfigMap, configMapDataChanged, nil
 }
 
+// getAppPackageLocalPath returns the Operator volume path for a given app package
+func getAppPackageLocalPath(cr splcommon.MetaObject, scope string, appSrcName string) string {
+	return filepath.Join(splcommon.AppDownloadVolume, "downloadedApps", cr.GetNamespace(), cr.GroupVersionKind().Kind, cr.GetName(), scope, appSrcName) + "/"
+}
+
 // ApplySmartstoreConfigMap creates the configMap with Smartstore config in INI format
 func ApplySmartstoreConfigMap(client splcommon.ControllerClient, cr splcommon.MetaObject,
 	smartstore *enterpriseApi.SmartStoreSpec) (*corev1.ConfigMap, bool, error) {


### PR DESCRIPTION
As a Splunk Operator Admin, I need the operator App framework scheduler to run a download worker job for copying and untarring(in case of cluster scoped apps) of any app packages that have been identified and new/updated so they can be installed on the Splunk Operator managed deployment.

Acceptance Criteria:
* If the download/install state of this CR is Ready then, call a new API which will do the following as part of each thread
Copy the App to Splunk Pod (init-apps) (if not already copied) - this is both for cluster & local scope
* For cluster-scope, Untar the copied App to respective destination (../etc/shcluster/apps/  OR ../etc/master-apps/)
* For local scope, no Untar as tarball is directly used for installation
* Update the state machine to correctly indicate the copy and untar state of apps.