### PR TITLE
CSPL-1494: Some misc improvements to AFW scheduler code

### DIFF
--- a/pkg/apis/enterprise/v3/common_types.go
+++ b/pkg/apis/enterprise/v3/common_types.go
@@ -339,6 +339,9 @@ const (
 
 	// AfwPhase3 represents Phase-3 app framework
 	AfwPhase3
+
+	// LatestAfwVersion represents latest App framework version
+	LatestAfwVersion = AfwPhase3
 )
 
 // AppDeploymentContext for storing the Apps deployment information

--- a/pkg/splunk/enterprise/afwscheduler.go
+++ b/pkg/splunk/enterprise/afwscheduler.go
@@ -33,11 +33,24 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-// createPipelineWorker creates a pipeline worker for an app package
-func createPipelineWorker(appDeployInfo *enterpriseApi.AppDeploymentInfo, appSrcName string, podName string,
-	appFrameworkConfig *enterpriseApi.AppFrameworkSpec, client splcommon.ControllerClient,
-	cr splcommon.MetaObject, statefulSet *appsv1.StatefulSet) *PipelineWorker {
-	return &PipelineWorker{
+// isFanOutApplicableToCR confirms if a given CR needs fanOut support
+func isFanOutApplicableToCR(cr splcommon.MetaObject) bool {
+	switch cr.GetObjectKind().GroupVersionKind().Kind {
+	case "Standalone":
+		return true
+	default:
+		return false
+	}
+}
+
+// createAndAddPipelineWorker used to add a worker to the pipeline on reconcile re-entry
+func (ppln *AppInstallPipeline) createAndAddPipelineWorker(phase enterpriseApi.AppPhaseType, appDeployInfo *enterpriseApi.AppDeploymentInfo,
+	appSrcName string, podName string, appFrameworkConfig *enterpriseApi.AppFrameworkSpec,
+	client splcommon.ControllerClient, cr splcommon.MetaObject, statefulSet *appsv1.StatefulSet) {
+
+	scopedLog := log.WithName("createAndAddPipelineWorker").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
+
+	worker := &PipelineWorker{
 		appDeployInfo: appDeployInfo,
 		appSrcName:    appSrcName,
 		targetPodName: podName,
@@ -45,21 +58,12 @@ func createPipelineWorker(appDeployInfo *enterpriseApi.AppDeploymentInfo, appSrc
 		client:        client,
 		cr:            cr,
 		sts:           statefulSet,
+		fanOut:        isFanOutApplicableToCR(cr),
 	}
-}
 
-// createAndAddAWorker used to add a worker to the pipeline on reconcile re-entry
-func (ppln *AppInstallPipeline) createAndAddPipelineWorker(phase enterpriseApi.AppPhaseType, appDeployInfo *enterpriseApi.AppDeploymentInfo,
-	appSrcName string, podName string, appFrameworkConfig *enterpriseApi.AppFrameworkSpec,
-	client splcommon.ControllerClient, cr splcommon.MetaObject, statefulSet *appsv1.StatefulSet) {
+	scopedLog.Info("Created new worker", "Pod name", worker.targetPodName, "App name", appDeployInfo.AppName, "digest", appDeployInfo.ObjectHash, "phase", appDeployInfo.PhaseInfo.Phase, "fan out", worker.fanOut)
 
-	scopedLog := log.WithName("createAndAddPipelineWorker").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
-	worker := createPipelineWorker(appDeployInfo, appSrcName, podName, appFrameworkConfig, client, cr, statefulSet)
-
-	if worker != nil {
-		scopedLog.Info("Created new worker", "Pod name", worker.targetPodName, "App name", appDeployInfo.AppName, "digest", appDeployInfo.ObjectHash, "phase", appDeployInfo.PhaseInfo.Phase)
-		ppln.addWorkersToPipelinePhase(phase, worker)
-	}
+	ppln.addWorkersToPipelinePhase(phase, worker)
 }
 
 // getApplicablePodNameForAppFramework gets the Pod name relevant for the CR under work
@@ -129,26 +133,39 @@ func (ppln *AppInstallPipeline) deleteWorkerFromPipelinePhase(phaseID enterprise
 	return false
 }
 
-// setContextForNewPhase makes the worker ready for the new phase
-func setContextForNewPhase(worker *PipelineWorker, phaseInfo *enterpriseApi.PhaseInfo, nextPhase enterpriseApi.AppPhaseType) {
-	phaseInfo.Phase = nextPhase
+// setContextForNewPhase sets the PhaseInfo to new phase
+func setContextForNewPhase(phaseInfo *enterpriseApi.PhaseInfo, newPhase enterpriseApi.AppPhaseType) {
+	phaseInfo.Phase = newPhase
 	phaseInfo.RetryCount = 0
-	if nextPhase == enterpriseApi.PhaseDownload {
-		phaseInfo.Status = enterpriseApi.AppPkgDownloadPending
-	} else if nextPhase == enterpriseApi.PhasePodCopy {
-		phaseInfo.Status = enterpriseApi.AppPkgPodCopyPending
-	} else if nextPhase == enterpriseApi.PhaseInstall {
-		phaseInfo.Status = enterpriseApi.AppPkgInstallPending
-	}
+	setPhaseStatusToPending(phaseInfo)
+}
 
+// makeWorkerInActive removes any pipeline specific context from the worker
+func makeWorkerInActive(worker *PipelineWorker) {
 	worker.isActive = false
 	worker.waiter = nil
+}
+
+// createFanOutWorker creates a fan-out worker
+func createFanOutWorker(seedWorker *PipelineWorker, ordinalIdx int) *PipelineWorker {
+	if seedWorker == nil {
+		return nil
+	}
+
+	if int32(ordinalIdx) >= *seedWorker.sts.Spec.Replicas {
+		return nil
+	}
+
+	newWorker := &PipelineWorker{}
+	*newWorker = *seedWorker
+	newWorker.fanOut = false
+	newWorker.targetPodName = getApplicablePodNameForAppFramework(seedWorker.cr, ordinalIdx)
+	return newWorker
 }
 
 // transitionWorkerPhase transitions a worker to new phase, and deletes from the current phase
 // In the case of Standalone CR with multiple replicas, Fan-out `replicas` number of new workers
 func (ppln *AppInstallPipeline) transitionWorkerPhase(worker *PipelineWorker, currentPhase, nextPhase enterpriseApi.AppPhaseType) {
-	kind := worker.cr.GetObjectKind().GroupVersionKind().Kind
 
 	scopedLog := log.WithName("transitionWorkerPhase").WithValues("name", worker.cr.GetName(), "namespace", worker.cr.GetNamespace(), "App name", worker.appDeployInfo.AppName, "digest", worker.appDeployInfo.ObjectHash, "pod name", worker.targetPodName, "current Phase", currentPhase, "next phase", nextPhase)
 
@@ -159,6 +176,9 @@ func (ppln *AppInstallPipeline) transitionWorkerPhase(worker *PipelineWorker, cu
 		replicaCount = 1
 	}
 
+	// Disable the  existing worker, so that either it can be safely transitioned to new pipeline or can act as a base for fan-out workers
+	makeWorkerInActive(worker)
+
 	// For now Standalone is the only CR unique with multiple replicas that is applicable for the AFW
 	// If the replica count is more than 1, and if it is Standalone, when transitioning from
 	// download phase, create a separate worker for the Pod copy(which also transition to install worker)
@@ -167,23 +187,11 @@ func (ppln *AppInstallPipeline) transitionWorkerPhase(worker *PipelineWorker, cu
 	// switches to download phase, once the download phase is complete, it will safely schedule a new pod copy worker,
 	// without affecting other pods.
 	appDeployInfo := worker.appDeployInfo
-	if replicaCount == 1 {
-		scopedLog.Info("Simple transition")
-
-		setContextForNewPhase(worker, &appDeployInfo.PhaseInfo, nextPhase)
-		ppln.addWorkersToPipelinePhase(nextPhase, worker)
-	} else if kind == "Standalone" {
-
-		// ToDo: sgontla: Strengthen this logic such that we don't depend the podName
-		if worker.targetPodName != "" {
-			podID, _ := getOrdinalValFromPodName(worker.targetPodName)
-			phaseInfo := &worker.appDeployInfo.AuxPhaseInfo[podID]
-			setContextForNewPhase(worker, phaseInfo, nextPhase)
-
-		} else if currentPhase == enterpriseApi.PhaseDownload {
+	if worker.fanOut {
+		scopedLog.Info("Fan-out transition")
+		if currentPhase == enterpriseApi.PhaseDownload {
 			// On a reconcile entry, processing the Standalone CR right after loading the appDeployContext from the CR status
-			var copyWorkers, installWorkers []*PipelineWorker
-			scopedLog.Info("Fan-out transition")
+			var podCopyWorkers, installWorkers []*PipelineWorker
 
 			// Seems like the download just finished. Allocate Phase info
 			if len(appDeployInfo.AuxPhaseInfo) == 0 {
@@ -192,56 +200,56 @@ func (ppln *AppInstallPipeline) transitionWorkerPhase(worker *PipelineWorker, cu
 				appDeployInfo.AuxPhaseInfo = make([]enterpriseApi.PhaseInfo, replicaCount)
 
 				// Create a slice of corresponding worker nodes
-				copyWorkers = make([]*PipelineWorker, replicaCount)
+				podCopyWorkers = make([]*PipelineWorker, replicaCount)
 
 				//Create the Aux PhaseInfo for tracking all the Standalone Pods
 				for podID := range appDeployInfo.AuxPhaseInfo {
 					// Create a new copy worker
-					copyWorkers[podID] = &PipelineWorker{}
-					*copyWorkers[podID] = *worker
-					copyWorkers[podID].targetPodName = getApplicablePodNameForAppFramework(worker.cr, podID)
+					podCopyWorkers[podID] = createFanOutWorker(worker, podID)
 
-					setContextForNewPhase(copyWorkers[podID], &appDeployInfo.AuxPhaseInfo[podID], enterpriseApi.PhasePodCopy)
+					setContextForNewPhase(&appDeployInfo.AuxPhaseInfo[podID], enterpriseApi.PhasePodCopy)
 					scopedLog.Info("Created a new fan-out pod copy worker", "pod name", worker.targetPodName)
 				}
 			} else {
 				scopedLog.Info("Installation was already in progress for replica members")
 				for podID := range appDeployInfo.AuxPhaseInfo {
 					phaseInfo := &appDeployInfo.AuxPhaseInfo[podID]
+					if !isPhaseInfoEligibleForSchedulerEntry(phaseInfo) {
+						continue
+					}
 
-					newWorker := &PipelineWorker{}
-					*newWorker = *worker
-					newWorker.targetPodName = getApplicablePodNameForAppFramework(worker.cr, podID)
-
-					if phaseInfo.RetryCount < pipelinePhaseMaxRetryCount {
-						if phaseInfo.Phase == enterpriseApi.PhaseInstall {
-							// If the install is already complete for that app, nothing to be done
-							if phaseInfo.Status == enterpriseApi.AppPkgInstallComplete {
-								scopedLog.Info("app already installed")
-								continue
-							} else {
-								scopedLog.Info("Created an install worker", "pod name", worker.targetPodName)
-								setContextForNewPhase(newWorker, phaseInfo, enterpriseApi.PhaseInstall)
-								installWorkers = append(installWorkers, newWorker)
-							}
-						} else if phaseInfo.Phase == enterpriseApi.PhasePodCopy {
-							scopedLog.Info("Created a pod copy worker", "pod name", worker.targetPodName)
-							setContextForNewPhase(newWorker, phaseInfo, enterpriseApi.PhasePodCopy)
-							copyWorkers = append(copyWorkers, newWorker)
-						} else {
-							scopedLog.Error(nil, "invalid phase info detected", "phase", phaseInfo.Phase, "phase status", phaseInfo.Status)
-						}
+					newWorker := createFanOutWorker(worker, podID)
+					// reset the phase status
+					setPhaseStatusToPending(phaseInfo)
+					if phaseInfo.Phase == enterpriseApi.PhaseInstall {
+						installWorkers = append(installWorkers, newWorker)
+					} else if phaseInfo.Phase == enterpriseApi.PhasePodCopy {
+						podCopyWorkers = append(podCopyWorkers, newWorker)
+					} else {
+						scopedLog.Error(nil, "invalid phase info detected", "phase", phaseInfo.Phase, "phase status", phaseInfo.Status)
 					}
 				}
-
 			}
 
-			ppln.addWorkersToPipelinePhase(enterpriseApi.PhasePodCopy, copyWorkers...)
+			ppln.addWorkersToPipelinePhase(enterpriseApi.PhasePodCopy, podCopyWorkers...)
 			ppln.addWorkersToPipelinePhase(enterpriseApi.PhaseInstall, installWorkers...)
 		} else {
 			scopedLog.Error(nil, "Invalid phase detected")
 		}
 
+	} else {
+		scopedLog.Info("Simple transition")
+		var phaseInfo *enterpriseApi.PhaseInfo
+
+		if isFanOutApplicableToCR(worker.cr) {
+			podID, _ := getOrdinalValFromPodName(worker.targetPodName)
+			phaseInfo = &worker.appDeployInfo.AuxPhaseInfo[podID]
+		} else {
+			phaseInfo = &appDeployInfo.PhaseInfo
+		}
+
+		setContextForNewPhase(phaseInfo, nextPhase)
+		ppln.addWorkersToPipelinePhase(nextPhase, worker)
 	}
 
 	// We have already moved the worker(s) to the required queue.
@@ -261,10 +269,12 @@ func checkIfWorkerIsEligibleForRun(worker *PipelineWorker, phaseInfo *enterprise
 }
 
 // needToUseAuxPhaseInfo confirms if aux phase info to be used
+// currently applicable only for Standalone deployment
 func needToUseAuxPhaseInfo(worker *PipelineWorker, phaseType enterpriseApi.AppPhaseType) bool {
-	if phaseType != enterpriseApi.PhaseDownload && worker.cr.GroupVersionKind().Kind == "Standalone" && worker.sts != nil && *worker.sts.Spec.Replicas > 1 {
+	if phaseType != enterpriseApi.PhaseDownload && isFanOutApplicableToCR(worker.cr) {
 		return true
 	}
+
 	return false
 }
 
@@ -363,10 +373,10 @@ func (downloadWorker *PipelineWorker) download(pplnPhase *PipelinePhase, s3Clien
 	scopedLog.Info("Finished downloading app")
 }
 
-// scheduleDownloads schedules the download workers to download app/s
-func (pplnPhase *PipelinePhase) scheduleDownloads(ppln *AppInstallPipeline, maxWorkers uint64, scheduleDownloadsWaiter *sync.WaitGroup) {
+// downloadWorkerHandler schedules the download workers to download app/s
+func (pplnPhase *PipelinePhase) downloadWorkerHandler(ppln *AppInstallPipeline, maxWorkers uint64, scheduleDownloadsWaiter *sync.WaitGroup) {
 
-	scopedLog := log.WithName("scheduleDownloads")
+	scopedLog := log.WithName("downloadWorkerHandler")
 
 	// derive a counting semaphore from the channel to represent worker run pool
 	var downloadWorkersRunPool = make(chan struct{}, maxWorkers)
@@ -479,7 +489,7 @@ func (ppln *AppInstallPipeline) downloadPhaseManager() {
 
 	scheduleDownloadsWaiter.Add(1)
 	// schedule the download threads to do actual download work
-	go pplnPhase.scheduleDownloads(ppln, maxWorkers, scheduleDownloadsWaiter)
+	go pplnPhase.downloadWorkerHandler(ppln, maxWorkers, scheduleDownloadsWaiter)
 	defer func() {
 		ppln.shutdownPipelinePhase(string(enterpriseApi.PhaseDownload), pplnPhase, scheduleDownloadsWaiter)
 	}()
@@ -496,10 +506,10 @@ downloadPhase:
 		default:
 			for _, downloadWorker := range pplnPhase.q {
 				phaseInfo := getPhaseInfoByPhaseType(downloadWorker, enterpriseApi.PhaseDownload)
-				if phaseInfo.RetryCount >= pipelinePhaseMaxRetryCount {
+				if isPhaseMaxRetriesReached(phaseInfo) {
 					downloadWorker.appDeployInfo.PhaseInfo.Status = enterpriseApi.AppPkgDownloadError
 					ppln.deleteWorkerFromPipelinePhase(phaseInfo.Phase, downloadWorker)
-				} else if downloadWorker.appDeployInfo.PhaseInfo.Status == enterpriseApi.AppPkgDownloadComplete {
+				} else if isPhaseStatusComplete(phaseInfo) {
 					ppln.transitionWorkerPhase(downloadWorker, enterpriseApi.PhaseDownload, enterpriseApi.PhasePodCopy)
 				} else if checkIfWorkerIsEligibleForRun(downloadWorker, phaseInfo, enterpriseApi.AppPkgDownloadComplete) {
 					downloadWorker.waiter = &pplnPhase.workerWaiter
@@ -630,7 +640,7 @@ func runPodCopyWorker(worker *PipelineWorker, ch chan struct{}) {
 		worker.waiter.Done()
 	}()
 
-	appPkgFileName := worker.appDeployInfo.AppName + "_" + strings.Trim(worker.appDeployInfo.ObjectHash, "\"")
+	appPkgFileName := worker.appDeployInfo.AppName + "_" + worker.appDeployInfo.ObjectHash
 
 	appSrcScope := getAppSrcScope(worker.afwConfig, worker.appSrcName)
 	appPkgLocalDir := getAppPackageLocalDir(cr, appSrcScope, worker.appSrcName)
@@ -749,10 +759,10 @@ podCopyPhase:
 		default:
 			for _, podCopyWorker := range pplnPhase.q {
 				phaseInfo := getPhaseInfoByPhaseType(podCopyWorker, enterpriseApi.PhasePodCopy)
-				if phaseInfo.RetryCount >= pipelinePhaseMaxRetryCount {
+				if isPhaseMaxRetriesReached(phaseInfo) {
 					podCopyWorker.appDeployInfo.PhaseInfo.Status = enterpriseApi.AppPkgPodCopyError
 					ppln.deleteWorkerFromPipelinePhase(phaseInfo.Phase, podCopyWorker)
-				} else if phaseInfo.Status == enterpriseApi.AppPkgPodCopyComplete {
+				} else if isPhaseStatusComplete(phaseInfo) {
 					// For cluster scoped apps, just delete the worker. install handler will trigger the bundle push
 					if enterpriseApi.ScopeCluster != getAppSrcScope(podCopyWorker.afwConfig, podCopyWorker.appSrcName) {
 						ppln.transitionWorkerPhase(podCopyWorker, enterpriseApi.PhasePodCopy, enterpriseApi.PhaseInstall)
@@ -818,7 +828,7 @@ func isPendingClusterScopeWork(afwPipeline *AppInstallPipeline) bool {
 		return false
 	}
 
-	// There is no cluster scoped apps pending for bundle push
+	// There are no cluster scoped apps pending for bundle push
 	if afwPipeline.appDeployContext.BundlePushStatus.BundlePushStage == enterpriseApi.BundlePushComplete || afwPipeline.appDeployContext.BundlePushStatus.BundlePushStage == enterpriseApi.BundlePushUninitialized {
 		return false
 	}
@@ -843,13 +853,8 @@ func needToRunClusterScopedPlaybook(afwPipeline *AppInstallPipeline) bool {
 // tryAppPkgCleanupFromOperatorPod tries to change the app install status, also cleans the app pkg from Operator Pod
 func tryAppPkgCleanupFromOperatorPod(installWorker *PipelineWorker) {
 	scopedLog := log.WithName("tryAppPkgCleanupFromOperatorPod")
-	if installWorker.sts == nil {
-		scopedLog.Error(nil, "sts is missing", "cr", installWorker.cr.GetName(), "kind", installWorker.cr.GroupVersionKind().Kind, "app pkg", installWorker.appDeployInfo.AppName)
-		deleteAppPkgFromOperator(installWorker)
-		return
-	}
 
-	if *installWorker.sts.Spec.Replicas > 1 {
+	if isFanOutApplicableToCR(installWorker.cr) {
 		if isAppInstallationCompleteOnAllReplicas(installWorker.appDeployInfo.AuxPhaseInfo) {
 			scopedLog.Info("app pkg installed on all the pods", "app pkg", installWorker.appDeployInfo.AppName)
 			installWorker.appDeployInfo.PhaseInfo.Phase = enterpriseApi.PhaseInstall
@@ -979,10 +984,10 @@ installPhase:
 				}
 
 				phaseInfo := getPhaseInfoByPhaseType(installWorker, enterpriseApi.PhaseInstall)
-				if phaseInfo.RetryCount >= pipelinePhaseMaxRetryCount {
-					installWorker.appDeployInfo.PhaseInfo.Status = enterpriseApi.AppPkgInstallError
+				if isPhaseMaxRetriesReached(phaseInfo) {
+					phaseInfo.Status = enterpriseApi.AppPkgInstallError
 					ppln.deleteWorkerFromPipelinePhase(phaseInfo.Phase, installWorker)
-				} else if phaseInfo.Status == enterpriseApi.AppPkgInstallComplete {
+				} else if isPhaseStatusComplete(phaseInfo) {
 					ppln.deleteWorkerFromPipelinePhase(phaseInfo.Phase, installWorker)
 				} else if phaseInfo.Status == enterpriseApi.AppPkgMissingOnPodError {
 					ppln.transitionWorkerPhase(installWorker, enterpriseApi.PhaseInstall, enterpriseApi.PhasePodCopy)
@@ -1007,6 +1012,36 @@ installPhase:
 
 		time.Sleep(200 * time.Millisecond)
 	}
+}
+
+// resetPhaseStatusToPending sets the phase status to pending
+func setPhaseStatusToPending(phaseInfo *enterpriseApi.PhaseInfo) {
+	switch phaseInfo.Phase {
+	case enterpriseApi.PhaseDownload:
+		phaseInfo.Status = enterpriseApi.AppPkgDownloadPending
+	case enterpriseApi.PhasePodCopy:
+		phaseInfo.Status = enterpriseApi.AppPkgPodCopyPending
+	case enterpriseApi.PhaseInstall:
+		phaseInfo.Status = enterpriseApi.AppPkgInstallPending
+	}
+}
+
+// isPhaseStatusComplete confirms if the given Phase status is complete or not
+func isPhaseStatusComplete(phaseInfo *enterpriseApi.PhaseInfo) bool {
+	switch phaseInfo.Phase {
+	case enterpriseApi.PhaseDownload:
+		return phaseInfo.Status == enterpriseApi.AppPkgDownloadComplete
+	case enterpriseApi.PhasePodCopy:
+		return phaseInfo.Status == enterpriseApi.AppPkgPodCopyComplete
+	case enterpriseApi.PhaseInstall:
+		return phaseInfo.Status == enterpriseApi.AppPkgInstallComplete
+	default:
+		return false
+	}
+}
+
+func isPhaseMaxRetriesReached(phaseInfo *enterpriseApi.PhaseInfo) bool {
+	return phaseInfo.RetryCount >= pipelinePhaseMaxRetryCount
 }
 
 // isPipelineEmpty checks if the pipeline is empty or not
@@ -1055,8 +1090,7 @@ func initPipelinePhase(afwPipeline *AppInstallPipeline, phase enterpriseApi.AppP
 	}
 }
 
-// initAppInstallPipeline creates the AFW scheduler pipeline
-// TBD: Do we need to make it singleton? For now leave it till we have the clarity on
+// initAppInstallPipeline creates the AFW scheduler pipelines
 func initAppInstallPipeline(appDeployContext *enterpriseApi.AppDeploymentContext, client splcommon.ControllerClient, cr splcommon.MetaObject) *AppInstallPipeline {
 
 	afwPipeline := &AppInstallPipeline{}
@@ -1398,6 +1432,19 @@ func checkAndUpdateAppFrameworkProgressFlag(afwPipeline *AppInstallPipeline) {
 	}
 }
 
+// isPhaseInfoEligibleForSchedulerEntry confirms if there is any pending work
+func isPhaseInfoEligibleForSchedulerEntry(phaseInfo *enterpriseApi.PhaseInfo) bool {
+	if phaseInfo.RetryCount >= pipelinePhaseMaxRetryCount {
+		return false
+	}
+
+	if phaseInfo.Phase == enterpriseApi.PhaseInstall && phaseInfo.Status == enterpriseApi.AppPkgInstallComplete {
+		return false
+	}
+
+	return true
+}
+
 // afwSchedulerEntry Starts the scheduler Pipeline with the required phases
 func afwSchedulerEntry(client splcommon.ControllerClient, cr splcommon.MetaObject, appDeployContext *enterpriseApi.AppDeploymentContext, appFrameworkConfig *enterpriseApi.AppFrameworkSpec) (bool, error) {
 	scopedLog := log.WithName("afwSchedulerEntry").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
@@ -1433,38 +1480,14 @@ func afwSchedulerEntry(client splcommon.ControllerClient, cr splcommon.MetaObjec
 	for appSrcName, appSrcDeployInfo := range appDeployContext.AppsSrcDeployStatus {
 		deployInfoList := appSrcDeployInfo.AppDeploymentInfoList
 		for i := range deployInfoList {
-			var pplnPhase enterpriseApi.AppPhaseType
-			var podName string
-
-			pplnPhase = ""
-			// Push All the Intermediatory work to the Pipeline phases and let the corresponding phase manager take care of them
-			if deployInfoList[i].PhaseInfo.RetryCount < pipelinePhaseMaxRetryCount {
-				phase := deployInfoList[i].PhaseInfo.Phase
-
-				switch phase {
-				case enterpriseApi.PhaseDownload, enterpriseApi.PhasePodCopy:
-					pplnPhase = phase
-
-				case enterpriseApi.PhaseInstall:
-					if deployInfoList[i].PhaseInfo.Status != enterpriseApi.AppPkgInstallComplete {
-						pplnPhase = phase
-					}
-				}
+			// Ignore any apps if there is no pending work
+			if !isPhaseInfoEligibleForSchedulerEntry(&deployInfoList[i].PhaseInfo) {
+				continue
 			}
 
-			// Ignore any other apps that are not in progress
-			podName = ""
-			if pplnPhase != "" {
-				// Don't worry about the standalone replicas at this time(auxPhaseInfo). Just queue it to the download phase, and
-				// let the download phase take care of it. Also, make sure not provide the podname at this time, so that the worker
-				// transision logic can fan-out new workers
-				// ToDo: sgontla: bring in a better alternative to strengthen this piece of code
-				sts := afwGetReleventStatefulsetByKind(cr, client)
-				if *sts.Spec.Replicas == 1 || cr.GroupVersionKind().Kind != "Standalone" {
-					podName = getApplicablePodNameForAppFramework(cr, 0)
-				}
-				afwPipeline.createAndAddPipelineWorker(pplnPhase, &deployInfoList[i], appSrcName, podName, appFrameworkConfig, client, cr, sts)
-			}
+			sts := afwGetReleventStatefulsetByKind(cr, client)
+			podName := getApplicablePodNameForAppFramework(cr, 0)
+			afwPipeline.createAndAddPipelineWorker(deployInfoList[i].PhaseInfo.Phase, &deployInfoList[i], appSrcName, podName, appFrameworkConfig, client, cr, sts)
 		}
 	}
 
@@ -1473,28 +1496,7 @@ func afwSchedulerEntry(client splcommon.ControllerClient, cr splcommon.MetaObjec
 	// while setting up the pipeline phases.
 	// Wait for the yield function to finish.
 	afwPipeline.phaseWaiter.Add(1)
-	go func(afwEntryTime int64) {
-		yieldTrigger := time.After(maxRunTimeBeforeAttemptingYield * time.Second)
-
-	yieldScheduler:
-		for {
-			select {
-			case <-yieldTrigger:
-				scopedLog.Info("Yielding from AFW scheduler", "time elapsed", time.Now().Unix()-afwEntryTime)
-				break yieldScheduler
-			default:
-				if afwPipeline.isPipelineEmpty() {
-					break yieldScheduler
-				}
-			}
-
-			time.Sleep(100 * time.Millisecond)
-		}
-
-		// Trigger the pipeline termination by closing the channel
-		close(afwPipeline.sigTerm)
-		afwPipeline.phaseWaiter.Done()
-	}(afwPipeline.afwEntryTime)
+	go afwPipeline.afwYieldWatcher(maxRunTimeBeforeAttemptingYield)
 
 	scopedLog.Info("Waiting for the phase managers to finish")
 
@@ -1506,4 +1508,30 @@ func afwSchedulerEntry(client splcommon.ControllerClient, cr splcommon.MetaObjec
 	checkAndUpdateAppFrameworkProgressFlag(afwPipeline)
 
 	return needToRevisitAppFramework(afwPipeline), nil
+}
+
+// afwYieldWatcher issues termination request to the scheduler when the yield time expires or the pipelines become empty.
+func (ppln *AppInstallPipeline) afwYieldWatcher(maxTimeToYield int64) {
+	scopedLog := log.WithName("afwYieldWatcher").WithValues("name", ppln.cr.GetName(), "namespace", ppln.cr.GetNamespace())
+	yieldTrigger := time.After(time.Duration(maxTimeToYield) * time.Second)
+
+yieldScheduler:
+	for {
+		select {
+		case <-yieldTrigger:
+			scopedLog.Info("Yielding from AFW scheduler", "time elapsed", time.Now().Unix()-ppln.afwEntryTime)
+			break yieldScheduler
+		default:
+			if ppln.isPipelineEmpty() {
+				break yieldScheduler
+			}
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Trigger the pipeline termination by closing the channel
+	close(ppln.sigTerm)
+	ppln.phaseWaiter.Done()
+	scopedLog.Info("Termination issued")
 }

--- a/pkg/splunk/enterprise/afwscheduler_test.go
+++ b/pkg/splunk/enterprise/afwscheduler_test.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -35,6 +34,37 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestIsFanOutApplicableToCR(t *testing.T) {
+	// Fan out is always applicable for Standalone case
+	crStdln := &enterpriseApi.Standalone{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Standalone",
+		},
+	}
+
+	if !isFanOutApplicableToCR(crStdln) {
+		t.Errorf("For Standalone, fanout is always applicable")
+	}
+
+	// Fan out is not applicable for ClusterMaster
+	crClusterMaster := &enterpriseApi.ClusterMaster{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ClusterMaster",
+		},
+	}
+
+	if isFanOutApplicableToCR(crClusterMaster) {
+		t.Errorf("For ClusterMaster, fanout is not applicable")
+	}
+
+	// When the CR kind is not "Standalone", fanout is not applicable
+	crUnknownKind := &enterpriseApi.Standalone{}
+	if isFanOutApplicableToCR(crUnknownKind) {
+		t.Errorf("For the CR with otherthan Standalone, should return false ")
+	}
+
+}
 
 func TestCreateAndAddPipelineWorker(t *testing.T) {
 	appDeployInfo := &enterpriseApi.AppDeploymentInfo{
@@ -61,7 +91,7 @@ func TestCreateAndAddPipelineWorker(t *testing.T) {
 		},
 	}
 
-	statefulSetName := "splunk-stand1-standalone"
+	statefulSetName := "splunk-stack1-standalone"
 	var replicas int32 = 32
 
 	sts := &appsv1.StatefulSet{
@@ -111,19 +141,6 @@ func TestCreateAndAddPipelineWorker(t *testing.T) {
 
 	appSrcName := appFrameworkConfig.AppSources[0].Name
 	var statefulSet *appsv1.StatefulSet = &appsv1.StatefulSet{}
-	worker := &PipelineWorker{
-		appDeployInfo: appDeployInfo,
-		appSrcName:    appSrcName,
-		targetPodName: podName,
-		afwConfig:     appFrameworkConfig,
-		client:        client,
-		cr:            &cr,
-		sts:           statefulSet,
-	}
-
-	if !reflect.DeepEqual(worker, createPipelineWorker(appDeployInfo, appSrcName, podName, appFrameworkConfig, client, &cr, statefulSet)) {
-		t.Errorf("Expected and Returned objects are not the same")
-	}
 
 	// Test for createAndAddPipelineWorker
 	afwPpln := initAppInstallPipeline(&appFrameworkContext, client, &cr)
@@ -132,6 +149,90 @@ func TestCreateAndAddPipelineWorker(t *testing.T) {
 	if len(afwPpln.pplnPhases[enterpriseApi.PhaseDownload].q) != 1 {
 		t.Errorf("Unable to add a worker to the pipeline phase")
 	}
+}
+
+func TestMakeWorkerInActive(t *testing.T) {
+	worker := &PipelineWorker{
+		isActive: true,
+		waiter:   &sync.WaitGroup{},
+	}
+
+	makeWorkerInActive(worker)
+
+	if worker.isActive || worker.waiter != nil {
+		t.Errorf("Failed to reest the worker")
+	}
+}
+
+func TestCreateFanOutWorker(t *testing.T) {
+	cr := enterpriseApi.Standalone{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Standalone",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stack1",
+			Namespace: "test",
+		},
+	}
+
+	appFrameworkConfig := &enterpriseApi.AppFrameworkSpec{
+		VolList: []enterpriseApi.VolumeSpec{
+			{Name: "msos_s2s3_vol", Endpoint: "https://s3-eu-west-2.amazonaws.com", Path: "testbucket-rs-london", SecretRef: "s3-secret", Type: "s3", Provider: "aws"},
+		},
+		AppSources: []enterpriseApi.AppSourceSpec{
+			{Name: "adminApps",
+				Location: "adminAppsRepo",
+				AppSourceDefaultSpec: enterpriseApi.AppSourceDefaultSpec{
+					VolName: "msos_s2s3_vol",
+					Scope:   enterpriseApi.ScopeLocal},
+			},
+		},
+	}
+
+	// create statefulset for the cluster master
+	statefulSetName := "splunk-stack1-standalone"
+	var replicas int32 = 1
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      statefulSetName,
+			Namespace: "test",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+	}
+
+	worker := &PipelineWorker{
+		cr: &cr,
+		appDeployInfo: &enterpriseApi.AppDeploymentInfo{
+			AppName: "app1.tgz",
+			PhaseInfo: enterpriseApi.PhaseInfo{
+				Phase:      enterpriseApi.PhaseInstall,
+				Status:     enterpriseApi.AppPkgInstallComplete,
+				RetryCount: 0,
+			},
+			ObjectHash: "abcd1234abcd",
+		},
+		sts:        sts,
+		appSrcName: appFrameworkConfig.AppSources[0].Name,
+		afwConfig:  appFrameworkConfig,
+		fanOut:     false,
+	}
+
+	fanOutWorker := createFanOutWorker(worker, 0)
+
+	if fanOutWorker == nil {
+		t.Errorf("Unable to create a fanout worker")
+	}
+
+	if fanOutWorker.fanOut {
+		t.Errorf("FanOut flag should be false on the new worker")
+	}
+	if fanOutWorker.targetPodName != "splunk-stack1-standalone-0" {
+		t.Errorf("Unexpected pod name: %v", fanOutWorker.targetPodName)
+	}
+
 }
 
 func TestGetApplicablePodNameForAppFramework(t *testing.T) {
@@ -354,6 +455,19 @@ func TestTransitionWorkerPhase(t *testing.T) {
 	ppln.pplnPhases[enterpriseApi.PhasePodCopy].q = nil
 	cr.TypeMeta.Kind = "Standalone"
 	replicas = 5
+	workerList[0] = &PipelineWorker{
+		sts: sts,
+		cr:  &cr,
+		appDeployInfo: &enterpriseApi.AppDeploymentInfo{
+			AppName: "app1.tgz",
+			PhaseInfo: enterpriseApi.PhaseInfo{
+				Phase:  enterpriseApi.PhaseDownload,
+				Status: enterpriseApi.AppPkgDownloadComplete,
+			},
+		},
+		fanOut: cr.TypeMeta.Kind == "Standalone",
+	}
+
 	ppln.pplnPhases[enterpriseApi.PhaseDownload].q = append(ppln.pplnPhases[enterpriseApi.PhaseDownload].q, workerList[0])
 	ppln.transitionWorkerPhase(workerList[0], enterpriseApi.PhaseDownload, enterpriseApi.PhasePodCopy)
 	if len(ppln.pplnPhases[enterpriseApi.PhasePodCopy].q) != int(replicas) {
@@ -573,6 +687,7 @@ func TestPhaseManagersMsgChannels(t *testing.T) {
 			},
 			afwConfig: &cr.Spec.AppFrameworkConfig,
 			client:    client,
+			fanOut:    cr.GetObjectKind().GroupVersionKind().Kind == "Standalone",
 		}
 	}
 
@@ -602,8 +717,12 @@ func TestPhaseManagersMsgChannels(t *testing.T) {
 	// add the worker to the pod copy phase
 	worker.appDeployInfo.PhaseInfo.RetryCount = 0
 	worker.isActive = false
-	worker.appDeployInfo.PhaseInfo.Phase = enterpriseApi.PhasePodCopy
-	worker.appDeployInfo.PhaseInfo.Status = enterpriseApi.AppPkgPodCopyPending
+	worker.fanOut = false
+	worker.appDeployInfo.AuxPhaseInfo = append(worker.appDeployInfo.AuxPhaseInfo,
+		enterpriseApi.PhaseInfo{
+			Phase:  enterpriseApi.PhasePodCopy,
+			Status: enterpriseApi.AppPkgPodCopyPending,
+		})
 	ppln.pplnPhases[enterpriseApi.PhasePodCopy].q = append(ppln.pplnPhases[enterpriseApi.PhasePodCopy].q, workerList...)
 
 	go ppln.podCopyPhaseManager()
@@ -625,8 +744,12 @@ func TestPhaseManagersMsgChannels(t *testing.T) {
 	// add the worker to the install phase
 	worker.appDeployInfo.PhaseInfo.RetryCount = 0
 	worker.isActive = false
-	worker.appDeployInfo.PhaseInfo.Phase = enterpriseApi.PhaseInstall
-	worker.appDeployInfo.PhaseInfo.Status = enterpriseApi.AppPkgInstallPending
+	worker.fanOut = false
+	worker.appDeployInfo.AuxPhaseInfo = append(worker.appDeployInfo.AuxPhaseInfo,
+		enterpriseApi.PhaseInfo{
+			Phase:  enterpriseApi.PhaseInstall,
+			Status: enterpriseApi.AppPkgInstallPending,
+		})
 	ppln.pplnPhases[enterpriseApi.PhaseInstall].q = append(ppln.pplnPhases[enterpriseApi.PhaseInstall].q, workerList...)
 
 	// Start the install phase manager
@@ -766,9 +889,117 @@ func TestNeedToUseAuxPhaseInfo(t *testing.T) {
 	}
 
 	*sts.Spec.Replicas = 1
-	// When replica count is 1, no need to use aux phase info
-	if needToUseAuxPhaseInfo(worker, enterpriseApi.PhasePodCopy) {
+	// Irrespective of the replica member count, aux. phase info should be used for any phase other than download
+	if !needToUseAuxPhaseInfo(worker, enterpriseApi.PhasePodCopy) {
 		t.Errorf("Suggesting Aux phase info, when it is not needed")
+	}
+}
+
+func TestSetPhaseStatusToPending(t *testing.T) {
+	phaseInfo := &enterpriseApi.PhaseInfo{
+		Phase: enterpriseApi.PhaseDownload,
+	}
+
+	setPhaseStatusToPending(phaseInfo)
+	if phaseInfo.Status != enterpriseApi.AppPkgDownloadPending {
+		t.Errorf("Expected status %v, but set to: %v", enterpriseApi.AppPkgDownloadPending, phaseInfo.Status)
+	}
+
+	phaseInfo.Phase = enterpriseApi.PhasePodCopy
+	setPhaseStatusToPending(phaseInfo)
+	if phaseInfo.Status != enterpriseApi.AppPkgPodCopyPending {
+		t.Errorf("Expected status %v, but set to: %v", enterpriseApi.AppPkgPodCopyPending, phaseInfo.Status)
+	}
+
+	phaseInfo.Phase = enterpriseApi.PhaseInstall
+	setPhaseStatusToPending(phaseInfo)
+	if phaseInfo.Status != enterpriseApi.AppPkgInstallPending {
+		t.Errorf("Expected status %v, but set to: %v", enterpriseApi.AppPkgInstallPending, phaseInfo.Status)
+	}
+}
+
+func TestIsPhaseStatusComplete(t *testing.T) {
+	phaseInfo := &enterpriseApi.PhaseInfo{
+		Phase: enterpriseApi.PhaseDownload,
+	}
+
+	// incomplete phaseInfo should always return false
+	if isPhaseStatusComplete(phaseInfo) {
+		t.Errorf("When the status is not set, should return false")
+	}
+
+	phaseInfo = &enterpriseApi.PhaseInfo{
+		Status: enterpriseApi.AppPkgDownloadPending,
+	}
+	if isPhaseStatusComplete(phaseInfo) {
+		t.Errorf("When the phase is invalid, should return false")
+	}
+
+	// If the status is not complete, should return false
+	phaseInfo.Phase = enterpriseApi.PhaseDownload
+	if isPhaseStatusComplete(phaseInfo) {
+		t.Errorf("When the status is not complete, should return false")
+	}
+
+	// When the status is complete, should return true
+	phaseInfo.Status = enterpriseApi.AppPkgDownloadComplete
+	if !isPhaseStatusComplete(phaseInfo) {
+		t.Errorf("When the status is complete, should return true")
+	}
+
+	phaseInfo.Phase = enterpriseApi.PhasePodCopy
+	phaseInfo.Status = enterpriseApi.AppPkgPodCopyComplete
+	if !isPhaseStatusComplete(phaseInfo) {
+		t.Errorf("When the status is complete, should return true")
+	}
+
+	phaseInfo.Phase = enterpriseApi.PhaseInstall
+	phaseInfo.Status = enterpriseApi.AppPkgInstallComplete
+	if !isPhaseStatusComplete(phaseInfo) {
+		t.Errorf("When the status is complete, should return true")
+	}
+}
+
+func TestIsPhaseMaxRetriesReached(t *testing.T) {
+	phaseInfo := &enterpriseApi.PhaseInfo{
+		RetryCount: 1,
+	}
+
+	// should return false, when the retries are not maxed out
+	if isPhaseMaxRetriesReached(phaseInfo) {
+		t.Errorf("Should return false, when the max retries are not reached")
+	}
+
+	// should return true, whe the max. retries are reached
+	phaseInfo.RetryCount = pipelinePhaseMaxRetryCount
+	if !isPhaseMaxRetriesReached(phaseInfo) {
+		t.Errorf("Should return true, when the max retries reached")
+	}
+}
+
+func TestIsPhaseInfoEligibleForSchedulerEntry(t *testing.T) {
+	phaseInfo := &enterpriseApi.PhaseInfo{
+		Phase:      enterpriseApi.PhaseDownload,
+		Status:     enterpriseApi.AppPkgDownloadComplete,
+		RetryCount: pipelinePhaseMaxRetryCount + 1,
+	}
+
+	// Should not be eligible once the max. retries are reached
+	if isPhaseInfoEligibleForSchedulerEntry(phaseInfo) {
+		t.Errorf("Should not be eligible once the max. retries reached")
+	}
+
+	phaseInfo.RetryCount = 0
+	// If the phase and status are not install complete, should return true
+	if !isPhaseInfoEligibleForSchedulerEntry(phaseInfo) {
+		t.Errorf("Should be eligible to run, when the install complete is not set")
+	}
+
+	// Once the install complete is set, should not be eligible to run
+	phaseInfo.Phase = enterpriseApi.PhaseInstall
+	phaseInfo.Status = enterpriseApi.AppPkgInstallComplete
+	if isPhaseInfoEligibleForSchedulerEntry(phaseInfo) {
+		t.Errorf("Should not be eligible to run, when the install complete is set")
 	}
 }
 
@@ -1334,7 +1565,7 @@ func TestScheduleDownloads(t *testing.T) {
 
 	downloadPhaseWaiter.Add(1)
 	// schedule the download threads to do actual download work
-	go pplnPhase.scheduleDownloads(ppln, uint64(maxWorkers), downloadPhaseWaiter)
+	go pplnPhase.downloadWorkerHandler(ppln, uint64(maxWorkers), downloadPhaseWaiter)
 
 	// add the workers to msgChannel so that scheduleDownlads thread can pick them up
 	for _, downloadWorker := range pplnPhase.q {
@@ -1348,7 +1579,7 @@ func TestScheduleDownloads(t *testing.T) {
 	downloadPhaseWaiter.Add(1)
 	close(ppln.sigTerm)
 	// schedule the download threads to do actual download work
-	go pplnPhase.scheduleDownloads(ppln, uint64(maxWorkers), downloadPhaseWaiter)
+	go pplnPhase.downloadWorkerHandler(ppln, uint64(maxWorkers), downloadPhaseWaiter)
 
 	downloadPhaseWaiter.Wait()
 }
@@ -2371,26 +2602,7 @@ func TestHandleAppPkgInstallComplete(t *testing.T) {
 		},
 	}
 
-	// create statefulset for the cluster master
-	statefulSetName := "splunk-stack1-standalone"
-	var replicas int32 = 1
-
-	sts := &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      statefulSetName,
-			Namespace: "test",
-		},
-		Spec: appsv1.StatefulSetSpec{
-			Replicas: &replicas,
-		},
-	}
-
 	client := spltest.NewMockClient()
-	_, err := splctrl.ApplyStatefulSet(client, sts)
-	if err != nil {
-		t.Errorf("unable to apply statefulset")
-	}
-
 	worker := &PipelineWorker{
 		cr:            &cr,
 		targetPodName: "splunk-stack1-standalone-0",
@@ -2404,7 +2616,6 @@ func TestHandleAppPkgInstallComplete(t *testing.T) {
 			ObjectHash: "abcd1234abcd",
 		},
 		client:     client,
-		sts:        sts,
 		appSrcName: appFrameworkConfig.AppSources[0].Name,
 		afwConfig:  appFrameworkConfig,
 	}
@@ -2419,7 +2630,7 @@ func TestHandleAppPkgInstallComplete(t *testing.T) {
 	appPkgLocalPath := getAppPackageLocalPath(worker)
 	appPkgLocalDir := path.Dir(appPkgLocalPath)
 
-	_, err = os.Stat(appPkgLocalDir)
+	_, err := os.Stat(appPkgLocalDir)
 	if os.IsNotExist(err) {
 		err = os.MkdirAll(appPkgLocalDir, 0755)
 		if err != nil {
@@ -2436,57 +2647,32 @@ func TestHandleAppPkgInstallComplete(t *testing.T) {
 	}
 	defer os.Remove(appPkgLocalPath)
 
-	// If sts is not set, should clean the app pkg
-	tryAppPkgCleanupFromOperatorPod(worker)
+	// Standalone with only one replicas
+	// Case-1: App pkg should not be deleted, when the installation is not complete on the Pod.
+	worker.appDeployInfo.AuxPhaseInfo = append(worker.appDeployInfo.AuxPhaseInfo, enterpriseApi.PhaseInfo{
+		Phase:  enterpriseApi.PhaseInstall,
+		Status: enterpriseApi.AppPkgInstallInProgress})
 
-	_, err = os.Stat(appPkgLocalPath)
-	if err == nil || !os.IsNotExist(err) {
-		t.Errorf("When the STS is nil, file should be removed")
-	}
-
-	// For standalone with replica count of 1, app package should be cleaned from the Operator
 	_, err = os.Create(appPkgLocalPath)
 	if err != nil {
 		t.Errorf("Unable to create the local package file, error: %v", err)
 	}
 
-	tryAppPkgCleanupFromOperatorPod(worker)
-	_, err = os.Stat(appPkgLocalPath)
-	if err == nil || !os.IsNotExist(err) {
-		t.Errorf("app pkg should be removed if the replica count is 1")
-	}
-
-	// Test cases with the Standalone replicas > 1
-	// Standalone with replicas > 1 should return false, unless the app installed on all the pods
-	_, err = os.Create(appPkgLocalPath)
-	if err != nil {
-		t.Errorf("Unable to create the local package file, error: %v", err)
-	}
-
-	replicas = 5
-	_, err = splctrl.ApplyStatefulSet(client, sts)
-	if err != nil {
-		t.Errorf("unable to update the statefulset")
-	}
-
-	worker.appDeployInfo.AuxPhaseInfo = make([]enterpriseApi.PhaseInfo, replicas)
 	tryAppPkgCleanupFromOperatorPod(worker)
 	_, err = os.Stat(appPkgLocalPath)
 	if os.IsNotExist(err) {
 		t.Errorf("App pkg should not be deleted when the install is not complete on all the Pods ")
 	}
 
-	// When all the app is installed on all the pods, should confirm app deletion from operator pod
+	// Case-2: When only one replica exists, should delete the app  package and also should set the main phase info to install
 	_, err = os.Create(appPkgLocalPath)
 	if err != nil {
 		t.Errorf("Unable to create the local package file, error: %v", err)
 	}
 
-	auxPhaseInfo := worker.appDeployInfo.AuxPhaseInfo
-	for i := range auxPhaseInfo {
-		auxPhaseInfo[i].Phase = enterpriseApi.PhaseInstall
-		auxPhaseInfo[i].Status = enterpriseApi.AppPkgInstallComplete
-	}
+	worker.appDeployInfo.AuxPhaseInfo[0] = enterpriseApi.PhaseInfo{
+		Phase:  enterpriseApi.PhaseInstall,
+		Status: enterpriseApi.AppPkgInstallComplete}
 
 	tryAppPkgCleanupFromOperatorPod(worker)
 	_, err = os.Stat(appPkgLocalPath)
@@ -2494,9 +2680,70 @@ func TestHandleAppPkgInstallComplete(t *testing.T) {
 		t.Errorf("App pkg should be deleted when the install is complete on all the Pods ")
 	}
 
-	// When the apps are installed across all the pods, same should be updated int the PhaseInfo
 	if worker.appDeployInfo.PhaseInfo.Phase != enterpriseApi.PhaseInstall || worker.appDeployInfo.PhaseInfo.Status != enterpriseApi.AppPkgInstallComplete {
 		t.Errorf("When app is installed on all the replica pods, same should be updated in the Phase info")
+	}
+
+	// Standalone with only multiple replicas
+	// Case-1: App pkg should not be deleted, when the installation is not complete on all the replica members.
+	worker.appDeployInfo.AuxPhaseInfo = append(worker.appDeployInfo.AuxPhaseInfo, enterpriseApi.PhaseInfo{
+		Phase:  enterpriseApi.PhasePodCopy,
+		Status: enterpriseApi.AppPkgPodCopyComplete})
+
+	_, err = os.Create(appPkgLocalPath)
+	if err != nil {
+		t.Errorf("Unable to create the local package file, error: %v", err)
+	}
+
+	tryAppPkgCleanupFromOperatorPod(worker)
+	_, err = os.Stat(appPkgLocalPath)
+	if os.IsNotExist(err) {
+		t.Errorf("App pkg should not be deleted when the install is not complete on all the Pods ")
+	}
+
+	// Case-2: When all the install is complete on all the replica members, should delete the app  package and also should set the main phase info to install
+	_, err = os.Create(appPkgLocalPath)
+	if err != nil {
+		t.Errorf("Unable to create the local package file, error: %v", err)
+	}
+
+	worker.appDeployInfo.AuxPhaseInfo[1] = enterpriseApi.PhaseInfo{
+		Phase:  enterpriseApi.PhaseInstall,
+		Status: enterpriseApi.AppPkgInstallComplete}
+
+	tryAppPkgCleanupFromOperatorPod(worker)
+	_, err = os.Stat(appPkgLocalPath)
+	if err == nil || !os.IsNotExist(err) {
+		t.Errorf("App pkg should be deleted when the install is complete on all the Pods ")
+	}
+
+	if worker.appDeployInfo.PhaseInfo.Phase != enterpriseApi.PhaseInstall || worker.appDeployInfo.PhaseInfo.Status != enterpriseApi.AppPkgInstallComplete {
+		t.Errorf("When app is installed on all the replica pods, same should be updated in the Phase info")
+	}
+
+	// For a CR, other than standalone, whenever the install is complete, should also delete the app pkg from operator pod
+	cr.TypeMeta.Kind = "ClusterMaster"
+	worker.appDeployInfo.AuxPhaseInfo = nil
+	appPkgLocalPath = getAppPackageLocalPath(worker)
+	appPkgLocalDir = path.Dir(appPkgLocalPath)
+
+	_, err = os.Stat(appPkgLocalDir)
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(appPkgLocalDir, 0755)
+		if err != nil {
+			t.Errorf("Unable to create the directory, error: %v", err)
+		}
+	}
+
+	_, err = os.Create(appPkgLocalPath)
+	if err != nil {
+		t.Errorf("Unable to create the local package file, error: %v", err)
+	}
+
+	tryAppPkgCleanupFromOperatorPod(worker)
+	_, err = os.Stat(appPkgLocalPath)
+	if err == nil || !os.IsNotExist(err) {
+		t.Errorf("App pkg should be deleted when the install is complete on all the Pods ")
 	}
 }
 
@@ -2630,14 +2877,75 @@ func TestInstallWorkerHandler(t *testing.T) {
 	appDeployContext.BundlePushStatus.BundlePushStage = enterpriseApi.BundlePushComplete
 }
 
-// TODO: gaurav/subba, commenting this UT for now.
-// It needs to be revisited once we have all the glue logic for all pipelines
-// For now, just covers the podCopy related flow
-/*
-func TestAfwSchedulerEntry(t *testing.T) {
+func TestAfwYieldWatcher(t *testing.T) {
 	cr := enterpriseApi.ClusterMaster{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "ClusterMaster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stack1",
+			Namespace: "test",
+		},
+		Spec: enterpriseApi.ClusterMasterSpec{
+			CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
+				Mock: true,
+			},
+		},
+	}
+
+	afwPipeline := &AppInstallPipeline{}
+	afwPipeline.cr = &cr
+	afwPipeline.sigTerm = make(chan struct{})
+	afwPipeline.afwEntryTime = time.Now().Unix()
+
+	// add a waiter
+	afwPipeline.phaseWaiter.Add(1)
+
+	// When the pipeline is empty, should break
+	yieldTime := 300
+	afwPipeline.afwYieldWatcher(int64(yieldTime))
+	afwPipeline.phaseWaiter.Wait()
+
+	_, channelOpen := <-afwPipeline.sigTerm
+
+	// This test should also fail, if the yield is really not happening for 300 seconds
+	if channelOpen {
+		t.Errorf("When the pipelines are empty, should yield immediately")
+	}
+
+	// When the pipeline is not empty, should wait for the max. yield time.
+	afwPipeline.pplnPhases = make(map[enterpriseApi.AppPhaseType]*PipelinePhase, 1)
+	initPipelinePhase(afwPipeline, enterpriseApi.PhaseDownload)
+	afwPipeline.pplnPhases[enterpriseApi.PhaseDownload].q = append(afwPipeline.pplnPhases[enterpriseApi.PhaseDownload].q, &PipelineWorker{})
+	afwPipeline.sigTerm = make(chan struct{})
+	afwPipeline.afwEntryTime = time.Now().Unix()
+	currentTime := afwPipeline.afwEntryTime
+
+	// Add a waiter
+	afwPipeline.phaseWaiter.Add(1)
+	// When the pipeline is empty, should break
+	yieldTime = 10
+	afwPipeline.afwYieldWatcher(int64(yieldTime))
+	afwPipeline.phaseWaiter.Wait()
+
+	_, channelOpen = <-afwPipeline.sigTerm
+	if channelOpen {
+		t.Errorf("Channel should be closed by the time we reach hear, OR else, this test should have failed due to max. timeout")
+	}
+
+	yieldTimeSpent := time.Now().Unix() - currentTime
+	if yieldTimeSpent < int64(yieldTime) {
+		t.Errorf("When the pipelines are not empty, yield should happen only on timer expiry. Time spent by scheduler: %v", yieldTimeSpent)
+	}
+}
+
+// Following test doesn't have anything to test in particular.
+// When there are no workers pending, the scheduler should return immediately.
+// If the scheduler is blocked for an extended period of time, it should fail at infra level.
+func TestAfwSchedulerEntry(t *testing.T) {
+	cr := enterpriseApi.ClusterMaster{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Standalone",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "stack1",
@@ -2664,93 +2972,34 @@ func TestAfwSchedulerEntry(t *testing.T) {
 		},
 	}
 
-	c := spltest.NewMockClient()
 	var appDeployContext *enterpriseApi.AppDeploymentContext = &enterpriseApi.AppDeploymentContext{
 		AppsStatusMaxConcurrentAppDownloads: 10,
 	}
-	// Create 2 apps for each app source, a total of 6 apps
-	appDeployContext.AppsSrcDeployStatus = make(map[string]enterpriseApi.AppSrcDeployInfo, 3)
 
-	appSrcDeploymentInfo := enterpriseApi.AppSrcDeployInfo{}
+	statefulSetName := "splunk-stack1-standalone"
+	var replicas int32 = 32
 
-	appDeployInfo := enterpriseApi.AppDeploymentInfo{
-		AppName:    fmt.Sprintf("app1.tgz"),
-		ObjectHash: fmt.Sprintf("abcd1234abcd"),
-		PhaseInfo: enterpriseApi.PhaseInfo{
-			Phase:  enterpriseApi.PhaseDownload,
-			Status: enterpriseApi.AppPkgDownloadPending,
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      statefulSetName,
+			Namespace: "test",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
 		},
 	}
-	appSrcDeploymentInfo.AppDeploymentInfoList = append(appSrcDeploymentInfo.AppDeploymentInfoList, appDeployInfo)
-	appDeployContext.AppsSrcDeployStatus[appFrameworkConfig.AppSources[0].Name] = appSrcDeploymentInfo
 
-	appDeployContext.AppFrameworkConfig = *appFrameworkConfig
-
-	afwPipeline = nil
-	afwPipeline = initAppInstallPipeline(appDeployContext)
-
-	var schedulerWaiter sync.WaitGroup
-	defer schedulerWaiter.Wait()
-
-	defaultVol := splcommon.AppDownloadVolume
-	splcommon.AppDownloadVolume = "/tmp/"
-	defer func() {
-		splcommon.AppDownloadVolume = defaultVol
-	}()
-
-	appPkgFileName := appDeployInfo.AppName + "_" + strings.Trim(appDeployInfo.ObjectHash, "\"")
-
-	appSrcScope := appFrameworkConfig.AppSources[0].Scope
-	appPkgLocalDir := getAppPackageLocalPath(&cr, appSrcScope, appFrameworkConfig.AppSources[0].Name)
-	appPkgLocalPath := appPkgLocalDir + appPkgFileName
-
-	_, err := os.Stat(appPkgLocalDir)
-	if os.IsNotExist(err) {
-		err = os.MkdirAll(appPkgLocalDir, 0755)
-		if err != nil {
-			t.Errorf("Unable to create the directory, error: %v", err)
-		}
+	client := spltest.NewMockClient()
+	_, err := splctrl.ApplyStatefulSet(client, sts)
+	if err != nil {
+		t.Errorf("unable to apply statefulset")
 	}
 
-	_, err = os.Stat(appPkgLocalPath)
-	if os.IsNotExist(err) {
-		_, err := os.Create(appPkgLocalPath)
-		if err != nil {
-			t.Errorf("Unable to create the local package file, error: %v", err)
-		}
+	startTime := time.Now().Unix()
+	afwSchedulerEntry(client, &cr, appDeployContext, appFrameworkConfig)
+	// Assuming the test is returning sooner, testing it for a 2 seconds value, which should be optimal for now
+	waitTime := time.Now().Unix() - startTime
+	if waitTime > 2 {
+		t.Errorf("For an empty pipeline, scheduler should return immediately, but spent: %v", waitTime)
 	}
-	defer os.Remove(appPkgLocalPath)
-
-	schedulerWaiter.Add(1)
-	go func() {
-		worker := <-afwPipeline.pplnPhases[enterpriseApi.PhaseDownload].msgChannel
-		worker.appDeployInfo.PhaseInfo.Status = enterpriseApi.AppPkgDownloadComplete
-		worker.isActive = false
-		// wait for the glue logic
-		//afwPipeline.pplnPhases[enterpriseApi.PhaseDownload].workerWaiter.Done()
-		schedulerWaiter.Done()
-	}()
-
-	// schedulerWaiter.Add(1)
-	// go func() {
-	// 	worker := <-afwPipeline.pplnPhases[enterpriseApi.PhasePodCopy].msgChannel
-	// 	worker.appDeployInfo.PhaseInfo.Status = enterpriseApi.AppPkgPodCopyComplete
-	// 	worker.isActive = false
-	// 	// wait for the glue logic
-	// 	//afwPipeline.pplnPhases[enterpriseApi.PhasePodCopy].workerWaiter.Done()
-	// 	schedulerWaiter.Done()
-	// }()
-
-	// schedulerWaiter.Add(1)
-	// go func() {
-	// 	worker := <-afwPipeline.pplnPhases[enterpriseApi.PhaseInstall].msgChannel
-	// 	worker.appDeployInfo.PhaseInfo.Status = enterpriseApi.AppPkgInstallComplete
-	// 	worker.isActive = false
-	// 	// wait for the glue logic
-	// 	// afwPipeline.pplnPhases[enterpriseApi.PhaseInstall].workerWaiter.Done()
-	// 	schedulerWaiter.Done()
-	// }()
-
-	afwSchedulerEntry(c, &cr, appDeployContext, appFrameworkConfig)
 }
-*/

--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -1000,6 +1000,11 @@ refCount: %d`, status, numOfObjects+1)
 func initAppFrameWorkContext(client splcommon.ControllerClient, cr splcommon.MetaObject, appFrameworkConf *enterpriseApi.AppFrameworkSpec, appStatusContext *enterpriseApi.AppDeploymentContext) error {
 	if appStatusContext.AppsSrcDeployStatus == nil {
 		appStatusContext.AppsSrcDeployStatus = make(map[string]enterpriseApi.AppSrcDeployInfo)
+		//Note:- Set version only at the time of allocating AppsSrcDeployStatus. This is important, so that we don't
+		// interfere with the upgrade scenarios. So, if the AppsSrcDeployStatus is already allocated
+		// and the version is not `CurrentAfwVersion`, means it is migration scenario, and the migration logic should
+		// handle upgrading to the latest version.
+		appStatusContext.Version = enterpriseApi.LatestAfwVersion
 
 		_, err := createOrUpdateAppUpdateConfigMap(client, cr)
 		if err != nil {
@@ -1054,11 +1059,23 @@ func CheckIfAppSrcExistsInConfig(appFrameworkConf *enterpriseApi.AppFrameworkSpe
 	return false
 }
 
+// isAppSourceScopeValid checks for valid app source
+func isAppSourceScopeValid(scope string) bool {
+	return scope == enterpriseApi.ScopeLocal || scope == enterpriseApi.ScopeCluster || scope == enterpriseApi.ScopeClusterWithPreConfig
+}
+
 // validateSplunkAppSources validates the App source config in App Framework spec
 func validateSplunkAppSources(appFramework *enterpriseApi.AppFrameworkSpec, localScope bool) error {
 
-	duplicateAppSourceStorageChecker := make(map[string]bool)
+	duplicateAppSourceStorageChecker := make(map[string]map[string]bool)
+	duplicateAppSourceStorageChecker[enterpriseApi.ScopeLocal] = make(map[string]bool)
+	if !localScope {
+		duplicateAppSourceStorageChecker[enterpriseApi.ScopeCluster] = make(map[string]bool)
+		duplicateAppSourceStorageChecker[enterpriseApi.ScopeClusterWithPreConfig] = make(map[string]bool)
+	}
+
 	duplicateAppSourceNameChecker := make(map[string]bool)
+
 	var vol string
 
 	// Make sure that all the App Sources are provided with the mandatory config values.
@@ -1089,30 +1106,36 @@ func validateSplunkAppSources(appFramework *enterpriseApi.AppFrameworkSpec, loca
 			vol = appFramework.Defaults.VolName
 		}
 
+		var scope string
 		if appSrc.Scope != "" {
 			if localScope && appSrc.Scope != enterpriseApi.ScopeLocal {
 				return fmt.Errorf("invalid scope for App Source: %s. Only local scope is supported for this kind of CR", appSrc.Name)
 			}
 
-			if !(appSrc.Scope == enterpriseApi.ScopeLocal || appSrc.Scope == enterpriseApi.ScopeCluster || appSrc.Scope == enterpriseApi.ScopeClusterWithPreConfig) {
+			if !isAppSourceScopeValid(appSrc.Scope) {
 				return fmt.Errorf("scope for App Source: %s should be either local or cluster or clusterWithPreConfig", appSrc.Name)
 			}
-		} else if appFramework.Defaults.Scope == "" {
-			return fmt.Errorf("app Source scope is missing for: %s", appSrc.Name)
+
+			scope = appSrc.Scope
+		} else {
+			if appFramework.Defaults.Scope == "" {
+				return fmt.Errorf("app Source scope is missing for: %s", appSrc.Name)
+			}
+
+			scope = appFramework.Defaults.Scope
 		}
 
-		if _, ok := duplicateAppSourceStorageChecker[vol+appSrc.Location]; ok {
+		if _, ok := duplicateAppSourceStorageChecker[scope][vol+appSrc.Location]; ok {
 			return fmt.Errorf("duplicate App Source configured for Volume: %s, and Location: %s combo. Remove the duplicate entry and reapply the configuration", vol, appSrc.Location)
 		}
-		duplicateAppSourceStorageChecker[vol+appSrc.Location] = true
-
+		duplicateAppSourceStorageChecker[scope][vol+appSrc.Location] = true
 	}
 
 	if localScope && appFramework.Defaults.Scope != "" && appFramework.Defaults.Scope != enterpriseApi.ScopeLocal {
 		return fmt.Errorf("invalid scope for defaults config. Only local scope is supported for this kind of CR")
 	}
 
-	if appFramework.Defaults.Scope != "" && appFramework.Defaults.Scope != enterpriseApi.ScopeLocal && appFramework.Defaults.Scope != enterpriseApi.ScopeCluster && appFramework.Defaults.Scope != enterpriseApi.ScopeClusterWithPreConfig {
+	if appFramework.Defaults.Scope != "" && !isAppSourceScopeValid(appFramework.Defaults.Scope) {
 		return fmt.Errorf("scope for defaults should be either local Or cluster, but configured as: %s", appFramework.Defaults.Scope)
 	}
 

--- a/pkg/splunk/enterprise/types.go
+++ b/pkg/splunk/enterprise/types.go
@@ -109,6 +109,9 @@ type PipelineWorker struct {
 
 	// waiter reference to inform the caller
 	waiter *sync.WaitGroup
+
+	// indicates a fan out worker
+	fanOut bool
 }
 
 // PipelinePhase represents one phase in the overall installation pipeline

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -1015,11 +1015,6 @@ func handleAppRepoChanges(client splcommon.ControllerClient, cr splcommon.MetaOb
 		}
 	}
 
-	// ToDo: Ideally, this check should go to the reconcile entry point once the glue logic in place.
-	if appDeployContext.AppsSrcDeployStatus == nil {
-		appDeployContext.AppsSrcDeployStatus = make(map[string]enterpriseApi.AppSrcDeployInfo)
-	}
-
 	// 1. Check if the AppSrc is deleted in latest config, OR missing with the remote listing.
 	for appSrc, appSrcDeploymentInfo := range appDeployContext.AppsSrcDeployStatus {
 		// If the AppSrc is missing mark all the corresponding apps for deletion
@@ -1048,7 +1043,7 @@ func handleAppRepoChanges(client splcommon.ControllerClient, cr splcommon.MetaOb
 			for appIdx := range currentList {
 				if !isAppRepoStateDeleted(appSrcDeploymentInfo.AppDeploymentInfoList[appIdx]) && !checkIfAnAppIsActiveOnRemoteStore(currentList[appIdx].AppName, s3Response.Objects) {
 					scopedLog.Info("App change", "deleting/disabling the App: ", currentList[appIdx].AppName, "as it is missing in the remote listing", nil)
-					setStateAndStatusForAppDeployInfo(&currentList[appIdx], enterpriseApi.RepoStateDeleted, enterpriseApi.DeployStatusPending)
+					setStateAndStatusForAppDeployInfo(&currentList[appIdx], enterpriseApi.RepoStateDeleted, enterpriseApi.DeployStatusComplete)
 				}
 			}
 		}
@@ -1121,6 +1116,8 @@ func AddOrUpdateAppSrcDeploymentInfoList(appSrcDeploymentInfo *enterpriseApi.App
 					appList[idx].DeployStatus = enterpriseApi.DeployStatusPending
 					appList[idx].PhaseInfo.Phase = enterpriseApi.PhaseDownload
 					appList[idx].PhaseInfo.Status = enterpriseApi.AppPkgDownloadPending
+					appList[idx].PhaseInfo.RetryCount = 0
+					appList[idx].AuxPhaseInfo = nil
 
 					// Make the state active for an app that was deleted earlier, and got activated again
 					if appList[idx].RepoState == enterpriseApi.RepoStateDeleted {
@@ -1145,7 +1142,7 @@ func AddOrUpdateAppSrcDeploymentInfoList(appSrcDeploymentInfo *enterpriseApi.App
 			appDeployInfo.PhaseInfo.Phase = enterpriseApi.PhaseDownload
 			appDeployInfo.PhaseInfo.Status = enterpriseApi.AppPkgDownloadPending
 
-			// Add it to a seperate list so that we don't loop through the newly added entries
+			// Add it to a separate list so that we don't loop through the newly added entries
 			newAppInfoList = append(newAppInfoList, appDeployInfo)
 			appChangesDetected = true
 		}
@@ -1395,6 +1392,19 @@ func shouldCheckAppRepoStatus(client splcommon.ControllerClient, cr splcommon.Me
 	return false
 }
 
+// getCleanObjectDigest returns only hexa-decimal portion of a string
+// Ex. '\"b38a8f911e2b43982b71a979fe1d3c3f\"' is converted to b38a8f911e2b43982b71a979fe1d3c3f
+func getCleanObjectDigest(rawObjectDigest *string) (*string, error) {
+	// S3: In the case of multipart upload, '-' is an allowed character as part of the etag
+	reg, err := regexp.Compile("[^A-Fa-f0-9\\-]+")
+	if err != nil {
+		return nil, err
+	}
+
+	cleanObjectHash := reg.ReplaceAllString(*rawObjectDigest, "")
+	return &cleanObjectHash, nil
+}
+
 // initAndCheckAppInfoStatus initializes the S3Clients and checks the status of apps on remote storage.
 func initAndCheckAppInfoStatus(client splcommon.ControllerClient, cr splcommon.MetaObject, appFrameworkConf *enterpriseApi.AppFrameworkSpec, appStatusContext *enterpriseApi.AppDeploymentContext) error {
 	scopedLog := log.WithName("initAndCheckAppInfoStatus").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
@@ -1433,8 +1443,18 @@ func initAndCheckAppInfoStatus(client splcommon.ControllerClient, cr splcommon.M
 		if len(sourceToAppsList) != len(appFrameworkConf.AppSources) {
 			scopedLog.Error(err, "Unable to get apps list, will retry in next reconcile...")
 		} else {
-
 			for _, appSource := range appFrameworkConf.AppSources {
+				// Clean-up for the object digest value
+				for i := range sourceToAppsList[appSource.Name].Objects {
+					cleanDigest, err := getCleanObjectDigest(sourceToAppsList[appSource.Name].Objects[i].Etag)
+					if err != nil {
+						scopedLog.Error(err, "unable to fetch clean object digest value", "Object Hash", sourceToAppsList[appSource.Name].Objects[i].Etag)
+						return err
+					}
+
+					sourceToAppsList[appSource.Name].Objects[i].Etag = cleanDigest
+				}
+
 				scopedLog.Info("Apps List retrieved from remote storage", "App Source", appSource.Name, "Content", sourceToAppsList[appSource.Name].Objects)
 			}
 
@@ -1920,12 +1940,15 @@ func migrateAfwStatus(client splcommon.ControllerClient, cr splcommon.MetaObject
 
 	// Upgrade one version at a time
 	// Start with the lowest version, then move towards the latest
-	for afwStatusContext.Version < currentAfwVersion {
+	for afwStatusContext.Version < enterpriseApi.LatestAfwVersion {
 		switch {
 		// Always start with the lowest version
 		case afwStatusContext.Version < enterpriseApi.AfwPhase3:
 			scopedLog.Info("Migrating the App framework", "old version", afwStatusContext.Version, "new version", enterpriseApi.AfwPhase3)
-			migrateAfwFromPhase2ToPhase3(client, cr, afwStatusContext)
+			err := migrateAfwFromPhase2ToPhase3(client, cr, afwStatusContext)
+			if err != nil {
+				return false
+			}
 
 			// case: Add the higher versions below
 		}
@@ -1941,7 +1964,7 @@ func migrateAfwStatus(client splcommon.ControllerClient, cr splcommon.MetaObject
 }
 
 // migrateAfwFromPhase2ToPhase3 migrates app framework status from Phase-2 to Phase-3
-func migrateAfwFromPhase2ToPhase3(client splcommon.ControllerClient, cr splcommon.MetaObject, afwStatusContext *enterpriseApi.AppDeploymentContext) {
+func migrateAfwFromPhase2ToPhase3(client splcommon.ControllerClient, cr splcommon.MetaObject, afwStatusContext *enterpriseApi.AppDeploymentContext) error {
 	scopedLog := log.WithName("migrateAfwFromPhase2ToPhase3").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
 
 	sts := afwGetReleventStatefulsetByKind(cr, client)
@@ -1950,7 +1973,12 @@ func migrateAfwFromPhase2ToPhase3(client splcommon.ControllerClient, cr splcommo
 		deployInfoList := appSrcDeployInfo.AppDeploymentInfoList
 		for i := range deployInfoList {
 			// Remove the special characters from Object hash
-			deployInfoList[i].ObjectHash = strings.Trim(deployInfoList[i].ObjectHash, "\"")
+			cleanDigest, err := getCleanObjectDigest(&deployInfoList[i].ObjectHash)
+			if err != nil {
+				scopedLog.Error(err, "clean-up failed", "digest", deployInfoList[i].ObjectHash)
+				return err
+			}
+			deployInfoList[i].ObjectHash = *cleanDigest
 
 			// If the app is already deleted, do not bother about the previous install state.
 			if deployInfoList[i].RepoState != enterpriseApi.RepoStateActive {
@@ -1978,6 +2006,7 @@ func migrateAfwFromPhase2ToPhase3(client splcommon.ControllerClient, cr splcommo
 
 	afwStatusContext.Version = enterpriseApi.AfwPhase3
 	scopedLog.Info("migration completed")
+	return nil
 }
 
 // isAppFrameworkMigrationNeeded confirms if the app framework version migration is needed

--- a/pkg/splunk/enterprise/util_test.go
+++ b/pkg/splunk/enterprise/util_test.go
@@ -713,6 +713,10 @@ func TestHandleAppRepoChanges(t *testing.T) {
 	var appFramworkConf enterpriseApi.AppFrameworkSpec = cr.Spec.AppFrameworkConfig
 	var err error
 
+	if appDeployContext.AppsSrcDeployStatus == nil {
+		appDeployContext.AppsSrcDeployStatus = make(map[string]enterpriseApi.AppSrcDeployInfo)
+	}
+
 	var S3Response splclient.S3Response
 
 	// Test-1: Empty remoteObjectList Map should return an error
@@ -1896,7 +1900,7 @@ func TestMigrateAfwStatus(t *testing.T) {
 	for i := range appSrcDeploymentInfo.AppDeploymentInfoList {
 		appSrcDeploymentInfo.AppDeploymentInfoList[i] = enterpriseApi.AppDeploymentInfo{
 			AppName:      fmt.Sprintf("app%v.spl", i),
-			ObjectHash:   fmt.Sprintf("\"abcdef1234567890abcdef%v\"", i),
+			ObjectHash:   fmt.Sprintf("\"abcdef1234567890abcdef%v-%v\"", i, i),
 			DeployStatus: enterpriseApi.DeployStatusComplete,
 			RepoState:    enterpriseApi.RepoStateDeleted,
 		}
@@ -2123,4 +2127,29 @@ func TestcheckAndMigrateAppDeployStatus(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestGetCleanObjectDigest(t *testing.T) {
+	// plain digest
+	var digests = []string{"\"b38a8f911e2b43982b71a979fe1d3c3f\"", "b38a8f911e2b43982b71a979fe1d3c3f"}
+	retDigest, err := getCleanObjectDigest(&digests[0])
+	if err != nil {
+		t.Errorf("Unable to clean the digest, error: %v", err)
+	}
+
+	if digests[1] != *retDigest {
+		t.Errorf("Converted digest value: %v is not equal to the expected digest value: %v", *retDigest, digests[1])
+	}
+
+	// digest in case of multi-part upload
+	digests = []string{"\"b38a8f911e2b43982b71a979fe1d3c3f-3\"", "b38a8f911e2b43982b71a979fe1d3c3f-3"}
+	retDigest, err = getCleanObjectDigest(&digests[0])
+	if err != nil {
+		t.Errorf("Unable to clean the digest, error: %v", err)
+	}
+
+	if digests[1] != *retDigest {
+		t.Errorf("Converted digest value: %v is not equal to the expected digest value: %v", *retDigest, digests[1])
+	}
+
 }


### PR DESCRIPTION
- For standalone CR, auxPhaseInfo is always used irrespective of the replica configuration
- new fanOut flag, to create fan-out workers during the download phase
- some refactoring across the scheduler code
- Enabled the UT coverage for afwSchedulerEntry()