### PR TITLE
CSPL:1417 Added different app source per CR

### DIFF
--- a/test/testenv/appframework_utils.go
+++ b/test/testenv/appframework_utils.go
@@ -2,8 +2,9 @@ package testenv
 
 import (
 	"fmt"
-	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 	"strings"
+
+	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 
 	enterpriseApi "github.com/splunk/splunk-operator/pkg/apis/enterprise/v3"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -132,4 +133,30 @@ func GetAppFileList(appList []string, version int) []string {
 		appFileList = append(appFileList, AppInfo[app][fileKey])
 	}
 	return appFileList
+}
+
+// GenerateAppFrameworkSpec Generate Appframework spec
+func GenerateAppFrameworkSpec(testenvInstance *TestEnv, volumeName string, scope string, appSourceName string, s3TestDir string, pollInterval int) enterpriseApi.AppFrameworkSpec {
+
+	// Create App framework volume
+	volumeSpec := []enterpriseApi.VolumeSpec{GenerateIndexVolumeSpec(volumeName, GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+
+	// AppSourceDefaultSpec: Remote Storage volume name and Scope of App deployment
+	appSourceDefaultSpec := enterpriseApi.AppSourceDefaultSpec{
+		VolName: volumeName,
+		Scope:   scope,
+	}
+
+	// appSourceSpec: App source name, location and volume name and scope from appSourceDefaultSpec
+	appSourceSpec := []enterpriseApi.AppSourceSpec{GenerateAppSourceSpec(appSourceName, s3TestDir, appSourceDefaultSpec)}
+
+	// appFrameworkSpec: AppSource settings, Poll Interval, volumes, appSources on volumes
+	appFrameworkSpec := enterpriseApi.AppFrameworkSpec{
+		Defaults:             appSourceDefaultSpec,
+		AppsRepoPollInterval: int64(pollInterval),
+		VolList:              volumeSpec,
+		AppSources:           appSourceSpec,
+	}
+
+	return appFrameworkSpec
 }

--- a/test/testenv/deployment.go
+++ b/test/testenv/deployment.go
@@ -615,9 +615,7 @@ func (d *Deployment) DeployLicenseManagerWithGivenSpec(name string, spec enterpr
 }
 
 // DeploySingleSiteClusterWithGivenAppFrameworkSpec deploys indexer cluster (lm, shc optional) with app framework spec
-func (d *Deployment) DeploySingleSiteClusterWithGivenAppFrameworkSpec(name string, indexerReplicas int, shc bool, appFrameworkSpec enterpriseApi.AppFrameworkSpec, mcName string) error {
-
-	licenseMaster := ""
+func (d *Deployment) DeploySingleSiteClusterWithGivenAppFrameworkSpec(name string, indexerReplicas int, shc bool, appFrameworkSpecIdxc enterpriseApi.AppFrameworkSpec, appFrameworkSpecShc enterpriseApi.AppFrameworkSpec, mcName string, licenseMaster string) error {
 
 	// If license file specified, deploy License Manager
 	if d.testenv.licenseFilePath != "" {
@@ -626,8 +624,6 @@ func (d *Deployment) DeploySingleSiteClusterWithGivenAppFrameworkSpec(name strin
 		if err != nil {
 			return err
 		}
-
-		licenseMaster = name
 	}
 
 	// Deploy the cluster manager
@@ -644,7 +640,7 @@ func (d *Deployment) DeploySingleSiteClusterWithGivenAppFrameworkSpec(name strin
 				Name: mcName,
 			},
 		},
-		AppFrameworkConfig: appFrameworkSpec,
+		AppFrameworkConfig: appFrameworkSpecIdxc,
 	}
 	_, err := d.DeployClusterMasterWithGivenSpec(name, cmSpec)
 	if err != nil {
@@ -674,7 +670,7 @@ func (d *Deployment) DeploySingleSiteClusterWithGivenAppFrameworkSpec(name strin
 			},
 		},
 		Replicas:           3,
-		AppFrameworkConfig: appFrameworkSpec,
+		AppFrameworkConfig: appFrameworkSpecShc,
 	}
 	if shc {
 		_, err = d.DeploySearchHeadClusterWithGivenSpec(name+"-shc", shSpec)


### PR DESCRIPTION
- Added a common function to generate Appframwork spec for a specific CR
- Added different AppFramework sources for each CR(IDXC and SHC)


```
• [SLOW TEST:3489.669 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:29
  Single Site Indexer Cluster with SHC (C3) with App Framework
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:270
    smoke, c3, appframework: can deploy a C3 SVA with App Framework enabled, install apps and downgrade them
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:271
------------------------------
• [SLOW TEST:834.511 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:29
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:556
    smoke, c3, appframework: can deploy a C3 SVA and have apps installed locally on CM and SHC Deployer
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:557
------------------------------
• [SLOW TEST:1751.116 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:29
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:673
    integration, c3, appframework: can deploy a C3 SVA and have ES app installed on SHC
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:674
------------------------------
• [SLOW TEST:1619.152 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:29
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:780
    c3, integration, appframework: can deploy a C3 SVA with apps installed locally on CM and SHC Deployer, and cluster-wide on Peers and SHs
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:781
------------------------------
• [SLOW TEST:1020.234 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:29
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:1010
    smoke, c3, appframework: can deploy a C3 SVA instance with App Framework enabled and install above 200MB of apps at once
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:1011
------------------------------
{"level":"info","ts":1635292555.407289,"msg":"testenv deleted.\n","testenv":"c3appfw-cdt"}
{"level":"info","ts":1635292555.407319,"msg":"testenv deleted.\n","testenv":"c3appfw-cdt"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/c3/appframework/c3appfw-cdt_junit.xml



Ran 6 of 6 Specs in 7291.286 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```