### PR TITLE
CSPL-2168: Ignore a ES install info stderr message in installation 

### DIFF
--- a/pkg/splunk/util/messages.go
+++ b/pkg/splunk/util/messages.go
@@ -46,4 +46,7 @@ const (
 
 	// splunkEsAppSSLWarning Note: The ES app post install spews out a harmless ES app message which can be ignored
 	splunkEsAppSSLWarning = "INFO: Installation complete\nINFO: SSL enablement set to ignore, continuing...\n"
+
+	// splunkEsAppSSLWarningRestart Note: The ES app post install spews out a harmless ES app message which can be ignored
+	splunkEsAppSSLWarningRestart = "INFO: Initialization complete, please restart Splunk\nINFO: SSL enablement set to ignore, continuing...\n"
 )

--- a/pkg/splunk/util/util.go
+++ b/pkg/splunk/util/util.go
@@ -245,6 +245,11 @@ func suppressHarmlessErrorMessages(values ...*string) {
 		if strings.Contains(*val, splunkEsAppSSLWarning) {
 			*val = strings.ReplaceAll(*val, splunkEsAppSSLWarning, "")
 		}
+
+		// Replace es app ssl warning with splunk restart
+		if strings.Contains(*val, splunkEsAppSSLWarningRestart) {
+			*val = strings.ReplaceAll(*val, splunkEsAppSSLWarningRestart, "")
+		}
 	}
 }
 

--- a/pkg/splunk/util/util_test.go
+++ b/pkg/splunk/util/util_test.go
@@ -235,10 +235,11 @@ func TestGetSetTargetPodName(t *testing.T) {
 func TestSuppressHarmlessErrorMessages(t *testing.T) {
 	string1 := splunkSSHWarningMessage
 	string2 := splunkEsAppSSLWarning
+	string3 := splunkEsAppSSLWarningRestart
 
 	// Test replacement of strings
-	suppressHarmlessErrorMessages(&string1, &string2)
-	if string1 != "" || string2 != "" {
-		t.Errorf("Strings are supposed to be empty")
+	suppressHarmlessErrorMessages(&string1, &string2, &string3)
+	if string1 != "" || string2 != "" || string3 != "" {
+		t.Errorf("Known messages did not get suppressed.")
 	}
 }


### PR DESCRIPTION
While installing es, we get this message in stderr that needs to be suppressed as it is not an error

INFO: Installation complete\nINFO: SSL enablement set to ignore, continuing...\n"

@Twain Pereira / @Arjun Kondur 