### PR TITLE
[Draft] CSPL-1406 - Update Github actions to use 'main' as branch ref

### DIFF
--- a/.github/workflows/automated-release-workflow.yml
+++ b/.github/workflows/automated-release-workflow.yml
@@ -15,7 +15,7 @@ jobs:
   automated-release:
     name: Automated Release Workflow
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/build-test-push-workflow.yml
+++ b/.github/workflows/build-test-push-workflow.yml
@@ -258,7 +258,7 @@ jobs:
           make cluster-down
   push-latest:
     needs: smoke-tests
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     env:
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator

--- a/.github/workflows/int-test-workflow.yml
+++ b/.github/workflows/int-test-workflow.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - develop
-      - master
+      - main
 jobs:
   build-operator-image:
     runs-on: ubuntu-latest
@@ -91,8 +91,8 @@ jobs:
             echo "CLUSTER_WORKERS=5" >> $GITHUB_ENV
             echo "CLUSTER_NODES=2" >> $GITHUB_ENV
           fi
-      - name: Change splunk enterprise to release on master branches
-        if: github.ref == 'ref/head/master'
+      - name: Change splunk enterprise to release on main branches
+        if: github.ref == 'ref/head/main'
         run: |
           echo "SPLUNK_ENTERPRISE_IMAGE=${{ env.SPLUNK_ENTERPRISE_RELEASE_IMAGE }}" >> $GITHUB_ENV
       - name: Checkcout code

--- a/.github/workflows/merge-develop-to-master-workflow.yml
+++ b/.github/workflows/merge-develop-to-master-workflow.yml
@@ -1,4 +1,4 @@
-name: Merge Develop To Master Workflow
+name: Merge Develop To Main Workflow
 on: 
   workflow_dispatch:
     inputs:
@@ -18,8 +18,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: master
-    - name: Reset master branch
+        ref: main
+    - name: Reset main branch
       run: |
         git fetch origin develop:develop
         git reset --hard develop
@@ -29,12 +29,12 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3.10.1
       with:
-        branch: "promote-develop-to-master-${{ github.event.inputs.release_version }}"
-        base: "master"
-        title: "Promote Develop to Master for Splunk Operator Release ${{ github.event.inputs.release_version }}"
+        branch: "promote-develop-to-main-${{ github.event.inputs.release_version }}"
+        base: "main"
+        title: "Promote Develop to Main for Splunk Operator Release ${{ github.event.inputs.release_version }}"
         reviewers: "${{ steps.dotenv.outputs.REVIEWERS }}"
         body: |
-          Automated Pull Request To Merge Develop To Master For Release Version ${{ github.event.inputs.release_version }}
+          Automated Pull Request To Merge Develop To Main For Release Version ${{ github.event.inputs.release_version }}
   
   rc-release:
     runs-on: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
       with:
-        ref: "promote-develop-to-master-${{ github.event.inputs.release_version }}"
+        ref: "promote-develop-to-main-${{ github.event.inputs.release_version }}"
 
     - name: Deep Fetch 
       run: |

--- a/docs/K8SCollectors.md
+++ b/docs/K8SCollectors.md
@@ -1,5 +1,5 @@
 # **K8s data collectors**
-The Splunk Operator for K8s deploys Splunk Enterprise custom resources across a single namespace or multiple namespaces. The helper scripts `k8s-splunk-collector.sh` and `k8s-systeminfo-collector.sh` in the [tools directory](https://github.com/splunk/splunk-operator/tree/master/tools/k8s_collectors) collect data from a K8s cluster which runs the Splunk Operator for K8s.
+The Splunk Operator for K8s deploys Splunk Enterprise custom resources across a single namespace or multiple namespaces. The helper scripts `k8s-splunk-collector.sh` and `k8s-systeminfo-collector.sh` in the [tools directory](https://github.com/splunk/splunk-operator/tree/main/tools/k8s_collectors) collect data from a K8s cluster which runs the Splunk Operator for K8s.
 
 ## **Splunk Collector for K8s - k8s-splunk-collector.sh**
 The Splunk collector for K8s collects data from multiple <kubectl> get/describe commands, container logs and diags from the Splunk instances (if opted for) in the context of the current namespace.


### PR DESCRIPTION
This PR will update the GIthub Actions to use `Main` as a branch ref instead of `Master`.

Merging this PR should be followed by:
1) Deleting the existing `main` branch that is outdated
2) Renaming `master` branch to `main` [Procedure here](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch)