### PR TITLE
fix: For Minio connections trust admin to pick protocol

### DIFF
--- a/pkg/splunk/client/minioclient.go
+++ b/pkg/splunk/client/minioclient.go
@@ -86,8 +86,9 @@ func InitMinioClientSession(appS3Endpoint string, accessKeyID string, secretAcce
 	useSSL := true
 	if strings.HasPrefix(appS3Endpoint, "http://") {
 		// We should always use a secure SSL endpoint, so we won't set useSSL = false
-		scopedLog.Info("Using insecure endpoint, forcing useSSL=true for Minio Client Session", "appS3Endpoint", appS3Endpoint)
+		scopedLog.Info("Using insecure endpoint, useSSL=false for Minio Client Session", "appS3Endpoint", appS3Endpoint)
 		appS3Endpoint = strings.TrimPrefix(appS3Endpoint, "http://")
+		useSSL = false
 	} else if strings.HasPrefix(appS3Endpoint, "https://") {
 		appS3Endpoint = strings.TrimPrefix(appS3Endpoint, "https://")
 	} else {


### PR DESCRIPTION
When using minio inside of a k8s cluster or in a network with other mitigations such as a cloud vpc with host to host network encryption use of TLS may be undesirable (double encryption) and can limit observability.