### PR TITLE
CSPL-1579: Temp AppFramework download location on Operator pod

### DIFF
--- a/docs/AppFramework.md
+++ b/docs/AppFramework.md
@@ -349,6 +349,8 @@ When `appsRepoPollIntervalSeconds` is set to `0` for a CR, the App Framework wil
 
 ## Add a persistent storage volume to the Operator pod
 
+Note:- If the persistent storage volume is not configured for the Operator, by default, the App Framework uses the main memory(RAM) as the staging area for app package downloads. In order to avoid pressure on the main memory, it is strongly advised to use a persistent volume for the operator pod.
+
 1. Create the persistent volume used by the Operator pod to cache apps and add-ons:
 
 ```yaml
@@ -468,7 +470,7 @@ metadata:
   name: splunk-manual-app-update
   namespace: default
   ownerReferences:
-  - apiVersion: enterprise.splunk.com/v2
+  - apiVersion: enterprise.splunk.com/v3
     controller: false
     kind: Standalone
     name: s1

--- a/pkg/splunk/enterprise/types.go
+++ b/pkg/splunk/enterprise/types.go
@@ -56,6 +56,9 @@ const (
 
 	// SplunkMonitoringConsole is a single instance of Splunk monitor for mc
 	SplunkMonitoringConsole InstanceType = "monitoring-console"
+
+	// TmpAppDownloadDir is the Operator directory for app framework, when there is no explicit volume specified
+	TmpAppDownloadDir string = "/tmp/appframework/"
 )
 
 const (

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -409,11 +409,22 @@ func getAvailableDiskSpace() (uint64, error) {
 
 	err := syscall.Statfs(splcommon.AppDownloadVolume, &stat)
 	if err != nil {
-		scopedLog.Error(err, "unable to get the info about disk space for volume")
-	} else {
-		availDiskSpace = stat.Bavail * uint64(stat.Bsize)
-		scopedLog.Info("current available disk space in GB", "availableDiskSpace(GB)", availDiskSpace/1024/1024/1024)
+		scopedLog.Error(err, "There is no volume configured for the App framework, use the temporary location: %s", TmpAppDownloadDir)
+		splcommon.AppDownloadVolume = TmpAppDownloadDir
+		err = os.MkdirAll(splcommon.AppDownloadVolume, 0755)
+		if err != nil {
+			scopedLog.Error(err, "Unable to create the directory %s", splcommon.AppDownloadVolume)
+			return 0, err
+		}
 	}
+
+	err = syscall.Statfs(splcommon.AppDownloadVolume, &stat)
+	if err != nil {
+		return 0, err
+	}
+
+	availDiskSpace = stat.Bavail * uint64(stat.Bsize)
+	scopedLog.Info("current available disk space in GB", "availableDiskSpace(GB)", availDiskSpace/1024/1024/1024)
 
 	return availDiskSpace, err
 }

--- a/pkg/splunk/enterprise/util_test.go
+++ b/pkg/splunk/enterprise/util_test.go
@@ -1646,9 +1646,18 @@ func TestGetAppPackageLocalPath(t *testing.T) {
 		afwConfig: &cr.Spec.AppFrameworkConfig,
 	}
 
-	expectedAppPkgLocalPath := "/opt/splunk/appframework/downloadedApps/test/ClusterMaster/stack1/local/appSrc1/testApp.spl_bcda23232a89"
+	// When there is no explicit volume configured, should use the temp location, as set by the initStorageTracker()
+	expectedAppPkgLocalPath := "/tmp/appframework/downloadedApps/test/ClusterMaster/stack1/local/appSrc1/testApp.spl_bcda23232a89"
 	calculatedAppPkgLocalPath := getAppPackageLocalPath(worker)
 
+	if calculatedAppPkgLocalPath != expectedAppPkgLocalPath {
+		t.Errorf("Expected appPkgLocal Path %s, but got %s", expectedAppPkgLocalPath, calculatedAppPkgLocalPath)
+	}
+
+	// When the explicit volume is set for the app framework, that path should be used for the app package location
+	splcommon.AppDownloadVolume = "/opt/splunk/appframework"
+	calculatedAppPkgLocalPath = getAppPackageLocalPath(worker)
+	expectedAppPkgLocalPath = "/opt/splunk/appframework/downloadedApps/test/ClusterMaster/stack1/local/appSrc1/testApp.spl_bcda23232a89"
 	if calculatedAppPkgLocalPath != expectedAppPkgLocalPath {
 		t.Errorf("Expected appPkgLocal Path %s, but got %s", expectedAppPkgLocalPath, calculatedAppPkgLocalPath)
 	}
@@ -1659,11 +1668,10 @@ func TestInitStorageTracker(t *testing.T) {
 		t.Errorf("operatorResourceTracker should be initialized as part of the enterprise package init()")
 	}
 
-	// When the volume is not configured, should return an error
-	splcommon.AppDownloadVolume = "/non-existingDir"
+	// When the volume is not configured, should use a temporary location from main memory
 	err := initStorageTracker()
-	if err == nil {
-		t.Errorf("When the volume doesn't exist, should return an error")
+	if err != nil {
+		t.Errorf("When the volume doesn't exist, should fall back to the temp location of the app framework")
 	}
 
 	// When the volume exists, should not return an error


### PR DESCRIPTION
When the Operator is not configured with an explicit volume mount,
use the '/tmp/appframework/' from main memory as the temporary staging area for the app package downloads.