### PR TITLE
CSPL-1553: Modify apiVersion in cluster_role.yaml

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:


### PR DESCRIPTION
Modify apiVersion in cluster_role.yaml to rbac.authorization.k8s.io/v1 (for compatibility with Kubernetes 1.22+)