### PR TITLE
CSPL-1468- Fix M4 Test case issues

### DIFF
--- a/test/testenv/deployment.go
+++ b/test/testenv/deployment.go
@@ -698,7 +698,7 @@ func (d *Deployment) DeploySingleSiteClusterWithGivenAppFrameworkSpec(name strin
 }
 
 // DeployMultisiteClusterWithSearchHeadAndAppFramework deploys cluster-manager, indexers in multiple sites (SHC LM Optional) with app framework spec
-func (d *Deployment) DeployMultisiteClusterWithSearchHeadAndAppFramework(name string, indexerReplicas int, siteCount int, appFrameworkSpec enterpriseApi.AppFrameworkSpec, shc bool, delaySeconds int, mcName string, licenseMaster string) error {
+func (d *Deployment) DeployMultisiteClusterWithSearchHeadAndAppFramework(name string, indexerReplicas int, siteCount int, appFrameworkSpec enterpriseApi.AppFrameworkSpec, shc bool, mcName string, licenseMaster string) error {
 
 	// If license file specified, deploy License Manager
 	if d.testenv.licenseFilePath != "" {
@@ -739,8 +739,6 @@ func (d *Deployment) DeployMultisiteClusterWithSearchHeadAndAppFramework(name st
 				Name: mcName,
 			},
 			Defaults: defaults,
-			// LivenessInitialDelaySeconds:  int32(delaySeconds),
-			// ReadinessInitialDelaySeconds: int32(delaySeconds),
 		},
 		AppFrameworkConfig: appFrameworkSpec,
 	}

--- a/test/testenv/verificationutils.go
+++ b/test/testenv/verificationutils.go
@@ -615,43 +615,41 @@ func VerifyPVCsPerDeployment(deployment *Deployment, testenvInstance *TestEnv, d
 // VerifyAppInstalled verify that app of specific version is installed. Method assumes that app is installed in all CR's in namespace
 func VerifyAppInstalled(deployment *Deployment, testenvInstance *TestEnv, ns string, pods []string, apps []string, versionCheck bool, statusCheck string, checkupdated bool, clusterWideInstall bool) {
 	for _, podName := range pods {
-		if !strings.Contains(podName, "monitoring-console") {
-			for _, appName := range apps {
-				status, versionInstalled, err := GetPodAppStatus(deployment, podName, ns, appName, clusterWideInstall)
-				logf.Log.Info("App info returned for app", "App-name", appName, "status", status, "versionInstalled", versionInstalled, "error", err)
-				gomega.Expect(err).To(gomega.Succeed(), "Unable to get app status on pod ")
-				comparison := strings.EqualFold(status, statusCheck)
-				//Check the app is installed on specific pods and un-installed on others for cluster-wide install
-				var check bool
-				if clusterWideInstall {
-					if strings.Contains(podName, "-indexer-") || strings.Contains(podName, "-search-head-") {
-						check = true
-						testenvInstance.Log.Info("App Install Check", "Pod Name", podName, "App Name", appName, "Expected", check, "Found", comparison, "Cluster Install Scope", clusterWideInstall)
-						gomega.Expect(comparison).Should(gomega.Equal(check))
-					}
-				} else {
-					// For local install check pods individually
-					if strings.Contains(podName, "-indexer-") || strings.Contains(podName, "-search-head-") {
-						check = false
-					} else {
-						check = true
-					}
+		for _, appName := range apps {
+			status, versionInstalled, err := GetPodAppStatus(deployment, podName, ns, appName, clusterWideInstall)
+			logf.Log.Info("App info returned for app", "App-name", appName, "status", status, "versionInstalled", versionInstalled, "error", err)
+			gomega.Expect(err).To(gomega.Succeed(), "Unable to get app status on pod ")
+			comparison := strings.EqualFold(status, statusCheck)
+			//Check the app is installed on specific pods and un-installed on others for cluster-wide install
+			var check bool
+			if clusterWideInstall {
+				if strings.Contains(podName, "-indexer-") || strings.Contains(podName, "-search-head-") {
+					check = true
 					testenvInstance.Log.Info("App Install Check", "Pod Name", podName, "App Name", appName, "Expected", check, "Found", comparison, "Cluster Install Scope", clusterWideInstall)
 					gomega.Expect(comparison).Should(gomega.Equal(check))
 				}
+			} else {
+				// For local install check pods individually
+				if strings.Contains(podName, "-indexer-") || strings.Contains(podName, "-search-head-") {
+					check = false
+				} else {
+					check = true
+				}
+				testenvInstance.Log.Info("App Install Check", "Pod Name", podName, "App Name", appName, "Expected", check, "Found", comparison, "Cluster Install Scope", clusterWideInstall)
+				gomega.Expect(comparison).Should(gomega.Equal(check))
+			}
 
-				if versionCheck {
-					// For clusterwide install do not check for versions on deployer and cluster-manager as the apps arent installed there
-					if !(clusterWideInstall && (strings.Contains(podName, splcommon.TestDeployerDashed) || strings.Contains(podName, splcommon.TestClusterManagerDashed))) {
-						var expectedVersion string
-						if checkupdated {
-							expectedVersion = AppInfo[appName]["V2"]
-						} else {
-							expectedVersion = AppInfo[appName]["V1"]
-						}
-						testenvInstance.Log.Info("Verify app Version", "Pod Name", podName, "App Name", appName, "Expected Version", expectedVersion, "Version Installed", versionInstalled, "Updated", checkupdated)
-						gomega.Expect(versionInstalled).Should(gomega.Equal(expectedVersion))
+			if versionCheck {
+				// For clusterwide install do not check for versions on deployer and cluster-manager as the apps arent installed there
+				if !(clusterWideInstall && (strings.Contains(podName, splcommon.TestDeployerDashed) || strings.Contains(podName, splcommon.TestClusterManagerDashed))) {
+					var expectedVersion string
+					if checkupdated {
+						expectedVersion = AppInfo[appName]["V2"]
+					} else {
+						expectedVersion = AppInfo[appName]["V1"]
 					}
+					testenvInstance.Log.Info("Verify app Version", "Pod Name", podName, "App Name", appName, "Expected Version", expectedVersion, "Version Installed", versionInstalled, "Updated", checkupdated)
+					gomega.Expect(versionInstalled).Should(gomega.Equal(expectedVersion))
 				}
 			}
 		}


### PR DESCRIPTION
#### Issues Found
* Disabled Test Case 
* Incorrect use of verification methods
* Removed MC from Scaling Test as the scenario covered in monitoring console test suite


#### Failure in GITHUB Action run is known issue 
```

• Failure [2600.949 seconds]
c3appfw test
/home/runner/work/splunk-operator/splunk-operator/test/c3/appframework/appframework_test.go:29
  Single Site Indexer Cluster with SHC (C3) with App Framework
  /home/runner/work/splunk-operator/splunk-operator/test/c3/appframework/appframework_test.go:455
    smoke, c3, appframework: can deploy a C3 SVA with App Framework enabled, install apps,scale up IDXC and SHC, install app on new pods, scale down [It]
    /home/runner/work/splunk-operator/splunk-operator/test/c3/appframework/appframework_test.go:456

    Timed out after 1500.001s.
    Expected
        <common.Phase>: 
    to equal
        <common.Phase>: Ready

    /home/runner/work/splunk-operator/splunk-operator/test/testenv/verificationutils.go:175
```

#### All test passed locally.

```
Ran 4 of 4 Specs in 7313.992 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```