### PR TITLE
CSPL-1752: Do not update status on cached CR

### DIFF
--- a/controllers/clustermaster_controller.go
+++ b/controllers/clustermaster_controller.go
@@ -76,7 +76,6 @@ func (r *ClusterMasterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	reqLogger := log.FromContext(ctx)
 	reqLogger = reqLogger.WithValues("clustermaster", req.NamespacedName)
-	reqLogger.Info("start")
 
 	// Fetch the ClusterMaster
 	instance := &enterpriseApi.ClusterMaster{}
@@ -101,7 +100,14 @@ func (r *ClusterMasterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	return ApplyClusterManager(ctx, r.Client, instance)
+	reqLogger.Info("start", "CR version", instance.GetResourceVersion())
+
+	result, err := ApplyClusterManager(ctx, r.Client, instance)
+	if result.Requeue && result.RequeueAfter != 0 {
+		reqLogger.Info("Requeued", "period(seconds)", int(result.RequeueAfter/time.Second))
+	}
+
+	return result, err
 }
 
 // ApplyClusterManager adding to handle unit test case

--- a/controllers/indexercluster_controller.go
+++ b/controllers/indexercluster_controller.go
@@ -76,7 +76,6 @@ func (r *IndexerClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	reqLogger := log.FromContext(ctx)
 	reqLogger = reqLogger.WithValues("indexercluster", req.NamespacedName)
-	reqLogger.Info("start")
 
 	// Fetch the IndexerCluster
 	instance := &enterpriseApi.IndexerCluster{}
@@ -101,7 +100,14 @@ func (r *IndexerClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
-	return ApplyIndexerCluster(ctx, r.Client, instance)
+	reqLogger.Info("start", "CR version", instance.GetResourceVersion())
+
+	result, err := ApplyIndexerCluster(ctx, r.Client, instance)
+	if result.Requeue && result.RequeueAfter != 0 {
+		reqLogger.Info("Requeued", "period(seconds)", int(result.RequeueAfter/time.Second))
+	}
+
+	return result, err
 }
 
 // ApplyIndexerCluster adding to handle unit test case

--- a/controllers/licensemaster_controller.go
+++ b/controllers/licensemaster_controller.go
@@ -76,7 +76,6 @@ func (r *LicenseMasterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	reqLogger := log.FromContext(ctx)
 	reqLogger = reqLogger.WithValues("licensemaster", req.NamespacedName)
-	reqLogger.Info("start")
 
 	// Fetch the LicenseMaster
 	instance := &enterpriseApi.LicenseMaster{}
@@ -101,7 +100,14 @@ func (r *LicenseMasterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	return ApplyLicenseManager(ctx, r.Client, instance)
+	reqLogger.Info("start", "CR version", instance.GetResourceVersion())
+
+	result, err := ApplyLicenseManager(ctx, r.Client, instance)
+	if result.Requeue && result.RequeueAfter != 0 {
+		reqLogger.Info("Requeued", "period(seconds)", int(result.RequeueAfter/time.Second))
+	}
+
+	return result, err
 }
 
 // ApplyLicenseManager adding to handle unit test case

--- a/controllers/monitoringconsole_controller.go
+++ b/controllers/monitoringconsole_controller.go
@@ -75,7 +75,6 @@ func (r *MonitoringConsoleReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	defer recordInstrumentionData(time.Now(), req, "controller", "MonitoringConsole")
 	reqLogger := log.FromContext(ctx)
 	reqLogger = reqLogger.WithValues("monitoringconsole", req.NamespacedName)
-	reqLogger.Info("start")
 
 	// Fetch the MonitoringConsole
 	instance := &enterpriseApi.MonitoringConsole{}
@@ -100,7 +99,14 @@ func (r *MonitoringConsoleReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	}
 
-	return ApplyMonitoringConsole(ctx, r.Client, instance)
+	reqLogger.Info("start", "CR version", instance.GetResourceVersion())
+
+	result, err := ApplyMonitoringConsole(ctx, r.Client, instance)
+	if result.Requeue && result.RequeueAfter != 0 {
+		reqLogger.Info("Requeued", "period(seconds)", int(result.RequeueAfter/time.Second))
+	}
+
+	return result, err
 }
 
 // ApplyMonitoringConsole adding to handle unit test case

--- a/controllers/searchheadcluster_controller.go
+++ b/controllers/searchheadcluster_controller.go
@@ -77,7 +77,6 @@ func (r *SearchHeadClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	reqLogger := log.FromContext(ctx)
 	reqLogger = reqLogger.WithValues("searchheadcluster", req.NamespacedName)
-	reqLogger.Info("start")
 
 	// Fetch the SearchHeadCluster
 	instance := &enterpriseApi.SearchHeadCluster{}
@@ -102,7 +101,14 @@ func (r *SearchHeadClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	}
 
-	return ApplySearchHeadCluster(ctx, r.Client, instance)
+	reqLogger.Info("start", "CR version", instance.GetResourceVersion())
+
+	result, err := ApplySearchHeadCluster(ctx, r.Client, instance)
+	if result.Requeue && result.RequeueAfter != 0 {
+		reqLogger.Info("Requeued", "period(seconds)", int(result.RequeueAfter/time.Second))
+	}
+
+	return result, err
 }
 
 // ApplySearchHeadCluster adding to handle unit test case

--- a/controllers/standalone_controller.go
+++ b/controllers/standalone_controller.go
@@ -81,7 +81,6 @@ func (r *StandaloneReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	reqLogger := log.FromContext(ctx)
 	reqLogger = reqLogger.WithValues("standalone", req.NamespacedName)
-	reqLogger.Info("start")
 
 	// Fetch the Standalone
 	instance := &enterpriseApi.Standalone{}
@@ -105,8 +104,15 @@ func (r *StandaloneReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{Requeue: true, RequeueAfter: pauseRetryDelay}, nil
 		}
 	}
-	return ApplyStandalone(ctx, r.Client, instance)
-	//return ctrl.Result{}, nil
+
+	reqLogger.Info("start", "CR version", instance.GetResourceVersion())
+
+	result, err := ApplyStandalone(ctx, r.Client, instance)
+	if result.Requeue && result.RequeueAfter != 0 {
+		reqLogger.Info("Requeued", "period(seconds)", int(result.RequeueAfter/time.Second))
+	}
+
+	return result, err
 }
 
 // ApplyStandalone adding to handle unit test case

--- a/pkg/splunk/enterprise/clustermaster.go
+++ b/pkg/splunk/enterprise/clustermaster.go
@@ -83,12 +83,8 @@ func ApplyClusterManager(ctx context.Context, client splcommon.ControllerClient,
 		return result, err
 	}
 
-	defer func() {
-		err = client.Status().Update(ctx, cr)
-		if err != nil {
-			scopedLog.Error(err, "Status update failed")
-		}
-	}()
+	// Update the CR Status
+	defer updateCRStatus(ctx, client, cr)
 
 	// If needed, Migrate the app framework status
 	err = checkAndMigrateAppDeployStatus(ctx, client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig, false)

--- a/pkg/splunk/enterprise/clustermaster_test.go
+++ b/pkg/splunk/enterprise/clustermaster_test.go
@@ -65,6 +65,8 @@ func TestApplyClusterManager(t *testing.T) {
 		{MetaName: "*v1.ConfigMap-test-splunk-stack1-clustermaster-smartstore"},
 		{MetaName: "*v1." + splcommon.TestStack1ClusterManagerStatefulSet},
 		{MetaName: "*v1." + splcommon.TestStack1ClusterManagerStatefulSet},
+		{MetaName: "*v3.ClusterMaster-test-stack1"},
+		{MetaName: "*v3.ClusterMaster-test-stack1"},
 	}
 	updateFuncCalls := []spltest.MockFuncCall{
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
@@ -79,6 +81,8 @@ func TestApplyClusterManager(t *testing.T) {
 		{MetaName: "*v1." + splcommon.TestStack1ClusterManagerStatefulSet},
 		{MetaName: "*v1." + splcommon.TestStack1ClusterManagerStatefulSet},
 		{MetaName: "*v1." + splcommon.TestStack1ClusterManagerStatefulSet},
+		{MetaName: "*v3.ClusterMaster-test-stack1"},
+		{MetaName: "*v3.ClusterMaster-test-stack1"},
 	}
 
 	labels := map[string]string{
@@ -209,6 +213,8 @@ func TestApplyClusterManagerWithSmartstore(t *testing.T) {
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-cluster-master"},
 		{MetaName: "*v1.Pod-test-splunk-stack1-cluster-master-0"},
 		{MetaName: "*v1.StatefulSet-test-splunk-test-monitoring-console"},
+		{MetaName: "*v3.ClusterMaster-test-stack1"},
+		{MetaName: "*v3.ClusterMaster-test-stack1"},
 	}
 	updateFuncCalls := []spltest.MockFuncCall{
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
@@ -229,6 +235,8 @@ func TestApplyClusterManagerWithSmartstore(t *testing.T) {
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-cluster-master"},
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-cluster-master"},
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-cluster-master"},
+		{MetaName: "*v3.ClusterMaster-test-stack1"},
+		{MetaName: "*v3.ClusterMaster-test-stack1"},
 	}
 
 	labels := map[string]string{

--- a/pkg/splunk/enterprise/finalizers_test.go
+++ b/pkg/splunk/enterprise/finalizers_test.go
@@ -126,6 +126,35 @@ func splunkDeletionTester(t *testing.T, cr splcommon.MetaObject, delete func(spl
 					{MetaName: "*v1.PersistentVolumeClaim-test-splunk-pvc-stack1-var"},
 				}
 			}
+
+			switch cr.GetObjectKind().GroupVersionKind().Kind {
+			case "Standalone":
+				mockCalls["Get"] = append(mockCalls["Get"], []spltest.MockFuncCall{
+					{MetaName: "*v3.Standalone-test-stack1"},
+					{MetaName: "*v3.Standalone-test-stack1"},
+				}...)
+
+			case "LicenseMaster":
+				mockCalls["Get"] = append(mockCalls["Get"], []spltest.MockFuncCall{
+					{MetaName: "*v3.LicenseMaster-test-stack1"},
+					{MetaName: "*v3.LicenseMaster-test-stack1"},
+				}...)
+
+			case "SearchHeadCluster":
+				mockCalls["Get"] = append(mockCalls["Get"], []spltest.MockFuncCall{
+					{MetaName: "*v3.SearchHeadCluster-test-stack1"},
+					{MetaName: "*v3.SearchHeadCluster-test-stack1"},
+				}...)
+
+			case "ClusterMaster":
+				mockCalls["Get"] = append(mockCalls["Get"], []spltest.MockFuncCall{
+					{MetaName: "*v3.ClusterMaster-test-stack1"},
+					{MetaName: "*v3.ClusterMaster-test-stack1"},
+				}...)
+
+			case "MonitoringConsole":
+				mockCalls["Get"] = append(mockCalls["Get"], spltest.MockFuncCall{MetaName: "*v3.MonitoringConsole-test-stack1"})
+			}
 		} else {
 			mockCalls["Update"] = []spltest.MockFuncCall{
 				{MetaName: "*v1.Secret-test-splunk-test-secret"},
@@ -147,6 +176,8 @@ func splunkDeletionTester(t *testing.T, cr splcommon.MetaObject, delete func(spl
 				{MetaName: "*v1.Secret-test-splunk-test-secret"},
 				{MetaName: "*v3.ClusterMaster-test-master1"},
 				{MetaName: "*v1.Secret-test-splunk-test-secret"},
+				{MetaName: "*v3.IndexerCluster-test-stack1"},
+				{MetaName: "*v3.IndexerCluster-test-stack1"},
 			}
 		}
 	}

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -50,7 +50,7 @@ func ApplyIndexerCluster(ctx context.Context, client splcommon.ControllerClient,
 		RequeueAfter: time.Second * 5,
 	}
 	reqLogger := log.FromContext(ctx)
-	scopedLog := reqLogger.WithName("ApplyIndexerCluster").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
+	scopedLog := reqLogger.WithName("ApplyIndexerCluster")
 	eventPublisher, _ := newK8EventPublisher(client, cr)
 
 	// validate and updates defaults for CR
@@ -73,13 +73,9 @@ func ApplyIndexerCluster(ctx context.Context, client splcommon.ControllerClient,
 	if cr.Status.IdxcPasswordChangedSecrets == nil {
 		cr.Status.IdxcPasswordChangedSecrets = make(map[string]bool)
 	}
-	defer func() {
-		err = client.Status().Update(ctx, cr)
-		if err != nil {
-			eventPublisher.Warning(ctx, "Update", fmt.Sprintf("custom resource update failed %s", err.Error()))
-			scopedLog.Error(err, "Status update failed")
-		}
-	}()
+
+	// Update the CR Status
+	defer updateCRStatus(ctx, client, cr)
 
 	// create or update general config resources
 	namespaceScopedSecret, err := ApplySplunkConfig(ctx, client, cr, cr.Spec.CommonSplunkSpec, SplunkIndexer)
@@ -132,6 +128,7 @@ func ApplyIndexerCluster(ctx context.Context, client splcommon.ControllerClient,
 		}
 		return result, err
 	}
+
 	// create or update a headless service for indexer cluster
 	err = splctrl.ApplyService(ctx, client, getSplunkService(ctx, cr, &cr.Spec.CommonSplunkSpec, SplunkIndexer, true))
 	if err != nil {

--- a/pkg/splunk/enterprise/indexercluster_test.go
+++ b/pkg/splunk/enterprise/indexercluster_test.go
@@ -60,6 +60,8 @@ func TestApplyIndexerCluster(t *testing.T) {
 		{MetaName: "*v1.Secret-test-splunk-stack1-indexer-secret-v1"},
 		{MetaName: "*v3.ClusterMaster-test-master1"},
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
+		{MetaName: "*v3.IndexerCluster-test-stack1"},
+		{MetaName: "*v3.IndexerCluster-test-stack1"},
 	}
 	updateFuncCalls := []spltest.MockFuncCall{
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
@@ -72,6 +74,8 @@ func TestApplyIndexerCluster(t *testing.T) {
 		{MetaName: "*v1.Secret-test-splunk-stack1-indexer-secret-v1"},
 		{MetaName: "*v3.ClusterMaster-test-master1"},
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
+		{MetaName: "*v3.IndexerCluster-test-stack1"},
+		{MetaName: "*v3.IndexerCluster-test-stack1"},
 	}
 
 	labels := map[string]string{

--- a/pkg/splunk/enterprise/licensemaster.go
+++ b/pkg/splunk/enterprise/licensemaster.go
@@ -72,9 +72,9 @@ func ApplyLicenseManager(ctx context.Context, client splcommon.ControllerClient,
 
 	// updates status after function completes
 	cr.Status.Phase = enterpriseApi.PhaseError
-	defer func() {
-		client.Status().Update(context.TODO(), cr)
-	}()
+
+	// Update the CR Status
+	defer updateCRStatus(ctx, client, cr)
 
 	// create or update general config resources
 	_, err = ApplySplunkConfig(ctx, client, cr, cr.Spec.CommonSplunkSpec, SplunkLicenseManager)

--- a/pkg/splunk/enterprise/licensemaster_test.go
+++ b/pkg/splunk/enterprise/licensemaster_test.go
@@ -53,6 +53,8 @@ func TestApplyLicenseManager(t *testing.T) {
 		{MetaName: "*v1." + splcommon.TestStack1LicenseManagerSecret},
 		{MetaName: "*v1." + splcommon.TestStack1LicenseManagerStatefulSet},
 		{MetaName: "*v1." + splcommon.TestStack1LicenseManagerStatefulSet},
+		{MetaName: "*v3.LicenseMaster-test-stack1"},
+		{MetaName: "*v3.LicenseMaster-test-stack1"},
 	}
 
 	labels := map[string]string{
@@ -66,9 +68,8 @@ func TestApplyLicenseManager(t *testing.T) {
 	listmockCall := []spltest.MockFuncCall{
 		{ListOpts: listOpts}}
 
-	updateFuncCalls := append(funcCalls, spltest.MockFuncCall{MetaName: "*v1." + splcommon.TestStack1LicenseManagerStatefulSet})
 	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[0], funcCalls[3], funcCalls[6], funcCalls[8]}, "Update": {funcCalls[0]}, "List": {listmockCall[0]}}
-	updateFuncCalls = append(updateFuncCalls[:2], updateFuncCalls[3:]...)
+	updateFuncCalls := []spltest.MockFuncCall{funcCalls[0], funcCalls[1], funcCalls[3], funcCalls[4], funcCalls[5], funcCalls[6], funcCalls[7], funcCalls[8], funcCalls[8], funcCalls[9], funcCalls[10]}
 	updateCalls := map[string][]spltest.MockFuncCall{"Get": updateFuncCalls, "Update": {funcCalls[4]}, "List": {listmockCall[0]}}
 	current := enterpriseApi.LicenseMaster{
 		TypeMeta: metav1.TypeMeta{
@@ -79,6 +80,7 @@ func TestApplyLicenseManager(t *testing.T) {
 			Namespace: "test",
 		},
 	}
+
 	revised := current.DeepCopy()
 	revised.Spec.Image = "splunk/test"
 	reconcile := func(c *spltest.MockClient, cr interface{}) error {

--- a/pkg/splunk/enterprise/monitoringconsole.go
+++ b/pkg/splunk/enterprise/monitoringconsole.go
@@ -80,13 +80,9 @@ func ApplyMonitoringConsole(ctx context.Context, client splcommon.ControllerClie
 	}
 
 	cr.Status.Selector = fmt.Sprintf("app.kubernetes.io/instance=splunk-%s-monitoring-console", cr.GetName())
-	defer func() {
-		client.Status().Update(ctx, cr)
-		if err != nil {
-			eventPublisher.Warning(ctx, "Update", fmt.Sprintf("update custom resource failed %s", err.Error()))
-			scopedLog.Error(err, "Status update failed")
-		}
-	}()
+
+	// Update the CR Status
+	defer updateCRStatus(ctx, client, cr)
 
 	// create or update general config resources
 	_, err = ApplySplunkConfig(ctx, client, cr, cr.Spec.CommonSplunkSpec, SplunkMonitoringConsole)

--- a/pkg/splunk/enterprise/monitoringconsole_test.go
+++ b/pkg/splunk/enterprise/monitoringconsole_test.go
@@ -53,6 +53,7 @@ func TestApplyMonitoringConsole(t *testing.T) {
 		{MetaName: "*v1.ConfigMap-test-splunk-stack1-monitoring-console"},
 		{MetaName: "*v1.ConfigMap-test-splunk-stack1-monitoring-console"},
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-monitoring-console"},
+		{MetaName: "*v3.MonitoringConsole-test-stack1"},
 	}
 
 	updateFuncCalls := []spltest.MockFuncCall{
@@ -69,6 +70,7 @@ func TestApplyMonitoringConsole(t *testing.T) {
 		{MetaName: "*v1.ConfigMap-test-splunk-stack1-monitoring-console"},
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-monitoring-console"},
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-monitoring-console"},
+		{MetaName: "*v3.MonitoringConsole-test-stack1"},
 	}
 
 	labels := map[string]string{

--- a/pkg/splunk/enterprise/searchheadcluster.go
+++ b/pkg/splunk/enterprise/searchheadcluster.go
@@ -83,7 +83,6 @@ func ApplySearchHeadCluster(ctx context.Context, client splcommon.ControllerClie
 	}
 	if cr.Status.ShcSecretChanged == nil {
 		cr.Status.ShcSecretChanged = []bool{}
-
 	}
 	if cr.Status.AdminSecretChanged == nil {
 		cr.Status.AdminSecretChanged = []bool{}
@@ -91,12 +90,9 @@ func ApplySearchHeadCluster(ctx context.Context, client splcommon.ControllerClie
 	if cr.Status.AdminPasswordChangedSecrets == nil {
 		cr.Status.AdminPasswordChangedSecrets = make(map[string]bool)
 	}
-	defer func() {
-		err = client.Status().Update(ctx, cr)
-		if err != nil {
-			scopedLog.Error(err, "Status update failed")
-		}
-	}()
+
+	// Update the CR Status
+	defer updateCRStatus(ctx, client, cr)
 
 	// create or update general config resources
 	namespaceScopedSecret, err := ApplySplunkConfig(ctx, client, cr, cr.Spec.CommonSplunkSpec, SplunkSearchHead)

--- a/pkg/splunk/enterprise/searchheadcluster_test.go
+++ b/pkg/splunk/enterprise/searchheadcluster_test.go
@@ -63,6 +63,8 @@ func TestApplySearchHeadCluster(t *testing.T) {
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-search-head"},
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-search-head"},
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
+		{MetaName: "*v3.SearchHeadCluster-test-stack1"},
+		{MetaName: "*v3.SearchHeadCluster-test-stack1"},
 	}
 	createFuncCalls := []spltest.MockFuncCall{
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
@@ -82,6 +84,8 @@ func TestApplySearchHeadCluster(t *testing.T) {
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-search-head"},
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-search-head"},
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
+		{MetaName: "*v3.SearchHeadCluster-test-stack1"},
+		{MetaName: "*v3.SearchHeadCluster-test-stack1"},
 	}
 
 	labels := map[string]string{

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -95,13 +95,8 @@ func ApplyStandalone(ctx context.Context, client splcommon.ControllerClient, cr 
 	}
 
 	cr.Status.Selector = fmt.Sprintf("app.kubernetes.io/instance=splunk-%s-standalone", cr.GetName())
-	defer func() {
-		err = client.Status().Update(ctx, cr)
-		if err != nil {
-			eventPublisher.Warning(ctx, "Update", fmt.Sprintf("update custom resource failed %s", err.Error()))
-			scopedLog.Error(err, "Status update failed")
-		}
-	}()
+	// Update the CR Status
+	defer updateCRStatus(ctx, client, cr)
 
 	// create or update general config resources
 	_, err = ApplySplunkConfig(ctx, client, cr, cr.Spec.CommonSplunkSpec, SplunkStandalone)
@@ -289,7 +284,7 @@ func validateStandaloneSpec(ctx context.Context, c splcommon.ControllerClient, c
 // helper function to get the list of Standalone types in the current namespace
 func getStandaloneList(ctx context.Context, c splcommon.ControllerClient, cr splcommon.MetaObject, listOpts []client.ListOption) (int, error) {
 	reqLogger := log.FromContext(ctx)
-	scopedLog := reqLogger.WithName("getStandaloneList").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
+	scopedLog := reqLogger.WithName("getStandaloneList")
 
 	objectList := enterpriseApi.StandaloneList{}
 

--- a/pkg/splunk/enterprise/standalone_test.go
+++ b/pkg/splunk/enterprise/standalone_test.go
@@ -54,7 +54,8 @@ func TestApplyStandalone(t *testing.T) {
 		{MetaName: "*v1.ConfigMap-test-splunk-stack1-standalone-smartstore"},
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-standalone"},
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-standalone"},
-		//{MetaName: "*v1.StatefulSet-test-splunk-stack1-standalone"},
+		{MetaName: "*v3.Standalone-test-stack1"},
+		{MetaName: "*v3.Standalone-test-stack1"},
 	}
 	updatefuncCalls := []spltest.MockFuncCall{
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
@@ -70,7 +71,13 @@ func TestApplyStandalone(t *testing.T) {
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-standalone"},
 		//{MetaName: "*v1.StatefulSet-test-splunk-stack1-standalone"},
 	}
-	updateFuncCalls := append(updatefuncCalls, spltest.MockFuncCall{MetaName: "*v1.StatefulSet-test-splunk-stack1-standalone"})
+	deltaCalls := []spltest.MockFuncCall{
+		{MetaName: "*v1.StatefulSet-test-splunk-stack1-standalone"},
+		{MetaName: "*v3.Standalone-test-stack1"},
+		{MetaName: "*v3.Standalone-test-stack1"},
+	}
+	updateFuncCalls := append(updatefuncCalls, deltaCalls...)
+
 	labels := map[string]string{
 		"app.kubernetes.io/component":  "versionedSecrets",
 		"app.kubernetes.io/managed-by": "splunk-operator",
@@ -131,6 +138,8 @@ func TestApplyStandaloneWithSmartstore(t *testing.T) {
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-standalone"},
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-standalone"},
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-standalone"},
+		{MetaName: "*v3.Standalone-test-stack1"},
+		{MetaName: "*v3.Standalone-test-stack1"},
 	}
 	createFuncCalls := []spltest.MockFuncCall{
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
@@ -150,6 +159,8 @@ func TestApplyStandaloneWithSmartstore(t *testing.T) {
 		{MetaName: "*v1.ConfigMap-test-splunk-stack1-standalone-smartstore"},
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-standalone"},
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-standalone"},
+		{MetaName: "*v3.Standalone-test-stack1"},
+		{MetaName: "*v3.Standalone-test-stack1"},
 	}
 
 	labels := map[string]string{

--- a/pkg/splunk/enterprise/types.go
+++ b/pkg/splunk/enterprise/types.go
@@ -27,11 +27,17 @@ import (
 )
 
 const (
+	// max. reconcile requeue schedule time(Seconds)
 	maxRecDuration time.Duration = 1<<63 - 1
-)
 
-const (
+	// Current App framework version
 	currentAfwVersion = enterpriseApi.AfwPhase3
+
+	// Max. of parallel installs for a given Pod
+	maxParallelInstallsPerPod = 1
+
+	// Max. number of retries to update the CR Status
+	maxRetryCountForCRStatusUpdate = 10
 )
 
 // InstanceType is used to represent the type of Splunk instance (search head, indexer, etc).
@@ -61,11 +67,6 @@ const (
 
 	// TmpAppDownloadDir is the Operator directory for app framework, when there is no explicit volume specified
 	TmpAppDownloadDir string = "/tmp/appframework/"
-)
-
-const (
-	// Max. of parallel installs for a given Pod
-	maxParallelInstallsPerPod = 1
 )
 
 type commonResourceTracker struct {

--- a/pkg/splunk/enterprise/util_test.go
+++ b/pkg/splunk/enterprise/util_test.go
@@ -30,6 +30,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -2247,4 +2250,282 @@ func TestUpdateReconcileRequeueTime(t *testing.T) {
 
 	rqTime = time.Duration(time.Second * 5)
 	updateReconcileRequeueTime(ctx, result, rqTime, true)
+}
+
+func TestUpdateCRStatus(t *testing.T) {
+	builder := fake.NewClientBuilder()
+	c := builder.Build()
+	utilruntime.Must(enterpriseApi.AddToScheme(clientgoscheme.Scheme))
+	ctx := context.TODO()
+
+	// create standalone custom resource
+	standalone := &enterpriseApi.Standalone{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Standalone",
+			APIVersion: "enterprise.splunk.com/v3",
+		},
+
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: enterpriseApi.StandaloneSpec{
+			CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
+				Spec: enterpriseApi.Spec{
+					ImagePullPolicy: "Always",
+				},
+				Volumes: []corev1.Volume{},
+			},
+		},
+		Status: enterpriseApi.StandaloneStatus{
+			ReadyReplicas: 2,
+		},
+	}
+
+	// When the CR is not even existing, error handling will keep retrying to update the CR, but fails at the end.
+	updateCRStatus(ctx, c, standalone)
+
+	// Creating a standalone, and updating the CR will cover the happy path
+	// simulate create standalone instance before reconcilation
+	err := c.Create(ctx, standalone)
+	if err != nil {
+		t.Errorf("standalone CR creation failed.")
+	}
+
+	// call reconciliation
+	_, err = ApplyStandalone(ctx, c, standalone)
+	if err != nil {
+		t.Errorf("Apply standalone failed.")
+	}
+	standalone.Status.ReadyReplicas = 3
+	updateCRStatus(ctx, c, standalone)
+}
+
+func TestFetchCurrentCRWithStatusUpdate(t *testing.T) {
+	builder := fake.NewClientBuilder()
+	c := builder.Build()
+	utilruntime.Must(enterpriseApi.AddToScheme(clientgoscheme.Scheme))
+	ctx := context.TODO()
+
+	// Standalone: should return a vaid CR
+	stdln := enterpriseApi.Standalone{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Standalone",
+			APIVersion: "enterprise.splunk.com/v3",
+		},
+
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: enterpriseApi.StandaloneSpec{
+			CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
+				Spec: enterpriseApi.Spec{
+					ImagePullPolicy: "Always",
+				},
+				Volumes: []corev1.Volume{},
+			},
+		},
+		Status: enterpriseApi.StandaloneStatus{
+			ReadyReplicas: 2,
+		},
+	}
+
+	// When the CR is available, should be able to fetch it.
+	err := c.Create(ctx, &stdln)
+	if err != nil {
+		t.Errorf("standalone CR creation failed.")
+	}
+
+	receivedCR, err := fetchCurrentCRWithStatusUpdate(ctx, c, &stdln)
+	if err != nil {
+		t.Errorf("Expected a valid CR without error, but got the error %v", err)
+	} else if receivedCR == nil || receivedCR.GroupVersionKind().Kind != "Standalone" {
+		t.Errorf("Failed to fetch the CR")
+	}
+
+	// When the CR is not available, should return and Error
+	invalidCR := stdln
+	invalidCR.ObjectMeta.Name = "unknownCR"
+	receivedCR, err = fetchCurrentCRWithStatusUpdate(ctx, c, &invalidCR)
+	if err == nil {
+		t.Errorf("When CR is not available, should return an error")
+	} else if !strings.Contains(err.Error(), "\"unknownCR\" not found") {
+		t.Errorf("Unexpected error: %s", err.Error())
+	} else if receivedCR != nil {
+		t.Errorf("Didn't expect to fetch the CR with name: %s", receivedCR.GetName())
+	}
+
+	// LicenseMaster: Should return a valid CR
+	lmCR := enterpriseApi.LicenseMaster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "LicenseMaster",
+			APIVersion: "enterprise.splunk.com/v3",
+		},
+
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: enterpriseApi.LicenseMasterSpec{
+			CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
+				Spec: enterpriseApi.Spec{
+					ImagePullPolicy: "Always",
+				},
+				Volumes: []corev1.Volume{},
+			},
+		},
+	}
+
+	err = c.Create(ctx, &lmCR)
+	if err != nil {
+		t.Errorf("LicenseMaster CR creation failed. error: %v", err)
+	}
+
+	receivedCR, err = fetchCurrentCRWithStatusUpdate(ctx, c, &lmCR)
+	if err != nil {
+		t.Errorf("Expected a valid CR without error, but got the error %v", err)
+	} else if receivedCR == nil || receivedCR.GroupVersionKind().Kind != "LicenseMaster" {
+		t.Errorf("Failed to fetch the CR")
+	}
+
+	// MonitoringConsole: Should return a valid CR
+	mcCR := enterpriseApi.MonitoringConsole{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MonitoringConsole",
+			APIVersion: "enterprise.splunk.com/v3",
+		},
+
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: enterpriseApi.MonitoringConsoleSpec{
+			CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
+				Spec: enterpriseApi.Spec{
+					ImagePullPolicy: "Always",
+				},
+				Volumes: []corev1.Volume{},
+			},
+		},
+		Status: enterpriseApi.MonitoringConsoleStatus{},
+	}
+
+	err = c.Create(ctx, &mcCR)
+	if err != nil {
+		t.Errorf("MonitoringConsole CR creation failed.")
+	}
+
+	receivedCR, err = fetchCurrentCRWithStatusUpdate(ctx, c, &mcCR)
+	if err != nil {
+		t.Errorf("Expected a valid CR without error, but got the error %v", err)
+	} else if receivedCR == nil || receivedCR.GroupVersionKind().Kind != "MonitoringConsole" {
+		t.Errorf("Failed to fetch the CR")
+	}
+
+	// ClusterMaster: Should return a valid CR
+	cmCR := enterpriseApi.ClusterMaster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterMaster",
+			APIVersion: "enterprise.splunk.com/v3",
+		},
+
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: enterpriseApi.ClusterMasterSpec{
+			CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
+				Spec: enterpriseApi.Spec{
+					ImagePullPolicy: "Always",
+				},
+				Volumes: []corev1.Volume{},
+			},
+		},
+		Status: enterpriseApi.ClusterMasterStatus{},
+	}
+
+	err = c.Create(ctx, &cmCR)
+	if err != nil {
+		t.Errorf("ClusterMaster CR creation failed.")
+	}
+
+	receivedCR, err = fetchCurrentCRWithStatusUpdate(ctx, c, &cmCR)
+	if err != nil {
+		t.Errorf("Expected a valid CR without error, but got the error %v", err)
+	} else if receivedCR == nil || receivedCR.GroupVersionKind().Kind != "ClusterMaster" {
+		t.Errorf("Failed to fetch the CR")
+	}
+
+	// IndexerCluster: Should return a valid CR
+	idxcCR := enterpriseApi.IndexerCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "IndexerCluster",
+			APIVersion: "enterprise.splunk.com/v3",
+		},
+
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: enterpriseApi.IndexerClusterSpec{
+			CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
+				Spec: enterpriseApi.Spec{
+					ImagePullPolicy: "Always",
+				},
+				Volumes: []corev1.Volume{},
+			},
+		},
+		Status: enterpriseApi.IndexerClusterStatus{
+			ReadyReplicas: 3,
+		},
+	}
+
+	err = c.Create(ctx, &idxcCR)
+	if err != nil {
+		t.Errorf("IndexerCluster CR creation failed.")
+	}
+
+	receivedCR, err = fetchCurrentCRWithStatusUpdate(ctx, c, &idxcCR)
+	if err != nil {
+		t.Errorf("Expected a valid CR without error, but got the error %v", err)
+	} else if receivedCR == nil || receivedCR.GroupVersionKind().Kind != "IndexerCluster" {
+		t.Errorf("Failed to fetch the CR")
+	}
+
+	// SearchHeadCluster: Should return valid CR
+	shcCR := enterpriseApi.SearchHeadCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SearchHeadCluster",
+			APIVersion: "enterprise.splunk.com/v3",
+		},
+
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: enterpriseApi.SearchHeadClusterSpec{
+			CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
+				Spec: enterpriseApi.Spec{
+					ImagePullPolicy: "Always",
+				},
+				Volumes: []corev1.Volume{},
+			},
+		},
+		Status: enterpriseApi.SearchHeadClusterStatus{
+			ReadyReplicas: 3,
+		},
+	}
+
+	err = c.Create(ctx, &shcCR)
+	if err != nil {
+		t.Errorf("SearchHeadCluster CR creation failed.")
+	}
+
+	receivedCR, err = fetchCurrentCRWithStatusUpdate(ctx, c, &shcCR)
+	if err != nil {
+		t.Errorf("Expected a valid CR without error, but got the error %v", err)
+	} else if receivedCR == nil || receivedCR.GroupVersionKind().Kind != "SearchHeadCluster" {
+		t.Errorf("Failed to fetch the CR")
+	}
 }

--- a/pkg/splunk/test/controller.go
+++ b/pkg/splunk/test/controller.go
@@ -448,6 +448,34 @@ func testReconcileForResource(t *testing.T, c *MockClient, methodPlus string, re
 	calls map[string][]MockFuncCall,
 	reconcile func(*MockClient, interface{}) error) {
 
+	// Create the CR. Having a CR instance helps to not to retry for the GET failures,
+	// that way, predictable number of CRUD function calls to satisfy the test cases.
+	switch resource.(type) {
+	case *enterpriseApi.Standalone:
+		cr := resource.(*enterpriseApi.Standalone)
+		c.Create(context.Background(), cr)
+
+	case *enterpriseApi.LicenseMaster:
+		cr := resource.(*enterpriseApi.LicenseMaster)
+		c.Create(context.Background(), cr)
+
+	case *enterpriseApi.IndexerCluster:
+		cr := resource.(*enterpriseApi.IndexerCluster)
+		c.Create(context.Background(), cr)
+
+	case *enterpriseApi.ClusterMaster:
+		cr := resource.(*enterpriseApi.ClusterMaster)
+		c.Create(context.Background(), cr)
+
+	case *enterpriseApi.MonitoringConsole:
+		cr := resource.(*enterpriseApi.MonitoringConsole)
+		c.Create(context.Background(), cr)
+
+	case *enterpriseApi.SearchHeadCluster:
+		cr := resource.(*enterpriseApi.SearchHeadCluster)
+		c.Create(context.Background(), cr)
+	}
+
 	c.ResetCalls()
 	err := reconcile(c, resource)
 	if err != nil {


### PR DESCRIPTION
On a reconcile entry, there is a possibility that the CR is cached(may not be
the latest). In such cases, CR status update fails, as the resource version
already changed.

Fix is made such that:
1. Always fetch the latest CR, then make the status update to avoid any update failures
2. Make sure that the cached CR is reflecting the latest, before yielding from current reconcile
so that the next reconcile has the latet status info to work with