### PR TITLE
CSPL-1606: Upgrade from 1.0.5 to 1.1.0 script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ make tidy
 make install
 ```
 
-You may need to add `$GOPATH/bin` to you path to run the `operator-sdk`
+You may need to add `$GOPATH/bin` to your path to run the `operator-sdk`
 command line tool:
 
 ```
@@ -114,19 +114,19 @@ Other make targets include (more info below):
 * `make catalog-push`: push catalog docker image to given repository example`make catalog-push IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=<tag name> IMG=docker.io/splunk/splunk-operator:<tag name>`
 
 ## Deploying the Splunk Operator
-`make deploy` command will deploy all the necessery resources to run splunk operator like RBAC policies, services ,config maps, deployment. operator will be installed in `splunk-operator` namespace. If `splunk-operator` namespace does not exist , it will create the namespace.  By default `make deploy` will install operator clusterwide. Operator will watch all the namespaces for any splunk enterprise custom resources.
+`make deploy` command will deploy all the necessery resources to run splunk operator like RBAC policies, services, config maps, deployment. Operator will be installed in `splunk-operator` namespace. If `splunk-operator` namespace does not exist, it will create the namespace. By default `make deploy` will install operator clusterwide. Operator will watch all the namespaces for any splunk enterprise custom resources.
 
 ```shell
 make deploy IMG=docker.io/splunk/splunk-operator:<tag name>
 ```
 
-If user wants operator for specific namespace then they must pass `WATCH_NAMESPACE` parameter to `make deploy` command
+If you want operator for specific namespace then you must pass `WATCH_NAMESPACE` parameter to `make deploy` command
  
 ```
 make deploy IMG=docker.io/splunk/splunk-operator:<tag name> WATCH_NAMESPACE="namespace1"
 ```
 
-If user wants operator to use specific version of splunk instance, then they must pass `RELATED_IMAGE_SPLUNK_ENTERPRISE` parameter to `make deploy` command 
+If you want operator to use specific version of splunk instance, then you must pass `RELATED_IMAGE_SPLUNK_ENTERPRISE` parameter to `make deploy` command 
  
 ```
 make deploy IMG=docker.io/splunk/splunk-operator:<tag name> WATCH_NAMESPACE="namespace1" RELATED_IMAGE_SPLUNK_ENTERPRISE="splunk/splunk:edge"

--- a/README.md
+++ b/README.md
@@ -22,20 +22,27 @@ deploy and use the latest release, please see the
 ## Prerequisites
 
 You must have [Docker Engine](https://docs.docker.com/install/) installed to
-build the Splunk Operator. 
+build the Splunk Operator.
 
 This project uses [Go modules](https://blog.golang.org/using-go-modules),
-and requires [golang](https://golang.org/doc/install) 1.17.3 or later.
+and requires [golang](https://golang.org/doc/install) 1.13 or later.
 You must `export GO111MODULE=on` if cloning these repositories into your
 `$GOPATH` (not recommended).
 
 The [Kubernetes Operator SDK](https://github.com/operator-framework/operator-sdk)
-must also be installed to build this project. Follow the steps from [Operator-SDK Installation Documentaion](https://sdk.operatorframework.io/docs/installation/)
+must also be installed to build this project.
+
+```
+git clone -b v1.15.0 https://github.com/operator-framework/operator-sdk
+cd operator-sdk
+make tidy
+make install
+```
 
 You may need to add `$GOPATH/bin` to you path to run the `operator-sdk`
 command line tool:
 
-```shell
+```
 export PATH=${PATH}:${GOPATH}/bin
 ```
 
@@ -113,13 +120,13 @@ Other make targets include (more info below):
 make deploy IMG=docker.io/splunk/splunk-operator:<tag name>
 ```
 
-If user wants to deploy operator for specific namespace then they has to pass `WATCH_NAMESPACE` parameter to `make deploy` command 
+If user wants to deploy operator for specific namespace then they have to pass `WATCH_NAMESPACE` parameter to `make deploy` command
  
 ```
 make deploy IMG=docker.io/splunk/splunk-operator:<tag name> WATCH_NAMESPACE="namespace1"
 ```
 
-If user wants to operator to use specific version of splunk instance, then user should pass `RELATED_IMAGE_SPLUNK_ENTERPRISE` parameter to `make deploy` command 
+If user wants operator to use specific version of splunk instance, then they has to pass `RELATED_IMAGE_SPLUNK_ENTERPRISE` parameter to `make deploy` command 
  
 ```
 make deploy IMG=docker.io/splunk/splunk-operator:<tag name> WATCH_NAMESPACE="namespace1" RELATED_IMAGE_SPLUNK_ENTERPRISE="splunk/splunk:edge"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ deploy and use the latest release, please see the
 ## Prerequisites
 
 You must have [Docker Engine](https://docs.docker.com/install/) installed to
-build the Splunk Operator.
+build the Splunk Operator. 
 
 This project uses [Go modules](https://blog.golang.org/using-go-modules),
 and requires [golang](https://golang.org/doc/install) 1.17.3 or later.
@@ -30,14 +30,7 @@ You must `export GO111MODULE=on` if cloning these repositories into your
 `$GOPATH` (not recommended).
 
 The [Kubernetes Operator SDK](https://github.com/operator-framework/operator-sdk)
-must also be installed to build this project.
-
-```shell
-git clone -b v1.15.0 https://github.com/operator-framework/operator-sdk
-cd operator-sdk
-make tidy
-make install
-```
+must also be installed to build this project. Follow the steps from [Operator-SDK Installation Documentaion](https://sdk.operatorframework.io/docs/installation/)
 
 You may need to add `$GOPATH/bin` to you path to run the `operator-sdk`
 command line tool:
@@ -113,12 +106,23 @@ Other make targets include (more info below):
 * `make catalog-build`: generates `splunk-operator-catalog` catalog container image example `make catalog-build IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=1.1.0 IMG=docker.io/splunk/splunk-operator:1.1.0`
 * `make catalog-push`: push catalog docker image to given repository example`make catalog-push IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=1.1.0 IMG=docker.io/splunk/splunk-operator:1.1.0`
 
-## Running the Splunk Operator
-
-Ensure that you have the Custom Resource Definitions and RBAC policies installed in your cluster:
+## Deploying the Splunk Operator
+`make deploy` command will deploy all the necessery RBAC policies, services ,config maps, deployment necessary to run splunk operator. opeartor will be installed in `splunk-operator` namespace. if `splunk-operator` namespace do not exist , it will create the namespace.  By default `make deploy` will install operator clusterwide. operator will watch all the namespaces for any splunk entrprise custom resources.
 
 ```shell
-make install
+make deploy IMG=docker.io/splunk/splunk-operator:1.1.0
+```
+
+If user wants to deploy operator for specific namespace then they has to pass `WATCH_NAMESPACE` parameter to `make deploy` command 
+ 
+```
+make deploy IMG=docker.io/splunk/splunk-operator:1.1.0 WATCH_NAMESPACE="namespace1"
+```
+
+If user wants to operator to use specific version of splunk instance, then they has to pass `RELATED_IMAGE_SPLUNK_ENTERPRISE` parameter to `make deploy` command 
+ 
+```
+make deploy IMG=docker.io/splunk/splunk-operator:1.1.0 WATCH_NAMESPACE="namespace1" RELATED_IMAGE_SPLUNK_ENTERPRISE="splunk/splunk:edge"
 ```
 
 Use this to run the operator as a local foreground process on your machine:

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Other make targets include (more info below):
 * `make catalog-push`: push catalog docker image to given repository example`make catalog-push IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=<tag name> IMG=docker.io/splunk/splunk-operator:<tag name>`
 
 ## Deploying the Splunk Operator
-`make deploy` command will deploy all the necessery RBAC policies, services ,config maps, deployment necessary to run splunk operator. operator will be installed in `splunk-operator` namespace. If `splunk-operator` namespace does not exist , it will create the namespace.  By default `make deploy` will install operator clusterwide. Operator will watch all the namespaces for any splunk enterprise custom resources.
+`make deploy` command will deploy all the necessery resources to run splunk operator like RBAC policies, services ,config maps, deployment. operator will be installed in `splunk-operator` namespace. If `splunk-operator` namespace does not exist , it will create the namespace.  By default `make deploy` will install operator clusterwide. Operator will watch all the namespaces for any splunk enterprise custom resources.
 
 ```shell
 make deploy IMG=docker.io/splunk/splunk-operator:<tag name>

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If user wants to deploy operator for specific namespace then they has to pass `W
 make deploy IMG=docker.io/splunk/splunk-operator:<tag name> WATCH_NAMESPACE="namespace1"
 ```
 
-If user wants to operator to use specific version of splunk instance, then they has to pass `RELATED_IMAGE_SPLUNK_ENTERPRISE` parameter to `make deploy` command 
+If user wants to operator to use specific version of splunk instance, then user should pass `RELATED_IMAGE_SPLUNK_ENTERPRISE` parameter to `make deploy` command 
  
 ```
 make deploy IMG=docker.io/splunk/splunk-operator:<tag name> WATCH_NAMESPACE="namespace1" RELATED_IMAGE_SPLUNK_ENTERPRISE="splunk/splunk:edge"

--- a/README.md
+++ b/README.md
@@ -108,13 +108,13 @@ Other make targets include (more info below):
 * `make run`: runs the splunk operator locally, monitoring the Kubernetes cluster configured in your current `kubectl` context
 * `make fmt`: runs `go fmt` on all `*.go` source files in this project
 * `make lint`: runs the `golint` utility on all `*.go` source files in this project
-* `make bundle-build`: generates `splunk-operator-bundle` bundle container image for OLM example `make bundle-build IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=<tag name> IMG=docker.io/splunk/splunk-operator:<tag name>`
-* `make bundle-push`: push OLM bundle docker image to given repository example `make bundle-push IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=<tag name>IMG=docker.io/splunk/splunk-operator:<tag name>`
+* `make bundle-build`: generates `splunk-operator-bundle` bundle container image for OLM example `make bundle-build IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=<tag name>  IMG=docker.io/splunk/splunk-operator:<tag name>`
+* `make bundle-push`: push OLM bundle docker image to given repository example `make bundle-push IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=<tag name> IMG=docker.io/splunk/splunk-operator:<tag name>`
 * `make catalog-build`: generates `splunk-operator-catalog` catalog container image example `make catalog-build IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=<tag name> IMG=docker.io/splunk/splunk-operator:<tag name>`
-* `make catalog-push`: push catalog docker image to given repository example`make catalog-push IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=<tag name>IMG=docker.io/splunk/splunk-operator:<tag name>`
+* `make catalog-push`: push catalog docker image to given repository example`make catalog-push IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=<tag name> IMG=docker.io/splunk/splunk-operator:<tag name>`
 
 ## Deploying the Splunk Operator
-`make deploy` command will deploy all the necessery RBAC policies, services ,config maps, deployment necessary to run splunk operator. operator will be installed in `splunk-operator` namespace. if `splunk-operator` namespace does not exist , it will create the namespace.  By default `make deploy` will install operator clusterwide. operator will watch all the namespaces for any splunk enterprise custom resources.
+`make deploy` command will deploy all the necessery RBAC policies, services ,config maps, deployment necessary to run splunk operator. operator will be installed in `splunk-operator` namespace. If `splunk-operator` namespace does not exist , it will create the namespace.  By default `make deploy` will install operator clusterwide. Operator will watch all the namespaces for any splunk enterprise custom resources.
 
 ```shell
 make deploy IMG=docker.io/splunk/splunk-operator:<tag name>

--- a/README.md
+++ b/README.md
@@ -114,19 +114,19 @@ Other make targets include (more info below):
 * `make catalog-push`: push catalog docker image to given repository example`make catalog-push IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=<tag name>IMG=docker.io/splunk/splunk-operator:<tag name>`
 
 ## Deploying the Splunk Operator
-`make deploy` command will deploy all the necessery RBAC policies, services ,config maps, deployment necessary to run splunk operator. opeartor will be installed in `splunk-operator` namespace. if `splunk-operator` namespace do not exist , it will create the namespace.  By default `make deploy` will install operator clusterwide. operator will watch all the namespaces for any splunk entrprise custom resources.
+`make deploy` command will deploy all the necessery RBAC policies, services ,config maps, deployment necessary to run splunk operator. operator will be installed in `splunk-operator` namespace. if `splunk-operator` namespace does not exist , it will create the namespace.  By default `make deploy` will install operator clusterwide. operator will watch all the namespaces for any splunk enterprise custom resources.
 
 ```shell
 make deploy IMG=docker.io/splunk/splunk-operator:<tag name>
 ```
 
-If user wants to deploy operator for specific namespace then they have to pass `WATCH_NAMESPACE` parameter to `make deploy` command
+If user wants operator for specific namespace then they must pass `WATCH_NAMESPACE` parameter to `make deploy` command
  
 ```
 make deploy IMG=docker.io/splunk/splunk-operator:<tag name> WATCH_NAMESPACE="namespace1"
 ```
 
-If user wants operator to use specific version of splunk instance, then they has to pass `RELATED_IMAGE_SPLUNK_ENTERPRISE` parameter to `make deploy` command 
+If user wants operator to use specific version of splunk instance, then they must pass `RELATED_IMAGE_SPLUNK_ENTERPRISE` parameter to `make deploy` command 
  
 ```
 make deploy IMG=docker.io/splunk/splunk-operator:<tag name> WATCH_NAMESPACE="namespace1" RELATED_IMAGE_SPLUNK_ENTERPRISE="splunk/splunk:edge"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You must have [Docker Engine](https://docs.docker.com/install/) installed to
 build the Splunk Operator.
 
 This project uses [Go modules](https://blog.golang.org/using-go-modules),
-and requires [golang](https://golang.org/doc/install) 1.13 or later.
+and requires [golang](https://golang.org/doc/install) 1.17.3 or later.
 You must `export GO111MODULE=on` if cloning these repositories into your
 `$GOPATH` (not recommended).
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Other make targets include (more info below):
 * `make catalog-push`: push catalog docker image to given repository example`make catalog-push IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=<tag name> IMG=docker.io/splunk/splunk-operator:<tag name>`
 
 ## Deploying the Splunk Operator
-`make deploy` command will deploy all the necessery resources to run splunk operator like RBAC policies, services, config maps, deployment. Operator will be installed in `splunk-operator` namespace. If `splunk-operator` namespace does not exist, it will create the namespace. By default `make deploy` will install operator clusterwide. Operator will watch all the namespaces for any splunk enterprise custom resources.
+`make deploy` command will deploy all the necessary resources to run splunk operator like RBAC policies, services, config maps, deployment. Operator will be installed in `splunk-operator` namespace. If `splunk-operator` namespace does not exist, it will create the namespace. By default `make deploy` will install operator clusterwide. Operator will watch all the namespaces for any splunk enterprise custom resources.
 
 ```shell
 make deploy IMG=docker.io/splunk/splunk-operator:<tag name>

--- a/README.md
+++ b/README.md
@@ -95,34 +95,34 @@ Other make targets include (more info below):
 * `make test`: Runs unit tests with Coveralls code coverage output to coverage.out
 * `make scorecard`: Runs operator-sdk scorecard tests using OLM installation bundle
 * `make generate`: runs operator-generate k8s, crds and csv commands, updating installation YAML files and OLM bundle
-* `make docker-build`: generates `splunk-operator` container image  example `make docker-build IMG=docker.io/splunk/splunk-operator:1.1.0`
-* `make docker-push`: push docker image to given repository example `make docker-push IMG=docker.io/splunk/splunk-operator:1.1.0`
-* `make clean`: removes the binary build output and `splunk-operator` container image example `make docker-push IMG=docker.io/splunk/splunk-operator:1.1.0`
+* `make docker-build`: generates `splunk-operator` container image  example `make docker-build IMG=docker.io/splunk/splunk-operator:<tag name>`
+* `make docker-push`: push docker image to given repository example `make docker-push IMG=docker.io/splunk/splunk-operator:<tag name>`
+* `make clean`: removes the binary build output and `splunk-operator` container image example `make docker-push IMG=docker.io/splunk/splunk-operator:<tag name>`
 * `make run`: runs the splunk operator locally, monitoring the Kubernetes cluster configured in your current `kubectl` context
 * `make fmt`: runs `go fmt` on all `*.go` source files in this project
 * `make lint`: runs the `golint` utility on all `*.go` source files in this project
-* `make bundle-build`: generates `splunk-operator-bundle` bundle container image for OLM example `make bundle-build IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=1.1.0 IMG=docker.io/splunk/splunk-operator:1.1.0`
-* `make bundle-push`: push OLM bundle docker image to given repository example `make bundle-push IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=1.1.0 IMG=docker.io/splunk/splunk-operator:1.1.0`
-* `make catalog-build`: generates `splunk-operator-catalog` catalog container image example `make catalog-build IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=1.1.0 IMG=docker.io/splunk/splunk-operator:1.1.0`
-* `make catalog-push`: push catalog docker image to given repository example`make catalog-push IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=1.1.0 IMG=docker.io/splunk/splunk-operator:1.1.0`
+* `make bundle-build`: generates `splunk-operator-bundle` bundle container image for OLM example `make bundle-build IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=<tag name> IMG=docker.io/splunk/splunk-operator:<tag name>`
+* `make bundle-push`: push OLM bundle docker image to given repository example `make bundle-push IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=<tag name>IMG=docker.io/splunk/splunk-operator:<tag name>`
+* `make catalog-build`: generates `splunk-operator-catalog` catalog container image example `make catalog-build IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=<tag name> IMG=docker.io/splunk/splunk-operator:<tag name>`
+* `make catalog-push`: push catalog docker image to given repository example`make catalog-push IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=<tag name>IMG=docker.io/splunk/splunk-operator:<tag name>`
 
 ## Deploying the Splunk Operator
 `make deploy` command will deploy all the necessery RBAC policies, services ,config maps, deployment necessary to run splunk operator. opeartor will be installed in `splunk-operator` namespace. if `splunk-operator` namespace do not exist , it will create the namespace.  By default `make deploy` will install operator clusterwide. operator will watch all the namespaces for any splunk entrprise custom resources.
 
 ```shell
-make deploy IMG=docker.io/splunk/splunk-operator:1.1.0
+make deploy IMG=docker.io/splunk/splunk-operator:<tag name>
 ```
 
 If user wants to deploy operator for specific namespace then they has to pass `WATCH_NAMESPACE` parameter to `make deploy` command 
  
 ```
-make deploy IMG=docker.io/splunk/splunk-operator:1.1.0 WATCH_NAMESPACE="namespace1"
+make deploy IMG=docker.io/splunk/splunk-operator:<tag name> WATCH_NAMESPACE="namespace1"
 ```
 
 If user wants to operator to use specific version of splunk instance, then they has to pass `RELATED_IMAGE_SPLUNK_ENTERPRISE` parameter to `make deploy` command 
  
 ```
-make deploy IMG=docker.io/splunk/splunk-operator:1.1.0 WATCH_NAMESPACE="namespace1" RELATED_IMAGE_SPLUNK_ENTERPRISE="splunk/splunk:edge"
+make deploy IMG=docker.io/splunk/splunk-operator:<tag name> WATCH_NAMESPACE="namespace1" RELATED_IMAGE_SPLUNK_ENTERPRISE="splunk/splunk:edge"
 ```
 
 Use this to run the operator as a local foreground process on your machine:

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -12,11 +12,11 @@ wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/
 
 ## Default Installation
 
-By default operator will be installed in `splunk-operator` namespace and will watch all the namespaces of your cluster for splunk enterprise custom resources:
+By default operator will be installed in `splunk-operator` namespace and will watch all the namespaces of your cluster for splunk enterprise custom resources
 
 ```
 wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/download/1.0.5/splunk-operator-install.yaml
-kubectl apply -f splunk-operator-cluster.yaml
+kubectl apply -f splunk-operator-install.yaml
 ```
 
 ## Install operator to watch single namespace

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -7,7 +7,7 @@
 If you want to customize the installation of the Splunk Operator, download a copy of the installation YAML locally, and open it in your favorite editor.
 
 ```
-wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-install.yaml
+wget -O splunk-operator-install.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-install.yaml
 ```
 
 ## Default Installation
@@ -15,7 +15,7 @@ wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/
 By default operator will be installed in `splunk-operator` namespace and will watch all the namespaces of your cluster for splunk enterprise custom resources
 
 ```
-wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-install.yaml
+wget -O splunk-operator-install.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-install.yaml
 kubectl apply -f splunk-operator-install.yaml
 ```
 

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -16,6 +16,7 @@ By default operator will be installed in `splunk-operator` and will watch all th
 
 ```
 wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/download/1.0.5/splunk-operator-cluster.yaml
+kubectl apply -f splunk-operator-cluster.yaml
 ```
 
 ## Install operator to watch single namespace

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -12,7 +12,7 @@ wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/
 
 ## Default Installation
 
-By default operator will be installed in `splunk-operator` and will watch all the namespaces of your cluster for splunk enterprise custom resources:
+By default operator will be installed in `splunk-operator` namespace and will watch all the namespaces of your cluster for splunk enterprise custom resources:
 
 ```
 wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/download/1.0.5/splunk-operator-install.yaml
@@ -21,8 +21,7 @@ kubectl apply -f splunk-operator-cluster.yaml
 
 ## Install operator to watch single namespace
 
-By default operator will be installed in `splunk-operator` namespace and will watch all the namespaces of your cluster for splunk enterprise custom resources:
-if user wants to watch only one namespace then edit `config-map` `splunk-operator-config` in `splunk-operator` namespace, set `WATCH_NAMESPACE` field to the namespace operator should watch
+By default operator will be installed in `splunk-operator` namespace and will watch all the namespaces of your cluster for splunk enterprise custom resources. If user wants to watch only one namespace then edit `config-map` `splunk-operator-config` in `splunk-operator` namespace, set `WATCH_NAMESPACE` field to the namespace operator should watch
 
 ```
 apiVersion: v1
@@ -38,7 +37,7 @@ metadata:
   namespace: splunk-operator
 ```
 
-## Install operator to watch multiple namespace
+## Install operator to watch multiple namespaces
 
 If user wants to manage multiple namespaces, they must add the namespaces to the WATCH_NAMESPACE field, with each namespace separated by a comma (,). example
 

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -10,7 +10,7 @@ If you want to customize the installation of the Splunk Operator, download a cop
 wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/download/1.0.5/splunk-operator-cluster.yaml
 ```
 
-## Admin Installation for All Namespaces
+## Default Installation
 
 By default operator will be installed in `splunk-operator` and will watch all the namespaces of your cluster for splunk enterprise custom resources:
 
@@ -18,7 +18,7 @@ By default operator will be installed in `splunk-operator` and will watch all th
 wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/download/1.0.5/splunk-operator-cluster.yaml
 ```
 
-## Installation operator to watch single namespace
+## Install operator to watch single namespace
 
 By default operator will be installed in `splunk-operator` namespace and will watch all the namespaces of your cluster for splunk enterprise custom resources:
 if user wants to watch only one namespace then eeit `config-map` `splunk-operator-config` in `splunk-operaor` namespace, set `WATCH_NAMESPACE` field to the namespace operator should watch
@@ -36,6 +36,8 @@ metadata:
   name: splunk-operator-config
   namespace: splunk-operator
 ```
+
+## Install operator to watch multiple namespace
 
 if user want to manager multiple namespaces, then they can set `WATCH_NAMESPACE` field to all those namespaces , names should be comma (,) sepearated. example
 

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -21,7 +21,7 @@ wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/
 ## Installation operator to watch single namespace
 
 By default operator will be installed in `splunk-operator` namespace and will watch all the namespaces of your cluster for splunk enterprise custom resources:
-if user wants to watch only one then eit `config-map` `splunk-operator-config` in `splunk-operaor` namespace, set `WATCH_NAMESPACE` field to the namespace operator need to watch
+if user wants to watch only one namespace then eeit `config-map` `splunk-operator-config` in `splunk-operaor` namespace, set `WATCH_NAMESPACE` field to the namespace operator should watch
 
 ```
 apiVersion: v1

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -7,7 +7,7 @@
 If you want to customize the installation of the Splunk Operator, download a copy of the installation YAML locally, and open it in your favorite editor.
 
 ```
-wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/download/1.0.5/splunk-operator-install.yaml
+wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-install.yaml
 ```
 
 ## Default Installation
@@ -15,7 +15,7 @@ wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/
 By default operator will be installed in `splunk-operator` namespace and will watch all the namespaces of your cluster for splunk enterprise custom resources
 
 ```
-wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/download/1.0.5/splunk-operator-install.yaml
+wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-install.yaml
 kubectl apply -f splunk-operator-install.yaml
 ```
 

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -22,7 +22,7 @@ kubectl apply -f splunk-operator-cluster.yaml
 ## Install operator to watch single namespace
 
 By default operator will be installed in `splunk-operator` namespace and will watch all the namespaces of your cluster for splunk enterprise custom resources:
-if user wants to watch only one namespace then eeit `config-map` `splunk-operator-config` in `splunk-operator` namespace, set `WATCH_NAMESPACE` field to the namespace operator should watch
+if user wants to watch only one namespace then edit `config-map` `splunk-operator-config` in `splunk-operator` namespace, set `WATCH_NAMESPACE` field to the namespace operator should watch
 
 ```
 apiVersion: v1
@@ -40,7 +40,7 @@ metadata:
 
 ## Install operator to watch multiple namespace
 
-if user want to manager multiple namespaces, then they can set `WATCH_NAMESPACE` field to all those namespaces , names should be comma (,) seperated. example
+If user wants to manage multiple namespaces, they must add the namespaces to the WATCH_NAMESPACE field, with each namespace separated by a comma (,). example
 
 ```
 apiVersion: v1

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -7,7 +7,7 @@
 If you want to customize the installation of the Splunk Operator, download a copy of the installation YAML locally, and open it in your favorite editor.
 
 ```
-wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/download/1.0.5/splunk-operator-cluster.yaml
+wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/download/1.0.5/splunk-operator-install.yaml
 ```
 
 ## Default Installation
@@ -15,14 +15,14 @@ wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/
 By default operator will be installed in `splunk-operator` and will watch all the namespaces of your cluster for splunk enterprise custom resources:
 
 ```
-wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/download/1.0.5/splunk-operator-cluster.yaml
+wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/download/1.0.5/splunk-operator-install.yaml
 kubectl apply -f splunk-operator-cluster.yaml
 ```
 
 ## Install operator to watch single namespace
 
 By default operator will be installed in `splunk-operator` namespace and will watch all the namespaces of your cluster for splunk enterprise custom resources:
-if user wants to watch only one namespace then eeit `config-map` `splunk-operator-config` in `splunk-operaor` namespace, set `WATCH_NAMESPACE` field to the namespace operator should watch
+if user wants to watch only one namespace then eeit `config-map` `splunk-operator-config` in `splunk-operator` namespace, set `WATCH_NAMESPACE` field to the namespace operator should watch
 
 ```
 apiVersion: v1
@@ -40,7 +40,7 @@ metadata:
 
 ## Install operator to watch multiple namespace
 
-if user want to manager multiple namespaces, then they can set `WATCH_NAMESPACE` field to all those namespaces , names should be comma (,) sepearated. example
+if user want to manager multiple namespaces, then they can set `WATCH_NAMESPACE` field to all those namespaces , names should be comma (,) seperated. example
 
 ```
 apiVersion: v1
@@ -65,7 +65,7 @@ If you plan to retag the container images as part of pushing it to a private reg
 image: splunk/splunk-operator
 ```
 
-If you are using a private registry for the Docker images, edit `config-map` `splunk-operator-config` in `splunk-operaor` namespace, set `RELATED_IMAGE_SPLUNK_ENTERPRISE` field splunk docker image path
+If you are using a private registry for the Docker images, edit `config-map` `splunk-operator-config` in `splunk-operator` namespace, set `RELATED_IMAGE_SPLUNK_ENTERPRISE` field splunk docker image path
 
 ```
 apiVersion: v1

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ Apps and add-ons can be installed using the Splunk Operator by following the ins
 ### Docker requirements
 The Splunk Operator requires these docker images to be present or available to your Kubernetes cluster:
 
-* `splunk/splunk-operator`: The Splunk Operator image built by this repository or the [official release](https://hub.docker.com/r/splunk/splunk-operator) (1.0.5 or later)
+* `splunk/splunk-operator`: The Splunk Operator image built by this repository or the [official release](https://hub.docker.com/r/splunk/splunk-operator) (1.1.0 or later)
 * `splunk/splunk:<version>`: The [Splunk Enterprise image](https://github.com/splunk/docker-splunk) (8.2.3.3 or later)
 
 All of the Splunk Enterprise images are publicly available on [Docker Hub](https://hub.docker.com/). If your cluster does not have access to pull from Docker Hub, see the [Required Images Documentation](Images.md) page.

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,7 +108,7 @@ For production environments, we are requiring the use of Splunk SmartStore. As a
 
 A Kubernetes cluster administrator can install and start the Splunk Operator by running:
 ```
-kubectl apply -f https://github.com/splunk/splunk-operator/releases/download/1.0.5/splunk-operator-install.yaml
+kubectl apply -f https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-install.yaml
 ```
 
 The [Advanced Installation Instructions](Install.md) page offers guidance for advanced configurations, including the use of private image registries, installation at cluster scope, and installing the Splunk Operator as a user who is not a Kubernetes administrator. Users of Red Hat OpenShift should review the [Red Hat OpenShift](OpenShift.md) page.

--- a/docs/SplunkOperatorUpgrade.md
+++ b/docs/SplunkOperatorUpgrade.md
@@ -21,24 +21,56 @@ A Splunk Operator for Kubernetes upgrade might include support for a later versi
 1. Download the latest Splunk Operator installation yaml file.
 ​
 ```
-wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-install.yaml
+wget -O splunk-operator-install.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-install.yaml
 ```
 ​
 2. (Optional) Review the file and update it with your specific customizations used during your install. 
 ​
 3. Upgrade the Splunk Operator.
-​
+# Splunk Operator Upgrade
+
+Upgrading the Splunk operator to Version 1.1.0 is a new installation rather than an upgrade from the current operator. The older Splunk operator must be cleaned up before installing the new version. Script `tools/upgrade-to-1.1.0.sh` helps you to do the cleanup. The script expects the current namespace where the operator is installed and the path to the 1.1.0 manifest file. The script performs the following steps
+
+* Backup of all the operator resources within the namespace like
+** service-account, deployment, role, role-binding, cluster-role, cluster-role-binding
+* Deletes all the old Splunk operator resources and deployment
+* Installs the operator 1.1.0 in Splunk-operator namespace.
+
+By default Splunk operator 1.1.0 will be installed to watch cluster-wide
+
+
+## Steps for upgrade from 1.0.5 to 1.1.0
+
+
+Set KUBECONFIG and run `upgrade-to-1.1.0.sh` script with the following mandatory arguments
+* `current_namespace` current namespace where operator is installed
+* `manifest_file`: path to 1.1.0 Splunk operator manifest file
+
+
+### Example
+
 ```
-kubectl apply -f splunk-operator.yaml
+>upgrade-to-1.1.0.sh --current_namespace=splunk-operator manifest_file=release-v1.1.0/splunk-operator-install.yaml
 ```
-​
-After applying the yaml, a new operator pod will be created and the existing operator pod will be terminated. Example:
-​
+
+Note: This script can be run from `Mac` or `Linux` system. To run this script on `Windows`, use `cygwin`.
+
+## Configuring Operator to watch specific namespace
+
+Edit `configmap` `splunk-operator-config` in `splunk-operator` namespace, set `WATCH_NAMESPACE` field to the namespace that needs to be monitored by Splunk operator
+
 ```
-kubectl get pods
-NAME                               READY   STATUS    RESTARTS   AGE
-splunk-operator-75f5d4d85b-8pshn   1/1     Running   0          5s
-​
+apiVersion: v1
+data:
+  OPERATOR_NAME: "splunk-operator"
+  RELATED_IMAGE_SPLUNK_ENTERPRISE: splunk/splunk:latest
+  WATCH_NAMESPACE: "add namespace here"
+kind: ConfigMap
+metadata:
+  labels:
+    name: splunk-operator
+  name: splunk-operator-config
+  namespace: splunk-operator
 ```
 ​
 If a Splunk Operator release changes the custom resource (CRD) API version, the administrator is responsible for updating their Custom Resource specification to reference the latest CRD API version.  

--- a/docs/SplunkOperatorUpgrade.md
+++ b/docs/SplunkOperatorUpgrade.md
@@ -21,7 +21,7 @@ A Splunk Operator for Kubernetes upgrade might include support for a later versi
 1. Download the latest Splunk Operator installation yaml file.
 ​
 ```
-wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/download/1.0.5/splunk-operator-install.yaml
+wget -O splunk-operator.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-install.yaml
 ```
 ​
 2. (Optional) Review the file and update it with your specific customizations used during your install. 

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -1,29 +1,28 @@
-=Splunk Operator Upgrade=
+# Splunk Operator Upgrade
 
-Please note upgrading Splunk operator to Version `1.1.0` is a new installation rather than upgrade from current operator. Due to this  older Splunk operator need to be cleaned up before installing the latest version.  The script will help customer in doing these steps. This script expect current namespace where operator is installed , and path to `1.1.0` manifest file. script will 
+Please note upgrading Splunk operator to Version `1.1.0` is a new installation rather than upgrade from current operator. Due to this  older Splunk operator need to be cleaned up before installing the latest version.  The script will help customer in doing these steps. This script expect current namespace where operator is installed , and path to `1.1.0` manifest file. script will follow the below mentioned steps
 
 * Backup of all the operator resources within the namespace like
 ** service-account, deployment, role, role-binding, cluster-role, cluster-role-binding
 * Deletes all the old Splunk operator resources and deployment
-* Installs the operator 1.1.0 in Splunk-operator namespace. 
+* Installs the operator 1.1.0 in Splunk-operator namespace.
 
 By default Splunk operator 1.1.0 will be installed to watch cluster-wide
 
-==Steps for upgrade from 1.0.5 to 1.1.0==
+## Steps for upgrade from 1.0.5 to 1.1.0
 
-run upgrade-to-1.1.0.sh script with below mentioned mandatory arguments 
-
+run upgrade-to-1.1.0.sh script with below mentioned mandatory arguments
 `current_namespace` current namespace where operator is installed, if its not found, it will exit with error message
-
 `manifest_file`: path where 1.1.0 Splunk operator manifest file exist
 
-===example===
+### Example
 
 ```upgrade-to-1.1.0.sh --current_namespace=splunk-operator manifest_file=release-v1.1.0/splunk-operator-cluster.yaml```
 
-==Configuring Operator to watch specific namespace==
+## Configuring Operator to watch specific namespace
 
 Edit config-map splunk-operator-config in splunk-operaor namespace, set WATCH_NAMESPACE field to the namespace operator need to watch
+
 ```
 apiVersion: v1
 data:

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -21,7 +21,7 @@ run upgrade-to-1.1.0.sh script with below mentioned mandatory arguments
 
 ## Configuring Operator to watch specific namespace
 
-Edit config-map splunk-operator-config in splunk-operaor namespace, set WATCH_NAMESPACE field to the namespace operator need to watch
+Edit config-map splunk-operator-config in splunk-operator namespace, set WATCH_NAMESPACE field to the namespace operator need to watch
 
 ```
 apiVersion: v1

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -9,19 +9,23 @@ Upgrading the Splunk operator to Version 1.1.0 is a new installation rather than
 
 By default Splunk operator 1.1.0 will be installed to watch cluster-wide
 
+
 ## Steps for upgrade from 1.0.5 to 1.1.0
 
-Run upgrade-to-1.1.0.sh script with the following mandatory arguments
-`current_namespace` current namespace where operator is installed
-`manifest_file`: path to 1.1.0 Splunk operator manifest file
+Run `upgrade-to-1.1.0.sh` script with the following mandatory arguments
+* `current_namespace` current namespace where operator is installed
+* `manifest_file`: path to 1.1.0 Splunk operator manifest file
+
 
 ### Example
 
-```upgrade-to-1.1.0.sh --current_namespace=splunk-operator manifest_file=release-v1.1.0/splunk-operator-install.yaml```
+```
+>upgrade-to-1.1.0.sh --current_namespace=splunk-operator manifest_file=release-v1.1.0/splunk-operator-install.yaml
+```
 
 ## Configuring Operator to watch specific namespace
 
-Edit config-map splunk-operator-config in splunk-operator namespace, set WATCH_NAMESPACE field namespace to be monitored by the Splunk operator
+Edit `config-map` `splunk-operator-config` in `splunk-operator` namespace, set `WATCH_NAMESPACE` field to the namespace that needs to be monitored by Splunk operator
 
 ```
 apiVersion: v1

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -1,6 +1,6 @@
 # Splunk Operator Upgrade
 
-Please note upgrading Splunk operator to Version `1.1.0` is a new installation rather than upgrade from current operator. Due to this  older Splunk operator need to be cleaned up before installing the latest version.  The script will help customer in doing these steps. This script expect current namespace where operator is installed , and path to `1.1.0` manifest file. script will follow the below mentioned steps
+Upgrading the Splunk operator to Version 1.1.0 is a new installation rather than an upgrade from the current operator. The older Splunk operator must be cleaned up before installing the new version. This script helps you to do the cleanup. The script expects the current namespace where the operator is installed and the path to the 1.1.0 manifest file. The script performs the following steps
 
 * Backup of all the operator resources within the namespace like
 ** service-account, deployment, role, role-binding, cluster-role, cluster-role-binding
@@ -11,8 +11,8 @@ By default Splunk operator 1.1.0 will be installed to watch cluster-wide
 
 ## Steps for upgrade from 1.0.5 to 1.1.0
 
-run upgrade-to-1.1.0.sh script with below mentioned mandatory arguments
-`current_namespace` current namespace where operator is installed, if its not found, it will exit with error message
+run upgrade-to-1.1.0.sh script with the following mandatory arguments
+`current_namespace` current namespace where operator is installed, if the operator is not found, the script exits with an error message
 `manifest_file`: path where 1.1.0 Splunk operator manifest file exist
 
 ### Example

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -12,7 +12,9 @@ By default Splunk operator 1.1.0 will be installed to watch cluster-wide
 
 ## Steps for upgrade from 1.0.5 to 1.1.0
 
-Run `upgrade-to-1.1.0.sh` script with the following mandatory arguments
+
+
+Set KUBECONFIG and run `upgrade-to-1.1.0.sh` script with the following mandatory arguments
 * `current_namespace` current namespace where operator is installed
 * `manifest_file`: path to 1.1.0 Splunk operator manifest file
 
@@ -22,6 +24,8 @@ Run `upgrade-to-1.1.0.sh` script with the following mandatory arguments
 ```
 >upgrade-to-1.1.0.sh --current_namespace=splunk-operator manifest_file=release-v1.1.0/splunk-operator-install.yaml
 ```
+
+Note: This script can be run from Mac or Linux system. To run this script on Windows, use cygwin.
 
 ## Configuring Operator to watch specific namespace
 

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -1,0 +1,39 @@
+=Splunk Operator Upgrade=
+
+Please note upgrading Splunk operator to Version `1.1.0` is a new installation rather than upgrade from current operator. Due to this  older Splunk operator need to be cleaned up before installing the latest version.  The script will help customer in doing these steps. This script expect current namespace where operator is installed , and path to `1.1.0` manifest file. script will 
+
+* Backup of all the operator resources within the namespace like
+** service-account, deployment, role, role-binding, cluster-role, cluster-role-binding
+* Deletes all the old Splunk operator resources and deployment
+* Installs the operator 1.1.0 in Splunk-operator namespace. 
+
+By default Splunk operator 1.1.0 will be installed to watch cluster-wide
+
+==Steps for upgrade from 1.0.5 to 1.1.0==
+
+run upgrade-to-1.1.0.sh script with below mentioned mandatory arguments 
+
+`current_namespace` current namespace where operator is installed, if its not found, it will exit with error message
+
+`manifest_file`: path where 1.1.0 Splunk operator manifest file exist
+
+===example===
+
+```upgrade-to-1.1.0.sh --current_namespace=splunk-operator manifest_file=release-v1.1.0/splunk-operator-cluster.yaml```
+
+==Configuring Operator to watch specific namespace==
+
+Edit config-map splunk-operator-config in splunk-operaor namespace, set WATCH_NAMESPACE field to the namespace operator need to watch
+```
+apiVersion: v1
+data:
+  OPERATOR_NAME: '"splunk-operator"'
+  RELATED_IMAGE_SPLUNK_ENTERPRISE: splunk/splunk:latest
+  WATCH_NAMESPACE: "add namespace here"
+kind: ConfigMap
+metadata:
+  labels:
+    name: splunk-operator
+  name: splunk-operator-config
+  namespace: splunk-operator
+```

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -11,9 +11,9 @@ By default Splunk operator 1.1.0 will be installed to watch cluster-wide
 
 ## Steps for upgrade from 1.0.5 to 1.1.0
 
-run upgrade-to-1.1.0.sh script with the following mandatory arguments
-`current_namespace` current namespace where operator is installed, if the operator is not found, the script exits with an error message
-`manifest_file`: path where 1.1.0 Splunk operator manifest file exist
+Run upgrade-to-1.1.0.sh script with the following mandatory arguments
+`current_namespace` current namespace where operator is installed
+`manifest_file`: path to 1.1.0 Splunk operator manifest file
 
 ### Example
 
@@ -21,12 +21,12 @@ run upgrade-to-1.1.0.sh script with the following mandatory arguments
 
 ## Configuring Operator to watch specific namespace
 
-Edit config-map splunk-operator-config in splunk-operator namespace, set WATCH_NAMESPACE field to the namespace operator need to watch
+Edit config-map splunk-operator-config in splunk-operator namespace, set WATCH_NAMESPACE field namespace to be monitored by the Splunk operator
 
 ```
 apiVersion: v1
 data:
-  OPERATOR_NAME: '"splunk-operator"'
+  OPERATOR_NAME: "splunk-operator"
   RELATED_IMAGE_SPLUNK_ENTERPRISE: splunk/splunk:latest
   WATCH_NAMESPACE: "add namespace here"
 kind: ConfigMap

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -17,7 +17,7 @@ Run upgrade-to-1.1.0.sh script with the following mandatory arguments
 
 ### Example
 
-```upgrade-to-1.1.0.sh --current_namespace=splunk-operator manifest_file=release-v1.1.0/splunk-operator-cluster.yaml```
+```upgrade-to-1.1.0.sh --current_namespace=splunk-operator manifest_file=release-v1.1.0/splunk-operator-install.yaml```
 
 ## Configuring Operator to watch specific namespace
 

--- a/tools/upgrade-to-1.1.0.sh
+++ b/tools/upgrade-to-1.1.0.sh
@@ -15,11 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Please note upgrading Splunk operator to Version 1.1.0 is a new installation rather 
-# than upgrade from current operator. Due to this older Splunk operator need to be 
-# cleaned up before installing the latest version. The script will help customer in 
-# doing these steps. This script expect current namespace where operator is installed,
-# and path to 1.1.0 manifest file. script will 
+# Upgrading the Splunk operator to Version 1.1.0 is a new installation rather than an 
+# upgrade from the current operator. The older Splunk operator must be cleaned up before 
+# installing the new version. This script helps you to do the cleanup. The script expects 
+# the current namespace where the operator is installed and the path to the 1.1.0 
+# manifest file. The script performs the following steps
 # * Backup of all the operator resources within the namespace like
 #   - service-account, deployment, role, role-binding, cluster-role, cluster-role-binding
 # * Deletes all the old Splunk operator resources and deployment
@@ -175,7 +175,7 @@ backup() {
         echo "---" >> ${backup_file_name}
     fi
     echo "--------------------------------------------------------------"
-    echo "backup of all the previsou splunk opeartor installation is complete, backup file is found in current diretory ${backup_file_name}"
+    echo "backup of all the previsou splunk operator installation is complete, backup file is found in current diretory ${backup_file_name}"
 }
 
 delete_operator() {

--- a/tools/upgrade-to-1.1.0.sh
+++ b/tools/upgrade-to-1.1.0.sh
@@ -27,13 +27,12 @@
 # 
 # By default Splunk operator 1.1.0 will be installed to watch cluster-wide
 # Steps for upgrade from 1.0.5 to 1.1.0
-# run upgrade-to-1.1.0.sh script with below mentioned mandatory arguments 
-# current_namespace current namespace where operator is installed, if its not found, it 
-# will exit with error message
+# run upgrade-to-1.1.0.sh script with the following mandatory arguments
+# current_namespace: current namespace where operator is installed
 # manifest_file: path where 1.1.0 Splunk operator manifest file exist
 #
 # example 
-# >upgrade-to-1.1.0.sh --current_namespace=splunk-operator manifest_file=release-v1.1.0/splunk-operator-cluster.yaml
+# >upgrade-to-1.1.0.sh --current_namespace=splunk-operator manifest_file=release-v1.1.0/splunk-operator-install.yaml
 #
 #
 # Configuring Operator to watch specific namespace:

--- a/tools/upgrade-to-1.1.0.sh
+++ b/tools/upgrade-to-1.1.0.sh
@@ -27,7 +27,7 @@
 # 
 # By default Splunk operator 1.1.0 will be installed to watch cluster-wide
 # Steps for upgrade from 1.0.5 to 1.1.0
-# run upgrade-to-1.1.0.sh script with the following mandatory arguments
+# Run upgrade-to-1.1.0.sh script with the following mandatory arguments
 # current_namespace: current namespace where operator is installed
 # manifest_file: path where 1.1.0 Splunk operator manifest file exist
 #

--- a/tools/upgrade-to-1.1.0.sh
+++ b/tools/upgrade-to-1.1.0.sh
@@ -37,7 +37,7 @@
 #
 #
 # Configuring Operator to watch specific namespace:
-# Edit config-map splunk-operator-config in splunk-operaor namespace, set WATCH_NAMESPACE 
+# Edit config-map splunk-operator-config in splunk-operator namespace, set WATCH_NAMESPACE 
 # field to the namespace operator need to watch
 #
 # apiVersion: v1

--- a/tools/upgrade-to-1.1.0.sh
+++ b/tools/upgrade-to-1.1.0.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (c) 2018-2022 Splunk Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Please note upgrading Splunk operator to Version 1.1.0 is a new installation rather 
+# than upgrade from current operator. Due to this older Splunk operator need to be 
+# cleaned up before installing the latest version. The script will help customer in 
+# doing these steps. This script expect current namespace where operator is installed,
+# and path to 1.1.0 manifest file. script will 
+# * Backup of all the operator resources within the namespace like
+#   - service-account, deployment, role, role-binding, cluster-role, cluster-role-binding
+# * Deletes all the old Splunk operator resources and deployment
+# * Installs the operator 1.1.0 in Splunk-operator namespace. 
+# 
+# By default Splunk operator 1.1.0 will be installed to watch cluster-wide
+# Steps for upgrade from 1.0.5 to 1.1.0
+# run upgrade-to-1.1.0.sh script with below mentioned mandatory arguments 
+# current_namespace current namespace where operator is installed, if its not found, it 
+# will exit with error message
+# manifest_file: path where 1.1.0 Splunk operator manifest file exist
+#
+# example 
+# >upgrade-to-1.1.0.sh --current_namespace=splunk-operator manifest_file=release-v1.1.0/splunk-operator-cluster.yaml
+#
+#
+# Configuring Operator to watch specific namespace:
+# Edit config-map splunk-operator-config in splunk-operaor namespace, set WATCH_NAMESPACE 
+# field to the namespace operator need to watch
+#
+# apiVersion: v1
+# data:
+#   OPERATOR_NAME: '"splunk-operator"'
+#   RELATED_IMAGE_SPLUNK_ENTERPRISE: splunk/splunk:latest
+#   WATCH_NAMESPACE: "add namespace here"
+# kind: ConfigMap
+# metadata:
+#   labels:
+#     name: splunk-operator
+#   name: splunk-operator-config
+#   namespace: splunk-operator
+
+readonly CURRENT_TIME=$(date +%Y-%m-%d_%H%M-%Z)
+readonly PROGRAM_NAME=$(basename "$0")
+
+help() {
+  echo ""
+  echo "USAGE: ${PROGRAM_NAME} --help [ --current_namespace=<namespacename> ] [ --manifest_file=<fulepath with filename of splunk operator 1.1.0 manfiests file>] "
+  echo ""
+  echo "OPTIONS:"
+  echo ""
+  echo -e "   --current_namespace specifiy the current namespace where operator is installed, \n" \
+       "                          script will delete existing serviceaccount, deployment, role and " \
+       "                          rolebinding and install the operator in splunk-operator namespace"
+  echo ""
+  echo "   --manifest_file splunk operator 1.1.0 manifest file path, this can be url link or full path of the file"
+  echo ""
+  echo ""
+  echo "   --help  Show this help message."
+  echo ""
+}
+
+parse_options() {
+  local count="$#"
+
+  for i in $(seq "${count}"); do
+    eval arg="\$$i"
+    param="$(echo "${arg}" | awk -F '=' '{print $1}' | sed -e 's|--||')"
+    val="$(echo "${arg}" | awk -F '=' '{print $2}')"
+
+    case "${param}" in
+      current_namespace)
+        eval "${param}"="${val}"
+        ;;
+      manifest_file)
+        eval "${param}"="${val}"
+        ;;
+      help)
+        help && exit 0
+        ;;
+      *)
+        echo "Parameter not found: '$param'"
+        help && exit 1
+        ;;
+    esac
+  done
+
+  if [[ -z "$current_namespace" ]]; then
+    echo "Must provide current_namespace" 1>&2
+    help
+    exit 1
+  fi
+  if [[ -z "$manifest_file" ]]; then
+    echo "Must provide manifest_file" 1>&2
+    help
+    exit 1
+  fi
+ 
+}
+
+namespace_exist() {
+    echo "check if namespace ${current_namespace} exist"
+    kubectl get namespace ${current_namespace}
+    if [ $? != 0 ]
+    then
+        echo "namespace ${current_namespace} do not exist, exiting..."
+        exit 13 
+    fi
+}
+
+backup() {
+    backup_file_name=backup_${CURRENT_TIME}.yaml
+    echo "--------------------------------------------------------------"
+    echo "taking backup of existing operator installation manifest files"
+    echo "backup namespace"
+    echo "---" >> ${backup_file_name}
+    kubectl get namespace ${current_namespace} -o yaml >> ${backup_file_name}
+    if [ $? == 0 ] 
+    then 
+        echo "" >> ${backup_file_name}
+        echo "---" >> ${backup_file_name}
+    fi
+    echo "backup serviceaccount details"
+    kubectl get serviceaccount ${current_namespace} -n splunk-operator -o yaml >> ${backup_file_name}
+    if [ $? == 0 ] 
+    then 
+        echo "" >> ${backup_file_name}
+        echo "---" >> ${backup_file_name}
+    fi
+    echo "backup if there are any role defined for splunk operator"
+    kubectl get role splunk:operator:namespace-manager -n ${current_namespace} -o yaml >> ${backup_file_name}
+    if [ $? == 0 ] 
+    then 
+        echo "" >> ${backup_file_name}
+        echo "---" >> ${backup_file_name}
+    fi
+    echo "backup if there are any role-biding defined for splunk operator"
+    kubectl get rolebinding splunk:operator:namespace-manager -n ${current_namespace}  -o yaml >> ${backup_file_name}
+    if [ $? == 0 ] 
+    then 
+        echo "" >> ${backup_file_name}
+        echo "---" >> ${backup_file_name}
+    fi
+    echo "backup if there are any cluster-role defined for splunk operator"
+    kubectl get clusterrole splunk:operator:resource-manager -o yaml  >> ${backup_file_name}
+    if [ $? == 0 ] 
+    then 
+        echo "" >> ${backup_file_name}
+        echo "---" >> ${backup_file_name}
+    fi
+    echo "backup if there are any cluster-role-binding defined for splunk operator"
+    kubectl get clusterrolebinding splunk:operator:resource-manager -o yaml >> ${backup_file_name}
+    if [ $? == 0 ] 
+    then 
+        echo "" >> ${backup_file_name}
+        echo "---" >> ${backup_file_name}
+    fi
+    echo "backup deployment details"
+    kubectl get deployment splunk-operator -n ${current_namespace} -o yaml >> ${backup_file_name}
+    if [ $? == 0 ] 
+    then 
+        echo "" >> ${backup_file_name}
+        echo "---" >> ${backup_file_name}
+    fi
+    echo "--------------------------------------------------------------"
+    echo "backup of all the previsou splunk opeartor installation is complete, backup file is found in current diretory ${backup_file_name}"
+}
+
+delete_operator() {
+    echo "--------------------------------------------------------------"
+    echo "deleting all the previsous splunk operator resources....."
+    echo "deleting clusterrole"
+    kubectl delete clusterrole splunk:operator:resource-manager 
+    echo "deleting cluster rolebinding"
+    kubectl delete clusterrolebinding splunk:operator:resource-manager 
+    echo "deletign deployment"
+    kubectl delete deployment splunk-operator -n ${current_namespace}
+    echo "deleting serviceaccount"
+    kubectl delete serviceaccount splunk-operator -n ${current_namespace}
+    echo "deleting role"
+    kubectl delete role splunk:operator:namespace-manager -n ${current_namespace}
+    echo "deleting rolebinding"
+    kubectl delete rolebinding splunk:operator:namespace-manager -n ${current_namespace}
+    echo "--------------------------------------------------------------"
+    echo "previous instance of splunk operator removed"
+}
+
+deploy_operator() {
+    echo "--------------------------------------------------------------"
+    echo "installing splunk operator 1.1.0....." 
+    kubectl apply -f ${manifest_file}
+    echo "--------------------------------------------------------------"
+    echo "deployment new splunk opearator 1.1.0 complete"
+}
+
+parse_options "$@"
+namespace_exist
+backup
+delete_operator
+deploy_operator

--- a/tools/upgrade-to-1.1.0.sh
+++ b/tools/upgrade-to-1.1.0.sh
@@ -27,13 +27,14 @@
 # 
 # By default Splunk operator 1.1.0 will be installed to watch cluster-wide
 # Steps for upgrade from 1.0.5 to 1.1.0
-# Run upgrade-to-1.1.0.sh script with the following mandatory arguments
+# Set KUBECONFIG environment variable and run upgrade-to-1.1.0.sh script with the following mandatory arguments
 # current_namespace: current namespace where operator is installed
 # manifest_file: path where 1.1.0 Splunk operator manifest file exist
 #
 # example 
 # >upgrade-to-1.1.0.sh --current_namespace=splunk-operator manifest_file=release-v1.1.0/splunk-operator-install.yaml
 #
+# Note: This script can be run from Mac or Linux system. To run this script on Windows, use cygwin.
 #
 # Configuring Operator to watch specific namespace:
 # Edit config-map splunk-operator-config in splunk-operator namespace, set WATCH_NAMESPACE 


### PR DESCRIPTION
This PR is for upgrade steps from 1.0.5 to 1.1.0. upgrade script takes 2 parameter,

-  current splunk installation namespace 
- splunk operator 1.1.0 manifest file path

` upgrade-to-1.1.0.sh --current_namespace=namespace1 manifest_file=release-v1.1.0/splunk-operator-cluster.yaml`

in the above example older operator was installed in `namespace1` namespace, so it takes the backup of the files first and then deleted all the older resources and installs the new operator in `splunk-operator `namespace. by default operator will be installed clusterwide. if user wants to watch specific namespace edit `config-map` `splunk-operator-config` in `splunk-opertao`r namespace, set `WATCH_NAMESPACE` field to the namespace operator need to watch