### PR TITLE
CSPL-2109: Fine tune command to get splunkd pid as it fails in AKS linux box

### DIFF
--- a/tools/k8_probes/livenessProbe.sh
+++ b/tools/k8_probes/livenessProbe.sh
@@ -37,7 +37,7 @@ get_http_proto_type() {
 
 # Check if the Splunkd process is running or not
 liveness_probe_check_splunkd_process() {
-  SPLUNK_PROCESS_ID=`ps ax | grep "splunkd.*start" | grep -v grep | head -1 | cut -d' ' -f2`
+  SPLUNK_PROCESS_ID=`ps ax | grep "splunkd.*start" | grep -v grep | head -1 | awk '{print $1}'`
 
   #If NO_HEALTHCHECK is NOT defined, then we want the healthcheck
   state="$(< $CONTAINER_ARTIFACT_DIR/splunk-container.state)"


### PR DESCRIPTION
The liveness probe was failing in AKS pods. This PR is to enhance the step that extracts the splunkd process id from `ps` command.
Verified that the SHC pods are no longer restarting after this fix.