### PR TITLE
CSPL-1632-changed home dir to appmount due to write permission issue…

### DIFF
--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -892,7 +892,12 @@ func setupAppInitContainers(client splcommon.ControllerClient, cr splcommon.Meta
 			appSrcScope := getAppSrcScope(appFrameworkConfig, appSrc.Name)
 			initContainerName := strings.ToLower(fmt.Sprintf(initContainerTemplate, appSrcName, i, appSrcScope))
 
-			initEnv := []corev1.EnvVar{}
+			initEnv := []corev1.EnvVar{
+				{
+					Name:  "HOME",
+					Value: appBktMnt,
+				},
+			}
 			if appSecretRef != "" {
 				initEnv = append(initEnv, corev1.EnvVar{
 					Name: "AWS_ACCESS_KEY_ID",


### PR DESCRIPTION
Changed the HOME env variable to `appBktMnt` to avoid permission issue for AWS CLI. 

When configuring AWS S3 access with service account AWS CLI would look for `credentials` file under `$HOME/.aws` directory. 
Since `splunk` user set by operator does not have access to root  `/` which is the default `HOME`, aws cli would fail to perform any s3 operation. 

On setting the `HOME` to `appBktMnt` the operator succeeds as when no .aws directory is found under `appBktMnt`, awscli moves forward to serviceaccount assume role auth.