### PR TITLE
CSPL-1326: Update the File permissions for the cluster scoped apps

### DIFF
--- a/pkg/splunk/enterprise/names.go
+++ b/pkg/splunk/enterprise/names.go
@@ -73,6 +73,13 @@ const (
 
 	idxcBundleAlreadyPresentStr = "No new bundle will be pushed. The cluster manager and peers already have this bundle"
 
+	shcAppsLocationOnDeployer = "/opt/splunk/etc/shcluster/apps/"
+
+	idxcAppsLocationOnClusterManager = "/opt/splunk/etc/master-apps/"
+
+	// command to append FS permissions to +rw-rw-
+	cmdSetFilePermissionsToRW = "chmod +660 -R %s"
+
 	// command for init container on a standalone
 	commandForStandaloneSmartstore = "mkdir -p /opt/splk/etc/apps/splunk-operator/local && ln -sfn  /mnt/splunk-operator/local/indexes.conf /opt/splk/etc/apps/splunk-operator/local/indexes.conf && ln -sfn  /mnt/splunk-operator/local/server.conf /opt/splk/etc/apps/splunk-operator/local/server.conf"
 

--- a/pkg/splunk/enterprise/searchheadcluster.go
+++ b/pkg/splunk/enterprise/searchheadcluster.go
@@ -206,7 +206,9 @@ func ApplySearchHeadCluster(client splcommon.ControllerClient, cr *enterpriseApi
 		cr.Status.NamespaceSecretResourceVersion = namespaceScopedSecret.ObjectMeta.ResourceVersion
 
 		// Update the requeue result as needed by the app framework
-		result = *finalResult
+		if finalResult != nil {
+			result = *finalResult
+		}
 	}
 	return result, nil
 }

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -1604,7 +1604,7 @@ func setInstallStateForClusterScopedApps(appDeployContext *enterpriseApi.AppDepl
 				deployInfoList[i].PhaseInfo.Phase = enterpriseApi.PhaseInstall
 				deployInfoList[i].PhaseInfo.Status = enterpriseApi.AppPkgInstallComplete
 				scopedLog.Info("Cluster scoped app installed", "app name", deployInfoList[i].AppName, "digest", deployInfoList[i].ObjectHash)
-			} else {
+			} else if deployInfoList[i].PhaseInfo.Phase != enterpriseApi.PhaseInstall || deployInfoList[i].PhaseInfo.Status != enterpriseApi.AppPkgInstallComplete {
 				scopedLog.Error(nil, "app missing from bundle push", "app name", deployInfoList[i].AppName, "digest", deployInfoList[i].ObjectHash, "phase", deployInfoList[i].PhaseInfo.Phase, "status", deployInfoList[i].PhaseInfo.Status)
 			}
 		}

--- a/pkg/splunk/test/util.go
+++ b/pkg/splunk/test/util.go
@@ -58,9 +58,9 @@ type MockPodExecReturnContext struct {
 
 // MockPodExecClient mocks the PodExecClient
 type MockPodExecClient struct {
-	client             splcommon.ControllerClient
-	cr                 splcommon.MetaObject
-	targetPodName      string
+	Client             splcommon.ControllerClient
+	Cr                 splcommon.MetaObject
+	TargetPodName      string
 	WantCmdList        []string
 	GotCmdList         []string
 	MockReturnContexts map[string]*MockPodExecReturnContext
@@ -104,6 +104,11 @@ func (client *MockPodExecClient) CheckPodExecCommands(t *testing.T, testMethod s
 	}
 }
 
+// GetCR returns the CR from the MockPodExecClient
+func (client *MockPodExecClient) GetCR() splcommon.MetaObject {
+	return client.Cr
+}
+
 // RunPodExecCommand returns the dummy values for mockPodExecClient
 func (client *MockPodExecClient) RunPodExecCommand(streamOptions *remotecommand.StreamOptions, baseCmd []string) (string, string, error) {
 
@@ -145,10 +150,10 @@ func (client *MockPodExecClient) RunPodExecCommand(streamOptions *remotecommand.
 
 // SetTargetPodName sets the targetPodName for MockPodExecClient
 func (client *MockPodExecClient) SetTargetPodName(targetPodName string) {
-	client.targetPodName = targetPodName
+	client.TargetPodName = targetPodName
 }
 
 // GetTargetPodName returns dummy target pod name for mockPodExecClient
 func (client *MockPodExecClient) GetTargetPodName() string {
-	return client.targetPodName
+	return client.TargetPodName
 }

--- a/pkg/splunk/util/util.go
+++ b/pkg/splunk/util/util.go
@@ -208,6 +208,7 @@ type PodExecClientImpl interface {
 	RunPodExecCommand(*remotecommand.StreamOptions, []string) (string, string, error)
 	SetTargetPodName(string)
 	GetTargetPodName() string
+	GetCR() splcommon.MetaObject
 }
 
 // blank assignment to implement PodExecClientImpl
@@ -242,6 +243,11 @@ func (podExecClient *PodExecClient) SetTargetPodName(targetPodName string) {
 // GetTargetPodName returns the target pod name
 func (podExecClient *PodExecClient) GetTargetPodName() string {
 	return podExecClient.targetPodName
+}
+
+// GetCR returns the CR from the PodExecClient
+func (podExecClient *PodExecClient) GetCR() splcommon.MetaObject {
+	return podExecClient.cr
 }
 
 // NewStreamOptionsObject return a new streamoptions object for the given command


### PR DESCRIPTION
Splunk volumes are set with the file permissions +660 by default. When an app
package(with their original file permissions) is included as part of a bundle push,
that app is deployed to the cluster members.  However, if there is a pod reset happens,
then all those apps are set with +660 values. Due to this permissions change, whenever
there is a next bundle push, it is  unnecessarily including those apps as part of the bundle
one more time.

Changes are made such that, always set the permissions to +660, before doing a bundle push,
that way the pod reset scenario will not include the apps(with just file permission changes)
that were already part of the last bundle push