### PR TITLE
CSPL-1278: Log additional debug information after a functional test fails

### DIFF
--- a/.github/workflows/build-test-push-workflow.yml
+++ b/.github/workflows/build-test-push-workflow.yml
@@ -229,8 +229,17 @@ jobs:
         run: |
            make cluster-up
       - name: Run smoke test
+        id: smoketest
         run: |
           make int-test
+          mkdir -p /tmp/pod_logs
+          find ./test -name "*.log" -exec cp {} /tmp/pod_logs \;
+      - name: Archive Pod Logs if Failure in Smoke Test
+        uses: actions/upload-artifact@v2
+        if: failure() && steps.smoketest.outcome == 'failure'
+        with:
+          name: "splunk-pods-logs--artifacts-${{ matrix.test }}"
+          path: "test/test_artifacts"
       - name: Cleanup up EKS cluster
         if: ${{ always() }}
         run: | 

--- a/.github/workflows/build-test-push-workflow.yml
+++ b/.github/workflows/build-test-push-workflow.yml
@@ -236,10 +236,9 @@ jobs:
           find ./test -name "*.log" -exec cp {} /tmp/pod_logs \;
       - name: Archive Pod Logs if Failure in Smoke Test
         uses: actions/upload-artifact@v2
-        if: failure() && steps.smoketest.outcome == 'failure'
         with:
           name: "splunk-pods-logs--artifacts-${{ matrix.test }}"
-          path: "test/test_artifacts"
+          path: "/tmp/pod_logs/**"
       - name: Cleanup up EKS cluster
         if: ${{ always() }}
         run: | 

--- a/.github/workflows/int-test-workflow.yml
+++ b/.github/workflows/int-test-workflow.yml
@@ -115,6 +115,13 @@ jobs:
       - name: Run Integration test
         run: |
           make int-test
+          mkdir -p /tmp/pod_logs
+          find ./test -name "*.log" -exec cp {} /tmp/pod_logs \;
+      - name: Archive Pod Logs if Failure in Smoke Test
+        uses: actions/upload-artifact@v2
+        with:
+          name: "splunk-pods-logs--artifacts-${{ matrix.test }}"
+          path: "/tmp/pod_logs/**"
       - name: Cleanup up EKS cluster
         if: ${{ always() }}
         run: | 

--- a/.github/workflows/nightly-int-test-workflow.yml
+++ b/.github/workflows/nightly-int-test-workflow.yml
@@ -115,6 +115,13 @@ jobs:
       - name: Run Integration test
         run: |
           make int-test
+          mkdir -p /tmp/pod_logs
+          find ./test -name "*.log" -exec cp {} /tmp/pod_logs \;
+      - name: Archive Pod Logs if Failure in Smoke Test
+        uses: actions/upload-artifact@v2
+        with:
+          name: "splunk-pods-logs--artifacts-${{ matrix.test }}"
+          path: "/tmp/pod_logs/**"
       - name: Cleanup up EKS cluster
         if: ${{ always() }}
         run: | 

--- a/test/testenv/deployment.go
+++ b/test/testenv/deployment.go
@@ -74,7 +74,6 @@ func (d *Deployment) popCleanupFunc() (cleanupFunc, error) {
 
 // Teardown teardowns the deployment resources
 func (d *Deployment) Teardown() error {
-	var cleanupErr error
 
 	// Formatted string for pod logs
 	podLogFile := "%s-%s.log"
@@ -114,6 +113,8 @@ func (d *Deployment) Teardown() error {
 		d.testenv.Log.Info("deployment teardown is skipped!\n")
 		return nil
 	}
+
+	var cleanupErr error
 
 	for fn, err := d.popCleanupFunc(); err == nil; fn, err = d.popCleanupFunc() {
 		cleanupErr = fn()

--- a/test/testenv/testenv.go
+++ b/test/testenv/testenv.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 	"os"
 	"time"
+
+	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 
 	"github.com/go-logr/logr"
 	"github.com/onsi/ginkgo"
@@ -101,6 +102,9 @@ const (
 
 	// DeployerServiceName Cluster Manager Service Template String
 	DeployerServiceName = "splunk-%s-shc-deployer-service"
+
+	// TestArtifacts defines splunk pods logs saving location
+	TestArtifacts = "test/test_artifacts/%s/%s/"
 )
 
 var (

--- a/test/testenv/testenv.go
+++ b/test/testenv/testenv.go
@@ -18,10 +18,9 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 	"os"
 	"time"
-
-	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 
 	"github.com/go-logr/logr"
 	"github.com/onsi/ginkgo"
@@ -102,9 +101,6 @@ const (
 
 	// DeployerServiceName Cluster Manager Service Template String
 	DeployerServiceName = "splunk-%s-shc-deployer-service"
-
-	// TestArtifacts defines splunk pods logs saving location
-	TestArtifacts = "test/test_artifacts/%s/%s/"
 )
 
 var (

--- a/test/testenv/util.go
+++ b/test/testenv/util.go
@@ -528,6 +528,19 @@ func DumpGetPods(ns string) []string {
 	return splunkPods
 }
 
+// GetOperatorPod prints and returns operator pod in the namespace
+func GetOperatorPod(ns string) string {
+	output, _ := exec.Command("kubectl", "get", "pods", "-n", ns).Output()
+	var operatorPod string
+	for _, line := range strings.Split(string(output), "\n") {
+		logf.Log.Info(line)
+		if strings.HasPrefix(line, "splunk-op") {
+			operatorPod = strings.Fields(line)[0]
+		}
+	}
+	return operatorPod
+}
+
 // DumpGetPvcs prints and returns list of pvcs in the namespace
 func DumpGetPvcs(ns string) []string {
 	output, err := exec.Command("kubectl", "get", "pvc", "-n", ns).Output()


### PR DESCRIPTION
In case of test failure, the code in this PR will do the following during teardown:
- print the operator pod logs.
- Save the logs (from /opt/container_artifact/ansible.log) of every splunk instance pod  in the namespace in a separate file based on this pattern:
  splunk-operator/test/test_artifacts/<namespace>/<deployment name>/<podname>.log
- Save these logs as artifacts when tests are run by github actions.

All artifacts are logged can be found in this run https://github.com/splunk/splunk-operator/actions/runs/1560923175