### PR TITLE
CSPL-1639: Fix a bug where streamoptions needs to be reset for running same command on pods

### DIFF
--- a/pkg/splunk/enterprise/clustermaster.go
+++ b/pkg/splunk/enterprise/clustermaster.go
@@ -18,14 +18,12 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
 	enterpriseApi "github.com/splunk/splunk-operator/pkg/apis/enterprise/v3"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/remotecommand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -261,9 +259,7 @@ func CheckIfsmartstoreConfigMapUpdatedToPod(c splcommon.ControllerClient, cr *en
 	scopedLog := log.WithName("CheckIfsmartstoreConfigMapUpdatedToPod").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
 
 	command := fmt.Sprintf("cat /mnt/splunk-operator/local/%s", configToken)
-	streamOptions := &remotecommand.StreamOptions{
-		Stdin: strings.NewReader(command),
-	}
+	streamOptions := splutil.NewStreamOptionsObject(command)
 
 	stdOut, stdErr, err := podExecClient.RunPodExecCommand(streamOptions, []string{"/bin/sh"})
 	if err != nil || stdErr != "" {

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -20,13 +20,11 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/remotecommand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -224,9 +222,7 @@ func SetClusterMaintenanceMode(c splcommon.ControllerClient, cr *enterpriseApi.I
 		command = fmt.Sprintf("/opt/splunk/bin/splunk disable maintenance-mode --answer-yes -auth admin:%s", adminPwd)
 	}
 
-	streamOptions := &remotecommand.StreamOptions{
-		Stdin: strings.NewReader(command),
-	}
+	streamOptions := splutil.NewStreamOptionsObject(command)
 
 	_, _, err = podExecClient.RunPodExecCommand(streamOptions, []string{"/bin/sh"})
 	if err != nil {

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -1429,9 +1429,7 @@ func checkIfFileExistsOnPod(cr splcommon.MetaObject, filePath string, podExecCli
 	// Make sure the destination directory is existing
 	fPath := path.Clean(filePath)
 	command := fmt.Sprintf("test -f %s; echo -n $?", fPath)
-	streamOptions := &remotecommand.StreamOptions{
-		Stdin: strings.NewReader(command),
-	}
+	streamOptions := splutil.NewStreamOptionsObject(command)
 
 	stdOut, stdErr, err := podExecClient.RunPodExecCommand(streamOptions, []string{"/bin/sh"})
 	if stdErr != "" || err != nil {
@@ -1443,21 +1441,32 @@ func checkIfFileExistsOnPod(cr splcommon.MetaObject, filePath string, podExecCli
 	return fileTestResult == 0
 }
 
+// resetStringReader resets the Stdin (of strings.Reader type) of the remotecommand.StreamOptions
+func resetStringReader(streamOptions *remotecommand.StreamOptions, command string) {
+	// convert Stdin of type io.Reader to strings.Reader type
+	stdInReader := streamOptions.Stdin.(*strings.Reader)
+
+	// reset the offset of the Reader
+	stdInReader.Reset(command)
+}
+
 // createDirOnSplunkPods creates the required directory for the pod/s
 func createDirOnSplunkPods(cr splcommon.MetaObject, replicas int32, path string, podExecClient splutil.PodExecClientImpl) error {
 	var err error
 	var stdOut, stdErr string
 
 	command := fmt.Sprintf("mkdir -p %s", path)
-	streamOptions := &remotecommand.StreamOptions{
-		Stdin: strings.NewReader(command),
-	}
-
+	streamOptions := splutil.NewStreamOptionsObject(command)
 	// create the directory on each replica pod
 	for replicaIndex := 0; replicaIndex < int(replicas); replicaIndex++ {
 		// get the target pod name
 		podName := getApplicablePodNameForAppFramework(cr, replicaIndex)
 		podExecClient.SetTargetPodName(podName)
+
+		// CSPL-1639: reset the Stdin so that reader pipe can read from the correct offset of the string reader.
+		// This is particularly needed in the cases where we are trying to run the same command across multiple pods
+		// and we need to clear the reader pipe so that we can read the read buffer from the correct offset again.
+		resetStringReader(streamOptions, command)
 
 		// Throw an error if we are not able to create the destination directory where we wish to copy the app package
 		stdOut, stdErr, err = podExecClient.RunPodExecCommand(streamOptions, []string{"/bin/sh"})
@@ -1508,9 +1517,7 @@ func CopyFileToPod(c splcommon.ControllerClient, namespace string, srcPath strin
 	destDir := path.Dir(destPath)
 	command := fmt.Sprintf("test -d %s; echo -n $?", destDir)
 
-	streamOptions := &remotecommand.StreamOptions{
-		Stdin: strings.NewReader(command),
-	}
+	streamOptions := splutil.NewStreamOptionsObject(command)
 
 	// If the Pod directory doesn't exist, do not try to create it. Instead throw an error
 	// Otherwise, in case of invalid dest path, we may end up creating too many invalid directories/files

--- a/pkg/splunk/util/util.go
+++ b/pkg/splunk/util/util.go
@@ -250,3 +250,12 @@ func NewStreamOptionsObject(command string) *remotecommand.StreamOptions {
 		Stdin: strings.NewReader(command),
 	}
 }
+
+// ResetStringReader resets the Stdin (of strings.Reader type) of the remotecommand.StreamOptions
+func ResetStringReader(streamOptions *remotecommand.StreamOptions, command string) {
+	// convert Stdin of type io.Reader to strings.Reader type
+	stdInReader := streamOptions.Stdin.(*strings.Reader)
+
+	// reset the offset of the Reader
+	stdInReader.Reset(command)
+}

--- a/pkg/splunk/util/util.go
+++ b/pkg/splunk/util/util.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"strings"
 
 	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 	corev1 "k8s.io/api/core/v1"
@@ -241,4 +242,11 @@ func (podExecClient *PodExecClient) SetTargetPodName(targetPodName string) {
 // GetTargetPodName returns the target pod name
 func (podExecClient *PodExecClient) GetTargetPodName() string {
 	return podExecClient.targetPodName
+}
+
+// NewStreamOptionsObject return a new streamoptions object for the given command
+func NewStreamOptionsObject(command string) *remotecommand.StreamOptions {
+	return &remotecommand.StreamOptions{
+		Stdin: strings.NewReader(command),
+	}
 }

--- a/pkg/splunk/util/util_test.go
+++ b/pkg/splunk/util/util_test.go
@@ -197,3 +197,32 @@ func TestRunPodExecCommand(t *testing.T) {
 		t.Errorf("expected stdOut and stdErr to be empty since it is a dummy podExec call")
 	}
 }
+
+func TestNewStreamOptionsObject(t *testing.T) {
+	command := "dummyCmd"
+
+	streamOptions := NewStreamOptionsObject(command)
+	var gotCmd string
+	streamOptionsCmd := streamOptions.Stdin.(*strings.Reader)
+	for i := 0; i < int(streamOptionsCmd.Size()); i++ {
+		cmd, _, _ := streamOptionsCmd.ReadRune()
+		gotCmd = gotCmd + string(cmd)
+	}
+
+	if gotCmd != command {
+		t.Errorf("got invalid command, expected: %s, got %s", command, gotCmd)
+	}
+}
+
+func TestGetSetTargetPodName(t *testing.T) {
+	podName := "pod-0"
+
+	var podExecClient PodExecClient = PodExecClient{}
+
+	podExecClient.SetTargetPodName(podName)
+
+	gotPodName := podExecClient.GetTargetPodName()
+	if gotPodName != podName {
+		t.Errorf("invalid targetPodName, expected: %s, got: %s", podName, gotPodName)
+	}
+}

--- a/test/s1/appframework/appframework_test.go
+++ b/test/s1/appframework/appframework_test.go
@@ -542,9 +542,8 @@ var _ = Describe("s1appfw test", func() {
 		})
 	})
 
-	// /CSPL-1639
-	XContext("Standalone deployment (S1) with App Framework", func() {
-		It("s1, integration, appframeworks1, appframework: can deploy a Standalone instance with App Framework enabled, install apps, scale up, install apps on new pod, scale down", func() {
+	Context("Standalone deployment (S1) with App Framework", func() {
+		It("s1, smoke, appframeworks1, appframework: can deploy a Standalone instance with App Framework enabled, install apps, scale up, install apps on new pod, scale down", func() {
 
 			/* Test Steps
 			   ################## SETUP ####################


### PR DESCRIPTION
**Problem**
Due to code cleanup for phase-2, we removed all the references of init-container and changed the directory(to temporarily store the apps to be installed) from "/init-apps/" to "/operator/appframework/<appSrcName>". In the latest code, operator would create the latter directory on the splunk pod/s. This worked fine for CRs with 1 pod. But for CRs like Standalone which can scale up to > 1 pods, it was an issue where we were not creating the directory structure required for staging the apps on splunk pod/s.
This eventually resulted in failure during PodCopy phase of app framework where operator was trying to copy the apps from operator pod to splunk pod/s.

**Solution**
Reset the `Stdin` field of the `streamoptions` data structure passed to the podExecClient, so that for each pod we read from the correct offset of the reader pipe.

Here is the link to the detailed description about the problem - https://splunk.atlassian.net/browse/CSPL-1639?focusedCommentId=8556652