### PR TITLE
CSPL-1762 - Remove remotepath docs example in defaults

### DIFF
--- a/docs/CustomResources.md
+++ b/docs/CustomResources.md
@@ -204,7 +204,6 @@ metadata:
 spec:
   smartstore:
     defaults:
-        remotePath: $_index_name
         volumeName: msos_s2s3_vol
     indexes:
       - name: salesdata1


### PR DESCRIPTION
Docs change to fix github [issue](https://github.com/splunk/splunk-operator/issues/761) involving `remotePath` in smartstore defaults config