### PR TITLE
CSPL- 1768 - Adding an annotation to define a default container

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,6 +25,8 @@ spec:
       labels:
         control-plane: controller-manager
         name: splunk-operator
+      annotations:
+        kubectl.kubernetes.io/default-logs-container: manager
     spec:
       securityContext:
         runAsUser: 1001
@@ -72,22 +74,9 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        #resources:
-        #  limits:
-        #    cpu: 1000m
-        #    memory: 1000Mi
-        #  requests:
-        #    cpu: 1000m
-        #    memory: 1000Mi
-        #volumeMounts:
-        #  - mountPath: /opt/splunk/appframework/
-        #    name: app-staging
       serviceAccountName: controller-manager
       volumes:
       - configMap:
           name: config
         name: splunk-operator-config
-      #  - name:  app-staging
-      #    persistentVolumeClaim:
-      #      claimName: tmp-app-download
       terminationGracePeriodSeconds: 10

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,6 +27,7 @@ spec:
         name: splunk-operator
       annotations:
         kubectl.kubernetes.io/default-logs-container: manager
+        kubectl.kubernetes.io/default-container: manager
     spec:
       securityContext:
         runAsUser: 1001


### PR DESCRIPTION
Adding an annotation to define a default container for the operator deployment pod. Addressing github enhancement [request](https://github.com/splunk/splunk-operator/issues/765) 