### PR TITLE
CSPL-1923: Addition of code and unittests to download the app packages

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,5 +16,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: splunk/splunk-operator
-  newTag: 1.1.0
+  newName: controller
+  newTag: latest

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,5 +16,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
-  newTag: latest
+  newName: splunk/splunk-operator
+  newTag: 1.1.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -17,4 +17,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: splunk/splunk-operator
-  newTag: 1.1.0
+  newTag: 2.0.0

--- a/pkg/splunk/client/azureblobclient.go
+++ b/pkg/splunk/client/azureblobclient.go
@@ -305,6 +305,7 @@ func updateAzureHTTPRequestHeaderWithIAM(ctx context.Context, client *AzureBlobC
 
 	return nil
 }
+	defer resp.Body.Close()
 
 // GetAppsList gets the list of apps from remote storage
 func (client *AzureBlobClient) GetAppsList(ctx context.Context) (RemoteDataListResponse, error) {
@@ -411,7 +412,23 @@ func extractResponse(ctx context.Context, httpResponse *http.Response) (RemoteDa
 
 	return azureAppsRemoteData, nil
 }
+		newStorageClass := "standard" //TODO : map to a azure blob field
 
+		// Create new object and append
+		newRemoteObject := RemoteObject{Etag: &newETag, Key: &newKey, LastModified: &newLastModified, Size: &newSize, StorageClass: &newStorageClass}
+		azureAppsRemoteData.Objects = append(azureAppsRemoteData.Objects, &newRemoteObject)
+	}
+<<<<<<< HEAD
+
+	return azureAppsRemoteData, nil
+}
+
+=======
+
+	return azureAppsRemoteData, nil
+}
+
+>>>>>>> 1a05e2a8... Add support to list azure apis with auth framework for secrets and IAM
 // DownloadApp downloads an app package from remote storage
 func (client *AzureBlobClient) DownloadApp(ctx context.Context, downloadRequest RemoteDataDownloadRequest) (bool, error) {
 	/*

--- a/pkg/splunk/client/azureblobclient.go
+++ b/pkg/splunk/client/azureblobclient.go
@@ -25,9 +25,11 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -310,9 +312,10 @@ func updateAzureHTTPRequestHeaderWithIAM(ctx context.Context, client *AzureBlobC
 // GetAppsList gets the list of apps from remote storage
 func (client *AzureBlobClient) GetAppsList(ctx context.Context) (RemoteDataListResponse, error) {
 	reqLogger := log.FromContext(ctx)
-	scopedLog := reqLogger.WithName("AzureBlob:GetAppsList")
+	scopedLog := reqLogger.WithName("AzureBlob:GetAppsList").WithValues("Endpoint", client.Endpoint, "Storage Account", client.BucketName,
+		"Prefix", client.Prefix)
 
-	scopedLog.Info("Getting Apps list", "Azure Blob Bucket", client.BucketName, "Prefix", client.Prefix)
+	scopedLog.Info("Getting Apps list")
 
 	// create rest request URL with storage account name, container, prefix
 	appsListFetchURL := fmt.Sprintf(azureBlobListAppFetchURL, client.Endpoint, client.BucketName, client.Prefix)
@@ -431,36 +434,66 @@ func extractResponse(ctx context.Context, httpResponse *http.Response) (RemoteDa
 >>>>>>> 1a05e2a8... Add support to list azure apis with auth framework for secrets and IAM
 // DownloadApp downloads an app package from remote storage
 func (client *AzureBlobClient) DownloadApp(ctx context.Context, downloadRequest RemoteDataDownloadRequest) (bool, error) {
-	/*
-		reqLogger := log.FromContext(ctx)
-		scopedLog := reqLogger.WithName("DownloadApp").WithValues("remoteFile", downloadRequest.RemoteFile,
-			downloadRequest.LocalFile, downloadRequest.Etag)
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("AzureBlob:DownloadApp").WithValues("Endpoint", client.Endpoint, "Storage Account", client.BucketName,
+		"Prefix", client.Prefix, "downloadRequest", downloadRequest)
 
-		file, err := os.Create(downloadRequest.LocalFile)
-		if err != nil {
-			scopedLog.Error(err, "Unable to create local file")
-			return false, err
-		}
-		defer file.Close()
+	scopedLog.Info("Download App package")
 
-		azureBlobClient := client.Client
+	// create rest request URL with storage account name, container, prefix
+	appPackageFetchURL := fmt.Sprintf(azureBlobDownloadAppFetchURL, client.Endpoint, client.BucketName, downloadRequest.RemoteFile)
 
-		//TODO : revise in next sprint . these are just place holder to more
-		// specific data structure so we can pass download options to rest calls
-		downloadOptions := make(map[string]string)
+	// Create a http request with the URL
+	httpRequest, err := http.NewRequest("GET", appPackageFetchURL, nil)
+	if err != nil {
+		scopedLog.Error(err, "Azure Blob Failed to create request for App package fetch URL")
+		return false, err
+	}
 
-		downloadOptions["maxChunkSize"] = "5gb"
-		downloadOptions["timeout"] = "5sec"
+	// Setup the httpRequest with required authentication
+	if client.StorageAccountName != "" && client.SecretAccessKey != "" {
+		// Use Secrets
+		err = updateAzureHTTPRequestHeaderWithSecrets(ctx, client, httpRequest)
+	} else {
+		// No Secret provided, try using IAM
+		err = updateAzureHTTPRequestHeaderWithIAM(ctx, client, httpRequest)
+	}
+	if err != nil {
+		scopedLog.Error(err, "Failed to get http request authenticated")
+		return false, err
+	}
 
-		err = azureBlobClient.DownloadApp(ctx, client.BucketName, downloadRequest.RemoteFile, downloadRequest.LocalFile, downloadOptions)
-		if err != nil {
-			scopedLog.Error(err, "Unable to download remote file")
-			return false, err
-		}
+	scopedLog.Info("Calling the download rest request")
 
-		scopedLog.Info("File downloaded")
-	*/
-	return true, nil
+	// Download the app
+	httpResponse, err := client.HTTPClient.Do(httpRequest)
+	if err != nil {
+		scopedLog.Error(err, "Azure blob, unable to execute download apps http request")
+		return false, err
+	}
+	defer httpResponse.Body.Close()
+
+	// Create local file on operator
+	localFile, err := os.Create(downloadRequest.LocalFile)
+	if err != nil {
+		scopedLog.Error(err, "Unable to open local file")
+		return false, err
+	}
+	defer localFile.Close()
+
+	scopedLog.Info("Copying the download response to localFile")
+
+	// Copy the http response (app packages to the local file path)
+	_, err = io.Copy(localFile, httpResponse.Body)
+	if err != nil {
+		fmt.Println(err.Error(), "Failed when copying resp body for app download")
+		return false, err
+	}
+
+	// Successfully listed apps
+	scopedLog.Info("Download apps successful")
+
+	return true, err
 }
 
 // RegisterAzureBlobClient will add the corresponding function pointer to the map

--- a/pkg/splunk/client/azureblobclient.go
+++ b/pkg/splunk/client/azureblobclient.go
@@ -372,7 +372,6 @@ func extractResponse(ctx context.Context, httpResponse *http.Response) (RemoteDa
 	if err != nil {
 		scopedLog.Error(err, "Azure blob,Errored when reading resp body for app download")
 	}
-	defer httpResponse.Body.Close()
 
 	// Variable to hold unmarshaled data
 	data := &EnumerationResults{}

--- a/pkg/splunk/client/azureblobclient_test.go
+++ b/pkg/splunk/client/azureblobclient_test.go
@@ -102,7 +102,10 @@ func TestAzureBlobGetAppsListShouldNotFail(t *testing.T) {
 
 	// Get App source and volume from spec
 	appSource := appFrameworkRef.AppSources[0]
-	vol, _ := GetAppSrcVolume(ctx, appSource, &appFrameworkRef)
+	vol, err := GetAppSrcVolume(ctx, appSource, &appFrameworkRef)
+	if err != nil {
+		t.Errorf("Unable to get volume for app source : %s", appSource.Name)
+	}
 
 	// Update the GetRemoteDataClient function pointer
 	getClientWrapper := RemoteDataClientsMap[vol.Provider]
@@ -245,7 +248,10 @@ func TestAzureBlobGetAppsListShouldFail(t *testing.T) {
 
 	// Get App source and volume from spec
 	appSource := appFrameworkRef.AppSources[0]
-	vol, _ := GetAppSrcVolume(ctx, appSource, &appFrameworkRef)
+	vol, err := GetAppSrcVolume(ctx, appSource, &appFrameworkRef)
+	if err != nil {
+		t.Errorf("Unable to get volume for app source : %s", appSource.Name)
+	}
 
 	// Update the GetRemoteDataClient function pointer
 	getClientWrapper := RemoteDataClientsMap[vol.Provider]
@@ -267,7 +273,7 @@ func TestAzureBlobGetAppsListShouldFail(t *testing.T) {
 	azureBlobClient.StorageAccountName = vol.Path
 	azureBlobClient.SecretAccessKey = "abcd"
 	azureBlobClient.Endpoint = "not-a-valid-end-point"
-	_, err := azureBlobClient.GetAppsList(ctx)
+	_, err = azureBlobClient.GetAppsList(ctx)
 	if err == nil {
 		t.Errorf("Expected error for invalid endpoint")
 	}
@@ -341,7 +347,10 @@ func TestAzureBlobDownloadAppShouldNotFail(t *testing.T) {
 
 	// Get App source and volume from spec
 	appSource := appFrameworkRef.AppSources[0]
-	vol, _ := GetAppSrcVolume(ctx, appSource, &appFrameworkRef)
+	vol, err := GetAppSrcVolume(ctx, appSource, &appFrameworkRef)
+	if err != nil {
+		t.Errorf("Unable to get volume for app source : %s", appSource.Name)
+	}
 
 	// Update the GetRemoteDataClient function pointer
 	getClientWrapper := RemoteDataClientsMap[vol.Provider]
@@ -369,7 +378,7 @@ func TestAzureBlobDownloadAppShouldNotFail(t *testing.T) {
 		LocalFile:  "app1.tgz",
 		RemoteFile: "adminAppsRepo/app1.tgz",
 	}
-	_, err := azureBlobClient.DownloadApp(ctx, downloadRequest)
+	_, err = azureBlobClient.DownloadApp(ctx, downloadRequest)
 	if err != nil {
 		t.Errorf("DownloadApps should not return nil")
 	}
@@ -449,7 +458,10 @@ func TestAzureBlobDownloadAppShouldFail(t *testing.T) {
 
 	// Get App source and volume from spec
 	appSource := appFrameworkRef.AppSources[0]
-	vol, _ := GetAppSrcVolume(ctx, appSource, &appFrameworkRef)
+	vol, err := GetAppSrcVolume(ctx, appSource, &appFrameworkRef)
+	if err != nil {
+		t.Errorf("Unable to get volume for app source : %s", appSource.Name)
+	}
 
 	// Update the GetRemoteDataClient function pointer
 	getClientWrapper := RemoteDataClientsMap[vol.Provider]
@@ -482,7 +494,7 @@ func TestAzureBlobDownloadAppShouldFail(t *testing.T) {
 
 	// Test error for http request to download
 	azureBlobClient.Endpoint = "dummy"
-	_, err := azureBlobClient.DownloadApp(ctx, downloadRequest)
+	_, err = azureBlobClient.DownloadApp(ctx, downloadRequest)
 	if err == nil {
 		t.Errorf("Expected error for incorrect http request")
 	}

--- a/pkg/splunk/client/names.go
+++ b/pkg/splunk/client/names.go
@@ -14,18 +14,21 @@ const (
 	// https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=linux
 	azureIMDSApiVersion = "2021-10-01"
 
-	// Azure URL for listing apps
+	// Azure URL for listing app packages
+	// URL format is {azure_end_point}/{bucketName}?prefix=%s&restype=container&comp=list&include=snapshots&include=metadata"
+	// For example : https://mystorageaccount.blob.core.windows.net/myappsbucket?prefix=standalone&restype=container&comp=list&include=snapshots&include=metadata
 	azureBlobListAppFetchURL = "%s/%s?prefix=%s&restype=container&comp=list&include=snapshots&include=metadata"
-
 =======
-	// Azure Instance Metadata Service (IMDS) api-version parameter
-	// IMDS is versioned and specifying the API version in the HTTP request is mandatory
-	// https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=linux
-	azureIMDSApiVersion = "2021-10-01"
+	// Azure URL for downloading an app package
+	// URL format is {azure_end_point}/{bucketName}/{pathToAppPackage}
+	// For example : https://mystorageaccount.blob.core.windows.net/myappsbucket/standlone/myappsteamapp.tgz
+	azureBlobDownloadAppFetchURL = "%s/%s/%s"
+>>>>>>> be844fd4... CSPL-1923 - addition for downloading app packages
 
->>>>>>> 54b5bd3e... addess review comments
-	// Azure URL for listing apps
-	azureBlobListAppFetchURL = "%s/%s?prefix=%s&restype=container&comp=list&include=snapshots&include=metadata"
+	// Azure URL for downloading an app package
+	// URL format is {azure_end_point}/{bucketName}/{pathToAppPackage}
+	// For example : https://mystorageaccount.blob.core.windows.net/myappsbucket/standlone/myappsteamapp.tgz
+	azureBlobDownloadAppFetchURL = "%s/%s/%s"
 
 	// Header strings
 	headerAuthorization      = "Authorization"

--- a/pkg/splunk/client/names.go
+++ b/pkg/splunk/client/names.go
@@ -17,7 +17,7 @@ const (
 	azureBlobListAppFetchURL = "%s/%s?prefix=%s&restype=container&comp=list&include=snapshots&include=metadata"
 
 	// Azure URL for listing apps
-	azureBlobListAppFetchUrl = "%s/%s?prefix=%s&restype=container&comp=list&include=snapshots&include=metadata"
+	azureBlobListAppFetchURL = "%s/%s?prefix=%s&restype=container&comp=list&include=snapshots&include=metadata"
 
 	// Header strings
 	headerAuthorization      = "Authorization"

--- a/pkg/splunk/client/names.go
+++ b/pkg/splunk/client/names.go
@@ -16,6 +16,9 @@ const (
 	// Azure URL for listing apps
 	azureBlobListAppFetchURL = "%s/%s?prefix=%s&restype=container&comp=list&include=snapshots&include=metadata"
 
+	// Azure URL for listing apps
+	azureBlobListAppFetchUrl = "%s/%s?prefix=%s&restype=container&comp=list&include=snapshots&include=metadata"
+
 	// Header strings
 	headerAuthorization      = "Authorization"
 	headerCacheControl       = "Cache-Control"

--- a/pkg/splunk/client/names.go
+++ b/pkg/splunk/client/names.go
@@ -8,6 +8,7 @@ const (
 	// https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services
 	azureHTTPHeaderXmsVersion = "2021-08-06"
 
+<<<<<<< HEAD
 	// Azure Instance Metadata Service (IMDS) api-version parameter.
 	// IMDS is versioned and specifying the API version in the HTTP request is mandatory.
 	// https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=linux
@@ -16,6 +17,13 @@ const (
 	// Azure URL for listing apps
 	azureBlobListAppFetchURL = "%s/%s?prefix=%s&restype=container&comp=list&include=snapshots&include=metadata"
 
+=======
+	// Azure Instance Metadata Service (IMDS) api-version parameter
+	// IMDS is versioned and specifying the API version in the HTTP request is mandatory
+	// https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=linux
+	azureIMDSApiVersion = "2021-10-01"
+
+>>>>>>> 54b5bd3e... addess review comments
 	// Azure URL for listing apps
 	azureBlobListAppFetchURL = "%s/%s?prefix=%s&restype=container&comp=list&include=snapshots&include=metadata"
 

--- a/pkg/splunk/client/util.go
+++ b/pkg/splunk/client/util.go
@@ -79,7 +79,6 @@ func NewMockMinioS3Client(ctx context.Context, bucketName string, accessKeyID st
 }
 
 // NewMockAzureBlobClient will create a mock azureblob client
-// TODO next sprint for completeness
 func NewMockAzureBlobClient(ctx context.Context, bucketName string, storageAccountName string, secretAccessKey string, prefix string, startAfter string, region string, endpoint string, fn GetInitFunc) (RemoteDataClient, error) {
 	var err error
 


### PR DESCRIPTION
**Adding functionality to download app packages from Azure blob**
Changes related to CSPL-1923:
Extending  `azureblobclient.go` to allow downloading app packages from azure blob containers (buckets) 
Extending the unit tests to tests the download functionality as well as enhance the app lists unit tests

