### PR TITLE
CSPL-1529: Fix a bug where ClusterMaster was not watching for changes in configMap

### DIFF
--- a/pkg/controller/add_clustermaster.go
+++ b/pkg/controller/add_clustermaster.go
@@ -49,7 +49,7 @@ func (ctrl ClusterManagerController) GetInstance() splcommon.MetaObject {
 
 // GetWatchTypes returns a list of types owned by the controller that it would like to receive watch events for
 func (ctrl ClusterManagerController) GetWatchTypes() []runtime.Object {
-	return []runtime.Object{&appsv1.StatefulSet{}, &corev1.Secret{}}
+	return []runtime.Object{&appsv1.StatefulSet{}, &corev1.Secret{}, &corev1.ConfigMap{}}
 }
 
 // Reconcile is used to perform an idempotent reconciliation of the custom resource managed by this controller

--- a/test/c3/appframework/appframework_test.go
+++ b/test/c3/appframework/appframework_test.go
@@ -2107,8 +2107,7 @@ var _ = Describe("c3appfw test", func() {
 		})
 	})
 
-	// Enable when CSPL-1529 is fixed
-	XContext("Single Site Indexer Cluster with Search Head Cluster (C3) with App Framework", func() {
+	Context("Single Site Indexer Cluster with Search Head Cluster (C3) with App Framework", func() {
 		It("integration, c3, appframework: can deploy a C3 SVA with App Framework enabled for manual update", func() {
 			/* Test Steps
 			   ################## SETUP ####################

--- a/test/m4/appframework/appframework_test.go
+++ b/test/m4/appframework/appframework_test.go
@@ -1261,8 +1261,7 @@ var _ = Describe("m4appfw test", func() {
 		})
 	})
 
-	// Enable when CSPL-1529 is fixed
-	XContext("Multi Site Indexer Cluster with SHC (m4) with App Framework", func() {
+	Context("Multi Site Indexer Cluster with SHC (m4) with App Framework", func() {
 		It("integration, m4, appframework: can deploy a M4 SVA with App Framework enabled for manual poll", func() {
 			/* Test Steps
 			   ################## SETUP ####################


### PR DESCRIPTION
**Problem Statement**
When we deploy a ClusterMaster along with any other CR such as SHC or Standalone with manual app update enabled(OR in other words, polling disabled), manual app update was not getting triggered when we changed the configMap to poll for the changes on the remote storage.

**Root Cause**
Because of a recent PR for merge from develop to feature branch, we reverted to the old code where ClusterMaster would not watch for changes in configMap. Because of this bug, any change in the manual app update configMap was not getting picked up by ClusterMaster.

**Solution**
1. Add configMap as a watch type to ClusterMaster CR.
2. Also enable in-tests related to manual app update in test/ folder.