### PR TITLE
CSPL-1536-removed-workaround-to-account-for-mc-reset

### DIFF
--- a/test/testenv/verificationutils.go
+++ b/test/testenv/verificationutils.go
@@ -68,16 +68,6 @@ func VerifyMonitoringConsoleReady(deployment *Deployment, mcName string, monitor
 		}
 		testenvInstance.Log.Info("Waiting for Monitoring Console phase to be ready", "instance", monitoringConsole.ObjectMeta.Name, "Phase", monitoringConsole.Status.Phase)
 		DumpGetPods(testenvInstance.GetName())
-		// CSPL-1532 - MC Resets after becoming READY. Remove the if block when bug is fixed.
-		if monitoringConsole.Status.Phase == splcommon.PhaseReady {
-			testenvInstance.Log.Info("After Monitoring Console Phase goes to Ready Phase in some instances it flips back to Pending/Updating. Adding Static Wait to avoid this situtaion")
-			time.Sleep(10 * time.Second)
-			err := deployment.GetInstance(mcName, monitoringConsole)
-			if err != nil {
-				return splcommon.PhaseError
-			}
-			testenvInstance.Log.Info("Waiting for Monitoring Console phase to be ready", "instance", monitoringConsole.ObjectMeta.Name, "Phase", monitoringConsole.Status.Phase)
-		}
 		return monitoringConsole.Status.Phase
 	}, deployment.GetTimeout(), PollInterval).Should(gomega.Equal(splcommon.PhaseReady))
 


### PR DESCRIPTION
Removed Workaround introduced as part of this [PR-618](https://github.com/splunk/splunk-operator/pull/618) for CSPL-1532 (Fixed in PR#[646](https://github.com/splunk/splunk-operator/pull/646))