### PR TITLE
CSPL-2167 - Make strict flag as default flag for essinstall

### DIFF
--- a/api/v4/common_types.go
+++ b/api/v4/common_types.go
@@ -387,12 +387,12 @@ type EsDefaults struct {
 	//     strict: Ensure that SSL is enabled
 	//             in the web.conf configuration file to use
 	//             this mode. Otherwise, the installer exists
-	//	     	   with an error.
+	//	     	   with an error. This is the DEFAULT mode used 
+	//             by the operator if left empty.
 	//     auto: Enables SSL in the etc/system/local/web.conf
 	//           configuration file.
 	//     ignore: Ignores whether SSL is enabled or disabled.
-	//             This is the DEFAULT mode used by the operator
-	//             if left empty.
+	//             
 	// +optional
 	SslEnablement string `json:"sslEnablement,omitempty"`
 }

--- a/pkg/splunk/enterprise/afwscheduler.go
+++ b/pkg/splunk/enterprise/afwscheduler.go
@@ -1824,14 +1824,15 @@ func (idxcPlaybookContext *IdxcPlaybookContext) runPlaybook(ctx context.Context)
 }
 
 // getSslCliOption gets the ssl cli option for installing ES app.
-// Returns `ignore` if not configured. Note: Validation of spec done already
+// Returns `strict` if not configured. Note: Validation of spec done already
+// Reference: https://docs.splunk.com/Documentation/ES/latest/Install/InstallEnterpriseSecuritySHC
 func getSslCliOption(appSrcSpec *enterpriseApi.AppSourceSpec) string {
 	sslEn := appSrcSpec.PremiumAppsProps.EsDefaults.SslEnablement
 	if sslEn != "" {
 		return sslEn
 	}
 
-	return enterpriseApi.SslEnablementIgnore
+	return enterpriseApi.SslEnablementStrict
 }
 
 // Handles ES app post install steps

--- a/pkg/splunk/enterprise/afwscheduler_test.go
+++ b/pkg/splunk/enterprise/afwscheduler_test.go
@@ -3048,6 +3048,10 @@ func TestPremiumAppScopedPlaybook(t *testing.T) {
 		t.Errorf("runPlayBook should have returned error")
 	}
 
+	if ! strings.Contains(err.Error(),"premium scoped app package install failed") {
+		t.Errorf("runPlayBook did not return `premium scoped app package install failed`")
+	}
+
 	// Test5: everything passes
 	mockPodExecReturnContexts[3].StdErr = ""
 	localInstallCtxt.sem <- struct{}{}

--- a/pkg/splunk/enterprise/afwscheduler_test.go
+++ b/pkg/splunk/enterprise/afwscheduler_test.go
@@ -3048,7 +3048,7 @@ func TestPremiumAppScopedPlaybook(t *testing.T) {
 		t.Errorf("runPlayBook should have returned error")
 	}
 
-	if ! strings.Contains(err.Error(),"premium scoped app package install failed") {
+	if !strings.Contains(err.Error(), "premium scoped app package install failed") {
 		t.Errorf("runPlayBook did not return `premium scoped app package install failed`")
 	}
 


### PR DESCRIPTION
CSPL-2167 - make essinstall default ssl_enablement flag as strict to adhere with splunk doc
https://docs.splunk.com/Documentation/ES/7.0.2/Install/InstallEnterpriseSecuritySHC#Installing_Splunk_Enterprise_Security_from_the_command_line_in_a_search_head_cluster_environment


