### PR TITLE
Fixing github issue #762 after reverting PR781 and PR794

### DIFF
--- a/pkg/splunk/enterprise/clustermaster.go
+++ b/pkg/splunk/enterprise/clustermaster.go
@@ -258,7 +258,7 @@ func getClusterManagerStatefulSet(ctx context.Context, client splcommon.Controll
 	smartStoreConfigMap := getSmartstoreConfigMap(ctx, client, cr, SplunkClusterManager)
 
 	if smartStoreConfigMap != nil {
-		setupInitContainer(&ss.Spec.Template, cr.Spec.Image, cr.Spec.ImagePullPolicy, commandForCMSmartstore)
+		setupInitContainer(&ss.Spec.Template, cr.Spec.Image, cr.Spec.ImagePullPolicy, commandForCMSmartstore, cr.Spec.CommonSplunkSpec.EtcVolumeStorageConfig.EphemeralStorage)
 	}
 	// Setup App framework staging volume for apps
 	setupAppsStagingVolume(ctx, client, cr, &ss.Spec.Template, &cr.Spec.AppFrameworkConfig)

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -249,7 +249,7 @@ func getStandaloneStatefulSet(ctx context.Context, client splcommon.ControllerCl
 	smartStoreConfigMap := getSmartstoreConfigMap(ctx, client, cr, SplunkStandalone)
 
 	if smartStoreConfigMap != nil {
-		setupInitContainer(&ss.Spec.Template, cr.Spec.Image, cr.Spec.ImagePullPolicy, commandForStandaloneSmartstore)
+		setupInitContainer(&ss.Spec.Template, cr.Spec.Image, cr.Spec.ImagePullPolicy, commandForStandaloneSmartstore, cr.Spec.CommonSplunkSpec.EtcVolumeStorageConfig.EphemeralStorage)
 	}
 
 	// Setup App framework staging volume for apps

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -638,7 +638,15 @@ func ApplySmartstoreConfigMap(ctx context.Context, client splcommon.ControllerCl
 }
 
 //  setupInitContainer modifies the podTemplateSpec object
-func setupInitContainer(podTemplateSpec *corev1.PodTemplateSpec, Image string, imagePullPolicy string, commandOnContainer string) {
+func setupInitContainer(podTemplateSpec *corev1.PodTemplateSpec, Image string, imagePullPolicy string, commandOnContainer string, isEtcVolEph bool) {
+	var volMntName string
+
+	// Populate the volume mount name based on volume type(eph, pvc) and use /opt/splk/etc for init container
+	if isEtcVolEph {
+		volMntName = fmt.Sprintf(splcommon.SplunkMountNamePrefix, splcommon.EtcVolumeStorage)
+	} else {
+		volMntName = fmt.Sprintf(splcommon.PvcNamePrefix, splcommon.EtcVolumeStorage)
+	}
 	containerSpec := corev1.Container{
 		Image:           Image,
 		ImagePullPolicy: corev1.PullPolicy(imagePullPolicy),
@@ -646,7 +654,7 @@ func setupInitContainer(podTemplateSpec *corev1.PodTemplateSpec, Image string, i
 
 		Command: []string{"bash", "-c", commandOnContainer},
 		VolumeMounts: []corev1.VolumeMount{
-			{Name: "pvc-etc", MountPath: "/opt/splk/etc"},
+			{Name: volMntName, MountPath: "/opt/splk/etc"},
 		},
 
 		Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
Fixing github [issue](https://github.com/splunk/splunk-operator/issues/762) after reverting PR781 and PR794 using [PR](https://github.com/splunk/splunk-operator/pull/828). Will rebase to develop once the revert is done.

Tested with the following yaml:

```
apiVersion: enterprise.splunk.com/v3
kind: ClusterMaster
metadata:
  name: cm-example
  namespace: splunk-operator
  finalizers:
  - enterprise.splunk.com/delete-pvc
spec:
  etcVolumeStorageConfig:
    ephemeralStorage: true
  varVolumeStorageConfig:
    ephemeralStorage: true
  smartstore:
    defaults:
        volumeName: pogdin_smartstore
    indexes:
      - name: main
        remotePath: $_index_name
        volumeName: pogdin_smartstore
      - name: cloudwatch
        remotePath: $_index_name
        volumeName: pogdin_smartstore
    volumes:
      - name: pogdin_smartstore
        path: pogdin/smartstore
        endpoint: https://s3-us-west-2.amazonaws.com
        secretRef: s3-secret-arjunk
```

Pod initializes with init container correctly:

```
bash> kubectl get pods
splunk-cm-example-cluster-master-0                    0/1     Pending       0          0s
splunk-cm-example-cluster-master-0                    0/1     Pending       0          0s
splunk-cm-example-cluster-master-0                    0/1     Init:0/1      0          0s
splunk-cm-example-cluster-master-0                    0/1     PodInitializing   0          2s
splunk-cm-example-cluster-master-0                    0/1     Running           0          3s
splunk-cm-example-cluster-master-0                    1/1     Running           0          105s


```