### PR TITLE
CSPL-1329: Migrate the Phase-2 App context status to Phase-3

### DIFF
--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -929,7 +929,7 @@ type: Opaque
 
 The kubectl command line tool can be used to decode the splunk secret tokens with the following command:
 
-`kubectl get secret splunk-<desired_namespace>-secret -o go-template=' {{range $k,$v := .data}}{{printf "%s: " $k}}{{if not $v}}{{$v}}{{else}}{{$v | base64decode}}{{end}}{{"\n"}}{{end}}'`
+`kubectl get secret splunk-<desired_namespace>-secret -o go-template='{{range $k,$v := .data}}{{printf "%s: " $k}}{{if not $v}}{{$v}}{{else}}{{$v | base64decode}}{{end}}{{"\n"}}{{end}}'`
 
 A sample global kubernetes secret object with tokens decoded looks like:
 

--- a/pkg/apis/enterprise/v3/common_types.go
+++ b/pkg/apis/enterprise/v3/common_types.go
@@ -333,6 +333,14 @@ type BundlePushTracker struct {
 	RetryCount int32 `json:"retryCount,omitempty"`
 }
 
+const (
+	// AfwPhase2 represents Phase-2 app framework
+	AfwPhase2 uint16 = iota
+
+	// AfwPhase3 represents Phase-3 app framework
+	AfwPhase3
+)
+
 // AppDeploymentContext for storing the Apps deployment information
 type AppDeploymentContext struct {
 	// App Framework version info for future use

--- a/pkg/splunk/enterprise/clustermaster.go
+++ b/pkg/splunk/enterprise/clustermaster.go
@@ -88,6 +88,12 @@ func ApplyClusterManager(client splcommon.ControllerClient, cr *enterpriseApi.Cl
 		}
 	}()
 
+	// If needed, Migrate the app framework status
+	err = checkAndMigrateAppDeployStatus(client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig, false)
+	if err != nil {
+		return result, err
+	}
+
 	// If the app framework is configured then do following things -
 	// 1. Initialize the S3Clients based on providers
 	// 2. Check the status of apps on remote storage.

--- a/pkg/splunk/enterprise/licensemaster.go
+++ b/pkg/splunk/enterprise/licensemaster.go
@@ -46,6 +46,12 @@ func ApplyLicenseManager(client splcommon.ControllerClient, cr *enterpriseApi.Li
 		return result, err
 	}
 
+	// If needed, Migrate the app framework status
+	err = checkAndMigrateAppDeployStatus(client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig, true)
+	if err != nil {
+		return result, err
+	}
+
 	// If the app framework is configured then do following things -
 	// 1. Initialize the S3Clients based on providers
 	// 2. Check the status of apps on remote storage.

--- a/pkg/splunk/enterprise/monitoringconsole.go
+++ b/pkg/splunk/enterprise/monitoringconsole.go
@@ -55,6 +55,12 @@ func ApplyMonitoringConsole(client splcommon.ControllerClient, cr *enterpriseApi
 	// updates status after function completes
 	cr.Status.Phase = splcommon.PhaseError
 
+	// If needed, Migrate the app framework status
+	err = checkAndMigrateAppDeployStatus(client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig, true)
+	if err != nil {
+		return result, err
+	}
+
 	// If the app framework is configured then do following things -
 	// 1. Initialize the S3Clients based on providers
 	// 2. Check the status of apps on remote storage.

--- a/pkg/splunk/enterprise/searchheadcluster.go
+++ b/pkg/splunk/enterprise/searchheadcluster.go
@@ -51,6 +51,12 @@ func ApplySearchHeadCluster(client splcommon.ControllerClient, cr *enterpriseApi
 		return result, err
 	}
 
+	// If needed, Migrate the app framework status
+	err = checkAndMigrateAppDeployStatus(client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig, false)
+	if err != nil {
+		return result, err
+	}
+
 	// If the app framework is configured then do following things -
 	// 1. Initialize the S3Clients based on providers
 	// 2. Check the status of apps on remote storage.

--- a/pkg/splunk/enterprise/types.go
+++ b/pkg/splunk/enterprise/types.go
@@ -28,6 +28,10 @@ const (
 	maxRecDuration time.Duration = 1<<63 - 1
 )
 
+const (
+	currentAfwVersion = enterpriseApi.AfwPhase3
+)
+
 // InstanceType is used to represent the type of Splunk instance (search head, indexer, etc).
 type InstanceType string
 


### PR DESCRIPTION
## App Framework Phase-2 to Phase-3 status migration
App framework Phase-2 leverages the Ansible to install APP packages.  As part of the Phase-3 app framework, Operator Pod downloads and copies the same to the Splunk Pod, and then installs the app package. This involves 3 different phases of the App framework scheduler that is introduced in the Phase-3 app framework.

To track these phases, there are new fields introduced as part of the App framework status. When the Operator is upgraded to the Phase-3 functionality, there needs to be migration logic to transition the phase-2 app framework status values into phase-3 compatible values.  
The code changes listed here address the migration logic needed.

### Before the Migration
```
    appSrcDeployStatus:
      ApsrcfullAps:
        appDeploymentInfo:
        - appName: Splunk_TA_aws-5.0.2.spl
          deployStatus: 3
          objectHash: '"b38a8f911e2b43982b71a979fe1d3c3f"'
          repoState: 1
        - appName: Splunk_TA_paloalto-3.6.1-3610.tgz
          deployStatus: 3
          objectHash: '"3d864310fdea6254446f3d1adfd78515"'
          repoState: 1
    appsRepoStatusPollIntervalSeconds: 3600
    isDeploymentInProgress: true
    lastAppInfoCheckTime: 1641412618
    version: 0

```

### After the Migration
```
    appSrcDeployStatus:
      ApsrcfullAps:
        appDeploymentInfo:
        - appName: Splunk_TA_aws-5.0.2.spl
          deployStatus: 3
          isUpdate: false
          objectHash: b38a8f911e2b43982b71a979fe1d3c3f
          phaseInfo:
            phase: install
            status: 303
          repoState: 1
        - appName: Splunk_TA_paloalto-3.6.1-3610.tgz
          deployStatus: 3
          isUpdate: false
          objectHash: 3d864310fdea6254446f3d1adfd78515
          phaseInfo:
            phase: install
            status: 303
          repoState: 1
    appsRepoStatusPollIntervalSeconds: 6002
    appsStatusMaxConcurrentAppDownloads: 5
    bundlePushStatus: {}
    isDeploymentInProgress: true
    lastAppInfoCheckTime: 1641445603
    version: 1
```

