### PR TITLE
Update the fsGroup context to 1001 on Operator Pod.

### DIFF
--- a/bundle/manifests/splunk-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/splunk-operator.clusterserviceversion.yaml
@@ -488,6 +488,7 @@ spec:
                   allowPrivilegeEscalation: false
               securityContext:
                 runAsUser: 1001
+                fsGroup: 1001
               serviceAccountName: splunk-operator-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:

--- a/docs/AppFramework.md
+++ b/docs/AppFramework.md
@@ -421,6 +421,7 @@ spec:
         name: splunk-operator
     spec:
       securityContext:
+        runAsUser: 1001
         fsGroup: 1001
       serviceAccountName: splunk-operator
       containers:


### PR DESCRIPTION
Update the fsGroup context to 1001, so that the mounted volume is accessible to the app framework.