### PR TITLE
CSPL-2151 - Changes to delete owner references of statefulSet on CR deletion, check for stale references to CM

### DIFF
--- a/pkg/splunk/controller/statefulset.go
+++ b/pkg/splunk/controller/statefulset.go
@@ -18,8 +18,9 @@ package controller
 import (
 	"context"
 	"fmt"
-	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 	"reflect"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 
 	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 	splutil "github.com/splunk/splunk-operator/pkg/splunk/util"
@@ -275,6 +276,32 @@ func SetStatefulSetOwnerRef(ctx context.Context, client splcommon.ControllerClie
 
 	// Update owner reference if needed
 	err = splutil.UpdateResource(ctx, client, statefulset)
+	return err
+}
+
+// RemoveUnwantedOwnerRefSs removes all the unwanted owner references for statefulset except the CR it belongs to
+func RemoveUnwantedOwnerRefSs(ctx context.Context, client splcommon.ControllerClient, namespacedName types.NamespacedName, cr splcommon.MetaObject) error {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("RemoveUnwantedOwnerRefSs").WithValues("statefulSet", namespacedName)
+
+	scopedLog.Info("Removing unwanted owner references on CR deletion")
+
+	// Get statefulSet
+	statefulset, err := GetStatefulSetByName(ctx, client, namespacedName)
+	if err != nil {
+		return err
+	}
+
+	// Configure statefulSet with only the CR's owner reference
+	crOwnerRef := make([]metav1.OwnerReference, 0)
+	statefulset.SetOwnerReferences(append(crOwnerRef, splcommon.AsOwner(cr, true)))
+
+	// Update statefulSet
+	err = splutil.UpdateResource(ctx, client, statefulset)
+	if err != nil {
+		return err
+	}
+
 	return err
 }
 

--- a/pkg/splunk/enterprise/afwscheduler.go
+++ b/pkg/splunk/enterprise/afwscheduler.go
@@ -63,7 +63,7 @@ func (ppln *AppInstallPipeline) createAndAddPipelineWorker(ctx context.Context, 
 		fanOut:        isFanOutApplicableToCR(cr),
 	}
 
-	scopedLog.Info("Created new worker", "Pod name", worker.targetPodName, "App name", appDeployInfo.AppName, "digest", appDeployInfo.ObjectHash, "phase", appDeployInfo.PhaseInfo.Phase, "fan out", worker.fanOut)
+	scopedLog.Info("Created new worker test", "Pod name", worker.targetPodName, "App name", appDeployInfo.AppName, "digest", appDeployInfo.ObjectHash, "phase", appDeployInfo.PhaseInfo.Phase, "fan out", worker.fanOut)
 
 	ppln.addWorkersToPipelinePhase(ctx, phase, worker)
 }

--- a/pkg/splunk/enterprise/afwscheduler.go
+++ b/pkg/splunk/enterprise/afwscheduler.go
@@ -63,7 +63,7 @@ func (ppln *AppInstallPipeline) createAndAddPipelineWorker(ctx context.Context, 
 		fanOut:        isFanOutApplicableToCR(cr),
 	}
 
-	scopedLog.Info("Created new worker test", "Pod name", worker.targetPodName, "App name", appDeployInfo.AppName, "digest", appDeployInfo.ObjectHash, "phase", appDeployInfo.PhaseInfo.Phase, "fan out", worker.fanOut)
+	scopedLog.Info("Created new worker", "Pod name", worker.targetPodName, "App name", appDeployInfo.AppName, "digest", appDeployInfo.ObjectHash, "phase", appDeployInfo.PhaseInfo.Phase, "fan out", worker.fanOut)
 
 	ppln.addWorkersToPipelinePhase(ctx, phase, worker)
 }

--- a/pkg/splunk/enterprise/clustermanager.go
+++ b/pkg/splunk/enterprise/clustermanager.go
@@ -18,10 +18,11 @@ package enterprise
 import (
 	"context"
 	"fmt"
-	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 	"reflect"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-logr/logr"
 	splclient "github.com/splunk/splunk-operator/pkg/splunk/client"
@@ -131,7 +132,14 @@ func ApplyClusterManager(ctx context.Context, client splcommon.ControllerClient,
 				return result, err
 			}
 		}
-		DeleteOwnerReferencesForResources(ctx, client, cr, &cr.Spec.SmartStore)
+
+		// Check if ClusterManager has any remaining references to other CRs, if so don't delete
+		err = checkCmRemainingReferences(ctx, client, cr)
+		if err != nil {
+			return result, err
+		}
+
+		DeleteOwnerReferencesForResources(ctx, client, cr, &cr.Spec.SmartStore, SplunkClusterManager)
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after

--- a/pkg/splunk/enterprise/clustermaster.go
+++ b/pkg/splunk/enterprise/clustermaster.go
@@ -18,9 +18,10 @@ package enterprise
 import (
 	"context"
 	"fmt"
-	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 	"reflect"
 	"time"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 
 	"github.com/go-logr/logr"
 	enterpriseApiV3 "github.com/splunk/splunk-operator/api/v3"
@@ -132,7 +133,7 @@ func ApplyClusterMaster(ctx context.Context, client splcommon.ControllerClient, 
 				return result, err
 			}
 		}
-		DeleteOwnerReferencesForResources(ctx, client, cr, &cr.Spec.SmartStore)
+		DeleteOwnerReferencesForResources(ctx, client, cr, &cr.Spec.SmartStore, SplunkClusterMaster)
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after

--- a/pkg/splunk/enterprise/finalizers_test.go
+++ b/pkg/splunk/enterprise/finalizers_test.go
@@ -18,9 +18,10 @@ package enterprise
 import (
 	"context"
 	"fmt"
-	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 	"testing"
 	"time"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,6 +63,7 @@ func splunkDeletionTester(t *testing.T, cr splcommon.MetaObject, delete func(spl
 		client.InNamespace(cr.GetNamespace()),
 		client.MatchingLabels(labelsB),
 	}
+
 	pvclist := corev1.PersistentVolumeClaimList{
 		Items: []corev1.PersistentVolumeClaim{
 			{
@@ -72,7 +74,6 @@ func splunkDeletionTester(t *testing.T, cr splcommon.MetaObject, delete func(spl
 			},
 		},
 	}
-
 	mockCalls := make(map[string][]spltest.MockFuncCall)
 	wantDeleted := false
 	if cr.GetObjectMeta().GetDeletionTimestamp() != nil {
@@ -138,41 +139,59 @@ func splunkDeletionTester(t *testing.T, cr splcommon.MetaObject, delete func(spl
 			switch cr.GetObjectKind().GroupVersionKind().Kind {
 			case "Standalone":
 				mockCalls["Get"] = append(mockCalls["Get"], []spltest.MockFuncCall{
+					{MetaName: "*v1.StatefulSet-test-splunk-stack1-standalone"},
 					{MetaName: "*v4.Standalone-test-stack1"},
 					{MetaName: "*v4.Standalone-test-stack1"},
 				}...)
 
 			case "LicenseMaster":
 				mockCalls["Get"] = append(mockCalls["Get"], []spltest.MockFuncCall{
+					{MetaName: "*v1.StatefulSet-test-splunk-stack1-license-master"},
 					{MetaName: "*v3.LicenseMaster-test-stack1"},
 					{MetaName: "*v3.LicenseMaster-test-stack1"},
 				}...)
 
 			case "LicenseManager":
 				mockCalls["Get"] = append(mockCalls["Get"], []spltest.MockFuncCall{
+					{MetaName: "*v1.StatefulSet-test-splunk-stack1-license-manager"},
 					{MetaName: "*v4.LicenseManager-test-stack1"},
 					{MetaName: "*v4.LicenseManager-test-stack1"},
 				}...)
 
 			case "SearchHeadCluster":
 				mockCalls["Get"] = append(mockCalls["Get"], []spltest.MockFuncCall{
+					{MetaName: "*v1.StatefulSet-test-splunk-stack1-search-head"},
 					{MetaName: "*v4.SearchHeadCluster-test-stack1"},
 					{MetaName: "*v4.SearchHeadCluster-test-stack1"},
 				}...)
 
 			case "ClusterMaster":
 				mockCalls["Get"] = append(mockCalls["Get"], []spltest.MockFuncCall{
+					{MetaName: "*v1.StatefulSet-test-splunk-stack1-cluster-master"},
 					{MetaName: "*v3.ClusterMaster-test-stack1"},
 					{MetaName: "*v3.ClusterMaster-test-stack1"},
 				}...)
 
 			case "ClusterManager":
 				mockCalls["Get"] = append(mockCalls["Get"], []spltest.MockFuncCall{
+					{MetaName: "*v1.StatefulSet-test-splunk-stack1-cluster-manager"},
 					{MetaName: "*v4.ClusterManager-test-stack1"},
 					{MetaName: "*v4.ClusterManager-test-stack1"},
 				}...)
 
+				listOptsTest := []client.ListOption{
+					client.InNamespace(cr.GetNamespace()),
+				}
+
+				mockCalls["List"] = append(mockCalls["List"], []spltest.MockFuncCall{
+					{ListOpts: listOptsTest},
+					{ListOpts: listOptsTest},
+					{ListOpts: listOptsTest},
+					{ListOpts: listOptsTest},
+				}...)
+				mockCalls["List"][0], mockCalls["List"][len(mockCalls["List"])-1] = mockCalls["List"][len(mockCalls["List"])-1], mockCalls["List"][0]
 			case "MonitoringConsole":
+				mockCalls["Get"] = append(mockCalls["Get"], spltest.MockFuncCall{MetaName: "*v4.MonitoringConsole-test-stack1"})
 				mockCalls["Get"] = append(mockCalls["Get"], spltest.MockFuncCall{MetaName: "*v4.MonitoringConsole-test-stack1"})
 			}
 		} else {
@@ -196,6 +215,7 @@ func splunkDeletionTester(t *testing.T, cr splcommon.MetaObject, delete func(spl
 				{MetaName: "*v1.Secret-test-splunk-test-secret"},
 				{MetaName: "*v4.ClusterManager-test-manager1"},
 				{MetaName: "*v1.Secret-test-splunk-test-secret"},
+				{MetaName: "*v1.StatefulSet-test-splunk-stack1-indexer"},
 				{MetaName: "*v4.IndexerCluster-test-stack1"},
 				{MetaName: "*v4.IndexerCluster-test-stack1"},
 			}

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -103,6 +103,7 @@ func ApplyIndexerClusterManager(ctx context.Context, client splcommon.Controller
 			cr.Status.ClusterManagerPhase = managerIdxCluster.Status.Phase
 		}
 	} else {
+		scopedLog.Error(nil, "The configured clusterMasterRef doesn't exist", "clusterManagerRef", cr.Spec.ClusterManagerRef.Name)
 		cr.Status.ClusterManagerPhase = enterpriseApi.PhaseError
 	}
 
@@ -118,7 +119,7 @@ func ApplyIndexerClusterManager(ctx context.Context, client splcommon.Controller
 
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
-		DeleteOwnerReferencesForResources(ctx, client, cr, nil)
+		DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkIndexer)
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after
 			cr.Status.Phase = enterpriseApi.PhaseTerminating
@@ -361,7 +362,7 @@ func ApplyIndexerCluster(ctx context.Context, client splcommon.ControllerClient,
 
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
-		DeleteOwnerReferencesForResources(ctx, client, cr, nil)
+		DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkIndexer)
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after
 			cr.Status.Phase = enterpriseApi.PhaseTerminating
@@ -1026,21 +1027,19 @@ func validateIndexerClusterSpec(ctx context.Context, c splcommon.ControllerClien
 }
 
 // helper function to get the list of IndexerCluster types in the current namespace
-func getIndexerClusterList(ctx context.Context, c splcommon.ControllerClient, cr splcommon.MetaObject, listOpts []client.ListOption) (int, error) {
+func getIndexerClusterList(ctx context.Context, c splcommon.ControllerClient, cr splcommon.MetaObject, listOpts []client.ListOption) (enterpriseApi.IndexerClusterList, error) {
 	reqLogger := log.FromContext(ctx)
 	scopedLog := reqLogger.WithName("getIndexerClusterList").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
 
 	objectList := enterpriseApi.IndexerClusterList{}
 
 	err := c.List(context.TODO(), &objectList, listOpts...)
-	numOfObjects := len(objectList.Items)
-
 	if err != nil {
 		scopedLog.Error(err, "IndexerCluster types not found in namespace", "namsespace", cr.GetNamespace())
-		return numOfObjects, err
+		return objectList, err
 	}
 
-	return numOfObjects, nil
+	return objectList, nil
 }
 
 // RetrieveCMSpec finds monitoringConsole ref from cm spec

--- a/pkg/splunk/enterprise/indexercluster_test.go
+++ b/pkg/splunk/enterprise/indexercluster_test.go
@@ -1210,11 +1210,12 @@ func TestGetIndexerClusterList(t *testing.T) {
 
 	client.ListObj = idxcList
 
-	numOfObjects, err := getIndexerClusterList(ctx, client, &idxc, listOpts)
+	objectList, err := getIndexerClusterList(ctx, client, &idxc, listOpts)
 	if err != nil {
 		t.Errorf("getNumOfObjects should not have returned error=%v", err)
 	}
 
+	numOfObjects := len(objectList.Items)
 	if numOfObjects != 1 {
 		t.Errorf("Got wrong number of IndexerCluster objects. Expected=%d, Got=%d", 1, numOfObjects)
 	}

--- a/pkg/splunk/enterprise/licensemanager.go
+++ b/pkg/splunk/enterprise/licensemanager.go
@@ -18,10 +18,11 @@ package enterprise
 import (
 	"context"
 	"fmt"
-	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
-	splutil "github.com/splunk/splunk-operator/pkg/splunk/util"
 	"reflect"
 	"time"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
+	splutil "github.com/splunk/splunk-operator/pkg/splunk/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -103,7 +104,7 @@ func ApplyLicenseManager(ctx context.Context, client splcommon.ControllerClient,
 			}
 		}
 
-		DeleteOwnerReferencesForResources(ctx, client, cr, nil)
+		DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkLicenseManager)
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after
@@ -207,19 +208,17 @@ func validateLicenseManagerSpec(ctx context.Context, c splcommon.ControllerClien
 }
 
 // helper function to get the list of LicenseManager types in the current namespace
-func getLicenseManagerList(ctx context.Context, c splcommon.ControllerClient, cr splcommon.MetaObject, listOpts []client.ListOption) (int, error) {
+func getLicenseManagerList(ctx context.Context, c splcommon.ControllerClient, cr splcommon.MetaObject, listOpts []client.ListOption) (enterpriseApi.LicenseManagerList, error) {
 	reqLogger := log.FromContext(ctx)
 	scopedLog := reqLogger.WithName("getLicenseManagerList").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
 
 	objectList := enterpriseApi.LicenseManagerList{}
 
 	err := c.List(context.TODO(), &objectList, listOpts...)
-	numOfObjects := len(objectList.Items)
-
 	if err != nil {
 		scopedLog.Error(err, "LicenseManager types not found in namespace", "namsespace", cr.GetNamespace())
-		return numOfObjects, err
+		return objectList, err
 	}
 
-	return numOfObjects, nil
+	return objectList, nil
 }

--- a/pkg/splunk/enterprise/licensemanager_test.go
+++ b/pkg/splunk/enterprise/licensemanager_test.go
@@ -678,11 +678,12 @@ func TestLicenseManagerList(t *testing.T) {
 
 	client.ListObj = lmList
 
-	numOfObjects, err = getLicenseManagerList(ctx, client, &lm, listOpts)
+	objList, err := getLicenseManagerList(ctx, client, &lm, listOpts)
 	if err != nil {
 		t.Errorf("getNumOfObjects should not have returned error=%v", err)
 	}
 
+	numOfObjects = len(objList.Items)
 	if numOfObjects != 1 {
 		t.Errorf("Got wrong number of LicenseManager objects. Expected=%d, Got=%d", 1, numOfObjects)
 	}

--- a/pkg/splunk/enterprise/licensemaster.go
+++ b/pkg/splunk/enterprise/licensemaster.go
@@ -18,9 +18,10 @@ package enterprise
 import (
 	"context"
 	"fmt"
-	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 	"reflect"
 	"time"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -104,7 +105,7 @@ func ApplyLicenseMaster(ctx context.Context, client splcommon.ControllerClient, 
 			}
 		}
 
-		DeleteOwnerReferencesForResources(ctx, client, cr, nil)
+		DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkLicenseMaster)
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after

--- a/pkg/splunk/enterprise/monitoringconsole_test.go
+++ b/pkg/splunk/enterprise/monitoringconsole_test.go
@@ -74,6 +74,7 @@ func TestApplyMonitoringConsole(t *testing.T) {
 		{MetaName: "*v1.ConfigMap-test-splunk-stack1-monitoring-console"},
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-monitoring-console"},
 		{MetaName: "*v4.MonitoringConsole-test-stack1"},
+		{MetaName: "*v4.MonitoringConsole-test-stack1"},
 	}
 
 	updateFuncCalls := []spltest.MockFuncCall{
@@ -91,6 +92,7 @@ func TestApplyMonitoringConsole(t *testing.T) {
 		{MetaName: "*v1.ConfigMap-test-splunk-stack1-monitoring-console"},
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-monitoring-console"},
 		{MetaName: "*v1.StatefulSet-test-splunk-stack1-monitoring-console"},
+		{MetaName: "*v4.MonitoringConsole-test-stack1"},
 		{MetaName: "*v4.MonitoringConsole-test-stack1"},
 	}
 
@@ -1069,5 +1071,31 @@ func TestApplyMonitoringConsoleDeletion(t *testing.T) {
 	_, err = ApplyMonitoringConsole(ctx, c, &mc)
 	if err != nil {
 		t.Errorf("ApplyMonitoringConsole should not have returned error here.")
+	}
+}
+
+func TestGetMonitoringConsoleList(t *testing.T) {
+	ctx := context.TODO()
+	mc := enterpriseApi.MonitoringConsole{}
+
+	listOpts := []client.ListOption{
+		client.InNamespace("test"),
+	}
+
+	client := spltest.NewMockClient()
+
+	mcList := &enterpriseApi.MonitoringConsoleList{}
+	mcList.Items = append(mcList.Items, mc)
+
+	client.ListObj = mcList
+
+	objectList, err := getMonitoringConsoleList(ctx, client, &mc, listOpts)
+	if err != nil {
+		t.Errorf("getNumOfObjects should not have returned error=%v", err)
+	}
+
+	numOfObjects := len(objectList.Items)
+	if numOfObjects != 1 {
+		t.Errorf("Got wrong number of IndexerCluster objects. Expected=%d, Got=%d", 1, numOfObjects)
 	}
 }

--- a/pkg/splunk/enterprise/searchheadcluster.go
+++ b/pkg/splunk/enterprise/searchheadcluster.go
@@ -122,7 +122,7 @@ func ApplySearchHeadCluster(ctx context.Context, client splcommon.ControllerClie
 			}
 		}
 
-		DeleteOwnerReferencesForResources(ctx, client, cr, nil)
+		DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkSearchHead)
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after
 			cr.Status.Phase = enterpriseApi.PhaseTerminating
@@ -653,19 +653,17 @@ func validateSearchHeadClusterSpec(ctx context.Context, c splcommon.ControllerCl
 }
 
 // helper function to get the list of SearchHeadCluster types in the current namespace
-func getSearchHeadClusterList(ctx context.Context, c splcommon.ControllerClient, cr splcommon.MetaObject, listOpts []client.ListOption) (int, error) {
+func getSearchHeadClusterList(ctx context.Context, c splcommon.ControllerClient, cr splcommon.MetaObject, listOpts []client.ListOption) (enterpriseApi.SearchHeadClusterList, error) {
 	reqLogger := log.FromContext(ctx)
 	scopedLog := reqLogger.WithName("getSearchHeadClusterList").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
 
 	objectList := enterpriseApi.SearchHeadClusterList{}
 
 	err := c.List(context.TODO(), &objectList, listOpts...)
-	numOfObjects := len(objectList.Items)
-
 	if err != nil {
 		scopedLog.Error(err, "SearchHeadCluster types not found in namespace", "namsespace", cr.GetNamespace())
-		return numOfObjects, err
+		return objectList, err
 	}
 
-	return numOfObjects, nil
+	return objectList, nil
 }

--- a/pkg/splunk/enterprise/searchheadcluster_test.go
+++ b/pkg/splunk/enterprise/searchheadcluster_test.go
@@ -1255,11 +1255,12 @@ func TestGetSearchHeadClusterList(t *testing.T) {
 
 	client.ListObj = shcList
 
-	numOfObjects, err = getSearchHeadClusterList(ctx, client, &shc, listOpts)
+	objList, err := getSearchHeadClusterList(ctx, client, &shc, listOpts)
 	if err != nil {
 		t.Errorf("getNumOfObjects should not have returned error=%v", err)
 	}
 
+	numOfObjects = len(objList.Items)
 	if numOfObjects != 1 {
 		t.Errorf("Got wrong number of SearchHeadCluster objects. Expected=%d, Got=%d", 1, numOfObjects)
 	}

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -18,9 +18,10 @@ package enterprise
 import (
 	"context"
 	"fmt"
-	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 	"reflect"
 	"time"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 
 	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 	splctrl "github.com/splunk/splunk-operator/pkg/splunk/controller"
@@ -125,7 +126,7 @@ func ApplyStandalone(ctx context.Context, client splcommon.ControllerClient, cr 
 				return result, err
 			}
 		}
-		DeleteOwnerReferencesForResources(ctx, client, cr, &cr.Spec.SmartStore)
+		DeleteOwnerReferencesForResources(ctx, client, cr, &cr.Spec.SmartStore, SplunkStandalone)
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after
@@ -294,19 +295,17 @@ func validateStandaloneSpec(ctx context.Context, c splcommon.ControllerClient, c
 }
 
 // helper function to get the list of Standalone types in the current namespace
-func getStandaloneList(ctx context.Context, c splcommon.ControllerClient, cr splcommon.MetaObject, listOpts []client.ListOption) (int, error) {
+func getStandaloneList(ctx context.Context, c splcommon.ControllerClient, cr splcommon.MetaObject, listOpts []client.ListOption) (enterpriseApi.StandaloneList, error) {
 	reqLogger := log.FromContext(ctx)
 	scopedLog := reqLogger.WithName("getStandaloneList")
 
 	objectList := enterpriseApi.StandaloneList{}
 
 	err := c.List(context.TODO(), &objectList, listOpts...)
-	numOfObjects := len(objectList.Items)
-
 	if err != nil {
 		scopedLog.Error(err, "Standalone types not found in namespace", "namsespace", cr.GetNamespace())
-		return numOfObjects, err
+		return objectList, err
 	}
 
-	return numOfObjects, nil
+	return objectList, nil
 }

--- a/pkg/splunk/enterprise/standalone_test.go
+++ b/pkg/splunk/enterprise/standalone_test.go
@@ -983,11 +983,12 @@ func TestGetStandaloneList(t *testing.T) {
 
 	client.ListObj = standaloneList
 
-	numOfObjects, err = getStandaloneList(ctx, client, &standalone, listOpts)
+	objList, err := getStandaloneList(ctx, client, &standalone, listOpts)
 	if err != nil {
 		t.Errorf("getNumOfObjects should not have returned error=%v", err)
 	}
 
+	numOfObjects = len(objList.Items)
 	if numOfObjects != 1 {
 		t.Errorf("Got wrong number of standalone objects. Expected=%d, Got=%d", 1, numOfObjects)
 	}

--- a/pkg/splunk/test/controller.go
+++ b/pkg/splunk/test/controller.go
@@ -69,6 +69,8 @@ func enterpriseObjCopier(dst, src *client.Object) bool {
 		*dstP.(*enterpriseApi.Standalone) = *srcP.(*enterpriseApi.Standalone)
 	case *enterpriseApi.SearchHeadCluster:
 		*dstP.(*enterpriseApi.SearchHeadCluster) = *srcP.(*enterpriseApi.SearchHeadCluster)
+	case *enterpriseApi.MonitoringConsole:
+		*dstP.(*enterpriseApi.MonitoringConsole) = *srcP.(*enterpriseApi.MonitoringConsole)
 	default:
 		return false
 	}
@@ -126,6 +128,8 @@ func enterpriseObjListCopier(dst, src *client.ObjectList) bool {
 		*dstP.(*enterpriseApiV3.ClusterMasterList) = *srcP.(*enterpriseApiV3.ClusterMasterList)
 	case *enterpriseApi.StandaloneList:
 		*dstP.(*enterpriseApi.StandaloneList) = *srcP.(*enterpriseApi.StandaloneList)
+	case *enterpriseApi.MonitoringConsoleList:
+		*dstP.(*enterpriseApi.MonitoringConsoleList) = *srcP.(*enterpriseApi.MonitoringConsoleList)
 	default:
 		return false
 	}


### PR DESCRIPTION
Changes are two fold:

1. Delete unnecessary owner references on the statefulSet in a CR during deletion. Retain the owner references to the CR only, delete rest.
2. On ClusterManager deletion, check if any other CR is holding a `clusterManagerRef` to it and wait till those are deleted/spec change to run the finalizer on the ClusterManager. This way, we retain the ClusterManager statefulSet until no other CR has a reference to it.