### PR TITLE
CSPL-1169: Apps should be correctly installed on standalone pods when scaling up/down

### DIFF
--- a/pkg/apis/enterprise/v3/common_types.go
+++ b/pkg/apis/enterprise/v3/common_types.go
@@ -425,3 +425,15 @@ const (
 	// AppPkgInstallError indicates error after retries
 	AppPkgInstallError = 399
 )
+
+// StatefulSetScalingType determines if the statefulset is scaling up/down
+type StatefulSetScalingType uint32
+
+const (
+	// StatefulSetNotScaling indicates sts is not scaling
+	StatefulSetNotScaling StatefulSetScalingType = iota
+	// StatefulSetScalingUp indicates sts is scaling up
+	StatefulSetScalingUp
+	// StatefulSetScalingDown indicates sts is scaling down
+	StatefulSetScalingDown
+)

--- a/pkg/splunk/controller/statefulset_test.go
+++ b/pkg/splunk/controller/statefulset_test.go
@@ -324,13 +324,13 @@ func TestIsStatefulSetScalingUp(t *testing.T) {
 	c := spltest.NewMockClient()
 
 	*current.Spec.Replicas = 2
-	_, err := IsStatefulSetScalingUp(c, &cr, statefulSetName, replicas)
+	_, err := IsStatefulSetScalingUpOrDown(c, &cr, statefulSetName, replicas)
 	if err == nil {
 		t.Errorf("IsStatefulSetScalingUp should have returned error as we have not yet added statefulset to client.")
 	}
 
 	c.AddObject(current)
-	_, err = IsStatefulSetScalingUp(c, &cr, statefulSetName, replicas)
+	_, err = IsStatefulSetScalingUpOrDown(c, &cr, statefulSetName, replicas)
 	if err != nil {
 		t.Errorf("IsStatefulSetScalingUp should not have returned error")
 	}

--- a/pkg/splunk/enterprise/afwscheduler_test.go
+++ b/pkg/splunk/enterprise/afwscheduler_test.go
@@ -375,8 +375,12 @@ func TestTransitionWorkerPhase(t *testing.T) {
 		ppln.pplnPhases[enterpriseApi.PhaseDownload].q[0].appDeployInfo.AuxPhaseInfo[i].Phase = enterpriseApi.PhasePodCopy
 	}
 	ppln.pplnPhases[enterpriseApi.PhaseDownload].q[0].appDeployInfo.AuxPhaseInfo[2].Phase = enterpriseApi.PhaseInstall
+
+	ppln.pplnPhases[enterpriseApi.PhaseDownload].q[0].appDeployInfo.AuxPhaseInfo[3].Phase = enterpriseApi.PhaseInstall
+	ppln.pplnPhases[enterpriseApi.PhaseDownload].q[0].appDeployInfo.AuxPhaseInfo[3].Status = enterpriseApi.AppPkgInstallComplete
+
 	ppln.transitionWorkerPhase(workerList[0], enterpriseApi.PhaseDownload, enterpriseApi.PhasePodCopy)
-	if len(ppln.pplnPhases[enterpriseApi.PhasePodCopy].q) != int(replicas)-1 {
+	if len(ppln.pplnPhases[enterpriseApi.PhasePodCopy].q) != int(replicas)-2 {
 		t.Errorf("Failed to create the pod copy workers, according to the AuxPhaseInfo")
 	}
 	if len(ppln.pplnPhases[enterpriseApi.PhaseInstall].q) != 1 {

--- a/pkg/splunk/enterprise/util_test.go
+++ b/pkg/splunk/enterprise/util_test.go
@@ -1768,3 +1768,89 @@ func TestReleaseStorage(t *testing.T) {
 		t.Errorf("Released storage is not reflecting in the storage tracker")
 	}
 }
+
+func TestChangePhaseInfo(t *testing.T) {
+	appSrcDeployStatus := make(map[string]enterpriseApi.AppSrcDeployInfo, 1)
+
+	appDeployInfoList := []enterpriseApi.AppDeploymentInfo{
+		{
+			AppName:    "app1.tgz",
+			ObjectHash: "abcdef12345abcdef",
+			PhaseInfo: enterpriseApi.PhaseInfo{
+				Phase:      enterpriseApi.PhaseDownload,
+				Status:     enterpriseApi.AppPkgDownloadPending,
+				RetryCount: 2,
+			},
+			AuxPhaseInfo: []enterpriseApi.PhaseInfo{
+				{
+					Phase:      enterpriseApi.PhaseDownload,
+					Status:     enterpriseApi.AppPkgDownloadPending,
+					RetryCount: 2,
+				},
+				{
+					Phase:      enterpriseApi.PhaseDownload,
+					Status:     enterpriseApi.AppPkgDownloadPending,
+					RetryCount: 2,
+				},
+				{
+					Phase:      enterpriseApi.PhaseDownload,
+					Status:     enterpriseApi.AppPkgDownloadPending,
+					RetryCount: 2,
+				},
+			},
+		},
+	}
+
+	var appSrcDeployInfo enterpriseApi.AppSrcDeployInfo = enterpriseApi.AppSrcDeployInfo{}
+	appSrcDeployInfo.AppDeploymentInfoList = appDeployInfoList
+	appSrcDeployStatus["appSrc1"] = appSrcDeployInfo
+
+	changePhaseInfo(5, "appSrc1", appSrcDeployStatus)
+
+	if len(appDeployInfoList[0].AuxPhaseInfo) != 5 {
+		t.Errorf("changePhaseInfo should have increased the size of AuxPhaseInfo")
+	}
+}
+
+func TestRemoveStaleEntriesFromAuxPhaseInfo(t *testing.T) {
+	appSrcDeployStatus := make(map[string]enterpriseApi.AppSrcDeployInfo, 1)
+
+	appDeployInfoList := []enterpriseApi.AppDeploymentInfo{
+		{
+			AppName:    "app1.tgz",
+			ObjectHash: "abcdef12345abcdef",
+			PhaseInfo: enterpriseApi.PhaseInfo{
+				Phase:      enterpriseApi.PhaseDownload,
+				Status:     enterpriseApi.AppPkgDownloadPending,
+				RetryCount: 2,
+			},
+			AuxPhaseInfo: []enterpriseApi.PhaseInfo{
+				{
+					Phase:      enterpriseApi.PhaseDownload,
+					Status:     enterpriseApi.AppPkgDownloadPending,
+					RetryCount: 2,
+				},
+				{
+					Phase:      enterpriseApi.PhaseDownload,
+					Status:     enterpriseApi.AppPkgDownloadPending,
+					RetryCount: 2,
+				},
+				{
+					Phase:      enterpriseApi.PhaseDownload,
+					Status:     enterpriseApi.AppPkgDownloadPending,
+					RetryCount: 2,
+				},
+			},
+		},
+	}
+
+	var appSrcDeployInfo enterpriseApi.AppSrcDeployInfo = enterpriseApi.AppSrcDeployInfo{}
+	appSrcDeployInfo.AppDeploymentInfoList = appDeployInfoList
+	appSrcDeployStatus["appSrc1"] = appSrcDeployInfo
+
+	removeStaleEntriesFromAuxPhaseInfo(1, "appSrc1", appSrcDeployStatus)
+
+	if len(appDeployInfoList[0].AuxPhaseInfo) > 1 {
+		t.Errorf("removeStaleEntriesFromAuxPhaseInfo should have cleared the last 2 entries from AuxPhaseInfo")
+	}
+}


### PR DESCRIPTION
**Description**
In case of Standalone CR type, during scaling up, the new pods would not have the already installed apps that were installed on the existing pods.

**Solution**
During reconcile, at the moment when we decide if we are scaling up/down, update the AuxPhaseInfo for standalone CR, so that when afw scheduler runs, it knows to install apps for these new pods.