### PR TITLE
Draft: cspl 1880: delete stateful set when image version differs

### DIFF
--- a/.github/workflows/int-test-workflow.yml
+++ b/.github/workflows/int-test-workflow.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - develop
       - master
-      - cspl-1880
 jobs:
   build-operator-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/int-test-workflow.yml
+++ b/.github/workflows/int-test-workflow.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - develop
       - master
+      - cspl-1880
 jobs:
   build-operator-image:
     runs-on: ubuntu-latest

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -152,18 +152,18 @@ func ApplyIndexerCluster(ctx context.Context, client splcommon.ControllerClient,
 	}
 
 	// Note:
-	// this it temporary fix for CSPL-1880. enterprise splunk 9.0.0 fails when we migrate from 8.2.6.
-	// splunk 9.0.0 app bundle transfer uses encryption while transferring data. if any of the 
-	// splunk instances were not enable support this option, then cluster master fails to transfer, this leads 
-	// to splunkd restart at the peer level. for more information refer 
-	// https://splunk.atlassian.net/browse/SPL-223386?jql=text%20~%20%22The%20downloaded%20bundle%20checksum%20doesn%27t%20match%20the%20activeBundleChecksum%22
-	// On Operator side we have set statefulset update strategy to OnDelete, so pods need to be 
-	// deleted by operator manually.  Before deleting the pod, operator controller code tries to decommission 
-	// the splunk instance, but splunkd is not running due to above splunk enterprise 9.0.0 issue. So controller 
-	// fail and returns. This goes on in a loop and we always try the same pod instance and rest of the replicas 
-	// are still in older version
-	// As a temporary fix for 9.0.0 , if the image version do not  match with pod image version we delete the 
-	// splunk statefulset for indexer 
+	// This is a temporary fix for CSPL-1880. Splunk enterprise 9.0.0 fails when we migrate from 8.2.6.
+    // Splunk 9.0.0 bundle push uses encryption while transferring data. If any of the 
+    // splunk instances were not able to support this option, then cluster master fails to transfer, this leads 
+    // to splunkd restart at the peer level. For more information refer 
+    // https://splunk.atlassian.net/browse/SPL-223386?jql=text%20~%20%22The%20downloaded%20bundle%20checksum%20doesn%27t%20match%20the%20activeBundleChecksum%22
+    // On Operator side we have set statefulset update strategy to OnDelete, so pods need to be 
+    // deleted by operator manually.  Before deleting the pod, operator controller code tries to decommission 
+    // the splunk instance, but splunkd is not running due to above splunk enterprise 9.0.0 issue. So controller 
+    // fail and returns. This goes on in a loop and we always try the same pod instance and rest of the replicas 
+    // are still in older version
+    // As a temporary fix for 9.0.0 , if the image version do not  match with pod image version we delete the 
+    // splunk statefulset for indexer
 
 	var phase enterpriseApi.Phase
 	versionUpgrade := false

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -27,8 +27,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	rclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/go-logr/logr"
 	enterpriseApi "github.com/splunk/splunk-operator/api/v3"
@@ -151,33 +151,33 @@ func ApplyIndexerCluster(ctx context.Context, client splcommon.ControllerClient,
 		return result, err
 	}
 
-	
-		// FIXME POC
-		var phase enterpriseApi.Phase
-		versionUpgrade := false
-		// get all the pods in the namespace
-		statefulsetPods := &corev1.PodList{}
-		opts := &rclient.ListOptions{
-			Namespace: cr.Namespace,
-		}
-		err = client.List(ctx, statefulsetPods, opts)
-		if err != nil {
-			return result , err
-		}
+	// FIXME POC
+	var phase enterpriseApi.Phase
+	versionUpgrade := false
+	// get all the pods in the namespace
+	statefulsetPods := &corev1.PodList{}
+	opts := []rclient.ListOption{
+		rclient.InNamespace(cr.GetNamespace()),
+	}
 
-		// filter the pods which are owned by statefulset
-		for _, v := range statefulsetPods.Items {
-			for _, owner := range v.GetOwnerReferences() {
-				if owner.UID == statefulSet.UID {
-					// get the pod image name
-					if v.Spec.Containers[0].Image != cr.Spec.Image {
-						versionUpgrade  = true
-						break
-					}
+	err = client.List(ctx, statefulsetPods, opts...)
+	if err != nil {
+		return result, nil
+	}
+
+	// filter the pods which are owned by statefulset
+	for _, v := range statefulsetPods.Items {
+		for _, owner := range v.GetOwnerReferences() {
+			if owner.UID == statefulSet.UID {
+				// get the pod image name
+				if v.Spec.Containers[0].Image != cr.Spec.Image {
+					versionUpgrade = true
+					break
 				}
 			}
 		}
-	
+	}
+
 	if !versionUpgrade {
 		phase, err = mgr.Update(ctx, client, statefulSet, cr.Spec.Replicas)
 		if err != nil {
@@ -185,14 +185,13 @@ func ApplyIndexerCluster(ctx context.Context, client splcommon.ControllerClient,
 			return result, err
 		}
 	} else {
-
 		err = client.Delete(ctx, statefulSet)
 		if err != nil {
 			eventPublisher.Warning(ctx, "UpdateManager", fmt.Sprintf("version mitmatch for indexer clustre and indexer container, delete statefulset failed %s", err.Error()))
 			eventPublisher.Warning(ctx, "UpdateManager", fmt.Sprintf("%s-%s, %s-%s", "indexer-image", cr.Spec.Image, "container-image", statefulSet.Spec.Template.Spec.Containers[0].Image))
 			return result, err
 		}
-		time.Sleep(1*time.Second)
+		time.Sleep(1 * time.Second)
 		phase, err = mgr.Update(ctx, client, statefulSet, cr.Spec.Replicas)
 		if err != nil {
 			eventPublisher.Warning(ctx, "UpdateManager", fmt.Sprintf("update statefulset failed %s", err.Error()))

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -208,6 +208,8 @@ func ApplyIndexerCluster(ctx context.Context, client splcommon.ControllerClient,
 			return result, err
 		}
 		time.Sleep(1 * time.Second)
+		// since we are creating new statefulset, setting resourceVersion to ""
+		statefulSet.ResourceVersion = ""
 		phase, err = mgr.Update(ctx, client, statefulSet, cr.Spec.Replicas)
 		if err != nil {
 			eventPublisher.Warning(ctx, "UpdateManager", fmt.Sprintf("update statefulset failed %s", err.Error()))

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -152,18 +152,18 @@ func ApplyIndexerCluster(ctx context.Context, client splcommon.ControllerClient,
 	}
 
 	// Note:
-	// this it temporary fix for CSPL-1880. enterprise splunk 9.0.0 fails when we migrate from 
+	// this it temporary fix for CSPL-1880. enterprise splunk 9.0.0 fails when we migrate from 8.2.6.
 	// splunk 9.0.0 app bundle transfer uses encryption while transferring data. if any of the 
-	// splunk instances not enable or supporeting then cluster master fails to transfer this leads 
+	// splunk instances were not enable support this option, then cluster master fails to transfer, this leads 
 	// to splunkd restart at the peer level. for more information refer 
 	// https://splunk.atlassian.net/browse/SPL-223386?jql=text%20~%20%22The%20downloaded%20bundle%20checksum%20doesn%27t%20match%20the%20activeBundleChecksum%22
-	// On Operator side we have set statefulset update strategy to OnDelete, so pod needed to be 
-	// deleted by opeartor, before deleting the pod, operator controller code tries to decommision the splunk
-	// instance, but splunkd is not running due to above splunk enterprise 9.0.0 issue so we fail and 
-	// return this goes on a loop and we always try the same pod instance, and rest of the replicas are still 
-	// in older version
-	// As a temporary fix for 9.0.0 , we delete the splunk statefulset for indexer if the image version do not
-	// match with pod image version
+	// On Operator side we have set statefulset update strategy to OnDelete,i so pods need to be 
+	// deleted by operator manually.  Before deleting the pod, operator controller code tries to decommission 
+	// the splunk instance, but splunkd is not running due to above splunk enterprise 9.0.0 issue. So controller 
+	// fail and returns. This goes on in a loop and we always try the same pod instance and rest of the replicas 
+	// are still in older version
+	// As a temporary fix for 9.0.0 , if the image version do not  match with pod image version we delete the 
+	// splunk statefulset for indexer 
 	var phase enterpriseApi.Phase
 	versionUpgrade := false
 	// get all the pods in the namespace

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -153,17 +153,17 @@ func ApplyIndexerCluster(ctx context.Context, client splcommon.ControllerClient,
 
 	// Note:
 	// This is a temporary fix for CSPL-1880. Splunk enterprise 9.0.0 fails when we migrate from 8.2.6.
-    // Splunk 9.0.0 bundle push uses encryption while transferring data. If any of the 
-    // splunk instances were not able to support this option, then cluster master fails to transfer, this leads 
-    // to splunkd restart at the peer level. For more information refer 
-    // https://splunk.atlassian.net/browse/SPL-223386?jql=text%20~%20%22The%20downloaded%20bundle%20checksum%20doesn%27t%20match%20the%20activeBundleChecksum%22
-    // On Operator side we have set statefulset update strategy to OnDelete, so pods need to be 
-    // deleted by operator manually.  Before deleting the pod, operator controller code tries to decommission 
-    // the splunk instance, but splunkd is not running due to above splunk enterprise 9.0.0 issue. So controller 
-    // fail and returns. This goes on in a loop and we always try the same pod instance and rest of the replicas 
-    // are still in older version
-    // As a temporary fix for 9.0.0 , if the image version do not  match with pod image version we delete the 
-    // splunk statefulset for indexer
+	// Splunk 9.0.0 bundle push uses encryption while transferring data. If any of the
+	// splunk instances were not able to support this option, then cluster master fails to transfer, this leads
+	// to splunkd restart at the peer level. For more information refer
+	// https://splunk.atlassian.net/browse/SPL-223386?jql=text%20~%20%22The%20downloaded%20bundle%20checksum%20doesn%27t%20match%20the%20activeBundleChecksum%22
+	// On Operator side we have set statefulset update strategy to OnDelete, so pods need to be
+	// deleted by operator manually.  Before deleting the pod, operator controller code tries to decommission
+	// the splunk instance, but splunkd is not running due to above splunk enterprise 9.0.0 issue. So controller
+	// fail and returns. This goes on in a loop and we always try the same pod instance and rest of the replicas
+	// are still in older version
+	// As a temporary fix for 9.0.0 , if the image version do not  match with pod image version we delete the
+	// splunk statefulset for indexer
 
 	var phase enterpriseApi.Phase
 	versionUpgrade := false

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -157,13 +157,14 @@ func ApplyIndexerCluster(ctx context.Context, client splcommon.ControllerClient,
 	// splunk instances were not enable support this option, then cluster master fails to transfer, this leads 
 	// to splunkd restart at the peer level. for more information refer 
 	// https://splunk.atlassian.net/browse/SPL-223386?jql=text%20~%20%22The%20downloaded%20bundle%20checksum%20doesn%27t%20match%20the%20activeBundleChecksum%22
-	// On Operator side we have set statefulset update strategy to OnDelete,i so pods need to be 
+	// On Operator side we have set statefulset update strategy to OnDelete, so pods need to be 
 	// deleted by operator manually.  Before deleting the pod, operator controller code tries to decommission 
 	// the splunk instance, but splunkd is not running due to above splunk enterprise 9.0.0 issue. So controller 
 	// fail and returns. This goes on in a loop and we always try the same pod instance and rest of the replicas 
 	// are still in older version
 	// As a temporary fix for 9.0.0 , if the image version do not  match with pod image version we delete the 
 	// splunk statefulset for indexer 
+
 	var phase enterpriseApi.Phase
 	versionUpgrade := false
 	// get all the pods in the namespace

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -183,6 +183,7 @@ func ApplyIndexerCluster(ctx context.Context, client splcommon.ControllerClient,
 			if owner.UID == statefulSet.UID {
 				// get the pod image name
 				if v.Spec.Containers[0].Image != cr.Spec.Image {
+					// image do not match that means its image upgrade
 					versionUpgrade = true
 					break
 				}
@@ -190,6 +191,7 @@ func ApplyIndexerCluster(ctx context.Context, client splcommon.ControllerClient,
 		}
 	}
 
+	// check if version upgrade is set
 	if !versionUpgrade {
 		phase, err = mgr.Update(ctx, client, statefulSet, cr.Spec.Replicas)
 		if err != nil {
@@ -197,6 +199,7 @@ func ApplyIndexerCluster(ctx context.Context, client splcommon.ControllerClient,
 			return result, err
 		}
 	} else {
+		// Delete the statefulset and recreate new one
 		err = client.Delete(ctx, statefulSet)
 		if err != nil {
 			eventPublisher.Warning(ctx, "UpdateManager", fmt.Sprintf("version mitmatch for indexer clustre and indexer container, delete statefulset failed %s", err.Error()))

--- a/pkg/splunk/enterprise/indexercluster_test.go
+++ b/pkg/splunk/enterprise/indexercluster_test.go
@@ -59,7 +59,6 @@ func TestApplyIndexerCluster(t *testing.T) {
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
 		{MetaName: "*v1.Secret-test-splunk-stack1-indexer-secret-v1"},
 		{MetaName: "*v3.ClusterMaster-test-master1"},
-		//{MetaName: "*v1.Secret-test-splunk-test-secret"},
 		{MetaName: "*v3.IndexerCluster-test-stack1"},
 		{MetaName: "*v3.IndexerCluster-test-stack1"},
 	}
@@ -73,7 +72,6 @@ func TestApplyIndexerCluster(t *testing.T) {
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
 		{MetaName: "*v1.Secret-test-splunk-stack1-indexer-secret-v1"},
 		{MetaName: "*v3.ClusterMaster-test-master1"},
-		//{MetaName: "*v1.Secret-test-splunk-test-secret"},
 		{MetaName: "*v3.IndexerCluster-test-stack1"},
 		{MetaName: "*v3.IndexerCluster-test-stack1"},
 	}

--- a/pkg/splunk/enterprise/indexercluster_test.go
+++ b/pkg/splunk/enterprise/indexercluster_test.go
@@ -59,7 +59,7 @@ func TestApplyIndexerCluster(t *testing.T) {
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
 		{MetaName: "*v1.Secret-test-splunk-stack1-indexer-secret-v1"},
 		{MetaName: "*v3.ClusterMaster-test-master1"},
-		{MetaName: "*v1.Secret-test-splunk-test-secret"},
+		//{MetaName: "*v1.Secret-test-splunk-test-secret"},
 		{MetaName: "*v3.IndexerCluster-test-stack1"},
 		{MetaName: "*v3.IndexerCluster-test-stack1"},
 	}
@@ -73,7 +73,7 @@ func TestApplyIndexerCluster(t *testing.T) {
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
 		{MetaName: "*v1.Secret-test-splunk-stack1-indexer-secret-v1"},
 		{MetaName: "*v3.ClusterMaster-test-master1"},
-		{MetaName: "*v1.Secret-test-splunk-test-secret"},
+		//{MetaName: "*v1.Secret-test-splunk-test-secret"},
 		{MetaName: "*v3.IndexerCluster-test-stack1"},
 		{MetaName: "*v3.IndexerCluster-test-stack1"},
 	}
@@ -86,10 +86,15 @@ func TestApplyIndexerCluster(t *testing.T) {
 		client.InNamespace("test"),
 		client.MatchingLabels(labels),
 	}
+	listOpts1 := []client.ListOption{
+		client.InNamespace("test"),
+	}
 	listmockCall := []spltest.MockFuncCall{
-		{ListOpts: listOpts}}
-	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[0], funcCalls[4], funcCalls[5], funcCalls[8]}, "Update": {funcCalls[0]}, "List": {listmockCall[0]}}
-	updateCalls := map[string][]spltest.MockFuncCall{"Get": updateFuncCalls, "List": {listmockCall[0]}}
+		{ListOpts: listOpts},
+		{ListOpts: listOpts1},
+	}
+	createCalls := map[string][]spltest.MockFuncCall{"Get": funcCalls, "Create": {funcCalls[0], funcCalls[4], funcCalls[5], funcCalls[8]}, "Update": {funcCalls[0]}, "List": {listmockCall[0], listmockCall[1]}}
+	updateCalls := map[string][]spltest.MockFuncCall{"Get": updateFuncCalls, "List": {listmockCall[0], listmockCall[1]}}
 
 	current := enterpriseApi.IndexerCluster{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
when we move from 8.2.6 to 9.0.0 , due to [enterprise issue](https://splunk.atlassian.net/browse/SPL-223386?jql=text%20~%20%22The%20downloaded%20bun[…]ecksum%20doesn%27t%20match%20the%20activeBundleChecksum%22](https://splunk.atlassian.net/browse/SPL-223386?jql=text%20~%20%22The%20downloaded%20bundle%20checksum%20doesn%27t%20match%20the%20activeBundleChecksum%22) migration fails for indexer cluster. In Operator code migration fails as we try to decommission the indexer. 

Fix: delete the indexer statefulset if container image version is different than statefulset image version