### PR TITLE
CSPL-1570: Fix a bug where if we scale standalone from 1 to any greater replica number, we were setting incorrect AuxPhase for replica 0

### DIFF
--- a/pkg/splunk/controller/statefulset_test.go
+++ b/pkg/splunk/controller/statefulset_test.go
@@ -324,13 +324,13 @@ func TestIsStatefulSetScalingUp(t *testing.T) {
 	c := spltest.NewMockClient()
 
 	*current.Spec.Replicas = 2
-	_, err := IsStatefulSetScalingUpOrDown(c, &cr, statefulSetName, replicas)
+	_, _, err := IsStatefulSetScalingUpOrDown(c, &cr, statefulSetName, replicas)
 	if err == nil {
 		t.Errorf("IsStatefulSetScalingUp should have returned error as we have not yet added statefulset to client.")
 	}
 
 	c.AddObject(current)
-	_, err = IsStatefulSetScalingUpOrDown(c, &cr, statefulSetName, replicas)
+	_, _, err = IsStatefulSetScalingUpOrDown(c, &cr, statefulSetName, replicas)
 	if err != nil {
 		t.Errorf("IsStatefulSetScalingUp should not have returned error")
 	}

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -150,7 +150,7 @@ func ApplyStandalone(client splcommon.ControllerClient, cr *enterpriseApi.Standa
 
 		statefulsetName := GetSplunkStatefulsetName(SplunkStandalone, cr.GetName())
 
-		isStatefulSetScaling, err := splctrl.IsStatefulSetScalingUpOrDown(client, cr, statefulsetName, cr.Spec.Replicas)
+		isStatefulSetScaling, currentReplicas, err := splctrl.IsStatefulSetScalingUpOrDown(client, cr, statefulsetName, cr.Spec.Replicas)
 		if err != nil {
 			return result, err
 		}
@@ -163,7 +163,7 @@ func ApplyStandalone(client splcommon.ControllerClient, cr *enterpriseApi.Standa
 
 			for appSrc := range appStatusContext.AppsSrcDeployStatus {
 				changeAppSrcDeployInfoStatus(appSrc, appStatusContext.AppsSrcDeployStatus, enterpriseApi.RepoStateActive, enterpriseApi.DeployStatusComplete, enterpriseApi.DeployStatusPending)
-				changePhaseInfo(cr.Spec.Replicas, appSrc, appStatusContext.AppsSrcDeployStatus)
+				adjustAfwPhaseInfoForScaleup(currentReplicas, cr.Spec.Replicas, appSrc, appStatusContext.AppsSrcDeployStatus)
 			}
 
 		// if we are scaling down, just delete the state auxPhaseInfo entries


### PR DESCRIPTION
**Problem**
When trying to scale a standalone CR from 1 to any greater number of replicas, we would try to reinstall the app/s on pod-0, which would result in installation failure and then setting the wrong AuxPhaseInfo for that pod.

**Solution**
Set AuxPhaseInfo for pod-0 to be Phase = PhaseInstall and Status = AppPkgInstallComplete. This way we wont be attempting to install the app/s again on that pod.