### PR TITLE
CSPL-1874: Helm chart support for all Splunk Instance types

### DIFF
--- a/helm-chart/splunk-enterprise/.helmignore
+++ b/helm-chart/splunk-enterprise/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-chart/splunk-enterprise/Chart.yaml
+++ b/helm-chart/splunk-enterprise/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+name: splunk-enterprise
+description: A Helm chart for Splunk Enterprise managed by the Splunk Operator
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "2.0.0"
+
+dependencies:
+- name: splunk-operator
+  version: "1.0.0"
+  repository: "file://splunk-operator/helm-chart/splunk-operator"
+  condition: splunk-operator.enabled

--- a/helm-chart/splunk-enterprise/templates/_helpers.tpl
+++ b/helm-chart/splunk-enterprise/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "splunk-enterprise.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "splunk-enterprise.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "splunk-enterprise.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "splunk-enterprise.labels" -}}
+helm.sh/chart: {{ include "splunk-enterprise.chart" . }}
+{{ include "splunk-enterprise.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "splunk-enterprise.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "splunk-enterprise.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "splunk-enterprise.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "splunk-enterprise.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define namespace of release and allow for namespace override
+*/}}
+{{- define "splunk-enterprise.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride }}
+{{- end }}

--- a/helm-chart/splunk-enterprise/templates/enterprise_v3_clustermaster.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v3_clustermaster.yaml
@@ -1,0 +1,106 @@
+{{- if .Values.clusterMaster.enabled }}
+apiVersion: enterprise.splunk.com/v3
+kind: ClusterMaster
+metadata:
+  name: {{ .Values.clusterMaster.name }}
+  namespace: {{ default (include "splunk-enterprise.namespace" . ) .Values.clusterMaster.namespaceOverride }}
+{{- with .Values.clusterMaster.additionalLabels }}
+  labels:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.clusterMaster.appRepo }}
+  appRepo: 
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.clusterMaster.smartstore }}
+  smartstore:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if .Values.existingLicenseMaster }}
+  licenseMasterRef:
+    name: {{ .Values.existingLicenseMaster.name }}
+  {{- if .Values.existingLicenseMaster.namespace }}
+    namespace: {{ .Values.existingLicenseMaster.namespace }}
+  {{- end }}
+{{- else if .Values.licenseMaster.enabled }}
+  licenseMasterRef:
+    name: {{ .Values.licenseMaster.name }}
+  {{- if .Values.licenseMaster.namespaceOverride }}
+    namespace: {{ .Values.licenseMaster.namespaceOverride }}
+  {{- end }}
+{{- end }}
+{{- if .Values.existingMonitoringConsole }}
+  monitoringConsoleRef:
+    name: {{ .Values.existingMonitoringConsole.name }}
+  {{- if .Values.existingMonitoringConsole.namespace }}
+    namespace: {{ .Values.existingMonitoringConsole.namespace }}
+  {{- end }}
+{{- else if .Values.monitoringConsole.enabled }}
+  monitoringConsoleRef:
+    name: {{ .Values.monitoringConsole.name }}
+  {{- if .Values.monitoringConsole.namespaceOverride }}
+    namespace: {{ .Values.monitoringConsole.namespaceOverride }}
+  {{- end }}
+{{- end }}
+{{- if .Values.image.repository }}
+  image: {{ .Values.image.repository }}
+{{- end }}
+{{- if .Values.image.imagePullPolicy }}
+  imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+{{- end }}
+{{- with .Values.image.imagePullSecrets }}
+  imagePullSecrets:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.clusterMaster.volumes }}      
+  volumes:
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- if .Values.clusterMaster.licenseUrl }}
+  licenseUrl: {{ .Values.clusterMaster.licenseUrl }}
+{{- end }}
+{{- if .Values.clusterMaster.defaultsUrl }}
+  defaultsUrl: {{ .Values.clusterMaster.defaultsUrl }}
+{{- end }}
+{{- if .Values.clusterMaster.defaults }}
+  defaults: |-
+{{ toYaml .Values.clusterMaster.defaults | indent 4 }}
+{{- end }}
+{{- if .Values.clusterMaster.defaultsUrlApps }}
+  defaultsUrlApps: {{ .Values.clusterMaster.defaultsUrlApps }}
+{{- end }}
+{{- with .Values.clusterMaster.extraEnv }}
+  extraEnv:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if .Values.clusterMaster.livenessInitialDelaySeconds }}
+  livenessInitialDelaySeconds: {{ .Values.clusterMaster.livenessInitialDelaySeconds }}
+{{- end }}
+{{- if .Values.clusterMaster.readinessInitialDelaySeconds }}
+  readinessInitialDelaySeconds: {{ .Values.clusterMaster.readinessInitialDelaySeconds }}
+{{- end }}
+{{- with .Values.clusterMaster.etcVolumeStorageConfig }}
+  etcVolumeStorageConfig:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.clusterMaster.varVolumeStorageConfig }}
+  varVolumeStorageConfig:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.clusterMaster.resources }}
+  resources:
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- if .Values.clusterMaster.serviceAccount }}
+  serviceAccount: {{ .Values.clusterMaster.serviceAccount }}
+{{- end }}
+{{- with .Values.clusterMaster.tolerations }}
+  tolerations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.clusterMaster.affinity }}
+  affinity:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}

--- a/helm-chart/splunk-enterprise/templates/enterprise_v3_indexercluster.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v3_indexercluster.yaml
@@ -1,0 +1,111 @@
+{{- if .Values.indexerCluster.enabled }}
+apiVersion: enterprise.splunk.com/v3
+kind: IndexerCluster
+metadata:
+  name: {{ .Values.indexerCluster.name }}
+  namespace: {{ default (include "splunk-enterprise.namespace" . ) .Values.indexerCluster.namespaceOverride }}
+{{- with .Values.indexerCluster.additionalLabels }}
+  labels:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.indexerCluster.replicaCount }}
+  replicas: {{ .Values.indexerCluster.replicaCount }}
+{{- end }}
+{{- if .Values.existingClusterMaster }}
+  clusterMasterRef:
+    name: {{ .Values.existingClusterMaster.name }}
+  {{- if .Values.existingClusterMaster.namespace }}
+    namespace: {{ .Values.existingClusterMaster.namespace }}
+  {{- end }}
+{{- else if .Values.clusterMaster.enabled }}
+  clusterMasterRef:
+    name: {{ .Values.clusterMaster.name }}
+  {{- if .Values.clusterMaster.namespaceOverride }}
+    namespace: {{ .Values.clusterMaster.namespaceOverride }}
+  {{- end }}
+{{- end }}
+{{- if .Values.existingLicenseMaster }}
+  licenseMasterRef:
+    name: {{ .Values.existingLicenseMaster.name }}
+  {{- if .Values.existingLicenseMaster.namespace }}
+    namespace: {{ .Values.existingLicenseMaster.namespace }}
+  {{- end }}
+{{- else if .Values.licenseMaster.enabled }}
+  licenseMasterRef:
+    name: {{ .Values.licenseMaster.name }}
+  {{- if .Values.licenseMaster.namespaceOverride }}
+    namespace: {{ .Values.licenseMaster.namespaceOverride }}
+  {{- end }}
+{{- end }}
+{{- if .Values.existingMonitoringConsole }}
+  monitoringConsoleRef:
+    name: {{ .Values.existingMonitoringConsole.name }}
+  {{- if .Values.existingMonitoringConsole.namespace }}
+    namespace: {{ .Values.existingMonitoringConsole.namespace }}
+  {{- end }}
+{{- else if .Values.monitoringConsole.enabled }}
+  monitoringConsoleRef:
+    name: {{ .Values.monitoringConsole.name }}
+  {{- if .Values.monitoringConsole.namespaceOverride }}
+    namespace: {{ .Values.monitoringConsole.namespaceOverride }}
+  {{- end }}
+{{- end }}
+{{- if .Values.image.repository }}
+  image: {{ .Values.image.repository }}
+{{- end }}
+{{- if .Values.image.imagePullPolicy }}
+  imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+{{- end }}
+{{- with .Values.image.imagePullSecrets }}
+  imagePullSecrets:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.indexerCluster.volumes }}      
+  volumes:
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- if .Values.indexerCluster.licenseUrl }}
+  licenseUrl: {{ .Values.indexerCluster.licenseUrl }}
+{{- end }}
+{{- if .Values.indexerCluster.defaultsUrl }}
+  defaultsUrl: {{ .Values.indexerCluster.defaultsUrl }}
+{{- end }}
+{{- if .Values.indexerCluster.defaults }}
+  defaults: |-
+{{ toYaml .Values.indexerCluster.defaults | indent 4 }}
+{{- end }}
+{{- with .Values.indexerCluster.extraEnv }}
+  extraEnv:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if .Values.indexerCluster.livenessInitialDelaySeconds }}
+  livenessInitialDelaySeconds: {{ .Values.indexerCluster.livenessInitialDelaySeconds }}
+{{- end }}
+{{- if .Values.indexerCluster.readinessInitialDelaySeconds }}
+  readinessInitialDelaySeconds: {{ .Values.indexerCluster.readinessInitialDelaySeconds }}
+{{- end }}
+{{- with .Values.indexerCluster.etcVolumeStorageConfig }}
+  etcVolumeStorageConfig:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.indexerCluster.varVolumeStorageConfig }}
+  varVolumeStorageConfig:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.indexerCluster.resources }}
+  resources:
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- if .Values.indexerCluster.serviceAccount }}
+  serviceAccount: {{ .Values.indexerCluster.serviceAccount }}
+{{- end }}
+{{- with .Values.indexerCluster.tolerations }}
+  tolerations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.indexerCluster.affinity }}
+  affinity:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}

--- a/helm-chart/splunk-enterprise/templates/enterprise_v3_licensemaster.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v3_licensemaster.yaml
@@ -1,0 +1,94 @@
+{{- if .Values.licenseMaster.enabled }}
+apiVersion: enterprise.splunk.com/v3
+kind: LicenseMaster
+metadata:
+  name: {{ .Values.licenseMaster.name }}
+  namespace: {{ default (include "splunk-enterprise.namespace" . ) .Values.licenseMaster.namespaceOverride }}
+{{- with .Values.licenseMaster.additionalLabels }}
+  labels:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.licenseMaster.appRepo }}
+  appRepo: 
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if .Values.existingClusterMaster }}
+  clusterMasterRef:
+    name: {{ .Values.existingClusterMaster.name }}
+  {{- if .Values.existingClusterMaster.namespace }}
+    namespace: {{ .Values.existingClusterMaster.namespace }}
+  {{- end }}
+{{- else if .Values.clusterMaster.enabled }}
+  clusterMasterRef:
+    name: {{ .Values.clusterMaster.name }}
+  {{- if .Values.clusterMaster.namespaceOverride }}
+    namespace: {{ .Values.clusterMaster.namespaceOverride }}
+  {{- end }}
+{{- end }}
+{{- if .Values.existingMonitoringConsole }}
+  monitoringConsoleRef:
+    name: {{ .Values.existingMonitoringConsole.name }}
+  {{- if .Values.existingMonitoringConsole.namespace }}
+    namespace: {{ .Values.existingMonitoringConsole.namespace }}
+  {{- end }}
+{{- else if .Values.monitoringConsole.enabled }}
+  monitoringConsoleRef:
+    name: {{ .Values.monitoringConsole.name }}
+  {{- if .Values.monitoringConsole.namespaceOverride }}
+    namespace: {{ .Values.monitoringConsole.namespaceOverride }}
+  {{- end }}
+{{- end }}
+{{- if .Values.image.repository }}
+  image: {{ .Values.image.repository }}
+{{- end }}
+{{- if .Values.image.imagePullPolicy }}
+  imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+{{- end }}
+{{- with .Values.image.imagePullSecrets }}
+  imagePullSecrets:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.licenseMaster.volumes }}      
+  volumes:
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- if .Values.licenseMaster.licenseUrl }}
+  licenseUrl: {{ .Values.licenseMaster.licenseUrl }}
+{{- end }}
+{{- if .Values.licenseMaster.defaultsUrl }}
+  defaultsUrl: {{ .Values.licenseMaster.defaultsUrl }}
+{{- end }}
+{{- if .Values.licenseMaster.defaults }}
+  defaults: |-
+{{ toYaml .Values.licenseMaster.defaults | indent 4 }}
+{{- end }}
+{{- if .Values.licenseMaster.defaultsUrlApps }}
+  defaultsUrlApps: {{ .Values.licenseMaster.defaultsUrlApps }}
+{{- end }}
+{{- with .Values.licenseMaster.extraEnv }}
+  extraEnv:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if .Values.licenseMaster.livenessInitialDelaySeconds }}
+  livenessInitialDelaySeconds: {{ .Values.licenseMaster.livenessInitialDelaySeconds }}
+{{- end }}
+{{- if .Values.licenseMaster.readinessInitialDelaySeconds }}
+  readinessInitialDelaySeconds: {{ .Values.licenseMaster.readinessInitialDelaySeconds }}
+{{- end }}
+{{- with .Values.licenseMaster.resources }}
+  resources:
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- if .Values.licenseMaster.serviceAccount }}
+  serviceAccount: {{ .Values.licenseMaster.serviceAccount }}
+{{- end }}
+{{- with .Values.licenseMaster.tolerations }}
+  tolerations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.licenseMaster.affinity }}
+  affinity:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}

--- a/helm-chart/splunk-enterprise/templates/enterprise_v3_monitoringconsole.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v3_monitoringconsole.yaml
@@ -1,0 +1,102 @@
+{{- if .Values.monitoringConsole.enabled }}
+apiVersion: enterprise.splunk.com/v3
+kind: MonitoringConsole
+metadata:
+  name: {{ .Values.monitoringConsole.name }}
+  namespace: {{ default (include "splunk-enterprise.namespace" . ) .Values.monitoringConsole.namespaceOverride }}
+{{- with .Values.monitoringConsole.additionalLabels }}
+  labels:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.monitoringConsole.appRepo }}
+  appRepo: 
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if .Values.existingClusterMaster }}
+  clusterMasterRef:
+    name: {{ .Values.existingClusterMaster.name }}
+  {{- if .Values.existingClusterMaster.namespace }}
+    namespace: {{ .Values.existingClusterMaster.namespace }}
+  {{- end }}
+{{- else if .Values.clusterMaster.enabled }}
+  clusterMasterRef:
+    name: {{ .Values.clusterMaster.name }}
+  {{- if .Values.clusterMaster.namespaceOverride }}
+    namespace: {{ .Values.clusterMaster.namespaceOverride }}
+  {{- end }}
+{{- end }}
+{{- if .Values.existingLicenseMaster }}
+  licenseMasterRef:
+    name: {{ .Values.existingLicenseMaster.name }}
+  {{- if .Values.existingLicenseMaster.namespace }}
+    namespace: {{ .Values.existingLicenseMaster.namespace }}
+  {{- end }}
+{{- else if .Values.licenseMaster.enabled }}
+  licenseMasterRef:
+    name: {{ .Values.licenseMaster.name }}
+  {{- if .Values.licenseMaster.namespaceOverride }}
+    namespace: {{ .Values.licenseMaster.namespaceOverride }}
+  {{- end }}
+{{- end }}
+{{- if .Values.image.repository }}
+  image: {{ .Values.image.repository }}
+{{- end }}
+{{- if .Values.image.imagePullPolicy }}
+  imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+{{- end }}
+{{- with .Values.image.imagePullSecrets }}
+  imagePullSecrets:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.monitoringConsole.volumes }}      
+  volumes:
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- if .Values.monitoringConsole.licenseUrl }}
+  licenseUrl: {{ .Values.monitoringConsole.licenseUrl }}
+{{- end }}
+{{- if .Values.monitoringConsole.defaultsUrl }}
+  defaultsUrl: {{ .Values.monitoringConsole.defaultsUrl }}
+{{- end }}
+{{- if .Values.monitoringConsole.defaults }}
+  defaults: |-
+{{ toYaml .Values.monitoringConsole.defaults | indent 4 }}
+{{- end }}
+{{- if .Values.monitoringConsole.defaultsUrlApps }}
+  defaultsUrlApps: {{ .Values.monitoringConsole.defaultsUrlApps }}
+{{- end }}
+{{- with .Values.monitoringConsole.extraEnv }}
+  extraEnv:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if .Values.monitoringConsole.livenessInitialDelaySeconds }}
+  livenessInitialDelaySeconds: {{ .Values.monitoringConsole.livenessInitialDelaySeconds }}
+{{- end }}
+{{- if .Values.monitoringConsole.readinessInitialDelaySeconds }}
+  readinessInitialDelaySeconds: {{ .Values.monitoringConsole.readinessInitialDelaySeconds }}
+{{- end }}
+{{- with .Values.monitoringConsole.etcVolumeStorageConfig }}
+  etcVolumeStorageConfig:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.monitoringConsole.varVolumeStorageConfig }}
+  varVolumeStorageConfig:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.monitoringConsole.resources }}
+  resources:
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- if .Values.monitoringConsole.serviceAccount }}
+  serviceAccount: {{ .Values.monitoringConsole.serviceAccount }}
+{{- end }}
+{{- with .Values.monitoringConsole.tolerations }}
+  tolerations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.monitoringConsole.affinity }}
+  affinity:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}

--- a/helm-chart/splunk-enterprise/templates/enterprise_v3_searchheadcluster.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v3_searchheadcluster.yaml
@@ -1,0 +1,91 @@
+{{- if .Values.searchHeadCluster.enabled }}
+apiVersion: enterprise.splunk.com/v3
+kind: SearchHeadCluster
+metadata:
+  name: {{ .Values.searchHeadCluster.name }}
+  namespace: {{ default (include "splunk-enterprise.namespace" . ) .Values.searchHeadCluster.namespaceOverride }}
+{{- with .Values.searchHeadCluster.additionalLabels }}
+  labels:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.searchHeadCluster.replicaCount }}
+  replicas: {{ .Values.searchHeadCluster.replicaCount }}
+{{- end }}
+{{- with .Values.searchHeadCluster.appRepo }}
+  appRepo: 
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if .Values.clusterMaster.enabled }}
+  clusterMasterRef: 
+    name: {{ .Values.clusterMaster.name }}
+{{- end }}
+{{- if .Values.licenseMaster.enabled }}
+  licenseMasterRef:
+    name: {{ .Values.licenseMaster.name }}
+{{- end }}
+{{- if .Values.monitoringConsole.enabled }}
+  monitoringConsoleRef: 
+    name: {{ .Values.monitoringConsole.name }}
+{{- end }}
+{{- if .Values.image.repository }}
+  image: {{ .Values.image.repository }}
+{{- end }}
+{{- if .Values.image.imagePullPolicy }}
+  imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+{{- end }}
+{{- with .Values.image.imagePullSecrets }}
+  imagePullSecrets:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.searchHeadCluster.volumes }}      
+  volumes:
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- if .Values.searchHeadCluster.licenseUrl }}
+  licenseUrl: {{ .Values.searchHeadCluster.licenseUrl }}
+{{- end }}
+{{- if .Values.searchHeadCluster.defaultsUrl }}
+  defaultsUrl: {{ .Values.searchHeadCluster.defaultsUrl }}
+{{- end }}
+{{- if .Values.searchHeadCluster.defaults }}
+  defaults: |-
+{{ toYaml .Values.searchHeadCluster.defaults | indent 4 }}
+{{- end }}
+{{- if .Values.searchHeadCluster.defaultsUrlApps }}
+  defaultsUrlApps: {{ .Values.searchHeadCluster.defaultsUrlApps }}
+{{- end }}
+{{- with .Values.searchHeadCluster.extraEnv }}
+  extraEnv:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if .Values.searchHeadCluster.livenessInitialDelaySeconds }}
+  livenessInitialDelaySeconds: {{ .Values.searchHeadCluster.livenessInitialDelaySeconds }}
+{{- end }}
+{{- if .Values.searchHeadCluster.readinessInitialDelaySeconds }}
+  readinessInitialDelaySeconds: {{ .Values.searchHeadCluster.readinessInitialDelaySeconds }}
+{{- end }}
+{{- with .Values.searchHeadCluster.etcVolumeStorageConfig }}
+  etcVolumeStorageConfig:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.searchHeadCluster.varVolumeStorageConfig }}
+  varVolumeStorageConfig:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.searchHeadCluster.resources }}
+  resources:
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- if .Values.searchHeadCluster.serviceAccount }}
+  serviceAccount: {{ .Values.searchHeadCluster.serviceAccount }}
+{{- end }}
+{{- with .Values.searchHeadCluster.tolerations }}
+  tolerations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.searchHeadCluster.affinity }}
+  affinity:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}

--- a/helm-chart/splunk-enterprise/templates/enterprise_v3_standalone.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v3_standalone.yaml
@@ -1,0 +1,122 @@
+{{- if .Values.standalone.enabled }}
+apiVersion: enterprise.splunk.com/v3
+kind: Standalone
+metadata:
+  name: {{ .Values.standalone.name }}
+  namespace: {{ default (include "splunk-enterprise.namespace" . ) .Values.standalone.namespaceOverride }}
+{{- with .Values.standalone.additionalLabels }}
+  labels:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.standalone.replicaCount }}
+  replicas: {{ .Values.standalone.replicaCount }}
+{{- end }}
+{{- with .Values.standalone.appRepo }}
+  appRepo: 
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.standalone.smartstore }}
+  smartstore:
+{{ toYaml .Values.standalone.smartstore | indent 4 }}
+{{- end }}
+{{- if .Values.existingClusterMaster }}
+  clusterMasterRef:
+    name: {{ .Values.existingClusterMaster.name }}
+  {{- if .Values.existingClusterMaster.namespace }}
+    namespace: {{ .Values.existingClusterMaster.namespace }}
+  {{- end }}
+{{- else if .Values.clusterMaster.enabled }}
+  clusterMasterRef:
+    name: {{ .Values.clusterMaster.name }}
+  {{- if .Values.clusterMaster.namespaceOverride }}
+    namespace: {{ .Values.clusterMaster.namespaceOverride }}
+  {{- end }}
+{{- end }}
+{{- if .Values.existingLicenseMaster }}
+  licenseMasterRef:
+    name: {{ .Values.existingLicenseMaster.name }}
+  {{- if .Values.existingLicenseMaster.namespace }}
+    namespace: {{ .Values.existingLicenseMaster.namespace }}
+  {{- end }}
+{{- else if .Values.licenseMaster.enabled }}
+  licenseMasterRef:
+    name: {{ .Values.licenseMaster.name }}
+  {{- if .Values.licenseMaster.namespaceOverride }}
+    namespace: {{ .Values.licenseMaster.namespaceOverride }}
+  {{- end }}
+{{- end }}
+{{- if .Values.existingMonitoringConsole }}
+  monitoringConsoleRef:
+    name: {{ .Values.existingMonitoringConsole.name }}
+  {{- if .Values.existingMonitoringConsole.namespace }}
+    namespace: {{ .Values.existingMonitoringConsole.namespace }}
+  {{- end }}
+{{- else if .Values.monitoringConsole.enabled }}
+  monitoringConsoleRef:
+    name: {{ .Values.monitoringConsole.name }}
+  {{- if .Values.monitoringConsole.namespaceOverride }}
+    namespace: {{ .Values.monitoringConsole.namespaceOverride }}
+  {{- end }}
+{{- end }}
+{{- if .Values.image.repository }}
+  image: {{ .Values.image.repository }}
+{{- end }}
+{{- if .Values.image.imagePullPolicy }}
+  imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+{{- end }}
+{{- with .Values.image.imagePullSecrets }}
+  imagePullSecrets:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.standalone.volumes }}      
+  volumes:
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- if .Values.standalone.licenseUrl }}
+  licenseUrl: {{ .Values.standalone.licenseUrl }}
+{{- end }}
+{{- if .Values.standalone.defaultsUrl }}
+  defaultsUrl: {{ .Values.standalone.defaultsUrl }}
+{{- end }}
+{{- if .Values.standalone.defaults }}
+  defaults: |-
+{{ toYaml .Values.standalone.defaults | indent 4 }}
+{{- end }}
+{{- if .Values.standalone.defaultsUrlApps }}
+  defaultsUrlApps: {{ .Values.standalone.defaultsUrlApps }}
+{{- end }}
+{{- with .Values.standalone.extraEnv }}
+  extraEnv:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if .Values.standalone.livenessInitialDelaySeconds }}
+  livenessInitialDelaySeconds: {{ .Values.standalone.livenessInitialDelaySeconds }}
+{{- end }}
+{{- if .Values.standalone.readinessInitialDelaySeconds }}
+  readinessInitialDelaySeconds: {{ .Values.standalone.readinessInitialDelaySeconds }}
+{{- end }}
+{{- with .Values.standalone.etcVolumeStorageConfig }}
+  etcVolumeStorageConfig:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.standalone.varVolumeStorageConfig }}
+  varVolumeStorageConfig:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.standalone.resources }}
+  resources:
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- if .Values.standalone.serviceAccount }}
+  serviceAccount: {{ .Values.standalone.serviceAccount }}
+{{- end }}
+{{- with .Values.standalone.tolerations }}
+  tolerations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.standalone.affinity }}
+  affinity:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}

--- a/helm-chart/splunk-enterprise/values.yaml
+++ b/helm-chart/splunk-enterprise/values.yaml
@@ -1,0 +1,529 @@
+# Image to use for Splunk pod containers 
+# Overrides RELATED_IMAGE_SPLUNK_ENTERPRISE environment variable in Splunk Operator manager container
+image:
+  repository: ""
+  imagePullPolicy: ""
+  imagePullSecrets: []
+
+# Deploy Splunk Operator chart
+# Disable if the Splunk Operator is already deployed
+splunk-operator:
+  enabled: true
+
+# Set name reference if ClusterMaster is already deployed
+# Namespace is optional, set if the resource exists outside of the release namespace
+existingClusterMaster:
+  # name:
+  # namespace: 
+
+# Set name reference if MonitoringConsole is already deployed
+# Namespace is optional, set if the resource exists outside of the release namespace
+existingMonitoringConsole: {}
+  # name: 
+  # namespace: 
+
+# Set name reference if LicenseMaster is already deployed
+# Namespace is optional, set if the resource exists outside of the release namespace
+existingLicenseMaster: {}
+  # name: 
+  # namespace: 
+
+# Configure a Splunk Cluster Master instance
+clusterMaster:
+
+  # Deploy a cluster master instance
+  enabled: false
+
+  # Specify the custom resource name
+  name: "cm"
+
+  # Override the custom resource namespace
+  # Default deploys to the release namespace
+  namespaceOverride: ""
+
+  # Specify additional labels
+  additionalLabels: {}
+
+  # Splunk Enterprise App repository
+  # Specifies remote App location and scope for Splunk App management
+  # reference: https://github.com/splunk/splunk-operator/blob/develop/docs/AppFramework.md
+  appRepo:
+    ## Example: Deploy apps on cluster master instance for local use
+    # appsRepoPollIntervalSeconds: 900
+    # appSources:
+    #   - name: networkApps
+    #     location: networkAppsLoc/
+    #   - name: clusterBase
+    #     location: clusterBaseLoc/
+    #   - name: adminApps
+    #     location: adminAppsLoc/
+    #     scope: local
+    # volumes:
+    #   - name: volume_app_repo_us
+    #     storageType: s3
+    #     provider: aws
+    #     path: bucket-app-framework-us-west-2/idxcAndCmApps/
+    #     endpoint: https://s3-us-west-2.amazonaws.com
+    #     region: us-west-2
+    #     secretRef: s3-secret
+    
+  # Splunk Smartstore configuration
+  # reference: https://github.com/splunk/splunk-operator/blob/develop/docs/SmartStore.md
+  smartstore: {}
+    ## Example: Deploy smartstore to a clustermaster, distributes config to indexer peers
+    # volumes:
+    #   - name: <remote_volume_name>
+    #     path: <remote_volume_path>
+    #     endpoint: https://s3-<region>.amazonaws.com
+    #     secretRef: <secret_store_obj>
+    # indexes:
+    #   - name: <index_name_1>
+    #     remotePath: $_index_name
+    #     volumeName: <remote_volume_name>
+    #   - name: <index_name_2>
+    #     remotePath: $_index_name
+    #     volumeName: <remote_volume_name>
+    #   - name: <index_name_3>
+    #     remotePath: $_index_name
+    #     volumeName: <remote_volume_name>
+  
+  # List volumes to be mounted in all pod containers
+  # reference: https://kubernetes.io/docs/concepts/storage/volumes/
+  volumes: []
+
+  # Full path or URL for a Splunk Enterprise license file
+  # Ignore if deploying a license master instance
+  licenseUrl: ""
+
+  # Full path or URL for one or more default.yml files, separated by commas
+  defaultsUrl: ""
+  
+  # Specify Splunk default.yaml to override intial environment config
+  defaults: {}
+    ## Example: Deploy a multi-site cluster master
+    # splunk:
+    #   site: site1
+    #   multisite_master: localhost
+    #   all_sites: site1,site2,site3
+    #   multisite_replication_factor_origin: 1
+    #   multisite_replication_factor_total: 2
+    #   multisite_search_factor_origin: 1
+    #   multisite_search_factor_total: 2
+    #   idxc:
+    #     search_factor: 2
+    #     replication_factor: 2
+
+  # Full path or URL for one or more defaults.yml files specific to App install, separated by commas
+  defaultsUrlApps: ""
+
+  # List additional environment variables to passed to the Splunk instance container
+  extraEnv: []
+  # - name: 
+  #   value: 
+
+  # Delay in seconds before probing liveness
+  # refernece: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command
+  livenessInitialDelaySeconds: 300
+
+  # Delay in seconds before probing readiness
+  # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command
+  readinessInitialDelaySeconds: 10
+
+  # Storage configuration for /opt/splunk/etc volume
+  # To use a StorageClass other than your default StorageClass, specify the storageClassName
+  # reference: https://github.com/splunk/splunk-operator/blob/develop/docs/StorageClass.md
+  etcVolumeStorageConfig:
+    ephemeralStorage: false
+    storageCapacity: 10Gi
+  # storageClassName: gp2
+
+  # Storage configuration for /opt/splunk/var volume
+  # To use a StorageClass other than your default StorageClass, specify the storageClassName
+  # reference: https://github.com/splunk/splunk-operator/blob/develop/docs/StorageClass.md
+  varVolumeStorageConfig:
+    ephemeralStorage: false
+    storageCapacity: 100Gi
+  # storageClassName: gp2
+
+  # Set resource requests and limits for Splunk instance pod containers
+  # reference: https://github.com/splunk/splunk-operator/blob/develop/docs/CustomResources.md#examples-of-guaranteed-and-burstable-qos
+  resources: {}
+    # requests:
+    #   memory: "2Gi"
+    #   cpu: "4"
+    # limits:
+    #   memory: "12Gi"
+    #   cpu: "24"  
+
+  # Specify a service account used by the Splunk instance pods
+  # Default uses the Default Service Account to access the API server
+  # reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  serviceAccount: ""
+
+  # Specify Splunk instance pod tolerations
+  # reference: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  tolerations: []
+
+  # Define affinity scheduling rules
+  # reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
+  affinity: {}
+    ## Example: schedule Splunk instance pod on a node in zone-1a 
+    # nodeAffinity:
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #     - matchExpressions:
+    #       - key: failure-domain.beta.kubernetes.io/zone
+    #         operator: In
+    #         values:
+    #         - zone-1a
+
+indexerCluster:
+
+  enabled: false
+
+  name: "idxc"
+
+  namespaceOverride: ""
+
+  additionalLabels: {}
+
+  replicaCount: 1
+  
+  volumes: []
+
+  licenseUrl: ""
+
+  defaultsUrl: ""
+
+  defaults: {}
+
+  extraEnv: []
+  # - name: 
+  #   value: 
+
+  livenessInitialDelaySeconds: 300
+
+  readinessInitialDelaySeconds: 10
+
+  etcVolumeStorageConfig:
+    ephemeralStorage: false
+    storageCapacity: 10Gi
+  # storageClassName: gp2
+
+  varVolumeStorageConfig:
+    ephemeralStorage: false
+    storageCapacity: 100Gi
+  # storageClassName: gp2
+
+  resources: {}
+    # requests:
+    #   memory: "2Gi"
+    #   cpu: "4"
+    # limits:
+    #   memory: "12Gi"
+    #   cpu: "24"  
+
+  serviceAccount: ""
+
+  tolerations: []
+  
+  affinity: {}
+
+searchHeadCluster:
+
+  enabled: false
+
+  name: "shc"
+
+  namespaceOverride: ""
+
+  additionalLabels: {}
+
+  replicaCount: 1
+
+  appRepo: {}
+    # appsRepoPollIntervalSeconds:
+    # defaults:
+    #   volumeName:
+    #   scope:
+    # appSources:
+    #   - name:
+    #     location:
+    # volumes:
+    #   - name:
+    #     storageType:
+    #     provider:
+    #     path:
+    #     endpoint:
+    #     region:
+    #     secretRef:
+  
+  volumes: []
+  
+  licenseUrl: ""
+
+  defaultsUrl: ""
+
+  defaults: {}
+
+  defaultsUrlApps: ""
+
+  extraEnv: []
+  # - name: 
+  #   value: 
+
+  livenessInitialDelaySeconds: 300
+
+  readinessInitialDelaySeconds: 10
+
+  etcVolumeStorageConfig:
+    ephemeralStorage: false
+    storageCapacity: 10Gi
+  # storageClassName: gp2
+
+  varVolumeStorageConfig:
+    ephemeralStorage: false
+    storageCapacity: 100Gi
+  # storageClassName: gp2
+
+  resources: {}
+    # requests:
+    #   memory: "2Gi"
+    #   cpu: "4"
+    # limits:
+    #   memory: "12Gi"
+    #   cpu: "24"  
+
+  serviceAccount: ""
+
+  tolerations: []
+  
+  affinity: {}
+
+monitoringConsole:
+
+  enabled: false
+
+  name: "mc"
+
+  namespaceOverride: ""
+
+  additionalLabels: {}
+
+  appRepo: {}
+    # appsRepoPollIntervalSeconds:
+    # defaults:
+    #   volumeName:
+    #   scope:
+    # appSources:
+    #   - name:
+    #     location:
+    # volumes:
+    #   - name:
+    #     storageType:
+    #     provider:
+    #     path:
+    #     endpoint:
+    #     region:
+    #     secretRef:
+  
+  volumes: []
+
+  licenseUrl: ""
+
+  defaultsUrl: ""
+
+  defaults: {}
+
+  defaultsUrlApps: ""
+
+  extraEnv: []
+  # - name: 
+  #   value: 
+
+  livenessInitialDelaySeconds: 300
+
+  readinessInitialDelaySeconds: 10
+
+  etcVolumeStorageConfig:
+    ephemeralStorage: false
+    storageCapacity: 10Gi
+  # storageClassName: gp2
+
+  varVolumeStorageConfig:
+    ephemeralStorage: false
+    storageCapacity: 100Gi
+  # storageClassName: gp2
+
+  resources: {}
+    # requests:
+    #   memory: "2Gi"
+    #   cpu: "4"
+    # limits:
+    #   memory: "12Gi"
+    #   cpu: "24"  
+
+  serviceAccount: ""
+
+  tolerations: []
+  
+  affinity: {}
+
+licenseMaster:
+
+  enabled: false
+
+  name: "lm"
+
+  namespaceOverride: ""
+
+  additionalLabels: {}
+
+  appRepo: {}
+    # appsRepoPollIntervalSeconds:
+    # defaults:
+    #   volumeName:
+    #   scope:
+    # appSources:
+    #   - name:
+    #     location:
+    # volumes:
+    #   - name:
+    #     storageType:
+    #     provider:
+    #     path:
+    #     endpoint:
+    #     region:
+    #     secretRef:
+  
+  volumes: []
+  ## Example: mounting volume containing license in Splunk instance pod container
+  # - name: licenses
+  #   configMap:
+  #     name: splunk-licenses
+
+  licenseUrl: ""
+  ## Example: using mounted volume to specify license file path
+  # licenseUrl: /mnt/licenses/enterprise.lic
+
+  defaultsUrl: ""
+
+  defaults: {}
+
+  defaultsUrlApps: ""
+
+  extraEnv: []
+  # - name: 
+  #   value: 
+
+  livenessInitialDelaySeconds: 300
+
+  readinessInitialDelaySeconds: 10
+
+  etcVolumeStorageConfig:
+    ephemeralStorage: false
+    storageCapacity: 10Gi
+  # storageClassName: gp2
+
+  varVolumeStorageConfig:
+    ephemeralStorage: false
+    storageCapacity: 100Gi
+  # storageClassName: gp2
+
+  resources: {}
+    # requests:
+    #   memory: "2Gi"
+    #   cpu: "4"
+    # limits:
+    #   memory: "12Gi"
+    #   cpu: "24"  
+
+  serviceAccount: ""
+
+  tolerations: []
+  
+  affinity: {}
+
+standalone:
+
+  enabled: false
+
+  name: "stdln"
+
+  namespaceOverride: ""
+
+  additionalLabels: {}
+
+  replicaCount: 1
+
+  appRepo: {}
+    # appsRepoPollIntervalSeconds:
+    # defaults:
+    #   volumeName:
+    #   scope:
+    # appSources:
+    #   - name:
+    #     location:
+    # volumes:
+    #   - name:
+    #     storageType:
+    #     provider:
+    #     path:
+    #     endpoint:
+    #     region:
+    #     secretRef:
+    
+  smartstore: {}
+    # defaults:
+    #   volumeName:
+    # indexes:
+    #   - name:
+    #     volumeName:
+    #     remotePath:
+    # volumes:
+    #   - name:
+    #     path:
+    #     endpoint:
+    #     secretRef:
+  
+  volumes: []
+
+  licenseUrl: ""
+
+  defaultsUrl: ""
+
+  defaults: {}
+
+  defaultsUrlApps: ""
+
+  extraEnv: []
+  # - name: 
+  #   value: 
+
+  livenessInitialDelaySeconds: 300
+
+  readinessInitialDelaySeconds: 10
+
+  etcVolumeStorageConfig:
+    ephemeralStorage: false
+    storageCapacity: 10Gi
+  # storageClassName: gp2
+
+  varVolumeStorageConfig:
+    ephemeralStorage: false
+    storageCapacity: 100Gi
+  # storageClassName: gp2
+
+  resources: {}
+    # requests:
+    #   memory: "2Gi"
+    #   cpu: "4"
+    # limits:
+    #   memory: "12Gi"
+    #   cpu: "24"
+
+  serviceAccount: ""
+
+  tolerations: []
+  
+  affinity: {}


### PR DESCRIPTION
Helm chart implementation of Splunk Instance as a separate chart from Operator.
Splunk Instance Chart to deploy a supported instance of Splunk managed by an Operator

- Standalone
- Cluster Manager
- Indexer Cluster
- Search Head Cluster
- Monitoring Console
- License Manager