### PR TITLE
CSPL-1801 - Avoid odd number of arguments passed for logging

### DIFF
--- a/pkg/splunk/client/awss3client.go
+++ b/pkg/splunk/client/awss3client.go
@@ -249,7 +249,7 @@ func (awsclient *AWSS3Client) DownloadApp(ctx context.Context, remoteFile, local
 			IfMatch: aws.String(etag),
 		})
 	if err != nil {
-		scopedLog.Error(err, fmt.Sprintf("Unable to download item %s, %v", remoteFile, err))
+		scopedLog.Error(err, fmt.Sprintf("Unable to download item %s", remoteFile))
 		os.Remove(localFile)
 		return false, err
 	}

--- a/pkg/splunk/client/awss3client.go
+++ b/pkg/splunk/client/awss3client.go
@@ -249,7 +249,7 @@ func (awsclient *AWSS3Client) DownloadApp(ctx context.Context, remoteFile, local
 			IfMatch: aws.String(etag),
 		})
 	if err != nil {
-		scopedLog.Error(err, "Unable to download item %s, %v", remoteFile, err)
+		scopedLog.Error(err, fmt.Sprintf("Unable to download item %s, %v", remoteFile, err))
 		os.Remove(localFile)
 		return false, err
 	}

--- a/pkg/splunk/enterprise/afwscheduler.go
+++ b/pkg/splunk/enterprise/afwscheduler.go
@@ -418,7 +418,7 @@ downloadWork:
 
 				err := reserveStorage(downloadWorker.appDeployInfo.Size)
 				if err != nil {
-					scopedLog.Error(err, "insufficient storage for the app pkg download. appSrcName: %s, app name: %s, app size: %d Bytes", downloadWorker.appSrcName, downloadWorker.appDeployInfo.AppName, downloadWorker.appDeployInfo.Size)
+					scopedLog.Error(err, fmt.Sprintf("insufficient storage for the app pkg download. appSrcName: %s, app name: %s, app size: %d Bytes", downloadWorker.appSrcName, downloadWorker.appDeployInfo.AppName, downloadWorker.appDeployInfo.Size))
 					// setting isActive to false here so that downloadPhaseManager can take care of it.
 					downloadWorker.isActive = false
 					<-downloadWorkersRunPool
@@ -918,7 +918,7 @@ installHandler:
 					go ctxt.runPlaybook(ctx)
 				} else {
 					<-installTracker[podID]
-					scopedLog.Error(nil, "unable to get the local scoped context. app name %s", installWorker.appDeployInfo.AppName)
+					scopedLog.Error(nil, fmt.Sprintf("unable to get the local scoped context. app name %s", installWorker.appDeployInfo.AppName))
 				}
 			} else {
 				// This should never happen
@@ -942,7 +942,7 @@ installHandler:
 			if ctxt != nil {
 				ctxt.runPlaybook(ctx)
 			} else {
-				scopedLog.Error(nil, "unable to get the cluster scoped playbook context, kind: %s, name: %s", ppln.cr.GroupVersionKind().Kind, ppln.cr.GetName())
+				scopedLog.Error(nil, fmt.Sprintf("unable to get the cluster scoped playbook context, kind: %s, name: %s", ppln.cr.GroupVersionKind().Kind, ppln.cr.GetName()))
 			}
 		} else {
 			break

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -573,7 +573,7 @@ func (mgr *indexerClusterPodManager) getClusterManagerClient(ctx context.Context
 	podName := fmt.Sprintf(splcommon.TestClusterManagerID, managerIdxcName, "0")
 	adminPwd, err := splutil.GetSpecificSecretTokenFromPod(ctx, mgr.c, podName, mgr.cr.GetNamespace(), "password")
 	if err != nil {
-		scopedLog.Error(err, "Couldn't retrieve the admin password from pod %v", err.Error())
+		scopedLog.Error(err, fmt.Sprintf("Couldn't retrieve the admin password from pod %v", err.Error()))
 	}
 
 	return mgr.newSplunkClient(fmt.Sprintf("https://%s:8089", fqdnName), "admin", adminPwd)

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -573,7 +573,7 @@ func (mgr *indexerClusterPodManager) getClusterManagerClient(ctx context.Context
 	podName := fmt.Sprintf(splcommon.TestClusterManagerID, managerIdxcName, "0")
 	adminPwd, err := splutil.GetSpecificSecretTokenFromPod(ctx, mgr.c, podName, mgr.cr.GetNamespace(), "password")
 	if err != nil {
-		scopedLog.Error(err, fmt.Sprintf("Couldn't retrieve the admin password from pod %v", err.Error()))
+		scopedLog.Error(err, fmt.Sprintf("Couldn't retrieve the admin password from pod %v", podName))
 	}
 
 	return mgr.newSplunkClient(fmt.Sprintf("https://%s:8089", fqdnName), "admin", adminPwd)

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -444,11 +444,11 @@ func getAvailableDiskSpace(ctx context.Context) (uint64, error) {
 
 	err := syscall.Statfs(splcommon.AppDownloadVolume, &stat)
 	if err != nil {
-		scopedLog.Error(err, "There is no volume configured for the App framework, use the temporary location: %s", TmpAppDownloadDir)
+		scopedLog.Error(err, fmt.Sprintf("There is no volume configured for the App framework, use the temporary location: %s", TmpAppDownloadDir))
 		splcommon.AppDownloadVolume = TmpAppDownloadDir
 		err = os.MkdirAll(splcommon.AppDownloadVolume, 0755)
 		if err != nil {
-			scopedLog.Error(err, "Unable to create the directory %s", splcommon.AppDownloadVolume)
+			scopedLog.Error(err, fmt.Sprintf("Unable to create the directory %s", splcommon.AppDownloadVolume))
 			return 0, err
 		}
 	}
@@ -704,7 +704,7 @@ func DeleteOwnerReferencesForS3SecretObjects(ctx context.Context, client splcomm
 		if err == nil {
 			scopedLog.Info("Success", "Removed references for Secret Object %s", volume.SecretRef)
 		} else {
-			scopedLog.Error(err, "Owner reference removal failed for Secret Object %s", volume.SecretRef)
+			scopedLog.Error(err, fmt.Sprintf("Owner reference removal failed for Secret Object %s", volume.SecretRef))
 		}
 	}
 
@@ -1789,7 +1789,7 @@ func updateReconcileRequeueTime(ctx context.Context, result *reconcile.Result, r
 		return
 	}
 	if rqTime <= 0 {
-		scopedLog.Error(nil, "invalid requeue time: %d", rqTime)
+		scopedLog.Error(nil, fmt.Sprintf("invalid requeue time: %d", rqTime))
 		return
 	}
 


### PR DESCRIPTION
This issue is most likely never exposed, but it can cause the Operator to crash under certain conditions. 

The third parameter for `scopedLog.Error()` should be a set of Key and values, as per the function declaration:

**go/pkg/mod/github.com/go-logr/logr@v1.2.0/logr.go:261**
```
func (l Logger) Error(err error, msg string, keysAndValues ...interface{}) {

}
```

When only one value is passed we can hit this crash for `odd number of arguments passed as key-value pairs for logging`

```
1.652302394894617e+09	DPANIC	controller.indexercluster.indexerClusterPodManager.getClusterManagerClient odd number of arguments passed as key-value pairs for logging	{"reconciler group": "enterprise.splunk.com", "reconciler kind": "IndexerCluster", "name": "example-idc", "namespace": "default", "ignored key": "Couldn't find pod"}
```

Sample Stack:
```
github.com/splunk/splunk-operator/pkg/splunk/enterprise.(*indexerClusterPodManager).verifyRFPeers
	/workspace/pkg/splunk/enterprise/indexercluster.go:793
github.com/splunk/splunk-operator/pkg/splunk/enterprise.glob..func2
	/workspace/pkg/splunk/enterprise/indexercluster.go:422
github.com/splunk/splunk-operator/pkg/splunk/enterprise.ApplyIndexerCluster
	/workspace/pkg/splunk/enterprise/indexercluster.go:304
github.com/splunk/splunk-operator/controllers.glob..func3
	/workspace/controllers/indexercluster_controller.go:112
github.com/splunk/splunk-operator/controllers.(*IndexerClusterReconciler).Reconcile
	/workspace/controllers/indexercluster_controller.go:104
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:114
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:311
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:227
```