### PR TITLE
CSPL-2103: Fix int test on develop

### DIFF
--- a/.github/workflows/int-test-workflow.yml
+++ b/.github/workflows/int-test-workflow.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - develop
       - master
-      - fix-int-test-on-develop
 jobs:
   build-operator-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/int-test-workflow.yml
+++ b/.github/workflows/int-test-workflow.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - develop
       - master
+      - fix-int-test-on-develop
 jobs:
   build-operator-image:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ deploy: manifests kustomize uninstall ## Deploy controller to the K8s cluster sp
 	$(SED) "s/value: WATCH_NAMESPACE_VALUE/value: \"${WATCH_NAMESPACE}\"/g"  config/default/kustomization.yaml
 	$(SED) "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	RELATED_IMAGE_SPLUNK_ENTERPRISE=${SPLUNK_ENTERPRISE_IMAGE} WATCH_NAMESPACE=${WATCH_NAMESPACE} $(KUSTOMIZE) build config/default | kubectl apply -f -
+	RELATED_IMAGE_SPLUNK_ENTERPRISE=${SPLUNK_ENTERPRISE_IMAGE} WATCH_NAMESPACE=${WATCH_NAMESPACE} $(KUSTOMIZE) build config/default | kubectl create -f -
 	$(SED) "s/namespace: ${NAMESPACE}/namespace: splunk-operator/g"  config/default/kustomization.yaml
 	$(SED) "s/value: \"${WATCH_NAMESPACE}\"/value: WATCH_NAMESPACE_VALUE/g"  config/default/kustomization.yaml
 	$(SED) "s|${SPLUNK_ENTERPRISE_IMAGE}|SPLUNK_ENTERPRISE_IMAGE|g"  config/default/kustomization.yaml

--- a/test/monitoring_console/monitoring_console_test.go
+++ b/test/monitoring_console/monitoring_console_test.go
@@ -471,7 +471,7 @@ var _ = Describe("Monitoring Console test", func() {
 			siteCount := 3
 			mcName := deployment.GetName()
 			err := deployment.DeployMultisiteClusterMasterWithMonitoringConsole(ctx, deployment.GetName(), defaultIndexerReplicas, siteCount, mcName, true)
-			Expect(err).To(Succeed(), "Unable to deploy Indexer Clsuter with SHC")
+			Expect(err).To(Succeed(), "Unable to deploy Indexer Cluster with SHC")
 
 			// Ensure that the cluster-master goes to Ready phase
 			testenv.ClusterMasterReady(ctx, deployment, testcaseEnvInst)

--- a/test/monitoring_console/monitoring_console_test.go
+++ b/test/monitoring_console/monitoring_console_test.go
@@ -470,8 +470,8 @@ var _ = Describe("Monitoring Console test", func() {
 			defaultIndexerReplicas := 1
 			siteCount := 3
 			mcName := deployment.GetName()
-			err := deployment.DeployMultisiteClusterWithMonitoringConsole(ctx, deployment.GetName(), defaultIndexerReplicas, siteCount, mcName, true)
-			Expect(err).To(Succeed(), "Unable to deploy Cluster Manager")
+			err := deployment.DeployMultisiteClusterMasterWithMonitoringConsole(ctx, deployment.GetName(), defaultIndexerReplicas, siteCount, mcName, true)
+			Expect(err).To(Succeed(), "Unable to deploy Indexer Clsuter with SHC")
 
 			// Ensure that the cluster-master goes to Ready phase
 			testenv.ClusterMasterReady(ctx, deployment, testcaseEnvInst)

--- a/test/testenv/deployment.go
+++ b/test/testenv/deployment.go
@@ -1719,17 +1719,17 @@ func (d *Deployment) DeployMultisiteClusterWithMonitoringConsole(ctx context.Con
 // DeployMultisiteClusterMasterWithMonitoringConsole deploys cluster-master, indexers in multiple sites (SHC LM Optional) with monitoring console
 func (d *Deployment) DeployMultisiteClusterMasterWithMonitoringConsole(ctx context.Context, name string, indexerReplicas int, siteCount int, monitoringConsoleName string, shc bool) error {
 
-	licenseManager := ""
+	licenseMaster := ""
 
 	// If license file specified, deploy License Manager
 	if d.testenv.licenseFilePath != "" {
 		// Deploy the license manager
-		_, err := d.DeployLicenseManager(ctx, name)
+		_, err := d.DeployLicenseMaster(ctx, name)
 		if err != nil {
 			return err
 		}
 
-		licenseManager = name
+		licenseMaster = name
 	}
 
 	// Deploy the cluster-manager
@@ -1754,7 +1754,7 @@ func (d *Deployment) DeployMultisiteClusterMasterWithMonitoringConsole(ctx conte
 			},
 			Volumes: []corev1.Volume{},
 			LicenseManagerRef: corev1.ObjectReference{
-				Name: licenseManager,
+				Name: licenseMaster,
 			},
 			Defaults: defaults,
 			MonitoringConsoleRef: corev1.ObjectReference{
@@ -1775,7 +1775,7 @@ func (d *Deployment) DeployMultisiteClusterMasterWithMonitoringConsole(ctx conte
   multisite_master: splunk-%s-%s-service
   site: %s
 `, name, "cluster-master", siteName)
-		_, err := d.DeployIndexerCluster(ctx, name+"-"+siteName, licenseManager, indexerReplicas, name, siteDefaults)
+		_, err := d.DeployIndexerCluster(ctx, name+"-"+siteName, licenseMaster, indexerReplicas, name, siteDefaults)
 		if err != nil {
 			return err
 		}
@@ -1796,7 +1796,7 @@ func (d *Deployment) DeployMultisiteClusterMasterWithMonitoringConsole(ctx conte
 				Name: name,
 			},
 			LicenseManagerRef: corev1.ObjectReference{
-				Name: licenseManager,
+				Name: licenseMaster,
 			},
 			Defaults: siteDefaults,
 			MonitoringConsoleRef: corev1.ObjectReference{


### PR DESCRIPTION
- Added new method for creation of M4 with Clustermaster CRD
- Update test to use the new method

Test failing because we were deploying manager and waiting for master to come up. 

Local Passing Run
```	{"testcaseenv": "mastermc-rqq-n9v"}
• [SLOW TEST:1392.361 seconds]
Monitoring Console test
/Users/pdhanoya/splunk-operator-git/splunk-livliness-probe/splunk-operator/test/monitoring_console/monitoring_console_test.go:31
  Multisite Clustered deployment (M4 - 3 Site clustered indexer, search head cluster)
  /Users/pdhanoya/splunk-operator-git/splunk-livliness-probe/splunk-operator/test/monitoring_console/monitoring_console_test.go:448
    mastermc, integration, testrun: MC can configure SHC, indexer instances and reconfigure Cluster Manager to new Monitoring Console
    /Users/pdhanoya/splunk-operator-git/splunk-livliness-probe/splunk-operator/test/monitoring_console/monitoring_console_test.go:449
------------------------------
SSSSSS2022-10-13T11:16:03.128132-07:00	INFO	testenv deleted.
	{"testenv": "mc-rqq"}

JUnit report was created: /Users/pdhanoya/splunk-operator-git/splunk-livliness-probe/splunk-operator/test/monitoring_console/mc-rqq_junit.xml

Ran 1 of 9 Specs in 1393.293 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 8 Skipped```
