### PR TITLE
CSPL-1600: Insufficient disk space on operator PV

### DIFF
--- a/test/c3/appframework/appframework_suite_test.go
+++ b/test/c3/appframework/appframework_suite_test.go
@@ -37,18 +37,20 @@ const (
 )
 
 var (
-	testenvInstance  *testenv.TestEnv
-	testSuiteName    = "c3appfw-" + testenv.RandomDNSName(3)
-	appListV1        []string
-	appListV2        []string
-	testDataS3Bucket = os.Getenv("TEST_BUCKET")
-	testS3Bucket     = os.Getenv("TEST_INDEXES_S3_BUCKET")
-	s3AppDirV1       = testenv.AppLocationV1
-	s3AppDirV2       = testenv.AppLocationV2
-	s3AppDirDisabled = testenv.AppLocationDisabledApps
-	currDir, _       = os.Getwd()
-	downloadDirV1    = filepath.Join(currDir, "c3appfwV1-"+testenv.RandomDNSName(4))
-	downloadDirV2    = filepath.Join(currDir, "c3appfwV2-"+testenv.RandomDNSName(4))
+	testenvInstance       *testenv.TestEnv
+	testSuiteName         = "c3appfw-" + testenv.RandomDNSName(3)
+	appListV1             []string
+	appListV2             []string
+	testDataS3Bucket      = os.Getenv("TEST_BUCKET")
+	testS3Bucket          = os.Getenv("TEST_INDEXES_S3_BUCKET")
+	s3AppDirV1            = testenv.AppLocationV1
+	s3AppDirV2            = testenv.AppLocationV2
+	s3AppDirDisabled      = testenv.AppLocationDisabledApps
+	s3PVTestApps          = testenv.PVTestAppsLocation
+	currDir, _            = os.Getwd()
+	downloadDirV1         = filepath.Join(currDir, "c3appfwV1-"+testenv.RandomDNSName(4))
+	downloadDirV2         = filepath.Join(currDir, "c3appfwV2-"+testenv.RandomDNSName(4))
+	downloadDirPVTestApps = filepath.Join(currDir, "c3appfwPVTestApps-"+testenv.RandomDNSName(4))
 )
 
 // TestBasic is the main entry point

--- a/test/c3/appframework/appframework_test.go
+++ b/test/c3/appframework/appframework_test.go
@@ -2806,7 +2806,95 @@ var _ = Describe("c3appfw test", func() {
 			shcAppSourceInfo.CrAppFileList = testenv.GetAppFileList(appListV2)
 			allAppSourceInfo = []testenv.AppSourceInfo{cmAppSourceInfo, shcAppSourceInfo}
 			testenv.AppFrameWorkVerifications(ctx, deployment, testcaseEnvInst, allAppSourceInfo, splunkPodAge, clusterManagerBundleHash)
+		})
+	})
 
+	Context("Clustered deployment (C3 - clustered indexer, search head cluster)", func() {
+		It("c3, integration, appframeworkc3, appframework: can deploy a C3 SVA and install a bigger volume of apps than the operator PV disk space", func() {
+
+			/* Test Steps
+			   ################## SETUP ####################
+			   * Upload 15 apps of 100MB size each to S3 for Indexer Cluster and Search Head Cluster for cluster scope
+			   * Create app sources for Cluster Manager and Deployer with cluster scope
+			   * Prepare and deploy C3 CRD with app framework and wait for the pods to be ready
+			   ######### INITIAL VERIFICATIONS #############
+			   * Verify Apps are Downloaded in App Deployment Info
+			   * Verify Apps Copied in App Deployment Info
+			   * Verify App Package is deleted from Operator Pod
+			   * Verify Apps Installed in App Deployment Info
+			   * Verify App Package is deleted from Splunk Pod
+			   * Verify bundle push is successful
+			   * Verify  apps are copied, installed on Search Heads and Indexers pods
+			*/
+
+			//################## SETUP ####################
+			// Download 15 apps around 100MB each (Total 1.4GB) to have total volume above Operator PV default size (1GB)
+			appVersion := "V1"
+			appList := testenv.PVTestApps
+			appFileList := testenv.GetAppFileList(appList)
+			err := testenv.DownloadFilesFromS3(testDataS3Bucket, s3PVTestApps, downloadDirPVTestApps, appFileList)
+			Expect(err).To(Succeed(), "Unable to download app files")
+
+			// Upload apps to S3 for Indexer Cluster
+			testcaseEnvInst.Log.Info("Upload 15 apps around 100MB each (Total 1.4GB) for Indexer Cluster to be above Operator PV default size (1GB)")
+			s3TestDirIdxc := "c3appfw-idxc-" + testenv.RandomDNSName(4)
+			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDirIdxc, appFileList, downloadDirPVTestApps)
+			Expect(err).To(Succeed(), fmt.Sprintf("Unable to upload %s apps to S3 test directory for Indexer Cluster", appVersion))
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+
+			// Upload apps to S3 for Search Head Cluster
+			testcaseEnvInst.Log.Info("Upload 15 apps around 100MB each (Total 1.4GB) for Search Head Cluster to be above Operator PV default size (1GB)")
+			s3TestDirShc := "c3appfw-shc-" + testenv.RandomDNSName(4)
+			uploadedFiles, err = testenv.UploadFilesToS3(testS3Bucket, s3TestDirShc, appFileList, downloadDirPVTestApps)
+			Expect(err).To(Succeed(), fmt.Sprintf("Unable to upload %s apps to S3 test directory for Search Head Cluster", appVersion))
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+
+			// Maximum apps to be downloaded in parallel
+			maxConcurrentAppDownloads := 30
+
+			// Create App framework Spec for C3
+			appSourceNameIdxc := "appframework-idxc-" + enterpriseApi.ScopeCluster + testenv.RandomDNSName(3)
+			appSourceNameShc := "appframework-shc-" + enterpriseApi.ScopeCluster + testenv.RandomDNSName(3)
+			appSourceVolumeNameIdxc := "appframework-test-volume-idxc-" + testenv.RandomDNSName(3)
+			appSourceVolumeNameShc := "appframework-test-volume-shc-" + testenv.RandomDNSName(3)
+			appFrameworkSpecIdxc := testenv.GenerateAppFrameworkSpec(testcaseEnvInst, appSourceVolumeNameIdxc, enterpriseApi.ScopeCluster, appSourceNameIdxc, s3TestDirIdxc, 60)
+			appFrameworkSpecIdxc.MaxConcurrentAppDownloads = uint64(maxConcurrentAppDownloads)
+			appFrameworkSpecShc := testenv.GenerateAppFrameworkSpec(testcaseEnvInst, appSourceVolumeNameShc, enterpriseApi.ScopeCluster, appSourceNameShc, s3TestDirShc, 60)
+			appFrameworkSpecShc.MaxConcurrentAppDownloads = uint64(maxConcurrentAppDownloads)
+
+			// Deploy C3 CRD
+			testcaseEnvInst.Log.Info("Deploy Single Site Indexer Cluster with Search Head Cluster")
+			indexerReplicas := 3
+			shReplicas := 3
+			cm, _, shc, err := deployment.DeploySingleSiteClusterWithGivenAppFrameworkSpec(ctx, deployment.GetName(), indexerReplicas, true, appFrameworkSpecIdxc, appFrameworkSpecShc, "", "")
+
+			Expect(err).To(Succeed(), "Unable to deploy Single Site Indexer Cluster with Search Head Cluster")
+
+			// Ensure that the Cluster Manager goes to Ready phase
+			testenv.ClusterManagerReady(ctx, deployment, testcaseEnvInst)
+
+			// Ensure Indexers go to Ready phase
+			testenv.SingleSiteIndexersReady(ctx, deployment, testcaseEnvInst)
+
+			// Ensure Search Head Cluster go to Ready phase
+			testenv.SearchHeadClusterReady(ctx, deployment, testcaseEnvInst)
+
+			// Verify RF SF is met
+			testenv.VerifyRFSFMet(ctx, deployment, testcaseEnvInst)
+
+			// Get Pod age to check for pod resets later
+			splunkPodAge := testenv.GetPodsStartTime(testcaseEnvInst.GetName())
+
+			//############ INITIAL VERIFICATIONS ##########
+			var idxcPodNames, shcPodNames []string
+			idxcPodNames = testenv.GeneratePodNameSlice(testenv.IndexerPod, deployment.GetName(), indexerReplicas, false, 1)
+			shcPodNames = testenv.GeneratePodNameSlice(testenv.SearchHeadPod, deployment.GetName(), indexerReplicas, false, 1)
+			cmPod := []string{fmt.Sprintf(testenv.ClusterManagerPod, deployment.GetName())}
+			deployerPod := []string{fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
+			cmAppSourceInfo := testenv.AppSourceInfo{CrKind: cm.Kind, CrName: cm.Name, CrAppSourceName: appSourceNameIdxc, CrAppSourceVolumeName: appSourceVolumeNameIdxc, CrPod: cmPod, CrAppVersion: appVersion, CrAppScope: enterpriseApi.ScopeCluster, CrAppList: appList, CrAppFileList: appFileList, CrReplicas: indexerReplicas, CrClusterPods: idxcPodNames}
+			shcAppSourceInfo := testenv.AppSourceInfo{CrKind: shc.Kind, CrName: shc.Name, CrAppSourceName: appSourceNameShc, CrAppSourceVolumeName: appSourceVolumeNameShc, CrPod: deployerPod, CrAppVersion: appVersion, CrAppScope: enterpriseApi.ScopeCluster, CrAppList: appList, CrAppFileList: appFileList, CrReplicas: shReplicas, CrClusterPods: shcPodNames}
+			allAppSourceInfo := []testenv.AppSourceInfo{cmAppSourceInfo, shcAppSourceInfo}
+			testenv.AppFrameWorkVerifications(ctx, deployment, testcaseEnvInst, allAppSourceInfo, splunkPodAge, "")
 		})
 	})
 })

--- a/test/m4/appframework/appframework_suite_test.go
+++ b/test/m4/appframework/appframework_suite_test.go
@@ -37,18 +37,20 @@ const (
 )
 
 var (
-	testenvInstance  *testenv.TestEnv
-	testSuiteName    = "m4appfw-" + testenv.RandomDNSName(3)
-	appListV1        []string
-	appListV2        []string
-	testDataS3Bucket = os.Getenv("TEST_BUCKET")
-	testS3Bucket     = os.Getenv("TEST_INDEXES_S3_BUCKET")
-	s3AppDirV1       = testenv.AppLocationV1
-	s3AppDirV2       = testenv.AppLocationV2
-	s3AppDirDisabled = testenv.AppLocationDisabledApps
-	currDir, _       = os.Getwd()
-	downloadDirV1    = filepath.Join(currDir, "m4appfwV1-"+testenv.RandomDNSName(4))
-	downloadDirV2    = filepath.Join(currDir, "m4appfwV2-"+testenv.RandomDNSName(4))
+	testenvInstance       *testenv.TestEnv
+	testSuiteName         = "m4appfw-" + testenv.RandomDNSName(3)
+	appListV1             []string
+	appListV2             []string
+	testDataS3Bucket      = os.Getenv("TEST_BUCKET")
+	testS3Bucket          = os.Getenv("TEST_INDEXES_S3_BUCKET")
+	s3AppDirV1            = testenv.AppLocationV1
+	s3AppDirV2            = testenv.AppLocationV2
+	s3AppDirDisabled      = testenv.AppLocationDisabledApps
+	s3PVTestApps          = testenv.PVTestAppsLocation
+	currDir, _            = os.Getwd()
+	downloadDirV1         = filepath.Join(currDir, "m4appfwV1-"+testenv.RandomDNSName(4))
+	downloadDirV2         = filepath.Join(currDir, "m4appfwV2-"+testenv.RandomDNSName(4))
+	downloadDirPVTestApps = filepath.Join(currDir, "m4appfwPVTestApps-"+testenv.RandomDNSName(4))
 )
 
 // TestBasic is the main entry point

--- a/test/m4/appframework/appframework_test.go
+++ b/test/m4/appframework/appframework_test.go
@@ -2377,4 +2377,90 @@ var _ = Describe("m4appfw test", func() {
 			testenv.AppFrameWorkVerifications(ctx, deployment, testcaseEnvInst, allAppSourceInfo, splunkPodAge, clusterManagerBundleHash)
 		})
 	})
+
+	Context("Multisite Indexer Cluster with Search Head Cluster (m4) with App Framework", func() {
+		It("m4, integration, appframeworkm4, appframework: can deploy a M4 SVA and install a bigger volume of apps than the operator PV disk space", func() {
+
+			/* Test Steps
+			   ################## SETUP ####################
+			   * Upload 15 apps of 100MB size each to S3 for Indexer Cluster and Search Head Cluster for cluster scope
+			   * Create app sources for Cluster Manager and Deployer with cluster scope
+			   * Prepare and deploy M4 CRD with app framework and wait for the pods to be ready
+			   ######### INITIAL VERIFICATIONS #############
+			   * Verify Apps are Downloaded in App Deployment Info
+			   * Verify Apps Copied in App Deployment Info
+			   * Verify App Package is deleted from Operator Pod
+			   * Verify Apps Installed in App Deployment Info
+			   * Verify App Package is deleted from Splunk Pod
+			   * Verify bundle push is successful
+			   * Verify  apps are copied, installed on Search Heads and Indexers pods
+			*/
+
+			//################## SETUP ####################
+			// Download 15 apps around 100MB each (Total 1.4GB) to have total volume above Operator PV default size (1GB)
+			appVersion := "V1"
+			appList := testenv.PVTestApps
+			appFileList := testenv.GetAppFileList(appList)
+			err := testenv.DownloadFilesFromS3(testDataS3Bucket, s3PVTestApps, downloadDirPVTestApps, appFileList)
+			Expect(err).To(Succeed(), "Unable to download app files")
+
+			// Upload apps to S3 for Indexer Cluster
+			testcaseEnvInst.Log.Info("Upload 15 apps around 100MB each (Total 1.4GB) for Indexer Cluster to be above Operator PV default size (1GB)")
+			s3TestDirIdxc := "m4appfw-idxc-" + testenv.RandomDNSName(4)
+			uploadedFiles, err := testenv.UploadFilesToS3(testS3Bucket, s3TestDirIdxc, appFileList, downloadDirPVTestApps)
+			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory for Indexer Cluster")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+
+			// Upload apps to S3 for Search Head Cluster
+			testcaseEnvInst.Log.Info("Upload 15 apps around 100MB each (Total 1.4GB) for Search Head Cluster to be above Operator PV default size (1GB)")
+			s3TestDirShc := "m4appfw-shc-" + testenv.RandomDNSName(4)
+			uploadedFiles, err = testenv.UploadFilesToS3(testS3Bucket, s3TestDirShc, appFileList, downloadDirPVTestApps)
+			Expect(err).To(Succeed(), "Unable to upload apps to S3 test directory for Search Head Cluster")
+			uploadedApps = append(uploadedApps, uploadedFiles...)
+
+			// Maximum apps to be downloaded in parallel
+			maxConcurrentAppDownloads := 30
+
+			// Create App framework Spec for C3
+			appSourceNameIdxc := "appframework-idxc-" + enterpriseApi.ScopeCluster + testenv.RandomDNSName(3)
+			appSourceNameShc := "appframework-shc-" + enterpriseApi.ScopeCluster + testenv.RandomDNSName(3)
+			appSourceVolumeNameIdxc := "appframework-test-volume-idxc-" + testenv.RandomDNSName(3)
+			appSourceVolumeNameShc := "appframework-test-volume-shc-" + testenv.RandomDNSName(3)
+			appFrameworkSpecIdxc := testenv.GenerateAppFrameworkSpec(testcaseEnvInst, appSourceVolumeNameIdxc, enterpriseApi.ScopeCluster, appSourceNameIdxc, s3TestDirIdxc, 60)
+			appFrameworkSpecIdxc.MaxConcurrentAppDownloads = uint64(maxConcurrentAppDownloads)
+			appFrameworkSpecShc := testenv.GenerateAppFrameworkSpec(testcaseEnvInst, appSourceVolumeNameShc, enterpriseApi.ScopeCluster, appSourceNameShc, s3TestDirShc, 60)
+			appFrameworkSpecShc.MaxConcurrentAppDownloads = uint64(maxConcurrentAppDownloads)
+
+			// Deploy Multisite Cluster and Search Head Cluster, with App Framework enabled on Cluster Manager and Deployer
+			siteCount := 3
+			shReplicas := 3
+			indexersPerSite := 1
+			testcaseEnvInst.Log.Info("Deploy Multisite Indexer Cluster with Search Head Cluster")
+			cm, _, shc, err := deployment.DeployMultisiteClusterWithSearchHeadAndAppFramework(ctx, deployment.GetName(), indexersPerSite, siteCount, appFrameworkSpecIdxc, appFrameworkSpecShc, true, "", "")
+			Expect(err).To(Succeed(), "Unable to deploy Multisite Indexer Cluster with Search Head Cluster")
+
+			// Ensure that the Cluster Manager goes to Ready phase
+			testenv.ClusterManagerReady(ctx, deployment, testcaseEnvInst)
+
+			// Ensure the Indexers of all sites go to Ready phase
+			testenv.IndexersReady(ctx, deployment, testcaseEnvInst, siteCount)
+
+			// Ensure Search Head Cluster go to Ready phase
+			testenv.SearchHeadClusterReady(ctx, deployment, testcaseEnvInst)
+
+			// Get Pod age to check for pod resets later
+			splunkPodAge := testenv.GetPodsStartTime(testcaseEnvInst.GetName())
+
+			//############ INITIAL VERIFICATIONS ##########
+			var idxcPodNames, shcPodNames []string
+			idxcPodNames = testenv.GeneratePodNameSlice(testenv.MultiSiteIndexerPod, deployment.GetName(), 1, true, siteCount)
+			shcPodNames = testenv.GeneratePodNameSlice(testenv.SearchHeadPod, deployment.GetName(), shReplicas, false, 1)
+			cmPod := []string{fmt.Sprintf(testenv.ClusterManagerPod, deployment.GetName())}
+			deployerPod := []string{fmt.Sprintf(testenv.DeployerPod, deployment.GetName())}
+			cmAppSourceInfo := testenv.AppSourceInfo{CrKind: cm.Kind, CrName: cm.Name, CrAppSourceName: appSourceNameIdxc, CrAppSourceVolumeName: appSourceVolumeNameIdxc, CrPod: cmPod, CrAppVersion: appVersion, CrAppScope: enterpriseApi.ScopeCluster, CrAppList: appList, CrAppFileList: appFileList, CrReplicas: indexersPerSite, CrMultisite: true, CrClusterPods: idxcPodNames}
+			shcAppSourceInfo := testenv.AppSourceInfo{CrKind: shc.Kind, CrName: shc.Name, CrAppSourceName: appSourceNameShc, CrAppSourceVolumeName: appSourceVolumeNameShc, CrPod: deployerPod, CrAppVersion: appVersion, CrAppScope: enterpriseApi.ScopeCluster, CrAppList: appList, CrAppFileList: appFileList, CrReplicas: shReplicas, CrClusterPods: shcPodNames}
+			allAppSourceInfo := []testenv.AppSourceInfo{cmAppSourceInfo, shcAppSourceInfo}
+			testenv.AppFrameWorkVerifications(ctx, deployment, testcaseEnvInst, allAppSourceInfo, splunkPodAge, "")
+		})
+	})
 })

--- a/test/s1/appframework/appframework_suite_test.go
+++ b/test/s1/appframework/appframework_suite_test.go
@@ -37,18 +37,20 @@ const (
 )
 
 var (
-	testenvInstance  *testenv.TestEnv
-	testSuiteName    = "s1appfw-" + testenv.RandomDNSName(3)
-	appListV1        []string
-	appListV2        []string
-	testDataS3Bucket = os.Getenv("TEST_BUCKET")
-	testS3Bucket     = os.Getenv("TEST_INDEXES_S3_BUCKET")
-	s3AppDirV1       = testenv.AppLocationV1
-	s3AppDirV2       = testenv.AppLocationV2
-	s3AppDirDisabled = testenv.AppLocationDisabledApps
-	currDir, _       = os.Getwd()
-	downloadDirV1    = filepath.Join(currDir, "s1appfwV1-"+testenv.RandomDNSName(4))
-	downloadDirV2    = filepath.Join(currDir, "s1appfwV2-"+testenv.RandomDNSName(4))
+	testenvInstance       *testenv.TestEnv
+	testSuiteName         = "s1appfw-" + testenv.RandomDNSName(3)
+	appListV1             []string
+	appListV2             []string
+	testDataS3Bucket      = os.Getenv("TEST_BUCKET")
+	testS3Bucket          = os.Getenv("TEST_INDEXES_S3_BUCKET")
+	s3AppDirV1            = testenv.AppLocationV1
+	s3AppDirV2            = testenv.AppLocationV2
+	s3AppDirDisabled      = testenv.AppLocationDisabledApps
+	s3PVTestApps          = testenv.PVTestAppsLocation
+	currDir, _            = os.Getwd()
+	downloadDirV1         = filepath.Join(currDir, "s1appfwV1-"+testenv.RandomDNSName(4))
+	downloadDirV2         = filepath.Join(currDir, "s1appfwV2-"+testenv.RandomDNSName(4))
+	downloadDirPVTestApps = filepath.Join(currDir, "s1appfwPVTestApps-"+testenv.RandomDNSName(4))
 )
 
 // TestBasic is the main entry point

--- a/test/testenv/appframework_utils.go
+++ b/test/testenv/appframework_utils.go
@@ -36,6 +36,21 @@ var AppInfo = map[string]map[string]string{
 	"test_app":                          {"V1": "1.0.0", "V2": "1.0.0", "filename": "test_app.tgz"},
 	"test_app2":                         {"V1": "1.0.0", "V2": "1.0.0", "filename": "test_app2.tgz"},
 	"test_app3":                         {"V1": "1.0.0", "V2": "1.0.0", "filename": "test_app3.tgz"},
+	"100mb-app-1":                       {"V1": "1.0.0", "V2": "1.0.0", "filename": "100mb-app-1.tgz"},
+	"100mb-app-2":                       {"V1": "1.0.0", "V2": "1.0.0", "filename": "100mb-app-2.tgz"},
+	"100mb-app-3":                       {"V1": "1.0.0", "V2": "1.0.0", "filename": "100mb-app-3.tgz"},
+	"100mb-app-4":                       {"V1": "1.0.0", "V2": "1.0.0", "filename": "100mb-app-4.tgz"},
+	"100mb-app-5":                       {"V1": "1.0.0", "V2": "1.0.0", "filename": "100mb-app-5.tgz"},
+	"100mb-app-6":                       {"V1": "1.0.0", "V2": "1.0.0", "filename": "100mb-app-6.tgz"},
+	"100mb-app-7":                       {"V1": "1.0.0", "V2": "1.0.0", "filename": "100mb-app-7.tgz"},
+	"100mb-app-8":                       {"V1": "1.0.0", "V2": "1.0.0", "filename": "100mb-app-8.tgz"},
+	"100mb-app-9":                       {"V1": "1.0.0", "V2": "1.0.0", "filename": "100mb-app-9.tgz"},
+	"100mb-app-10":                      {"V1": "1.0.0", "V2": "1.0.0", "filename": "100mb-app-10.tgz"},
+	"100mb-app-11":                      {"V1": "1.0.0", "V2": "1.0.0", "filename": "100mb-app-11.tgz"},
+	"100mb-app-12":                      {"V1": "1.0.0", "V2": "1.0.0", "filename": "100mb-app-12.tgz"},
+	"100mb-app-13":                      {"V1": "1.0.0", "V2": "1.0.0", "filename": "100mb-app-13.tgz"},
+	"100mb-app-14":                      {"V1": "1.0.0", "V2": "1.0.0", "filename": "100mb-app-14.tgz"},
+	"100mb-app-15":                      {"V1": "1.0.0", "V2": "1.0.0", "filename": "100mb-app-15.tgz"},
 }
 
 //AppSourceInfo holds info related to app sources
@@ -70,6 +85,9 @@ var BigSingleApp = []string{"test_app"}
 //ExtraApps is 2 apps to be added to app source during app installa in progress
 var ExtraApps = []string{"test_app2", "test_app3"}
 
+// PVTestApps is a group of 100MB-size apps used to test Operator PV
+var PVTestApps = []string{"100mb-app-1", "100mb-app-2", "100mb-app-3", "100mb-app-4", "100mb-app-5", "100mb-app-6", "100mb-app-7", "100mb-app-8", "100mb-app-9", "100mb-app-10", "100mb-app-11", "100mb-app-12", "100mb-app-13", "100mb-app-14", "100mb-app-15"}
+
 // AppLocationV1 Location of apps on S3 for V1 Apps
 var AppLocationV1 = "appframework/v1apps/"
 
@@ -78,6 +96,9 @@ var AppLocationV2 = "appframework/v2apps/"
 
 // AppLocationDisabledApps Location of apps on S3 for Disabled Apps
 var AppLocationDisabledApps = "appframework/Disabledapps/"
+
+// PVTestAppsLocation stores location of 100mb-size apps used to test Operator PV
+var PVTestAppsLocation = "appframework/100mb_sample_apps/"
 
 // AppStagingLocOnPod is the volume on Splunk pod where apps will be copied from operator
 var AppStagingLocOnPod = "/operator-staging/appframework/"


### PR DESCRIPTION
Test added to S1,C3 and M4 SVA of insufficient disk space on operator PV.
By default, Operator PV size is 1GB, so S1 test download 15 100MB-size apps in parallel and verifies all apps are eventually installed. For C3 and M4, it's 15 apps for Indexer Cluster and 15 for Search Head Cluster.