### PR TITLE
CSPL-1916 - Update Makefile to ensure correct order in artifact generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,7 @@ generate-artifacts-cluster: manifests kustomize ## Deploy controller to the K8s 
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	RELATED_IMAGE_SPLUNK_ENTERPRISE=${SPLUNK_ENTERPRISE_IMAGE} WATCH_NAMESPACE=${WATCH_NAMESPACE} $(KUSTOMIZE) build config/default > release-${VERSION}/splunk-operator-cluster.yaml
 
-generate-artifacts: generate-artifacts-cluster generate-artifacts-namespace
+generate-artifacts: generate-artifacts-namespace generate-artifacts-cluster
 	echo "artifacts generation complete"
 
 #############################


### PR DESCRIPTION
The current order of artifact generation can leave the remaining `config/default/kustomization.yaml` set to only watch namespaces after execution, which is not the default. This Task aims at fixing the order of generation in the Makefile to ensure the default value remains after execution. 