### PR TITLE
CSPL-1443: Remove references to old MCPodReady function. (#586)

### DIFF
--- a/test/delete_cr/deletecr_test.go
+++ b/test/delete_cr/deletecr_test.go
@@ -66,9 +66,6 @@ var _ = Describe("DeleteCR test", func() {
 			// Ensure search head cluster go to Ready phase
 			testenv.SearchHeadClusterReady(deployment, testenvInstance)
 
-			// Verify MC Pod is Ready
-			// testenv.MCPodReady(testenvInstance.GetName(), deployment)
-
 			// Verify no SH in disconnected status is present on CM
 			testenv.VerifyNoDisconnectedSHPresentOnCM(deployment, testenvInstance)
 

--- a/test/monitoring_console/monitoring_console_test.go
+++ b/test/monitoring_console/monitoring_console_test.go
@@ -381,7 +381,6 @@ var _ = Describe("Monitoring Console test", func() {
 		})
 	})
 
-	// TO BE READDED WHEN CSPL-1379 fixed
 	Context("Clustered deployment (C3 - clustered indexer, search head cluster)", func() {
 		It("monitoringconsole, smoke: MC can configure SHC, indexer instances after scale up and standalone in a namespace", func() {
 			/*
@@ -390,12 +389,12 @@ var _ = Describe("Monitoring Console test", func() {
 				2. Deploy Monitoring Console
 				3. Wait for Monitoring Console status to go back to READY
 				4. Verify SH are configured in MC Config Map
-				5. Verify SH are configured in peer strings on MC Pod
-				6. Verify Monitoring Console Pod has peers in Peer string on MC Pod
+				5. VerifyMonitoring Console Pod has Search Heads in Peer strings
+				6. Verify Monitoring Console Pod has peers(indexers) in Peer string
 				7. Scale SH Cluster
-				8. Scale Indexer Count on One Site
+				8. Scale Indexer Count
 				9. Add a standalone
-				10. Verify Standalone is configured in MC Config Map
+				10. Verify Standalone is configured in MC Config Map and Peer String
 				11. Verify SH are configured in MC Config Map and Peers String
 				12. Verify Indexers are configured in Peer String
 			*/
@@ -500,8 +499,8 @@ var _ = Describe("Monitoring Console test", func() {
 			// Adding this check in the end as SHC take the longest time to scale up due recycle of SHC members
 			testenv.SearchHeadClusterReady(deployment, testenvInstance)
 
-			// Wait for MC to go to Updating Phase
-			testenv.VerifyMonitoringConsolePhase(deployment, testenvInstance, deployment.GetName(), splcommon.PhaseUpdating)
+			// Wait for MC to go to PENDING Phase
+			testenv.VerifyMonitoringConsolePhase(deployment, testenvInstance, deployment.GetName(), splcommon.PhasePending)
 
 			// Verify Monitoring Console is Ready and stays in ready state
 			testenv.VerifyMonitoringConsoleReady(deployment, deployment.GetName(), mc, testenvInstance)
@@ -652,9 +651,10 @@ var _ = Describe("Monitoring Console test", func() {
 			testenvInstance.Log.Info("Verify Cluster Manager NOT in Monitoring Console One Config Map after Cluster Manager Reconfig")
 			testenv.VerifyPodsInMCConfigMap(deployment, testenvInstance, []string{fmt.Sprintf(testenv.ClusterMasterServiceName, deployment.GetName())}, "SPLUNK_CLUSTER_MASTER_URL", mcName, false)
 
-			// Check Monitoring console One is NOT configured with all Indexer in Name Space
-			testenvInstance.Log.Info("Verify Indexers NOT in Monitoring Console One Pod Config String after Cluster Manager Reconfig")
-			testenv.VerifyPodsInMCConfigString(deployment, testenvInstance, indexerPods, mcName, false, true)
+			// Check Monitoring console One is Not configured with all Indexer in Name Space
+			// CSPL-619
+			// testenvInstance.Log.Info("Verify Indexers NOT in Monitoring Console One Pod Config String after Cluster Manager Reconfig")
+			// testenv.VerifyPodsInMCConfigString(deployment, testenvInstance, indexerPods, mcName, false, true)
 
 			// Check Monitoring Console One is still configured with Search Head in namespace
 			testenvInstance.Log.Info("Verify Search Head Pods on Monitoring Console One Config Map after Cluster Manager Reconfig")

--- a/test/scaling_test/scaling_test.go
+++ b/test/scaling_test/scaling_test.go
@@ -50,17 +50,13 @@ var _ = Describe("Scaling test", func() {
 	})
 
 	Context("Standalone deployment (S1)", func() {
-		It("scaling_test: Can Scale Up and Scale Down Standalone CR", func() {
+		It("scaling_test, integration: Can Scale Up and Scale Down Standalone CR", func() {
 
 			standalone, err := deployment.DeployStandalone(deployment.GetName(), "", "")
 			Expect(err).To(Succeed(), "Unable to deploy standalone instance ")
 
 			// Wait for Standalone to be in READY status
 			testenv.StandaloneReady(deployment, deployment.GetName(), standalone, testenvInstance)
-
-			// Check Monitoring console is configured with all standalone instances in namespace
-			peerList := testenv.GetConfiguredPeers(testenvInstance.GetName(), deployment.GetName())
-			testenvInstance.Log.Info("Peer List", "instance", peerList)
 
 			// Scale Standalone instance
 			testenvInstance.Log.Info("Scaling Up Standalone CR")
@@ -101,7 +97,7 @@ var _ = Describe("Scaling test", func() {
 	})
 
 	Context("Clustered deployment (C3 - clustered indexer, search head cluster)", func() {
-		It("scaling_test: SHC and IDXC can be scaled up and data is searchable", func() {
+		It("scaling_test, integration: SHC and IDXC can be scaled up and data is searchable", func() {
 
 			defaultSHReplicas := 3
 			defaultIndexerReplicas := 3

--- a/test/testenv/mcutil.go
+++ b/test/testenv/mcutil.go
@@ -23,8 +23,6 @@ import (
 	"github.com/splunk/splunk-operator/pkg/splunk/enterprise"
 	corev1 "k8s.io/api/core/v1"
 
-	gomega "github.com/onsi/gomega"
-
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -114,25 +112,6 @@ func DeleteMCPod(ns string) {
 	} else {
 		logf.Log.Info("Monitoring Console Stateful Set deleted", "Statefulset", mcSts, "stdout", output)
 	}
-}
-
-// MCPodReady waits for MC pod to be in ready state
-func MCPodReady(ns string, deployment *Deployment) {
-	// Monitoring Console Pod is in Ready State
-	gomega.Eventually(func() bool {
-		logf.Log.Info("Checking status of Monitoring Console Pod")
-		check := CheckMCPodReady(ns)
-		DumpGetPods(ns)
-		return check
-	}, deployment.GetTimeout(), PollInterval).Should(gomega.Equal(true))
-
-	// Verify MC Pod Stays in ready state
-	gomega.Consistently(func() bool {
-		logf.Log.Info("Checking status of Monitoring Console Pod")
-		check := CheckMCPodReady(ns)
-		DumpGetPods(ns)
-		return check
-	}, ConsistentDuration, ConsistentPollInterval).Should(gomega.Equal(true))
 }
 
 // CheckPodNameOnMC Check given pod is configured on Monitoring console pod


### PR DESCRIPTION
Backport for PR : https://github.com/splunk/splunk-operator/pull/586

* Added test to integration pipeline. Removed references to MCPodReady

* Resolve mc flaky test

(cherry picked from commit e4e1c69148c60cafa541cc203f70d421217e8d99)

