### PR TITLE
CSPL-1636: Replace tag for 3rd party github actions with the SHA

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
 OPERATOR_SDK_VERSION=v0.18.2
 REVIEWERS=pdhanoyasplunk,smohan-splunk,kashok-splunk,akondur,sgontla,vebken-splunk,gaurav-splunk,mgaldino-splunk,jambrosiano,tpereirasplunk,jryb
 GO_VERSION=1.17.3
+AWSCLI_URL=https://s3.amazonaws.com/aws-cli/awscli-bundle-1.20.8.zip
+KUBECTL_VERSION=v1.16.13

--- a/.github/workflows/automated-release-workflow.yml
+++ b/.github/workflows/automated-release-workflow.yml
@@ -75,7 +75,7 @@ jobs:
         docker images
 
     - name: Update Operator Image name in Release Folder
-      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d
+      uses: jacobtomlinson/gha-find-replace@f485fdc3f67a6d87ae6e3d11e41f648c26d7aee3
       with:
         find: "splunk/splunk-operator:${{ env.SHORT_SHA }}"
         replace: "splunk/splunk-operator:${{ github.event.inputs.operator_image_tag }}"

--- a/.github/workflows/automated-release-workflow.yml
+++ b/.github/workflows/automated-release-workflow.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Dotenv Action
       id: dotenv
-      uses: falti/dotenv-action@v0.2.7
+      uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
 
     - name: Install yq
       run: |
@@ -75,14 +75,14 @@ jobs:
         docker images
 
     - name: Update Operator Image name in Release Folder
-      uses: jacobtomlinson/gha-find-replace@master
+      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d
       with:
         find: "splunk/splunk-operator:${{ env.SHORT_SHA }}"
         replace: "splunk/splunk-operator:${{ github.event.inputs.operator_image_tag }}"
         include: "release-${{ env.SHORT_SHA }}/**"
   
     - name: Upload Release Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
       with:
         name: "release-artifacts-${{ github.event.inputs.release_version }}"
         path: "release-**"
@@ -94,7 +94,7 @@ jobs:
         sed -n "4,${a}p" docs/ChangeLog.md >> docs/ReleaseNotes.md >> docs/ReleaseNotes.md
 
     - name: Create Release
-      uses: ncipollo/release-action@v1
+      uses: ncipollo/release-action@40bb172bd05f266cf9ba4ff965cb61e9ee5f6d01
       with:
         artifacts: "release-${{ env.SHORT_SHA }}/splunk-operator-install.yaml,release-${{ env.SHORT_SHA }}/splunk-operator-cluster.yaml,release-${{ env.SHORT_SHA }}/splunk-operator-noadmin.yaml,release-${{ env.SHORT_SHA }}/splunk-operator-crds.yaml"
         bodyFile: "docs/ReleaseNotes.md"

--- a/.github/workflows/build-test-push-workflow.yml
+++ b/.github/workflows/build-test-push-workflow.yml
@@ -167,12 +167,12 @@ jobs:
       - name: Install Kubectl
         uses: Azure/setup-kubectl@v1
         with:
-          version: 'v1.16.13'
+          version: ${{ steps.dotenv.outputs.KUBECTL_VERSION }}
       - name: Install Python
         uses: actions/setup-python@v2
       - name: Install AWS CLI
         run: |
-          curl "https://s3.amazonaws.com/aws-cli/awscli-bundle-1.20.8.zip" -o "awscli-bundle.zip"
+          curl "${{ steps.dotenv.outputs.AWSCLI_URL}}" -o "awscli-bundle.zip"
           unzip awscli-bundle.zip
           sudo ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
           aws --version

--- a/.github/workflows/build-test-push-workflow.yml
+++ b/.github/workflows/build-test-push-workflow.yml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Dotenv Action
       id: dotenv
-      uses: falti/dotenv-action@v0.2.7
+      uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Dotenv Action
         id: dotenv
-        uses: falti/dotenv-action@v0.2.7
+        uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -45,7 +45,7 @@ jobs:
       - name: Run Code Coverage
         run: goveralls -coverprofile=coverage.out -service=circle-ci -repotoken ${{ secrets.COVERALLS_TOKEN }}
       - name: Upload Coverage artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
         with:
           name: coverage.out
           path: coverage.out
@@ -61,7 +61,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Dotenv Action
       id: dotenv
-      uses: falti/dotenv-action@v0.2.7
+      uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
     - name: setup-docker
       uses: docker-practice/actions-setup-docker@v1
     - name: Install Operator SDK
@@ -97,7 +97,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Dotenv Action
       id: dotenv
-      uses: falti/dotenv-action@v0.2.7
+      uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
     - name: setup-docker
       uses: docker-practice/actions-setup-docker@v1
     - name: Configure AWS credentials
@@ -121,7 +121,7 @@ jobs:
     - name: Stop clair scanner
       run: make stop_clair_scanner
     - name: Save scan results as artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
       with:
         name: clair-scanner-logs
         path: clair-scanner-logs
@@ -163,7 +163,7 @@ jobs:
         uses: actions/checkout@v2  
       - name: Dotenv Action
         id: dotenv
-        uses: falti/dotenv-action@v0.2.7 
+        uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
       - name: Install Kubectl
         uses: Azure/setup-kubectl@v1
         with:
@@ -235,7 +235,7 @@ jobs:
           mkdir -p /tmp/pod_logs
           find ./test -name "*.log" -exec cp {} /tmp/pod_logs \;
       - name: Archive Pod Logs if Failure in Smoke Test
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
         with:
           name: "splunk-pods-logs--artifacts-${{ matrix.test }}"
           path: "/tmp/pod_logs/**"
@@ -255,7 +255,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Dotenv Action
       id: dotenv
-      uses: falti/dotenv-action@v0.2.7
+      uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
     - name: setup-docker
       uses: docker-practice/actions-setup-docker@v1
     - name: Configure Docker Hub credentials

--- a/.github/workflows/int-test-workflow.yml
+++ b/.github/workflows/int-test-workflow.yml
@@ -8,7 +8,7 @@ jobs:
   int-tests:
     strategy:
       matrix:
-        test: [appframework, secret, smartstore, monitoringconsole, scaling, crcrud, licensemaster]
+        test: [appframework, secret, smartstore, monitoringconsole, scaling, crcrud, licensemanager]
     runs-on: ubuntu-latest
     env:
       CLUSTER_NODES: 1
@@ -46,12 +46,12 @@ jobs:
       - name: Install Kubectl
         uses: Azure/setup-kubectl@v1
         with:
-          version: 'v1.16.13'
+          version: ${{ steps.dotenv.outputs.KUBECTL_VERSION }}
       - name: Install Python
         uses: actions/setup-python@v2
       - name: Install AWS CLI
         run: |
-          curl "https://s3.amazonaws.com/aws-cli/awscli-bundle-1.20.8.zip" -o "awscli-bundle.zip"
+          curl "${{ steps.dotenv.outputs.AWSCLI_URL}}" -o "awscli-bundle.zip"
           unzip awscli-bundle.zip
           sudo ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
           aws --version

--- a/.github/workflows/int-test-workflow.yml
+++ b/.github/workflows/int-test-workflow.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v2   
       - name: Dotenv Action
         id: dotenv
-        uses: falti/dotenv-action@v0.2.7
+        uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
       - name: Install Kubectl
         uses: Azure/setup-kubectl@v1
         with:
@@ -118,7 +118,7 @@ jobs:
           mkdir -p /tmp/pod_logs
           find ./test -name "*.log" -exec cp {} /tmp/pod_logs \;
       - name: Archive Pod Logs if Failure in Smoke Test
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
         with:
           name: "splunk-pods-logs--artifacts-${{ matrix.test }}"
           path: "/tmp/pod_logs/**"
@@ -137,7 +137,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Dotenv Action
       id: dotenv
-      uses: falti/dotenv-action@v0.2.7
+      uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
     - name: setup-docker
       uses: docker-practice/actions-setup-docker@v1
     - name: Configure AWS credentials

--- a/.github/workflows/merge-develop-to-master-workflow.yml
+++ b/.github/workflows/merge-develop-to-master-workflow.yml
@@ -19,7 +19,7 @@ jobs:
         git reset --hard develop
     - name: Dotenv Action
       id: dotenv
-      uses: falti/dotenv-action@v0.2.7
+      uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3.10.1
       with:

--- a/.github/workflows/nightly-int-test-workflow.yml
+++ b/.github/workflows/nightly-int-test-workflow.yml
@@ -6,7 +6,7 @@ jobs:
   int-tests:
     strategy:
       matrix:
-        test: [appframework, secret, smartstore, monitoringconsole, scaling, crcrud, licensemaster]
+        test: [appframework, secret, smartstore, monitoringconsole, scaling, crcrud, licensemanager]
     runs-on: ubuntu-latest
     env:
       CLUSTER_NODES: 1
@@ -46,12 +46,12 @@ jobs:
       - name: Install Kubectl
         uses: Azure/setup-kubectl@v1
         with:
-          version: 'v1.16.13'
+          version: ${{ steps.dotenv.outputs.KUBECTL_VERSION }}
       - name: Install Python
         uses: actions/setup-python@v2
       - name: Install AWS CLI
         run: |
-          curl "https://s3.amazonaws.com/aws-cli/awscli-bundle-1.20.8.zip" -o "awscli-bundle.zip"
+          curl "${{ steps.dotenv.outputs.AWSCLI_URL}}" -o "awscli-bundle.zip"
           unzip awscli-bundle.zip
           sudo ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
           aws --version
@@ -134,6 +134,8 @@ jobs:
       TAG: edge
     steps:
     - uses: actions/checkout@v2
+      with:
+          ref: develop
     - name: Dotenv Action
       id: dotenv
       uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359

--- a/.github/workflows/nightly-int-test-workflow.yml
+++ b/.github/workflows/nightly-int-test-workflow.yml
@@ -42,7 +42,7 @@ jobs:
           ref: develop
       - name: Dotenv Action
         id: dotenv
-        uses: falti/dotenv-action@v0.2.7
+        uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
       - name: Install Kubectl
         uses: Azure/setup-kubectl@v1
         with:
@@ -118,7 +118,7 @@ jobs:
           mkdir -p /tmp/pod_logs
           find ./test -name "*.log" -exec cp {} /tmp/pod_logs \;
       - name: Archive Pod Logs if Failure in Smoke Test
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
         with:
           name: "splunk-pods-logs--artifacts-${{ matrix.test }}"
           path: "/tmp/pod_logs/**"
@@ -136,7 +136,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Dotenv Action
       id: dotenv
-      uses: falti/dotenv-action@v0.2.7
+      uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
     - name: setup-docker
       uses: docker-practice/actions-setup-docker@v1
     - name: Configure AWS credentials

--- a/.github/workflows/pre-release-workflow.yml
+++ b/.github/workflows/pre-release-workflow.yml
@@ -84,7 +84,7 @@ jobs:
 
     - name: Update Operator Version in version.go
       if: github.event.inputs.old_operator_version != github.event.inputs.new_operator_version
-      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d
+      uses: jacobtomlinson/gha-find-replace@f485fdc3f67a6d87ae6e3d11e41f648c26d7aee3
       with:
         find: "${{ github.event.inputs.old_operator_version }}"
         replace: "${{ github.event.inputs.new_operator_version }}"
@@ -92,7 +92,7 @@ jobs:
 
     - name: Update Operator Image name in DOCS
       if: github.event.inputs.old_operator_version != github.event.inputs.new_operator_version
-      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d
+      uses: jacobtomlinson/gha-find-replace@f485fdc3f67a6d87ae6e3d11e41f648c26d7aee3
       with:
         find: "splunk-operator:${{ github.event.inputs.old_operator_version }}"
         replace: "splunk-operator:${{ github.event.inputs.new_operator_version }}"
@@ -101,7 +101,7 @@ jobs:
 
     - name: Update Splunk Operator Install URL in DOCS
       if: github.event.inputs.old_operator_version != github.event.inputs.new_operator_version
-      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d
+      uses: jacobtomlinson/gha-find-replace@f485fdc3f67a6d87ae6e3d11e41f648c26d7aee3
       with:
         find: "/download/${{ github.event.inputs.old_operator_version }}/splunk-operator"
         replace: "/download/${{ github.event.inputs.new_operator_version }}/splunk-operator"
@@ -110,7 +110,7 @@ jobs:
 
     - name: Update Splunk Operator VERSION in DOCS
       if: github.event.inputs.old_operator_version != github.event.inputs.new_operator_version
-      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d
+      uses: jacobtomlinson/gha-find-replace@f485fdc3f67a6d87ae6e3d11e41f648c26d7aee3
       with:
         find: "${{ github.event.inputs.old_operator_version }} or later"
         replace: "${{ github.event.inputs.new_operator_version }} or later"
@@ -119,7 +119,7 @@ jobs:
 
     - name: Update Splunk Enterprise Image in operator.yaml
       if: github.event.inputs.old_enterprise_version != github.event.inputs.new_enterprise_version
-      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d
+      uses: jacobtomlinson/gha-find-replace@f485fdc3f67a6d87ae6e3d11e41f648c26d7aee3
       with:
         find: "${{ github.event.inputs.old_enterprise_version }}"
         replace: "${{ github.event.inputs.new_enterprise_version }}"
@@ -127,7 +127,7 @@ jobs:
 
     - name: Update Splunk Enterprise image in DOCS
       if: github.event.inputs.old_enterprise_version != github.event.inputs.new_enterprise_version
-      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d
+      uses: jacobtomlinson/gha-find-replace@f485fdc3f67a6d87ae6e3d11e41f648c26d7aee3
       with:
         find: "${{ github.event.inputs.old_enterprise_version }} or later"
         replace: "${{ github.event.inputs.new_enterprise_version }} or later"
@@ -146,7 +146,7 @@ jobs:
         docker images
 
     - name: Update Operator Image name in Release Folder
-      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d
+      uses: jacobtomlinson/gha-find-replace@f485fdc3f67a6d87ae6e3d11e41f648c26d7aee3
       with:
         find: "splunk/splunk-operator:${{ env.SHORT_SHA }}"
         replace: "splunk/splunk-operator-rc:${{ github.event.inputs.release_version }}"

--- a/.github/workflows/pre-release-workflow.yml
+++ b/.github/workflows/pre-release-workflow.yml
@@ -46,7 +46,7 @@ jobs:
         echo $SHORT_SHA
     - name: Dotenv Action
       id: dotenv
-      uses: falti/dotenv-action@v0.2.7
+      uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
 
     - name: Install yq
       run: |
@@ -84,7 +84,7 @@ jobs:
 
     - name: Update Operator Version in version.go
       if: github.event.inputs.old_operator_version != github.event.inputs.new_operator_version
-      uses: jacobtomlinson/gha-find-replace@master
+      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d
       with:
         find: "${{ github.event.inputs.old_operator_version }}"
         replace: "${{ github.event.inputs.new_operator_version }}"
@@ -92,7 +92,7 @@ jobs:
 
     - name: Update Operator Image name in DOCS
       if: github.event.inputs.old_operator_version != github.event.inputs.new_operator_version
-      uses: jacobtomlinson/gha-find-replace@master
+      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d
       with:
         find: "splunk-operator:${{ github.event.inputs.old_operator_version }}"
         replace: "splunk-operator:${{ github.event.inputs.new_operator_version }}"
@@ -101,7 +101,7 @@ jobs:
 
     - name: Update Splunk Operator Install URL in DOCS
       if: github.event.inputs.old_operator_version != github.event.inputs.new_operator_version
-      uses: jacobtomlinson/gha-find-replace@master
+      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d
       with:
         find: "/download/${{ github.event.inputs.old_operator_version }}/splunk-operator"
         replace: "/download/${{ github.event.inputs.new_operator_version }}/splunk-operator"
@@ -110,7 +110,7 @@ jobs:
 
     - name: Update Splunk Operator VERSION in DOCS
       if: github.event.inputs.old_operator_version != github.event.inputs.new_operator_version
-      uses: jacobtomlinson/gha-find-replace@master
+      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d
       with:
         find: "${{ github.event.inputs.old_operator_version }} or later"
         replace: "${{ github.event.inputs.new_operator_version }} or later"
@@ -119,7 +119,7 @@ jobs:
 
     - name: Update Splunk Enterprise Image in operator.yaml
       if: github.event.inputs.old_enterprise_version != github.event.inputs.new_enterprise_version
-      uses: jacobtomlinson/gha-find-replace@master
+      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d
       with:
         find: "${{ github.event.inputs.old_enterprise_version }}"
         replace: "${{ github.event.inputs.new_enterprise_version }}"
@@ -127,7 +127,7 @@ jobs:
 
     - name: Update Splunk Enterprise image in DOCS
       if: github.event.inputs.old_enterprise_version != github.event.inputs.new_enterprise_version
-      uses: jacobtomlinson/gha-find-replace@master
+      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d
       with:
         find: "${{ github.event.inputs.old_enterprise_version }} or later"
         replace: "${{ github.event.inputs.new_enterprise_version }} or later"
@@ -146,14 +146,14 @@ jobs:
         docker images
 
     - name: Update Operator Image name in Release Folder
-      uses: jacobtomlinson/gha-find-replace@master
+      uses: jacobtomlinson/gha-find-replace@b76729678e8d52dadb12e0e16454a93e301a919d
       with:
         find: "splunk/splunk-operator:${{ env.SHORT_SHA }}"
         replace: "splunk/splunk-operator-rc:${{ github.event.inputs.release_version }}"
         include: "release-${{ env.SHORT_SHA }}/**"
 
     - name: Upload Release Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
       with:
         name: "release-artifacts-${{ github.event.inputs.release_version }}"
         path: "release-**"


### PR DESCRIPTION
- Replaces 3rd party github tags with the git commit sha.
- Moved AWS CLI URL into the env file
- Replace keyword `licensemaster` with `licensemanager` in workflow files to align with bias language change in test cases.

