### PR TITLE
CSPL 1218: App framework authentication tests

### DIFF
--- a/test/c3/appframework/appframework_test.go
+++ b/test/c3/appframework/appframework_test.go
@@ -2524,8 +2524,7 @@ var _ = Describe("c3appfw test", func() {
 			testenv.VerifyAppState(ctx, deployment, testcaseEnvInst, deployment.GetName(), cm.Kind, appSourceNameIdxc, appFileList, enterpriseApi.AppPkgDownloadComplete, enterpriseApi.AppPkgDownloadPending)
 
 			// Delete Operator pod while Install in progress
-			opPod := testenv.GetOperatorPodName(testcaseEnvInst.GetName())
-			testenv.DeletePod(testcaseEnvInst.GetName(), opPod)
+			testenv.DeleteOperatorPod(testcaseEnvInst)
 
 			// Ensure Cluster Manager goes to Ready phase
 			testenv.ClusterManagerReady(ctx, deployment, testcaseEnvInst)

--- a/test/c3/appframework/appframework_test.go
+++ b/test/c3/appframework/appframework_test.go
@@ -2524,7 +2524,8 @@ var _ = Describe("c3appfw test", func() {
 			testenv.VerifyAppState(ctx, deployment, testcaseEnvInst, deployment.GetName(), cm.Kind, appSourceNameIdxc, appFileList, enterpriseApi.AppPkgDownloadComplete, enterpriseApi.AppPkgDownloadPending)
 
 			// Delete Operator pod while Install in progress
-			testenv.DeleteOperatorPod(testcaseEnvInst)
+			opPod := testenv.GetOperatorPodName(testcaseEnvInst.GetName())
+			testenv.DeletePod(testcaseEnvInst.GetName(), opPod)
 
 			// Ensure Cluster Manager goes to Ready phase
 			testenv.ClusterManagerReady(ctx, deployment, testcaseEnvInst)


### PR DESCRIPTION
a test case with the following -

- Use random credentials
- Attempt Install an app from remote store, expect it to fail
- Change remote store credentials  to a new valid set
- Install a new app or update existing app from remote store, expect it to pass

Clean Run: https://github.com/splunk/splunk-operator/runs/6103552270?check_suite_focus=true