### PR TITLE
CSPL-1549: Reduce aggressive poll timer to basic 60 secs configured

### DIFF
--- a/test/c3/appframework/appframework_test.go
+++ b/test/c3/appframework/appframework_test.go
@@ -295,7 +295,7 @@ var _ = Describe("c3appfw test", func() {
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
 			// Wait for the poll period for the apps to be downloaded
-			time.Sleep(2 * time.Minute)
+			time.Sleep(1 * time.Minute)
 
 			// Ensure that the Cluster Manager goes to Ready phase
 			testenv.ClusterManagerReady(deployment, testenvInstance)
@@ -625,7 +625,7 @@ var _ = Describe("c3appfw test", func() {
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
 			// Wait for the poll period for the apps to be downloaded
-			time.Sleep(2 * time.Minute)
+			time.Sleep(1 * time.Minute)
 
 			// Ensure that the Cluster Manager goes to Ready phase
 			testenv.ClusterManagerReady(deployment, testenvInstance)
@@ -1210,7 +1210,7 @@ var _ = Describe("c3appfw test", func() {
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
 			// Wait for the poll period for the apps to be downloaded
-			time.Sleep(2 * time.Minute)
+			time.Sleep(1 * time.Minute)
 
 			// Ensure that the Cluster Manager goes to Ready phase
 			testenv.ClusterManagerReady(deployment, testenvInstance)
@@ -1597,7 +1597,7 @@ var _ = Describe("c3appfw test", func() {
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
 			// Wait for the poll period for the apps to be downloaded
-			time.Sleep(2 * time.Minute)
+			time.Sleep(1 * time.Minute)
 
 			// Ensure that the Cluster Manager goes to Ready phase
 			testenv.ClusterManagerReady(deployment, testenvInstance)
@@ -1894,7 +1894,7 @@ var _ = Describe("c3appfw test", func() {
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
 			// Wait for the poll period for the apps to be downloaded
-			time.Sleep(2 * time.Minute)
+			time.Sleep(1 * time.Minute)
 
 			// Ensure that the Cluster Manager goes to Ready phase
 			testenv.ClusterManagerReady(deployment, testenvInstance)
@@ -2258,7 +2258,7 @@ var _ = Describe("c3appfw test", func() {
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
 			// Wait for the poll period for the apps to be downloaded
-			time.Sleep(2 * time.Minute)
+			time.Sleep(1 * time.Minute)
 
 			// Ensure that the Cluster Manager goes to Ready phase
 			testenv.ClusterManagerReady(deployment, testenvInstance)

--- a/test/m4/appframework/appframework_test.go
+++ b/test/m4/appframework/appframework_test.go
@@ -296,7 +296,7 @@ var _ = Describe("m4appfw test", func() {
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
 			// Wait for the poll period for the apps to be downloaded
-			time.Sleep(2 * time.Minute)
+			time.Sleep(1 * time.Minute)
 
 			// Ensure that the Cluster Manager goes to Ready phase
 			testenv.ClusterManagerReady(deployment, testenvInstance)
@@ -625,7 +625,7 @@ var _ = Describe("m4appfw test", func() {
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
 			// Wait for the poll period for the apps to be downloaded
-			time.Sleep(2 * time.Minute)
+			time.Sleep(1 * time.Minute)
 
 			// Ensure that the Cluster Manager goes to Ready phase
 			testenv.ClusterManagerReady(deployment, testenvInstance)
@@ -1201,7 +1201,7 @@ var _ = Describe("m4appfw test", func() {
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
 			// Wait for the poll period for the apps to be downloaded
-			time.Sleep(2 * time.Minute)
+			time.Sleep(1 * time.Minute)
 
 			// Ensure that the Cluster Manager goes to Ready phase
 			testenv.ClusterManagerReady(deployment, testenvInstance)
@@ -1413,7 +1413,7 @@ var _ = Describe("m4appfw test", func() {
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
 			// Wait for the poll period for the apps to be downloaded
-			time.Sleep(2 * time.Minute)
+			time.Sleep(1 * time.Minute)
 
 			// Ensure that the Cluster Manager goes to Ready phase
 			testenv.ClusterManagerReady(deployment, testenvInstance)

--- a/test/s1/appframework/appframework_test.go
+++ b/test/s1/appframework/appframework_test.go
@@ -243,7 +243,7 @@ var _ = Describe("s1appfw test", func() {
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
 			// Wait for the poll period for the apps to be downloaded
-			time.Sleep(2 * time.Minute)
+			time.Sleep(1 * time.Minute)
 
 			// Wait for Standalone to be in READY status
 			testenv.StandaloneReady(deployment, deployment.GetName(), standalone, testenvInstance)
@@ -483,7 +483,7 @@ var _ = Describe("s1appfw test", func() {
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
 			// Wait for the poll period for the apps to be downloaded
-			time.Sleep(2 * time.Minute)
+			time.Sleep(1 * time.Minute)
 
 			// Wait for Standalone to be in READY status
 			testenv.StandaloneReady(deployment, deployment.GetName(), standalone, testenvInstance)
@@ -1142,7 +1142,7 @@ var _ = Describe("s1appfw test", func() {
 			uploadedApps = append(uploadedApps, uploadedFiles...)
 
 			// Wait for the poll period for the apps to be downloaded
-			time.Sleep(2 * time.Minute)
+			time.Sleep(1 * time.Minute)
 
 			// Wait for Standalone to be in READY status
 			testenv.StandaloneReady(deployment, deployment.GetName(), standalone, testenvInstance)


### PR DESCRIPTION

Reduce aggressive poll timer added in each test case to basic 60 secs configured in spec for each SVA.


```
Local results:
• [SLOW TEST:556.723 seconds]
s1appfw test
/Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:32
  Standalone deployment (S1) with App Framework
  /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:62
    smoke, s1, appframework: can deploy a Standalone instance with App Framework enabled, install apps then upgrade them
    /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:63
------------------------------
• [SLOW TEST:574.594 seconds]
s1appfw test
/Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:32
  Standalone deployment (S1) with App Framework
  /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:307
    smoke, s1, appframework: can deploy a Standalone instance with App Framework enabled, install apps then downgrade them
    /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:308
------------------------------
• [SLOW TEST:815.710 seconds]
s1appfw test
/Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:32
  Standalone deployment (S1) with App Framework
  /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:546
    s1, integration, appframework: can deploy a Standalone instance with App Framework enabled, install apps, scale up, install apps on new pod, scale down
    /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:547
------------------------------
P [PENDING]
s1appfw test
/Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:32
  Standalone deployment (S1) with App Framework
  /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:861
    s1, integration, appframework: can deploy a Standalone and have ES app installed
    /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:862
------------------------------
• [SLOW TEST:256.295 seconds]
s1appfw test
/Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:32
  Standalone deployment (S1) with App Framework
  /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:935
    integration, s1, appframework: can deploy a Standalone instance with App Framework enabled and install around 350MB of apps at once
    /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:936
------------------------------
• [SLOW TEST:218.159 seconds]
s1appfw test
/Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:32
  Standalone deployment (S1) with App Framework
  /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:1031
    s1, smoke, appframework: can deploy a standalone instance with App Framework enabled for manual poll
    /Users/tpereira/Git/splunk-operator/test/s1/appframework/appframework_test.go:1032
------------------------------
{"level":"info","ts":1641246312.45906,"msg":"testenv deleted.\n","testenv":"s1appfw-pun"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/s1/appframework/s1appfw-pun_junit.xml

Ran 5 of 6 Specs in 2468.361 seconds
SUCCESS! -- 5 Passed | 0 Failed | 1 Pending | 0 Skipped
PASS
















• [SLOW TEST:1331.374 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:31
  Single Site Indexer Cluster with Search Head Cluster (C3) and App Framework
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:64
    smoke, c3, appframework: can deploy a C3 SVA with App Framework enabled, install apps then upgrade them
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:65
------------------------------
• [SLOW TEST:1160.183 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:31
  Single Site Indexer Cluster with Search Head Cluster (C3) with App Framework
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:393
    smoke, c3, appframework: can deploy a C3 SVA with App Framework enabled, install apps then downgrade them
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:394
------------------------------
• [SLOW TEST:423.983 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:31
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:1070
    smoke, c3, appframework: can deploy a C3 SVA and have apps installed locally on Cluster Manager and Deployer
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:1071
------------------------------
P [PENDING]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:31
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:1276
    integration, c3, appframework: can deploy a C3 SVA and have ES app installed on Search Head Cluster
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:1277
------------------------------
• [SLOW TEST:644.862 seconds]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:31
  Clustered deployment (C3 - clustered indexer, search head cluster)
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:1380
    c3, integration, appframework: can deploy a C3 SVA with apps installed locally on Cluster Manager and Deployer, cluster-wide on Peers and Search Heads, then upgrade them
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:1381
------------------------------
P [PENDING]
c3appfw test
/Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:31
  Single Site Indexer Cluster with Search Head Cluster (C3) with App Framework
  /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:2111
    integration, c3, appframework: can deploy a C3 SVA with App Framework enabled for manual update
    /Users/tpereira/Git/splunk-operator/test/c3/appframework/appframework_test.go:2112
------------------------------
{"level":"info","ts":1641254999.346549,"msg":"testenv teardown is skipped!\n","testenv":"c3appfw-rfu"}
{"level":"info","ts":1641254999.346571,"msg":"testenv teardown is skipped!\n","testenv":"c3appfw-rfu"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/c3/appframework/c3appfw-rfu_junit.xml

Ran 7 of 9 Specs in  8314.528 seconds
SUCCESS! -- 7 Passed | 0 Failed | 2 Pending | 0 Skipped
PASS









• [SLOW TEST:1079.023 seconds]
m4appfw test
/Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:32
  Multisite Indexer Cluster with Search Head Cluster (m4) with App Framework
  /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:67
    smoke, m4, appframework: can deploy a M4 SVA with App Framework enabled, install apps and upgrade them
    /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:68
------------------------------
• [SLOW TEST:1357.579 seconds]
m4appfw test
/Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:32
  Multisite Indexer Cluster with Search Head Cluster (m4) with App Framework
  /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:397
    integration, m4, appframework: can deploy a M4 SVA with App Framework enabled, install apps and downgrade them
    /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:398
------------------------------
• [SLOW TEST:2072.603 seconds]
m4appfw test
/Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:32
  Multisite Indexer Cluster with Search Head Cluster (m4) with App Framework
  /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:727
    integration, m4, appframework: can deploy a M4 SVA with App Framework enabled, install apps, scale up clusters, install apps on new pods, scale down
    /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:728
------------------------------
• [SLOW TEST:551.741 seconds]
m4appfw test
/Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:32
  Multi Site Indexer Cluster with Search Head Cluster (m4) with App Framework)
  /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:1064
    integration, m4, appframework: can deploy a M4 SVA and have apps installed locally on Cluster Manager and Deployer
    /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:1065
------------------------------
P [PENDING]
m4appfw test
/Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:32
  Multi Site Indexer Cluster with SHC (m4) with App Framework
  /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:1265
    integration, m4, appframework: can deploy a M4 SVA with App Framework enabled for manual poll
    /Users/tpereira/Git/splunk-operator/test/m4/appframework/appframework_test.go:1266
------------------------------
{"level":"info","ts":1641324025.8717859,"msg":"testenv deleted.\n","testenv":"m4appfw-tey"}
{"level":"info","ts":1641324025.871816,"msg":"testenv deleted.\n","testenv":"m4appfw-tey"}

JUnit report was created: /Users/tpereira/Git/splunk-operator/test/m4/appframework/m4appfw-tey_junit.xml

Ran 4 of 5 Specs in 5105.626 seconds
SUCCESS! -- 4 Passed | 0 Failed | 1 Pending | 0 Skipped
PASS
```