### PR TITLE
CSPL-1379 IDXC fails to scale up when MC CR is deployed with pre-existing IDXC

### DIFF
--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -153,8 +153,8 @@ func ApplyIndexerCluster(client splcommon.ControllerClient, cr *enterpriseApi.In
 					return result, err
 				}
 			}
-			if len(cr.Spec.MonitoringConsoleRef.Name) > 0 || (cr.Spec.MonitoringConsoleRef.Name != cmMonitoringConsoleConfigRef) {
-				scopedLog.Info("Indexer Cluster CR should not specify monitoringConsoleRef and if specified, should be similar to cluster masnager spec")
+			if len(cr.Spec.MonitoringConsoleRef.Name) > 0 && (cr.Spec.MonitoringConsoleRef.Name != cmMonitoringConsoleConfigRef) {
+				scopedLog.Info("Indexer Cluster CR should not specify monitoringConsoleRef and if specified, should be similar to cluster manager spec")
 			}
 		}
 		if len(cr.Status.IndexerSecretChanged) > 0 {

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -149,10 +149,12 @@ func ApplyIndexerCluster(client splcommon.ControllerClient, cr *enterpriseApi.In
 			if err == nil {
 				c := mgr.getMonitoringConsoleClient(cr, cmMonitoringConsoleConfigRef)
 				err := c.AutomateMCApplyChanges(false)
-				return result, err
+				if err != nil {
+					return result, err
+				}
 			}
-			if cr.Spec.MonitoringConsoleRef.Name != "" || cr.Spec.MonitoringConsoleRef.Name != cmMonitoringConsoleConfigRef {
-				scopedLog.Info("Indexer Cluster CR should not specify monitoringConsoleRef if same is specified in Cluster Manager spec and if specified both should be same")
+			if len(cr.Spec.MonitoringConsoleRef.Name) > 0 || (cr.Spec.MonitoringConsoleRef.Name != cmMonitoringConsoleConfigRef) {
+				scopedLog.Info("Indexer Cluster CR should not specify monitoringConsoleRef and if specified, should be similar to cluster masnager spec")
 			}
 		}
 		if len(cr.Status.IndexerSecretChanged) > 0 {

--- a/test/m4/appframework/appframework_test.go
+++ b/test/m4/appframework/appframework_test.go
@@ -473,7 +473,7 @@ var _ = Describe("m4appfw test", func() {
 		})
 	})
 
-	XContext("Multi Site Indexer Cluster with SHC (m4) with App Framework", func() {
+	Context("Multi Site Indexer Cluster with SHC (m4) with App Framework", func() {
 		It("integration, m4, appframework: can deploy a M4 SVA with App Framework enabled, install apps, scale up IDXC and SHC, install app on new pods", func() {
 
 			/* Test Steps

--- a/test/monitoring_console/monitoring_console_test.go
+++ b/test/monitoring_console/monitoring_console_test.go
@@ -382,7 +382,7 @@ var _ = Describe("Monitoring Console test", func() {
 	})
 
 	// TO BE READDED WHEN CSPL-1379 fixed
-	XContext("Clustered deployment (C3 - clustered indexer, search head cluster)", func() {
+	Context("Clustered deployment (C3 - clustered indexer, search head cluster)", func() {
 		It("monitoringconsole, smoke: MC can configure SHC, indexer instances after scale up and standalone in a namespace", func() {
 			/*
 				Test Steps


### PR DESCRIPTION
IDXC fails to scale up when MC CR is deployed in the namespace with pre-existing IDXC.

**Problem Description:** 
Create the below scenario:
1. Create CM and Indexer Cluster
2. Create Monitoring Console Pod
3. Scale up the indexer cluster from 3 replicas to 4 replicas

Indxer Cluster CR will fail to scale up with the below error: 
```
{"level":"info","ts":1634179846.5632071,"logger":"splunk.enterprise.ApplyIdxcSecret","msg":"Namespaced scoped secret revision has changed","Desired replicas":4,"IdxcSecretChanged":[],"NamespaceSecretResourceVersion":"28455441","mock":false}
{"level":"error","ts":1634179846.6101015,"logger":"splunk.reconcile.Reconcile","msg":"Reconciliation requeued","Group":"enterprise.splunk.com","Version":"v3","Kind":"IndexerCluster","Namespace":"default","Name":"example-idxc","RequeueAfter":5,"error":"Couldn't find secret in Pod splunk-example-idxc-indexer-3","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tgo/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\ngithub.com/splunk/splunk-operator/pkg/splunk/controller.splunkReconciler.Reconcile\n\tsplunk-operator/pkg/splunk/controller/controller.go:125\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tgo/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:256\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tgo/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\tgo/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\tgo/pkg/mod/k8s.io/apimachinery@v0.18.17/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\tgo/pkg/mod/k8s.io/apimachinery@v0.18.17/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\tgo/pkg/mod/k8s.io/apimachinery@v0.18.17/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\tgo/pkg/mod/k8s.io/apimachinery@v0.18.17/pkg/util/wait/wait.go:90"}
```
In the previous code, once we create MC pod, the NamespaceSecretResourceVersion changed BUT we never updated the IDXC CR with the new NamespaceSecretResourceVersion because after updating the MC with the indexer information we were returning from this place itself https://github.com/splunk/splunk-operator/blob/develop/pkg/splunk/enterprise/indexercluster.go#L152 so we never updated/executed the https://github.com/splunk/splunk-operator/blob/develop/pkg/splunk/enterprise/indexercluster.go#L168 to update indexer CR with latest NamespaceSecretResourceVersion.
And then when we were trying to scale up the indexer CR since it has old NamespaceSecretResourceVersion it was failing with the above error. 

**Problem Solution:**
We should have only returned from [line](https://github.com/splunk/splunk-operator/blob/develop/pkg/splunk/enterprise/indexercluster.go#L152) if there was an error in updating MC, in normal scenario after creating and updating MC we should just update the Indexer CR with the latest NamespaceSecretResourceVersion

