### PR TITLE
CSPL-1670: Add region as a configurable parameter in volume spec

### DIFF
--- a/deploy/crds/enterprise.splunk.com_clustermasters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_clustermasters_crd.yaml
@@ -707,6 +707,10 @@ spec:
                           description: 'App Package Remote Store provider. Supported
                             values: aws, minio'
                           type: string
+                        region:
+                          description: Region of the remote storage volume where apps
+                            reside
+                          type: string
                         secretRef:
                           description: Secret object name
                           type: string
@@ -1396,6 +1400,10 @@ spec:
                         provider:
                           description: 'App Package Remote Store provider. Supported
                             values: aws, minio'
+                          type: string
+                        region:
+                          description: Region of the remote storage volume where apps
+                            reside
                           type: string
                         secretRef:
                           description: Secret object name
@@ -2753,6 +2761,10 @@ spec:
                               description: 'App Package Remote Store provider. Supported
                                 values: aws, minio'
                               type: string
+                            region:
+                              description: Region of the remote storage volume where
+                                apps reside
+                              type: string
                             secretRef:
                               description: Secret object name
                               type: string
@@ -3004,6 +3016,10 @@ spec:
                         provider:
                           description: 'App Package Remote Store provider. Supported
                             values: aws, minio'
+                          type: string
+                        region:
+                          description: Region of the remote storage volume where apps
+                            reside
                           type: string
                         secretRef:
                           description: Secret object name

--- a/deploy/crds/enterprise.splunk.com_licensemasters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_licensemasters_crd.yaml
@@ -712,6 +712,10 @@ spec:
                           description: 'App Package Remote Store provider. Supported
                             values: aws, minio'
                           type: string
+                        region:
+                          description: Region of the remote storage volume where apps
+                            reside
+                          type: string
                         secretRef:
                           description: Secret object name
                           type: string
@@ -2648,6 +2652,10 @@ spec:
                             provider:
                               description: 'App Package Remote Store provider. Supported
                                 values: aws, minio'
+                              type: string
+                            region:
+                              description: Region of the remote storage volume where
+                                apps reside
                               type: string
                             secretRef:
                               description: Secret object name

--- a/deploy/crds/enterprise.splunk.com_monitoringconsoles_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_monitoringconsoles_crd.yaml
@@ -707,6 +707,10 @@ spec:
                           description: 'App Package Remote Store provider. Supported
                             values: aws, minio'
                           type: string
+                        region:
+                          description: Region of the remote storage volume where apps
+                            reside
+                          type: string
                         secretRef:
                           description: Secret object name
                           type: string
@@ -2642,6 +2646,10 @@ spec:
                             provider:
                               description: 'App Package Remote Store provider. Supported
                                 values: aws, minio'
+                              type: string
+                            region:
+                              description: Region of the remote storage volume where
+                                apps reside
                               type: string
                             secretRef:
                               description: Secret object name

--- a/deploy/crds/enterprise.splunk.com_searchheadclusters_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_searchheadclusters_crd.yaml
@@ -725,6 +725,10 @@ spec:
                           description: 'App Package Remote Store provider. Supported
                             values: aws, minio'
                           type: string
+                        region:
+                          description: Region of the remote storage volume where apps
+                            reside
+                          type: string
                         secretRef:
                           description: Secret object name
                           type: string
@@ -2677,6 +2681,10 @@ spec:
                             provider:
                               description: 'App Package Remote Store provider. Supported
                                 values: aws, minio'
+                              type: string
+                            region:
+                              description: Region of the remote storage volume where
+                                apps reside
                               type: string
                             secretRef:
                               description: Secret object name

--- a/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
+++ b/deploy/crds/enterprise.splunk.com_standalones_crd.yaml
@@ -720,6 +720,10 @@ spec:
                           description: 'App Package Remote Store provider. Supported
                             values: aws, minio'
                           type: string
+                        region:
+                          description: Region of the remote storage volume where apps
+                            reside
+                          type: string
                         secretRef:
                           description: Secret object name
                           type: string
@@ -1413,6 +1417,10 @@ spec:
                         provider:
                           description: 'App Package Remote Store provider. Supported
                             values: aws, minio'
+                          type: string
+                        region:
+                          description: Region of the remote storage volume where apps
+                            reside
                           type: string
                         secretRef:
                           description: Secret object name
@@ -2771,6 +2779,10 @@ spec:
                               description: 'App Package Remote Store provider. Supported
                                 values: aws, minio'
                               type: string
+                            region:
+                              description: Region of the remote storage volume where
+                                apps reside
+                              type: string
                             secretRef:
                               description: Secret object name
                               type: string
@@ -3021,6 +3033,10 @@ spec:
                         provider:
                           description: 'App Package Remote Store provider. Supported
                             values: aws, minio'
+                          type: string
+                        region:
+                          description: Region of the remote storage volume where apps
+                            reside
                           type: string
                         secretRef:
                           description: Secret object name

--- a/docs/AppFramework.md
+++ b/docs/AppFramework.md
@@ -63,6 +63,7 @@ spec:
         provider: aws
         path: bucket-app-framework-us-west-2/Standalone-us/
         endpoint: https://s3-us-west-2.amazonaws.com
+        region: us-west-2
         secretRef: s3-secret
 ```
 
@@ -128,6 +129,7 @@ spec:
         provider: aws
         path: bucket-app-framework-us-west-2/idxcAndCmApps/
         endpoint: https://s3-us-west-2.amazonaws.com
+        region: us-west-2
         secretRef: s3-secret
 ```
 
@@ -202,6 +204,7 @@ spec:
         provider: aws
         path: bucket-app-framework-us-west-2/shcLoc-us/
         endpoint: https://s3-us-west-2.amazonaws.com
+        region: us-west-2
         secretRef: s3-secret
 ```
 
@@ -291,6 +294,10 @@ Here is a typical App framework configuration in a Custom Resource definition:
                           description: 'App Package Remote Store provider. For e.g.
                             aws, azure, minio, etc. Currently we are only supporting
                             aws. TODO: Support minio as well.'
+                          type: string
+                        region:
+                          description: Region of the remote storage volume where apps
+                            reside
                           type: string
                         secretRef:
                           description: Secret object name

--- a/pkg/apis/enterprise/v3/common_types.go
+++ b/pkg/apis/enterprise/v3/common_types.go
@@ -200,6 +200,9 @@ type VolumeSpec struct {
 
 	// App Package Remote Store provider. Supported values: aws, minio
 	Provider string `json:"provider"`
+
+	// Region of the remote storage volume where apps reside
+	Region string `json:"region"`
 }
 
 // VolumeAndTypeSpec used to add any custom varaibles for volume implementation

--- a/pkg/splunk/client/awss3client.go
+++ b/pkg/splunk/client/awss3client.go
@@ -52,12 +52,10 @@ type AWSS3Client struct {
 	AWSSecretAccessKey string
 	Prefix             string
 	StartAfter         string
-	Endpoint           string
 	Client             SplunkAWSS3Client
 	Downloader         SplunkAWSDownloadClient
 }
 
-// regex to extract the region from the s3 endpoint
 var regionRegex = ".*.s3[-,.](?P<region>.*).amazonaws.com"
 
 // GetRegion extracts the region from the endpoint field
@@ -125,10 +123,15 @@ func InitAWSClientSession(region, accessKeyID, secretAccessKey string) SplunkAWS
 }
 
 // NewAWSS3Client returns an AWS S3 client
-func NewAWSS3Client(bucketName string, accessKeyID string, secretAccessKey string, prefix string, startAfter string, endpoint string, fn GetInitFunc) (S3Client, error) {
+func NewAWSS3Client(bucketName string, accessKeyID string, secretAccessKey string, prefix string, startAfter string, region string, endpoint string, fn GetInitFunc) (S3Client, error) {
 	var s3SplunkClient SplunkAWSS3Client
 	var err error
-	region := GetRegion(endpoint)
+
+	// for backward compatibility, if `region` is not specified in the CR,
+	// then derive the region from the endpoint.
+	if region == "" {
+		region = GetRegion(endpoint)
+	}
 	cl := fn(region, accessKeyID, secretAccessKey)
 	if cl == nil {
 		err = fmt.Errorf("failed to create an AWS S3 client")
@@ -145,7 +148,6 @@ func NewAWSS3Client(bucketName string, accessKeyID string, secretAccessKey strin
 		AWSSecretAccessKey: secretAccessKey,
 		Prefix:             prefix,
 		StartAfter:         startAfter,
-		Endpoint:           endpoint,
 		Client:             s3SplunkClient,
 		Downloader:         downloader,
 	}, nil

--- a/pkg/splunk/client/awss3client_test.go
+++ b/pkg/splunk/client/awss3client_test.go
@@ -40,6 +40,18 @@ func TestNewAWSS3Client(t *testing.T) {
 		t.Errorf("NewAWSS3Client should have returned a valid AWS S3 client.")
 	}
 
+	// just test the backward compatibility where we do not pass a region explicitly
+	awsS3Client, err = NewAWSS3Client("sample_bucket", "abcd", "xyz", "admin/", "admin", "", "https://s3.us-west-2.amazonaws.com", fn)
+	if awsS3Client == nil || err != nil {
+		t.Errorf("NewAWSS3Client should have returned a valid AWS S3 client.")
+	}
+
+	// test the invalid scenario where we cannot extract region from endpoint
+	awsS3Client, err = NewAWSS3Client("sample_bucket", "abcd", "xyz", "admin/", "admin", "", "https://s3.us-west-2.dummyprovider.com", fn)
+	if awsS3Client != nil || err == nil {
+		t.Errorf("NewAWSS3Client should have returned a valid AWS S3 client.")
+	}
+
 	// Test for invalid scenario, where we return nil client
 	fn = func(string, string, string) interface{} {
 		return nil

--- a/pkg/splunk/client/awss3client_test.go
+++ b/pkg/splunk/client/awss3client_test.go
@@ -35,7 +35,7 @@ func TestInitAWSClientWrapper(t *testing.T) {
 func TestNewAWSS3Client(t *testing.T) {
 
 	fn := InitAWSClientWrapper
-	awsS3Client, err := NewAWSS3Client("sample_bucket", "abcd", "xyz", "admin/", "admin", "https://s3.us-west-2.amazonaws.com", fn)
+	awsS3Client, err := NewAWSS3Client("sample_bucket", "abcd", "xyz", "admin/", "admin", "us-west-2", "https://s3.us-west-2.amazonaws.com", fn)
 	if awsS3Client == nil || err != nil {
 		t.Errorf("NewAWSS3Client should have returned a valid AWS S3 client.")
 	}
@@ -44,7 +44,7 @@ func TestNewAWSS3Client(t *testing.T) {
 	fn = func(string, string, string) interface{} {
 		return nil
 	}
-	_, err = NewAWSS3Client("sample_bucket", "abcd", "xyz", "admin/", "admin", "https://s3.us-west-2.amazonaws.com", fn)
+	_, err = NewAWSS3Client("sample_bucket", "abcd", "xyz", "admin/", "admin", "us-west-2", "https://s3.us-west-2.amazonaws.com", fn)
 	if err == nil {
 		t.Errorf("NewAWSS3Client should have returned error.")
 	}

--- a/pkg/splunk/client/minioclient.go
+++ b/pkg/splunk/client/minioclient.go
@@ -46,7 +46,7 @@ type MinioClient struct {
 }
 
 // NewMinioClient returns an Minio client
-func NewMinioClient(bucketName string, accessKeyID string, secretAccessKey string, prefix string, startAfter string, endpoint string, fn GetInitFunc) (S3Client, error) {
+func NewMinioClient(bucketName string, accessKeyID string, secretAccessKey string, prefix string, startAfter string, region string, endpoint string, fn GetInitFunc) (S3Client, error) {
 	var s3SplunkClient SplunkMinioClient
 	var err error
 

--- a/pkg/splunk/client/minioclient_test.go
+++ b/pkg/splunk/client/minioclient_test.go
@@ -37,19 +37,19 @@ func TestNewMinioClient(t *testing.T) {
 	fn := InitMinioClientWrapper
 
 	// Test1. Test for endpoint with https
-	minioS3Client, err := NewMinioClient("sample_bucket", "abcd", "xyz", "admin/", "admin", "https://s3.us-west-2.amazonaws.com", fn)
+	minioS3Client, err := NewMinioClient("sample_bucket", "abcd", "xyz", "admin/", "admin", "us-west-2", "https://s3.us-west-2.amazonaws.com", fn)
 	if minioS3Client == nil || err != nil {
 		t.Errorf("NewMinioClient should have returned a valid Minio S3 client.")
 	}
 
 	// Test2. Test for endpoint with http
-	minioS3Client, err = NewMinioClient("sample_bucket", "abcd", "xyz", "admin/", "admin", "http://s3.us-west-2.amazonaws.com", fn)
+	minioS3Client, err = NewMinioClient("sample_bucket", "abcd", "xyz", "admin/", "admin", "us-west-2", "http://s3.us-west-2.amazonaws.com", fn)
 	if minioS3Client == nil || err != nil {
 		t.Errorf("NewMinioClient should have returned a valid Minio S3 client.")
 	}
 
 	// Test3. Test for invalid endpoint
-	minioS3Client, err = NewMinioClient("sample_bucket", "abcd", "xyz", "admin/", "admin", "random-endpoint.com", fn)
+	minioS3Client, err = NewMinioClient("sample_bucket", "abcd", "xyz", "admin/", "admin", "us-west-2", "random-endpoint.com", fn)
 	if minioS3Client != nil || err == nil {
 		t.Errorf("NewMinioClient should have returned a error.")
 	}

--- a/pkg/splunk/client/s3client.go
+++ b/pkg/splunk/client/s3client.go
@@ -51,7 +51,7 @@ type GetInitFunc func(string, string, string) interface{}
 
 //GetS3Client gets the required S3Client based on the provider
 type GetS3Client func(string /* bucket */, string, /* AWS access key ID */
-	string /* AWS secret access key */, string /* Prefix */, string /* StartAfter */, string /* Endpoint */, GetInitFunc) (S3Client, error)
+	string /* AWS secret access key */, string /* Prefix */, string /* StartAfter */, string /* Region */, string /* Endpoint */, GetInitFunc) (S3Client, error)
 
 // S3Clients is a map of provider name to init functions
 var S3Clients = make(map[string]GetS3ClientWrapper)

--- a/pkg/splunk/client/util.go
+++ b/pkg/splunk/client/util.go
@@ -26,10 +26,9 @@ import (
 // Ideally this function should live in test package but due to
 // dependency of some variables in client package and to avoid
 // cyclic dependency this has to live here.
-func NewMockAWSS3Client(bucketName string, accessKeyID string, secretAccessKey string, prefix string, startAfter string, endpoint string, fn GetInitFunc) (S3Client, error) {
+func NewMockAWSS3Client(bucketName string, accessKeyID string, secretAccessKey string, prefix string, startAfter string, region string, endpoint string, fn GetInitFunc) (S3Client, error) {
 	var s3SplunkClient SplunkAWSS3Client
 	var err error
-	region := GetRegion(endpoint)
 
 	cl := fn(region, accessKeyID, secretAccessKey)
 	if cl == nil {
@@ -47,14 +46,13 @@ func NewMockAWSS3Client(bucketName string, accessKeyID string, secretAccessKey s
 		AWSSecretAccessKey: secretAccessKey,
 		Prefix:             prefix,
 		StartAfter:         startAfter,
-		Endpoint:           endpoint,
 		Client:             s3SplunkClient,
 		Downloader:         downloader,
 	}, nil
 }
 
 // NewMockMinioS3Client is mock client for testing minio client
-func NewMockMinioS3Client(bucketName string, accessKeyID string, secretAccessKey string, prefix string, startAfter string, endpoint string, fn GetInitFunc) (S3Client, error) {
+func NewMockMinioS3Client(bucketName string, accessKeyID string, secretAccessKey string, prefix string, startAfter string, region string, endpoint string, fn GetInitFunc) (S3Client, error) {
 	var s3SplunkClient SplunkMinioClient
 	var err error
 

--- a/pkg/splunk/client/util_test.go
+++ b/pkg/splunk/client/util_test.go
@@ -68,7 +68,7 @@ func TestNewMockAWSS3Client(t *testing.T) {
 		cl := spltest.MockAWSS3Client{}
 		return cl
 	}
-	_, err := NewMockAWSS3Client("sample_bucket", "abcd", "1234", "admin/", "admin", "htts://s3.us-west-2.amazonaws.com", initFn)
+	_, err := NewMockAWSS3Client("sample_bucket", "abcd", "1234", "admin/", "admin", "us-west-2", "htts://s3.us-west-2.amazonaws.com", initFn)
 	if err != nil {
 		t.Errorf("NewMockAWSS3Client should have returned a Mock AWS client.")
 	}
@@ -77,7 +77,7 @@ func TestNewMockAWSS3Client(t *testing.T) {
 	initFn = func(region, accessKeyID, secretAccessKey string) interface{} {
 		return nil
 	}
-	_, err = NewMockAWSS3Client("sample_bucket", "abcd", "1234", "admin/", "admin", "htts://s3.us-west-2.amazonaws.com", initFn)
+	_, err = NewMockAWSS3Client("sample_bucket", "abcd", "1234", "admin/", "admin", "us-west-2", "htts://s3.us-west-2.amazonaws.com", initFn)
 	if err == nil {
 		t.Errorf("NewMockAWSS3Client should have returned an error since we passed nil client in init function.")
 	}

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -183,7 +183,7 @@ func GetRemoteStorageClient(client splcommon.ControllerClient, cr splcommon.Meta
 	scopedLog.Info("Creating the client", "volume", vol.Name, "bucket", bucket, "bucket path", prefix)
 
 	var err error
-	s3Client.Client, err = getClient(bucket, accessKeyID, secretAccessKey, prefix, prefix /* startAfter*/, vol.Endpoint, fn)
+	s3Client.Client, err = getClient(bucket, accessKeyID, secretAccessKey, prefix, prefix /* startAfter*/, vol.Region, vol.Endpoint, fn)
 	if err != nil {
 		scopedLog.Error(err, "Failed to get the S3 client")
 		return s3Client, err

--- a/test/c3/appframework/appframework_test.go
+++ b/test/c3/appframework/appframework_test.go
@@ -974,7 +974,7 @@ var _ = Describe("c3appfw test", func() {
 
 			// Create App framework Spec for Cluster manager with scope local and append cluster scope
 			appFrameworkSpecIdxc := testenv.GenerateAppFrameworkSpec(testenvInstance, appSourceVolumeNameIdxcLocal, enterpriseApi.ScopeLocal, appSourceNameLocalIdxc, s3TestDirIdxcLocal, 60)
-			volumeSpecCluster := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(appSourceVolumeNameIdxcCluster, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+			volumeSpecCluster := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(appSourceVolumeNameIdxcCluster, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3", testenv.GetDefaultS3Region())}
 			appFrameworkSpecIdxc.VolList = append(appFrameworkSpecIdxc.VolList, volumeSpecCluster...)
 			appSourceClusterDefaultSpec := enterpriseApi.AppSourceDefaultSpec{
 				VolName: appSourceVolumeNameIdxcCluster,
@@ -985,7 +985,7 @@ var _ = Describe("c3appfw test", func() {
 
 			// Create App framework Spec for Search head cluster with scope local and append cluster scope
 			appFrameworkSpecShc := testenv.GenerateAppFrameworkSpec(testenvInstance, appSourceVolumeNameShcLocal, enterpriseApi.ScopeLocal, appSourceNameLocalShc, s3TestDirShcLocal, 60)
-			volumeSpecCluster = []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(appSourceVolumeNameShcCluster, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+			volumeSpecCluster = []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(appSourceVolumeNameShcCluster, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3", testenv.GetDefaultS3Region())}
 			appFrameworkSpecShc.VolList = append(appFrameworkSpecShc.VolList, volumeSpecCluster...)
 			appSourceClusterDefaultSpec = enterpriseApi.AppSourceDefaultSpec{
 				VolName: appSourceVolumeNameShcCluster,
@@ -1179,7 +1179,7 @@ var _ = Describe("c3appfw test", func() {
 
 			// Create App framework Spec for Cluster manager with scope local and append cluster scope
 			appFrameworkSpecIdxc := testenv.GenerateAppFrameworkSpec(testenvInstance, appSourceVolumeNameIdxcLocal, enterpriseApi.ScopeLocal, appSourceNameLocalIdxc, s3TestDirIdxcLocal, 60)
-			volumeSpecCluster := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(appSourceVolumeNameIdxcCluster, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+			volumeSpecCluster := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(appSourceVolumeNameIdxcCluster, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3", testenv.GetDefaultS3Region())}
 			appFrameworkSpecIdxc.VolList = append(appFrameworkSpecIdxc.VolList, volumeSpecCluster...)
 			appSourceClusterDefaultSpec := enterpriseApi.AppSourceDefaultSpec{
 				VolName: appSourceVolumeNameIdxcCluster,
@@ -1190,7 +1190,7 @@ var _ = Describe("c3appfw test", func() {
 
 			// Create App framework Spec for Search head cluster with scope local and append cluster scope
 			appFrameworkSpecShc := testenv.GenerateAppFrameworkSpec(testenvInstance, appSourceVolumeNameShcLocal, enterpriseApi.ScopeLocal, appSourceNameLocalShc, s3TestDirShcLocal, 60)
-			volumeSpecCluster = []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(appSourceVolumeNameShcCluster, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+			volumeSpecCluster = []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(appSourceVolumeNameShcCluster, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3", testenv.GetDefaultS3Region())}
 			appFrameworkSpecShc.VolList = append(appFrameworkSpecShc.VolList, volumeSpecCluster...)
 			appSourceClusterDefaultSpec = enterpriseApi.AppSourceDefaultSpec{
 				VolName: appSourceVolumeNameShcCluster,
@@ -1902,7 +1902,7 @@ var _ = Describe("c3appfw test", func() {
 
 			// Create App framework Spec for Cluster manager with scope local and append cluster scope
 			appFrameworkSpecIdxc := testenv.GenerateAppFrameworkSpec(testenvInstance, appSourceVolumeNameIdxcLocal, enterpriseApi.ScopeLocal, appSourceNameLocalIdxc, s3TestDirIdxcLocal, 0)
-			volumeSpecCluster := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(appSourceVolumeNameIdxcCluster, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+			volumeSpecCluster := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(appSourceVolumeNameIdxcCluster, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3", testenv.GetDefaultS3Region())}
 			appFrameworkSpecIdxc.VolList = append(appFrameworkSpecIdxc.VolList, volumeSpecCluster...)
 			appSourceClusterDefaultSpec := enterpriseApi.AppSourceDefaultSpec{
 				VolName: appSourceVolumeNameIdxcCluster,
@@ -1913,7 +1913,7 @@ var _ = Describe("c3appfw test", func() {
 
 			// Create App framework Spec for Search head cluster with scope local and append cluster scope
 			appFrameworkSpecShc := testenv.GenerateAppFrameworkSpec(testenvInstance, appSourceVolumeNameShcLocal, enterpriseApi.ScopeLocal, appSourceNameLocalShc, s3TestDirShcLocal, 0)
-			volumeSpecCluster = []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(appSourceVolumeNameShcCluster, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+			volumeSpecCluster = []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(appSourceVolumeNameShcCluster, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3", testenv.GetDefaultS3Region())}
 			appFrameworkSpecShc.VolList = append(appFrameworkSpecShc.VolList, volumeSpecCluster...)
 			appSourceClusterDefaultSpec = enterpriseApi.AppSourceDefaultSpec{
 				VolName: appSourceVolumeNameShcCluster,

--- a/test/licensemanager/lm_c3_test.go
+++ b/test/licensemanager/lm_c3_test.go
@@ -142,7 +142,7 @@ var _ = Describe("Licensemanager test", func() {
 
 			// Create App framework Spec
 			volumeName := "lm-test-volume-" + testenv.RandomDNSName(3)
-			volumeSpec := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volumeName, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+			volumeSpec := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volumeName, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3", testenv.GetDefaultS3Region())}
 
 			// AppSourceDefaultSpec: Remote Storage volume name and Scope of App deployment
 			appSourceDefaultSpec := enterpriseApi.AppSourceDefaultSpec{

--- a/test/m4/appframework/appframework_test.go
+++ b/test/m4/appframework/appframework_test.go
@@ -1307,7 +1307,7 @@ var _ = Describe("m4appfw test", func() {
 
 			// Create App framework Spec for Cluster manager with scope local and append cluster scope
 			appFrameworkSpecIdxc := testenv.GenerateAppFrameworkSpec(testenvInstance, appSourceVolumeNameIdxcLocal, enterpriseApi.ScopeLocal, appSourceNameLocalIdxc, s3TestDirIdxcLocal, 0)
-			volumeSpecCluster := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(appSourceVolumeNameIdxcCluster, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+			volumeSpecCluster := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(appSourceVolumeNameIdxcCluster, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3", testenv.GetDefaultS3Region())}
 			appFrameworkSpecIdxc.VolList = append(appFrameworkSpecIdxc.VolList, volumeSpecCluster...)
 			appSourceClusterDefaultSpec := enterpriseApi.AppSourceDefaultSpec{
 				VolName: appSourceVolumeNameIdxcCluster,
@@ -1318,7 +1318,7 @@ var _ = Describe("m4appfw test", func() {
 
 			// Create App framework Spec for Search head cluster with scope local and append cluster scope
 			appFrameworkSpecShc := testenv.GenerateAppFrameworkSpec(testenvInstance, appSourceVolumeNameShcLocal, enterpriseApi.ScopeLocal, appSourceNameLocalShc, s3TestDirShcLocal, 0)
-			volumeSpecCluster = []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(appSourceVolumeNameShcCluster, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+			volumeSpecCluster = []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(appSourceVolumeNameShcCluster, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3", testenv.GetDefaultS3Region())}
 			appFrameworkSpecShc.VolList = append(appFrameworkSpecShc.VolList, volumeSpecCluster...)
 			appSourceClusterDefaultSpec = enterpriseApi.AppSourceDefaultSpec{
 				VolName: appSourceVolumeNameShcCluster,

--- a/test/smartstore/smartstore_test.go
+++ b/test/smartstore/smartstore_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Smartstore test", func() {
 			testenvInstance.Log.Info("Index secret name ", "secret name ", testenvInstance.GetIndexSecretName())
 
 			var indexSpec []enterpriseApi.IndexSpec
-			volumeSpec := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volName, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+			volumeSpec := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volName, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3", testenv.GetDefaultS3Region())}
 
 			// Create index volume spec from index volume map
 			for index, volume := range indexVolumeMap {
@@ -87,7 +87,7 @@ var _ = Describe("Smartstore test", func() {
 
 			specialConfig := map[string]int{"MaxGlobalDataSizeMB": 100, "MaxGlobalRawDataSizeMB": 100}
 
-			volSpec := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volName, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+			volSpec := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volName, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3", testenv.GetDefaultS3Region())}
 			indexSpec := []enterpriseApi.IndexSpec{{Name: indexName, RemotePath: indexName}}
 			defaultSmartStoreSpec := enterpriseApi.IndexConfDefaultsSpec{IndexAndGlobalCommonSpec: enterpriseApi.IndexAndGlobalCommonSpec{VolName: volName, MaxGlobalDataSizeMB: uint(specialConfig["MaxGlobalDataSizeMB"]), MaxGlobalRawDataSizeMB: uint(specialConfig["MaxGlobalRawDataSizeMB"])}}
 			cacheManagerSmartStoreSpec := enterpriseApi.CacheManagerSpec{MaxCacheSizeMB: 9900000, EvictionPaddingSizeMB: 1000, MaxConcurrentDownloads: 6, MaxConcurrentUploads: 6, EvictionPolicy: "lru"}
@@ -151,7 +151,7 @@ var _ = Describe("Smartstore test", func() {
 			volName := "test-volume-" + testenv.RandomDNSName(3)
 			indexName := "test-index-" + testenv.RandomDNSName(3)
 
-			volSpec := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volName, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+			volSpec := []enterpriseApi.VolumeSpec{testenv.GenerateIndexVolumeSpec(volName, testenv.GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3", testenv.GetDefaultS3Region())}
 			indexSpec := []enterpriseApi.IndexSpec{testenv.GenerateIndexSpec(indexName, volName)}
 			smartStoreSpec := enterpriseApi.SmartStoreSpec{
 				VolList:   volSpec,

--- a/test/testenv/appframework_utils.go
+++ b/test/testenv/appframework_utils.go
@@ -299,7 +299,7 @@ func GetAppDeploymentInfo(deployment *Deployment, testenvInstance *TestEnv, name
 func GenerateAppFrameworkSpec(testenvInstance *TestEnv, volumeName string, scope string, appSourceName string, s3TestDir string, pollInterval int) enterpriseApi.AppFrameworkSpec {
 
 	// Create App framework volume
-	volumeSpec := []enterpriseApi.VolumeSpec{GenerateIndexVolumeSpec(volumeName, GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3")}
+	volumeSpec := []enterpriseApi.VolumeSpec{GenerateIndexVolumeSpec(volumeName, GetS3Endpoint(), testenvInstance.GetIndexSecretName(), "aws", "s3", GetDefaultS3Region())}
 
 	// AppSourceDefaultSpec: Remote Storage volume name and Scope of App deployment
 	appSourceDefaultSpec := enterpriseApi.AppSourceDefaultSpec{

--- a/test/testenv/remote_index_utils.go
+++ b/test/testenv/remote_index_utils.go
@@ -85,7 +85,7 @@ func RollHotToWarm(deployment *Deployment, podName string, indexName string) boo
 }
 
 // GenerateIndexVolumeSpec return VolumeSpec struct with given values
-func GenerateIndexVolumeSpec(volumeName string, endpoint string, secretRef string, provider string, storageType string) enterpriseApi.VolumeSpec {
+func GenerateIndexVolumeSpec(volumeName string, endpoint string, secretRef string, provider string, storageType string, region string) enterpriseApi.VolumeSpec {
 	return enterpriseApi.VolumeSpec{
 		Name:      volumeName,
 		Endpoint:  endpoint,
@@ -93,6 +93,7 @@ func GenerateIndexVolumeSpec(volumeName string, endpoint string, secretRef strin
 		SecretRef: secretRef,
 		Provider:  provider,
 		Type:      storageType,
+		Region:    region,
 	}
 }
 


### PR DESCRIPTION
**Problem**
Because of the issue mentioned [here](https://github.com/splunk/splunk-operator/issues/655), we were not able to pass in the region for a S3 compatible storage other than AWS and hence it would pass empty value as region.

**Solution**
Add `region` field as part of volume spec so that users can directly specify the region irrespective of the remote storage they are using.