### PR TITLE
CSPL-1727: Manifest files to differentiate namespace scoped and cluster scoped

### DIFF
--- a/.github/workflows/automated-release-workflow.yml
+++ b/.github/workflows/automated-release-workflow.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Create Release
       uses: ncipollo/release-action@40bb172bd05f266cf9ba4ff965cb61e9ee5f6d01
       with:
-        artifacts: "release-${{ github.event.inputs.release_version }}/splunk-operator-install.yaml"
+        artifacts: "release-${{ github.event.inputs.release_version }}/splunk-operator-cluster.yaml"
         bodyFile: "docs/ReleaseNotes.md"
         tag: "${{ github.event.inputs.release_version }}"
         draft: true

--- a/Makefile
+++ b/Makefile
@@ -289,23 +289,23 @@ run_clair_scan:
 generate-artifacts-namespace: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	mkdir -p release-${VERSION}
 	cp config/default/kustomization-namespace.yaml config/default/kustomization.yaml
-	sed -i "" "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
-	sed -i "" "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
-	sed -i "" "s/ClusterRole/Role/g"  config/rbac/role.yaml
-	sed -i "" "s/ClusterRole/Role/g"  config/rbac/role_binding.yaml
+	sed -i "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
+	sed -i "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
+	sed -i "s/ClusterRole/Role/g"  config/rbac/role.yaml
+	sed -i "s/ClusterRole/Role/g"  config/rbac/role_binding.yaml
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	RELATED_IMAGE_SPLUNK_ENTERPRISE=${SPLUNK_ENTERPRISE_IMAGE} WATCH_NAMESPACE=${WATCH_NAMESPACE} $(KUSTOMIZE) build config/default > release-${VERSION}/splunk-operator-namespace.yaml
-	sed -i "" "s/Role/ClusterRole/g"  config/rbac/role.yaml
-	sed -i "" "s/Role/ClusterRole/g"  config/rbac/role_binding.yaml
+	sed -i "s/Role/ClusterRole/g"  config/rbac/role.yaml
+	sed -i "s/Role/ClusterRole/g"  config/rbac/role_binding.yaml
 
 
 # generate artifacts needed to deploy operator, this is current way of doing it, need to fix this
 generate-artifacts-cluster: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	mkdir -p release-${VERSION}
 	cp config/default/kustomization-cluster.yaml config/default/kustomization.yaml
-	sed -i "" "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
-	sed -i "" "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
-	sed -i "" "s/WATCH_NAMESPACE_VALUE/\"${WATCH_NAMESPACE}\"/g"  config/default/kustomization.yaml
+	sed -i "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
+	sed -i "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
+	sed -i "s/WATCH_NAMESPACE_VALUE/\"${WATCH_NAMESPACE}\"/g"  config/default/kustomization.yaml
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	RELATED_IMAGE_SPLUNK_ENTERPRISE=${SPLUNK_ENTERPRISE_IMAGE} WATCH_NAMESPACE=${WATCH_NAMESPACE} $(KUSTOMIZE) build config/default > release-${VERSION}/splunk-operator-cluster.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,7 @@ generate-artifacts-cluster: manifests kustomize ## Deploy controller to the K8s 
 	cp config/default/kustomization-cluster.yaml config/default/kustomization.yaml
 	sed -i "" "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
 	sed -i "" "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
+	sed -i "" "s/WATCH_NAMESPACE_VALUE/\"${WATCH_NAMESPACE}\"/g"  config/default/kustomization.yaml
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	RELATED_IMAGE_SPLUNK_ENTERPRISE=${SPLUNK_ENTERPRISE_IMAGE} WATCH_NAMESPACE=${WATCH_NAMESPACE} $(KUSTOMIZE) build config/default > release-${VERSION}/splunk-operator-cluster.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	sed -i "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
 	sed -i "s/value: WATCH_NAMESPACE_VALUE/value: \"${WATCH_NAMESPACE}\"/g"  config/default/kustomization.yaml
-	sed -i "" "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
+	sed -i "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	RELATED_IMAGE_SPLUNK_ENTERPRISE=${SPLUNK_ENTERPRISE_IMAGE} WATCH_NAMESPACE=${WATCH_NAMESPACE} $(KUSTOMIZE) build config/default | kubectl apply -f -
 	sed -i "s/namespace: ${NAMESPACE}/namespace: splunk-operator/g"  config/default/kustomization.yaml

--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ cluster-up:
 cluster-down:
 	@test/deploy-cluster.sh down
 
-.PHONY: ins-test
+.PHONY: int-test
 int-test:
 	@echo Run integration test
 	@test/run-tests.sh

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,15 @@ else
 	SCANNER_FILE = clair-scanner_windows_amd64.exe
 endif
 
+SED := sed -i 
+ifeq ($(shell uname), Linux)
+	SED = sed -i  
+else ifeq ($(shell uname), Darwin)
+	SED = sed -i "" 
+else
+	SED = sed -i  
+endif
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -136,15 +145,15 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	sed -i "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
-	sed -i "s/value: WATCH_NAMESPACE_VALUE/value: \"${WATCH_NAMESPACE}\"/g"  config/default/kustomization.yaml
-	sed -i "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
+	${SED} "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
+	${SED} "s/value: WATCH_NAMESPACE_VALUE/value: \"${WATCH_NAMESPACE}\"/g"  config/default/kustomization.yaml
+	${SED} "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	RELATED_IMAGE_SPLUNK_ENTERPRISE=${SPLUNK_ENTERPRISE_IMAGE} WATCH_NAMESPACE=${WATCH_NAMESPACE} $(KUSTOMIZE) build config/default | kubectl apply -f -
-	sed -i "s/namespace: ${NAMESPACE}/namespace: splunk-operator/g"  config/default/kustomization.yaml
-	sed -i "s/value: \"${WATCH_NAMESPACE}\"/value: WATCH_NAMESPACE_VALUE/g"  config/default/kustomization.yaml
-	sed -i "s|${SPLUNK_ENTERPRISE_IMAGE}|SPLUNK_ENTERPRISE_IMAGE|g"  config/default/kustomization.yaml
-
+	${SED} "s/namespace: ${NAMESPACE}/namespace: splunk-operator/g"  config/default/kustomization.yaml
+	${SED} "s/value: \"${WATCH_NAMESPACE}\"/value: WATCH_NAMESPACE_VALUE/g"  config/default/kustomization.yaml
+	${SED} "s|${SPLUNK_ENTERPRISE_IMAGE}|SPLUNK_ENTERPRISE_IMAGE|g"  config/default/kustomization.yaml
+ 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
@@ -179,8 +188,8 @@ endef
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	operator-sdk generate kustomize manifests -q
 	cp config/default/kustomization-cluster.yaml config/default/kustomization.yaml
-	sed -i "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
-	sed -i "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
+	${SED} "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
+	${SED} "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle
@@ -289,23 +298,23 @@ run_clair_scan:
 generate-artifacts-namespace: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	mkdir -p release-${VERSION}
 	cp config/default/kustomization-namespace.yaml config/default/kustomization.yaml
-	sed -i "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
-	sed -i "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
-	sed -i "s/ClusterRole/Role/g"  config/rbac/role.yaml
-	sed -i "s/ClusterRole/Role/g"  config/rbac/role_binding.yaml
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	${SED} "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
+	${SED} "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
+	${SED} "s/ClusterRole/Role/g"  config/rbac/role.yaml
+	${SED} "s/ClusterRole/Role/g"  config/rbac/role_binding.yaml
+	cd conig/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	RELATED_IMAGE_SPLUNK_ENTERPRISE=${SPLUNK_ENTERPRISE_IMAGE} WATCH_NAMESPACE=${WATCH_NAMESPACE} $(KUSTOMIZE) build config/default > release-${VERSION}/splunk-operator-namespace.yaml
-	sed -i "s/Role/ClusterRole/g"  config/rbac/role.yaml
-	sed -i "s/Role/ClusterRole/g"  config/rbac/role_binding.yaml
+	${SED} "s/Role/ClusterRole/g"  config/rbac/role.yaml
+	${SED} "s/Role/ClusterRole/g"  config/rbac/role_binding.yaml
 
 
 # generate artifacts needed to deploy operator, this is current way of doing it, need to fix this
 generate-artifacts-cluster: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	mkdir -p release-${VERSION}
 	cp config/default/kustomization-cluster.yaml config/default/kustomization.yaml
-	sed -i "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
-	sed -i "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
-	sed -i "s/WATCH_NAMESPACE_VALUE/\"${WATCH_NAMESPACE}\"/g"  config/default/kustomization.yaml
+	${SED} "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
+	${SED} "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
+	${SED} "s/WATCH_NAMESPACE_VALUE/\"${WATCH_NAMESPACE}\"/g"  config/default/kustomization.yaml
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	RELATED_IMAGE_SPLUNK_ENTERPRISE=${SPLUNK_ENTERPRISE_IMAGE} WATCH_NAMESPACE=${WATCH_NAMESPACE} $(KUSTOMIZE) build config/default > release-${VERSION}/splunk-operator-cluster.yaml
 
@@ -313,8 +322,7 @@ generate-artifacts: generate-artifacts-cluster generate-artifacts-namespace
 	echo "artifacts generation complete"
 
 #############################
-export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
-export OS=$(uname | awk '{print tolower($0)}')
+
 GO_DOWNLOAD_URL=https://go.dev/dl/go1.17.7.darwin-amd64.pkg
 export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.17.0
 OPERATOR_SDK_DOWNLOAD_URL=curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}

--- a/Makefile
+++ b/Makefile
@@ -291,8 +291,12 @@ generate-artifacts-namespace: manifests kustomize ## Deploy controller to the K8
 	cp config/default/kustomization-namespace.yaml config/default/kustomization.yaml
 	sed -i "" "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
 	sed -i "" "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
+	sed -i "" "s/ClusterRole/Role/g"  config/rbac/role.yaml
+	sed -i "" "s/ClusterRole/Role/g"  config/rbac/role_binding.yaml
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	RELATED_IMAGE_SPLUNK_ENTERPRISE=${SPLUNK_ENTERPRISE_IMAGE} WATCH_NAMESPACE=${WATCH_NAMESPACE} $(KUSTOMIZE) build config/default > release-${VERSION}/splunk-operator-namespace.yaml
+	sed -i "" "s/Role/ClusterRole/g"  config/rbac/role.yaml
+	sed -i "" "s/Role/ClusterRole/g"  config/rbac/role_binding.yaml
 
 
 # generate artifacts needed to deploy operator, this is current way of doing it, need to fix this

--- a/Makefile
+++ b/Makefile
@@ -145,14 +145,14 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	${SED} "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
-	${SED} "s/value: WATCH_NAMESPACE_VALUE/value: \"${WATCH_NAMESPACE}\"/g"  config/default/kustomization.yaml
-	${SED} "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
+	$(SED) "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
+	$(SED) "s/value: WATCH_NAMESPACE_VALUE/value: \"${WATCH_NAMESPACE}\"/g"  config/default/kustomization.yaml
+	$(SED) "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	RELATED_IMAGE_SPLUNK_ENTERPRISE=${SPLUNK_ENTERPRISE_IMAGE} WATCH_NAMESPACE=${WATCH_NAMESPACE} $(KUSTOMIZE) build config/default | kubectl apply -f -
-	${SED} "s/namespace: ${NAMESPACE}/namespace: splunk-operator/g"  config/default/kustomization.yaml
-	${SED} "s/value: \"${WATCH_NAMESPACE}\"/value: WATCH_NAMESPACE_VALUE/g"  config/default/kustomization.yaml
-	${SED} "s|${SPLUNK_ENTERPRISE_IMAGE}|SPLUNK_ENTERPRISE_IMAGE|g"  config/default/kustomization.yaml
+	$(SED) "s/namespace: ${NAMESPACE}/namespace: splunk-operator/g"  config/default/kustomization.yaml
+	$(SED) "s/value: \"${WATCH_NAMESPACE}\"/value: WATCH_NAMESPACE_VALUE/g"  config/default/kustomization.yaml
+	$(SED) "s|${SPLUNK_ENTERPRISE_IMAGE}|SPLUNK_ENTERPRISE_IMAGE|g"  config/default/kustomization.yaml
  
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
@@ -188,8 +188,8 @@ endef
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	operator-sdk generate kustomize manifests -q
 	cp config/default/kustomization-cluster.yaml config/default/kustomization.yaml
-	${SED} "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
-	${SED} "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
+	$(SED) "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
+	$(SED) "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle
@@ -298,23 +298,23 @@ run_clair_scan:
 generate-artifacts-namespace: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	mkdir -p release-${VERSION}
 	cp config/default/kustomization-namespace.yaml config/default/kustomization.yaml
-	${SED} "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
-	${SED} "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
-	${SED} "s/ClusterRole/Role/g"  config/rbac/role.yaml
-	${SED} "s/ClusterRole/Role/g"  config/rbac/role_binding.yaml
+	$(SED) "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
+	$(SED) "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
+	$(SED) "s/ClusterRole/Role/g"  config/rbac/role.yaml
+	$(SED) "s/ClusterRole/Role/g"  config/rbac/role_binding.yaml
 	cd conig/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	RELATED_IMAGE_SPLUNK_ENTERPRISE=${SPLUNK_ENTERPRISE_IMAGE} WATCH_NAMESPACE=${WATCH_NAMESPACE} $(KUSTOMIZE) build config/default > release-${VERSION}/splunk-operator-namespace.yaml
-	${SED} "s/Role/ClusterRole/g"  config/rbac/role.yaml
-	${SED} "s/Role/ClusterRole/g"  config/rbac/role_binding.yaml
+	$(SED) "s/Role/ClusterRole/g"  config/rbac/role.yaml
+	$(SED) "s/Role/ClusterRole/g"  config/rbac/role_binding.yaml
 
 
 # generate artifacts needed to deploy operator, this is current way of doing it, need to fix this
 generate-artifacts-cluster: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	mkdir -p release-${VERSION}
 	cp config/default/kustomization-cluster.yaml config/default/kustomization.yaml
-	${SED} "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
-	${SED} "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
-	${SED} "s/WATCH_NAMESPACE_VALUE/\"${WATCH_NAMESPACE}\"/g"  config/default/kustomization.yaml
+	$(SED) "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
+	$(SED) "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
+	$(SED) "s/WATCH_NAMESPACE_VALUE/\"${WATCH_NAMESPACE}\"/g"  config/default/kustomization.yaml
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	RELATED_IMAGE_SPLUNK_ENTERPRISE=${SPLUNK_ENTERPRISE_IMAGE} WATCH_NAMESPACE=${WATCH_NAMESPACE} $(KUSTOMIZE) build config/default > release-${VERSION}/splunk-operator-cluster.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -277,8 +277,10 @@ run_clair_scan:
 generate-artifacts: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	mkdir -p release-${VERSION}
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	RELATED_IMAGE_SPLUNK_ENTERPRISE=${SPLUNK_ENTERPRISE_IMAGE} WATCH_NAMESPACE=${WATCH_NAMESPACE} $(KUSTOMIZE) build config/default > release-${VERSION}/splunk-operator-cluster.yaml
 	RELATED_IMAGE_SPLUNK_ENTERPRISE=${SPLUNK_ENTERPRISE_IMAGE} WATCH_NAMESPACE=${WATCH_NAMESPACE} $(KUSTOMIZE) build config/default > release-${VERSION}/splunk-operator-install.yaml
-
+	sed -i "s/ClusterRole/Role/g"  release-${VERSION}/splunk-operator-install.yaml
+	sed -i "s/ClusterRoleBinding/RoleBinding/g" release-${VERSION}/splunk-operator-install.yaml
 
 #############################
 export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)

--- a/Makefile
+++ b/Makefile
@@ -136,14 +136,14 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	sed -i "" "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
-	sed -i "" "s/value: WATCH_NAMESPACE_VALUE/value: \"${WATCH_NAMESPACE}\"/g"  config/default/kustomization.yaml
+	sed -i "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
+	sed -i "s/value: WATCH_NAMESPACE_VALUE/value: \"${WATCH_NAMESPACE}\"/g"  config/default/kustomization.yaml
 	sed -i "" "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	RELATED_IMAGE_SPLUNK_ENTERPRISE=${SPLUNK_ENTERPRISE_IMAGE} WATCH_NAMESPACE=${WATCH_NAMESPACE} $(KUSTOMIZE) build config/default | kubectl apply -f -
-	sed -i "" "s/namespace: ${NAMESPACE}/namespace: splunk-operator/g"  config/default/kustomization.yaml
-	sed -i "" "s/value: \"${WATCH_NAMESPACE}\"/value: WATCH_NAMESPACE_VALUE/g"  config/default/kustomization.yaml
-	sed -i "" "s|${SPLUNK_ENTERPRISE_IMAGE}|SPLUNK_ENTERPRISE_IMAGE|g"  config/default/kustomization.yaml
+	sed -i "s/namespace: ${NAMESPACE}/namespace: splunk-operator/g"  config/default/kustomization.yaml
+	sed -i "s/value: \"${WATCH_NAMESPACE}\"/value: WATCH_NAMESPACE_VALUE/g"  config/default/kustomization.yaml
+	sed -i "s|${SPLUNK_ENTERPRISE_IMAGE}|SPLUNK_ENTERPRISE_IMAGE|g"  config/default/kustomization.yaml
 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
@@ -179,8 +179,8 @@ endef
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	operator-sdk generate kustomize manifests -q
 	cp config/default/kustomization-cluster.yaml config/default/kustomization.yaml
-	sed -i "" "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
-	sed -i "" "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
+	sed -i "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
+	sed -i "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle

--- a/config/default/kustomization-cluster.yaml
+++ b/config/default/kustomization-cluster.yaml
@@ -122,9 +122,9 @@ patches:
       path: /spec/template/spec/containers/0/env
       value: 
       - name: WATCH_NAMESPACE
-        value: ""
+        value: WATCH_NAMESPACE_VALUE
       - name: RELATED_IMAGE_SPLUNK_ENTERPRISE
-        value: splunk/splunk:8.2.6
+        value: SPLUNK_ENTERPRISE_IMAGE
       - name: OPERATOR_NAME
         value: splunk-operator
       - name: POD_NAME

--- a/config/default/kustomization-cluster.yaml
+++ b/config/default/kustomization-cluster.yaml
@@ -119,7 +119,7 @@ patches:
     name: controller-manager
   patch: |-
     - op: add
-      path: /spec/template/spec/containers/0/env
+      path: /spec/template/spec/containers/1/env
       value: 
       - name: WATCH_NAMESPACE
         value: WATCH_NAMESPACE_VALUE

--- a/config/default/kustomization-namespace.yaml
+++ b/config/default/kustomization-namespace.yaml
@@ -119,7 +119,7 @@ patches:
     name: controller-manager
   patch: |-
     - op: add
-      path: /spec/template/spec/containers/0/env
+      path: /spec/template/spec/containers/1/env
       value: 
       - name: WATCH_NAMESPACE
         valueFrom:

--- a/config/default/kustomization-namespace.yaml
+++ b/config/default/kustomization-namespace.yaml
@@ -122,9 +122,11 @@ patches:
       path: /spec/template/spec/containers/0/env
       value: 
       - name: WATCH_NAMESPACE
-        value: ""
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
       - name: RELATED_IMAGE_SPLUNK_ENTERPRISE
-        value: splunk/splunk:8.2.6
+        value: SPLUNK_ENTERPRISE_IMAGE
       - name: OPERATOR_NAME
         value: splunk-operator
       - name: POD_NAME

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -119,7 +119,7 @@ patches:
     name: controller-manager
   patch: |-
     - op: add
-      path: /spec/template/spec/containers/0/env
+      path: /spec/template/spec/containers/1/env
       value: 
       - name: WATCH_NAMESPACE
         value: ""

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -43,21 +43,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: WATCH_NAMESPACE
-          valueFrom:
-            configMapKeyRef:
-              name: splunk-operator-config
-              key: WATCH_NAMESPACE
-        - name: RELATED_IMAGE_SPLUNK_ENTERPRISE
-          valueFrom:
-            configMapKeyRef:
-              name: splunk-operator-config
-              key: RELATED_IMAGE_SPLUNK_ENTERPRISE
-        - name: OPERATOR_NAME
-          valueFrom:
-            configMapKeyRef:
-              name: splunk-operator-config
-              key: OPERATOR_NAME
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -7,7 +7,7 @@
 If you want to customize the installation of the Splunk Operator, download a copy of the installation YAML locally, and open it in your favorite editor.
 
 ```
-wget -O splunk-operator-install.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-install.yaml
+wget -O splunk-operator-cluster.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-cluster.yaml
 ```
 
 ## Default Installation
@@ -15,7 +15,7 @@ wget -O splunk-operator-install.yaml https://github.com/splunk/splunk-operator/r
 By default operator will be installed in `splunk-operator` namespace and will watch all the namespaces of your cluster for splunk enterprise custom resources
 
 ```
-wget -O splunk-operator-install.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-install.yaml
+wget -O splunk-operator-install.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-cluster.yaml
 kubectl apply -f splunk-operator-install.yaml
 ```
 
@@ -53,6 +53,14 @@ metadata:
     name: splunk-operator
   name: splunk-operator-config
   namespace: splunk-operator
+```
+## Install operator to watch single namespace with restrictive permission
+
+In order to install operator with restrictive permission to watch only single namespace use [splunk-operator-install.yaml](https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-cluster.yaml). This will create Role and Role-Binding to only watch single namespace. By default operator will be installed in `splunk-operator` namespace, user can edit the file to change the namespace
+
+```
+wget -O splunk-operator-install.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-install.yaml
+kubectl apply -f splunk-operator-install.yaml
 ```
 
 ## Private Registries

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -15,8 +15,8 @@ wget -O splunk-operator-cluster.yaml https://github.com/splunk/splunk-operator/r
 By default operator will be installed in `splunk-operator` namespace and will watch all the namespaces of your cluster for splunk enterprise custom resources
 
 ```
-wget -O splunk-operator-install.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-cluster.yaml
-kubectl apply -f splunk-operator-install.yaml
+wget -O splunk-operator-cluster.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-cluster.yaml
+kubectl apply -f splunk-operator-cluster.yaml
 ```
 
 ## Install operator to watch single namespace
@@ -56,11 +56,11 @@ metadata:
 ```
 ## Install operator to watch single namespace with restrictive permission
 
-In order to install operator with restrictive permission to watch only single namespace use [splunk-operator-install.yaml](https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-cluster.yaml). This will create Role and Role-Binding to only watch single namespace. By default operator will be installed in `splunk-operator` namespace, user can edit the file to change the namespace
+In order to install operator with restrictive permission to watch only single namespace use [splunk-operator-namespace.yaml](https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-namespace.yaml). This will create Role and Role-Binding to only watch single namespace. By default operator will be installed in `splunk-operator` namespace, user can edit the file to change the namespace
 
 ```
-wget -O splunk-operator-install.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-install.yaml
-kubectl apply -f splunk-operator-install.yaml
+wget -O splunk-operator-namespace.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-namespace.yaml
+kubectl apply -f splunk-operator-namespace.yaml
 ```
 
 ## Private Registries


### PR DESCRIPTION
Now there will 2 different manifest files generated for release. (as earlier)
1. namespace scoped - `splunk-operator-install.yaml`
2. cluster scoped - `splunk-operator-cluster.yaml`
