### PR TITLE
CSPL-1737: Smartstore init container fails to initialize due to incorrect imagePullPolicy

### DIFF
--- a/pkg/splunk/enterprise/clustermaster.go
+++ b/pkg/splunk/enterprise/clustermaster.go
@@ -258,7 +258,7 @@ func getClusterManagerStatefulSet(ctx context.Context, client splcommon.Controll
 	smartStoreConfigMap := getSmartstoreConfigMap(ctx, client, cr, SplunkClusterManager)
 
 	if smartStoreConfigMap != nil {
-		setupInitContainer(&ss.Spec.Template, cr.Spec.Image, cr.Spec.Image, commandForCMSmartstore)
+		setupInitContainer(&ss.Spec.Template, cr.Spec.Image, cr.Spec.ImagePullPolicy, commandForCMSmartstore)
 	}
 
 	// Setup App framework init containers


### PR DESCRIPTION
The [PR](https://github.com/splunk/splunk-operator/pull/723) for enterpriseApi changes introduced a [bug](https://github.com/splunk/splunk-operator/pull/723/files#r853401204) where wrong parameters are passed in **clustermaster.go** for the function setupInitContainer i.e image vs imagePullPolicy.