### PR TITLE
CSPL-1620: Remove SHC pods from podReset verification for C3/M4 tests

### DIFF
--- a/test/c3/appframework/appframework_test.go
+++ b/test/c3/appframework/appframework_test.go
@@ -993,8 +993,12 @@ var _ = Describe("c3appfw test", func() {
 			testenvInstance.Log.Info(fmt.Sprintf("Verify %s apps are NOT copied to /etc/apps on Cluster Manager and Deployer after scaling up of Indexers and Search Heads", appVersion))
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), managerPodNames, appListV1, false, false)
 
-			//Verify no pods reset by checking the pod age
-			testenv.VerifyNoPodReset(deployment, testenvInstance, testenvInstance.GetName(), splunkPodAge, nil)
+			// Listing the Search Head Cluster pods to exclude them from the 'no pod reset' test as they are expected to be reset after scaling
+			shcPodNames := []string{fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
+			shcPodNames = append(shcPodNames, testenv.GeneratePodNameSlice(testenv.SearchHeadPod, deployment.GetName(), shReplicas, false, 1)...)
+
+			// Verify no pods reset by checking the pod age
+			testenv.VerifyNoPodReset(deployment, testenvInstance, testenvInstance.GetName(), splunkPodAge, shcPodNames)
 
 			// Verify V1 apps are installed on C3
 			testenvInstance.Log.Info(fmt.Sprintf("Verify %s apps are installed on Indexers and Search Heads after scaling up", appVersion))
@@ -1093,7 +1097,7 @@ var _ = Describe("c3appfw test", func() {
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), managerPodNames, appListV1, false, false)
 
 			//Verify no pods reset by checking the pod age
-			testenv.VerifyNoPodReset(deployment, testenvInstance, testenvInstance.GetName(), splunkPodAge, nil)
+			testenv.VerifyNoPodReset(deployment, testenvInstance, testenvInstance.GetName(), splunkPodAge, shcPodNames)
 
 			// Verify apps are installed cluster-wide after scaling down
 			testenvInstance.Log.Info(fmt.Sprintf("Verify %s apps are installed on the pods after scaling down of Indexers and Search Heads", appVersion))

--- a/test/m4/appframework/appframework_test.go
+++ b/test/m4/appframework/appframework_test.go
@@ -990,8 +990,12 @@ var _ = Describe("m4appfw test", func() {
 			testenvInstance.Log.Info(fmt.Sprintf("Verify %s apps are NOT copied to /etc/apps on Cluster Manager and Deployer after scaling up of Indexers and Search Heads", appVersion))
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), managerPodNames, appListV1, false, false)
 
-			//Verify no pods reset by checking the pod age
-			testenv.VerifyNoPodReset(deployment, testenvInstance, testenvInstance.GetName(), splunkPodAge, nil)
+			// Listing the Search Head cluster pods to exclude them from the 'no pod reset' test as they are expected to be reset after scaling
+			shcPodNames := []string{fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
+			shcPodNames = append(shcPodNames, testenv.GeneratePodNameSlice(testenv.SearchHeadPod, deployment.GetName(), shReplicas, false, 1)...)
+
+			// Verify no pods reset by checking the pod age
+			testenv.VerifyNoPodReset(deployment, testenvInstance, testenvInstance.GetName(), splunkPodAge, shcPodNames)
 
 			// Verify V1 apps are installed cluster-wide
 			testenvInstance.Log.Info(fmt.Sprintf("Verify %s apps are installed on the pods after scaling up of Indexers and Search Heads", appVersion))
@@ -1088,7 +1092,7 @@ var _ = Describe("m4appfw test", func() {
 			testenv.VerifyAppsCopied(deployment, testenvInstance, testenvInstance.GetName(), managerPodNames, appListV1, false, false)
 
 			//Verify no pods reset by checking the pod age
-			testenv.VerifyNoPodReset(deployment, testenvInstance, testenvInstance.GetName(), splunkPodAge, nil)
+			testenv.VerifyNoPodReset(deployment, testenvInstance, testenvInstance.GetName(), splunkPodAge, shcPodNames)
 
 			// Verify apps are installed cluster-wide after scaling down
 			testenvInstance.Log.Info(fmt.Sprintf("Verify %s apps are installed on the pods after scaling down of Indexers and Search Heads", appVersion))


### PR DESCRIPTION
Automation scaling tests have been failing at VerifyNoPodReset as it was expected no pods at all to be reset, but actually the SHC pods would be reset after scaling.
This PR removes the SHC pods of the list of pod to be tested for no reset.

Tests run:
C3:
`[1] • [SLOW TEST:2393.876 seconds]
[1] c3appfw test
[1] /Users/jambrosiano/splunk-operator/CSPL-1620/splunk-operator/test/c3/appframework/appframework_test.go:30
[1]   Single Site Indexer Cluster with Search Head Cluster (C3) with App Framework
[1]   /Users/jambrosiano/splunk-operator/CSPL-1620/splunk-operator/test/c3/appframework/appframework_test.go:747
[1]     integration, c3, appframework: can deploy a C3 SVA with App Framework enabled, install apps, scale up clusters, install apps on new pods, scale down
[1]     /Users/jambrosiano/splunk-operator/CSPL-1620/splunk-operator/test/c3/appframework/appframework_test.go:748
[1] ------------------------------
[1] {"level":"info","ts":1643850125.282223,"msg":"testenv deleted.\n","testenv":"c3appfw-uiv"}
[1] {"level":"info","ts":1643850125.2822511,"msg":"testenv deleted.\n","testenv":"c3appfw-uiv"}
[1]
[1] JUnit report was created: /Users/jambrosiano/splunk-operator/CSPL-1620/splunk-operator/test/c3/appframework/c3appfw-uiv_junit.xml
[1]
[1] Ran 1 of 3 Specs in 2425.375 seconds
[1] SUCCESS! -- 1 Passed | 0 Failed | 2 Pending | 0 Skipped
[1] PASS
`

M4:
`[1] • [SLOW TEST:2148.752 seconds]
[1] m4appfw test
[1] /Users/jambrosiano/splunk-operator/CSPL-1620/splunk-operator/test/m4/appframework/appframework_test.go:31
[1]   Multisite Indexer Cluster with Search Head Cluster (m4) with App Framework
[1]   /Users/jambrosiano/splunk-operator/CSPL-1620/splunk-operator/test/m4/appframework/appframework_test.go:750
[1]     integration, m4, appframework: can deploy a M4 SVA with App Framework enabled, install apps, scale up clusters, install apps on new pods, scale down
[1]     /Users/jambrosiano/splunk-operator/CSPL-1620/splunk-operator/test/m4/appframework/appframework_test.go:751
[1] ------------------------------
[1] {"level":"info","ts":1643852913.4427562,"msg":"testenv deleted.\n","testenv":"m4appfw-d1i"}
[1] {"level":"info","ts":1643852913.4428,"msg":"testenv deleted.\n","testenv":"m4appfw-d1i"}
[1]
[1] JUnit report was created: /Users/jambrosiano/splunk-operator/CSPL-1620/splunk-operator/test/m4/appframework/m4appfw-d1i_junit.xml
[1]
[1] Ran 1 of 3 Specs in 2185.268 seconds
[1] SUCCESS! -- 1 Passed | 0 Failed | 2 Pending | 0 Skipped
[1] PASS`