### PR TITLE
CSPL-2172 - Fix es install fail scenario

### DIFF
--- a/api/v4/common_types.go
+++ b/api/v4/common_types.go
@@ -387,12 +387,12 @@ type EsDefaults struct {
 	//     strict: Ensure that SSL is enabled
 	//             in the web.conf configuration file to use
 	//             this mode. Otherwise, the installer exists
-	//	     	   with an error. This is the DEFAULT mode used 
+	//	     	   with an error. This is the DEFAULT mode used
 	//             by the operator if left empty.
 	//     auto: Enables SSL in the etc/system/local/web.conf
 	//           configuration file.
 	//     ignore: Ignores whether SSL is enabled or disabled.
-	//             
+	//
 	// +optional
 	SslEnablement string `json:"sslEnablement,omitempty"`
 }

--- a/config/crd/bases/enterprise.splunk.com_clustermanagers.yaml
+++ b/config/crd/bases/enterprise.splunk.com_clustermanagers.yaml
@@ -928,10 +928,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -976,11 +976,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -3755,11 +3755,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -3806,10 +3806,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:

--- a/config/crd/bases/enterprise.splunk.com_clustermasters.yaml
+++ b/config/crd/bases/enterprise.splunk.com_clustermasters.yaml
@@ -928,10 +928,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -976,11 +976,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -3755,11 +3755,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -3806,10 +3806,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:

--- a/config/crd/bases/enterprise.splunk.com_licensemanagers.yaml
+++ b/config/crd/bases/enterprise.splunk.com_licensemanagers.yaml
@@ -918,10 +918,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -966,11 +966,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -3629,11 +3629,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -3680,10 +3680,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:

--- a/config/crd/bases/enterprise.splunk.com_licensemasters.yaml
+++ b/config/crd/bases/enterprise.splunk.com_licensemasters.yaml
@@ -917,10 +917,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -965,11 +965,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -3628,11 +3628,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -3679,10 +3679,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:

--- a/config/crd/bases/enterprise.splunk.com_monitoringconsoles.yaml
+++ b/config/crd/bases/enterprise.splunk.com_monitoringconsoles.yaml
@@ -924,10 +924,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -972,11 +972,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -3634,11 +3634,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -3685,10 +3685,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:
@@ -4804,10 +4805,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -4852,11 +4853,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -7514,11 +7515,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -7565,10 +7566,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:

--- a/config/crd/bases/enterprise.splunk.com_searchheadclusters.yaml
+++ b/config/crd/bases/enterprise.splunk.com_searchheadclusters.yaml
@@ -930,10 +930,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -978,11 +978,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -3657,11 +3657,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -3708,10 +3708,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:
@@ -4897,10 +4898,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -4945,11 +4946,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -7624,11 +7625,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -7675,10 +7676,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:

--- a/config/crd/bases/enterprise.splunk.com_standalones.yaml
+++ b/config/crd/bases/enterprise.splunk.com_standalones.yaml
@@ -925,10 +925,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -973,11 +973,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -3757,11 +3757,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -3808,10 +3808,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:
@@ -5049,10 +5050,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -5097,11 +5098,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -7881,11 +7882,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -7932,10 +7933,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:

--- a/pkg/splunk/enterprise/afwscheduler.go
+++ b/pkg/splunk/enterprise/afwscheduler.go
@@ -1883,7 +1883,7 @@ func handleEsappPostinstall(rctx context.Context, preCtx *premiumAppScopePlayboo
 	stdOut, stdErr, err := preCtx.localCtx.podExecClient.RunPodExecCommand(rctx, streamOptions, []string{"/bin/sh"})
 	if stdErr != "" || err != nil {
 		phaseInfo.FailCount++
-		scopedLog.Error(err, "premium scoped app package install failed new", "stdout", stdOut, "stderr", stdErr, "post install command", command, "failCount", phaseInfo.FailCount)
+		scopedLog.Error(err, "premium scoped app package install failed", "stdout", stdOut, "stderr", stdErr, "post install command", command, "failCount", phaseInfo.FailCount)
 		return fmt.Errorf("premium scoped app package install failed. stdOut: %s, stdErr: %s, post install command: %s, failCount: %d", stdOut, stdErr, command, phaseInfo.FailCount)
 	}
 

--- a/pkg/splunk/enterprise/afwscheduler.go
+++ b/pkg/splunk/enterprise/afwscheduler.go
@@ -685,7 +685,7 @@ func installApp(rctx context.Context, localCtx *localScopePlaybookContext, cr sp
 	worker := localCtx.worker
 
 	reqLogger := log.FromContext(rctx)
-	scopedLog := reqLogger.WithName("installAppAndCleanup").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace(), "pod", worker.targetPodName, "app name", worker.appDeployInfo.AppName)
+	scopedLog := reqLogger.WithName("installApp").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace(), "pod", worker.targetPodName, "app name", worker.appDeployInfo.AppName)
 
 	// if the app name is app1.tgz and hash is "abcd1234", then appPkgFileName is app1.tgz_abcd1234
 	appPkgFileName := getAppPackageName(worker)
@@ -726,7 +726,7 @@ func cleanupApp(rctx context.Context, localCtx *localScopePlaybookContext, cr sp
 	worker := localCtx.worker
 
 	reqLogger := log.FromContext(rctx)
-	scopedLog := reqLogger.WithName("installAppAndCleanup").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace(), "pod", worker.targetPodName, "app name", worker.appDeployInfo.AppName)
+	scopedLog := reqLogger.WithName("cleanupApp").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace(), "pod", worker.targetPodName, "app name", worker.appDeployInfo.AppName)
 
 	// if the app name is app1.tgz and hash is "abcd1234", then appPkgFileName is app1.tgz_abcd1234
 	appPkgFileName := getAppPackageName(worker)

--- a/pkg/splunk/enterprise/afwscheduler.go
+++ b/pkg/splunk/enterprise/afwscheduler.go
@@ -1883,7 +1883,7 @@ func handleEsappPostinstall(rctx context.Context, preCtx *premiumAppScopePlayboo
 	stdOut, stdErr, err := preCtx.localCtx.podExecClient.RunPodExecCommand(rctx, streamOptions, []string{"/bin/sh"})
 	if stdErr != "" || err != nil {
 		phaseInfo.FailCount++
-		scopedLog.Error(err, "premium scoped app package install failed", "stdout", stdOut, "stderr", stdErr, "post install command", command, "failCount", phaseInfo.FailCount)
+		scopedLog.Error(err, "premium scoped app package install failed new", "stdout", stdOut, "stderr", stdErr, "post install command", command, "failCount", phaseInfo.FailCount)
 		return fmt.Errorf("premium scoped app package install failed. stdOut: %s, stdErr: %s, post install command: %s, failCount: %d", stdOut, stdErr, command, phaseInfo.FailCount)
 	}
 

--- a/pkg/splunk/enterprise/afwscheduler_test.go
+++ b/pkg/splunk/enterprise/afwscheduler_test.go
@@ -2944,8 +2944,8 @@ func TestPremiumAppScopedPlaybook(t *testing.T) {
 	podExecCommands := []string{
 		"test -f",
 		"/opt/splunk/bin/splunk install app",
-		"rm -f",
 		"/opt/splunk/bin/splunk search",
+		"rm -f",
 	}
 
 	mockPodExecReturnContexts := []*spltest.MockPodExecReturnContext{

--- a/pkg/splunk/enterprise/afwscheduler_test.go
+++ b/pkg/splunk/enterprise/afwscheduler_test.go
@@ -3030,16 +3030,16 @@ func TestPremiumAppScopedPlaybook(t *testing.T) {
 		t.Errorf("Failed to detect missingApp pkg: err: %s", err.Error())
 	}
 
-	// Test3: install command passes but removing app package from pod returns error
+	// Test3: failure in es post install pod exec command
 	mockPodExecReturnContexts[1].StdErr = ""
 	localInstallCtxt.sem <- struct{}{}
 	waiter.Add(1)
 	err = pCtx.runPlaybook(ctx)
-	if err == nil {
+	if !strings.Contains(err.Error(), "premium scoped app package install failed") {
 		t.Errorf("Failed to detect missingApp pkg: err: %s", err.Error())
 	}
 
-	// Test4: failure in es post install pod exec command
+	// Test4: install command passes but removing app package from pod returns error
 	mockPodExecReturnContexts[2].StdErr = ""
 	localInstallCtxt.sem <- struct{}{}
 	waiter.Add(1)
@@ -3048,8 +3048,8 @@ func TestPremiumAppScopedPlaybook(t *testing.T) {
 		t.Errorf("runPlayBook should have returned error")
 	}
 
-	if !strings.Contains(err.Error(), "premium scoped app package install failed") {
-		t.Errorf("runPlayBook did not return `premium scoped app package install failed`")
+	if err == nil {
+		t.Errorf("runPlayBook did not return `premium scoped app package install failed` got %v", err.Error())
 	}
 
 	// Test5: everything passes

--- a/pkg/splunk/enterprise/clustermanager.go
+++ b/pkg/splunk/enterprise/clustermanager.go
@@ -18,10 +18,11 @@ package enterprise
 import (
 	"context"
 	"fmt"
-	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 	"reflect"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-logr/logr"
 	splclient "github.com/splunk/splunk-operator/pkg/splunk/client"
@@ -250,7 +251,7 @@ func validateClusterManagerSpec(ctx context.Context, c splcommon.ControllerClien
 	}
 
 	if !reflect.DeepEqual(cr.Status.AppContext.AppFrameworkConfig, cr.Spec.AppFrameworkConfig) {
-		err := ValidateAppFrameworkSpec(ctx, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext, false)
+		err := ValidateAppFrameworkSpec(ctx, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext, false, cr.GetObjectKind().GroupVersionKind().Kind)
 		if err != nil {
 			return err
 		}

--- a/pkg/splunk/enterprise/clustermaster.go
+++ b/pkg/splunk/enterprise/clustermaster.go
@@ -18,9 +18,10 @@ package enterprise
 import (
 	"context"
 	"fmt"
-	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 	"reflect"
 	"time"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 
 	"github.com/go-logr/logr"
 	enterpriseApiV3 "github.com/splunk/splunk-operator/api/v3"
@@ -251,7 +252,7 @@ func validateClusterMasterSpec(ctx context.Context, c splcommon.ControllerClient
 	}
 
 	if !reflect.DeepEqual(cr.Status.AppContext.AppFrameworkConfig, cr.Spec.AppFrameworkConfig) {
-		err := ValidateAppFrameworkSpec(ctx, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext, false)
+		err := ValidateAppFrameworkSpec(ctx, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext, false, cr.GetObjectKind().GroupVersionKind().Kind)
 		if err != nil {
 			return err
 		}

--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -1470,6 +1470,7 @@ func validateSplunkAppSources(appFramework *enterpriseApi.AppFrameworkSpec, loca
 	return nil
 }
 
+// validatePremiumAppsInputs validates premium app source spec
 func validatePremiumAppsInputs(appSrc enterpriseApi.AppSourceSpec) error {
 
 	if appSrc.AppSourceDefaultSpec.PremiumAppsProps.Type != enterpriseApi.PremiumAppsTypeEs {

--- a/pkg/splunk/enterprise/configuration_test.go
+++ b/pkg/splunk/enterprise/configuration_test.go
@@ -655,7 +655,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 		AppsRepoStatusPollInterval: 60,
 	}
 
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err == nil {
 		t.Errorf("App Framework configuration should have returned error as we have not mounted app download volume: %v", err)
 	}
@@ -667,14 +667,14 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	}
 	defer os.RemoveAll(splcommon.AppDownloadVolume)
 
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 
 	if err != nil {
 		t.Errorf("Valid App Framework configuration should not cause error: %v", err)
 	}
 
 	AppFramework.VolList[0].SecretRef = ""
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err != nil {
 		t.Errorf("Missing Secret Object reference is a valid config that should not cause error: %v", err)
 	}
@@ -683,7 +683,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	// App Framework config with missing App Source name
 	AppFramework.AppSources[0].Name = ""
 
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err == nil || !strings.HasPrefix(err.Error(), "app Source name is missing for AppSource at:") {
 
 		t.Errorf("Should not accept an app source with missing name ")
@@ -692,7 +692,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	//App Framework config app source config with missing location(withot default location) should errro out
 	AppFramework.AppSources[0].Name = "adminApps"
 	AppFramework.AppSources[0].Location = ""
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err == nil || !strings.HasPrefix(err.Error(), "app Source location is missing for AppSource") {
 		t.Errorf("An App Source with missing location should cause an error, when there is no default location configured")
 	}
@@ -703,7 +703,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	AppFramework.Defaults.VolName = "msos_s2s3_vol"
 	AppFramework.AppSources[0].Scope = ""
 
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err != nil {
 		t.Errorf("Should accept an App Source with missing scope, when default scope is configured. But, got the error: %v", err)
 	}
@@ -711,7 +711,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	AppFramework.AppSources[0].Scope = enterpriseApi.ScopeLocal
 
 	// Empty App Repo config should not cause an error
-	err = ValidateAppFrameworkSpec(ctx, nil, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, nil, &appFrameworkContext, false, "")
 	if err != nil {
 		t.Errorf("App Repo config is optional, should not cause an error. But, got the error: %v", err)
 	}
@@ -740,7 +740,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 		},
 	}
 
-	err = ValidateAppFrameworkSpec(ctx, &AppFrameworkWithoutVolumeSpec, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFrameworkWithoutVolumeSpec, &appFrameworkContext, false, "")
 	if err == nil || !strings.HasPrefix(err.Error(), "invalid Volume Name for App Source") {
 		t.Errorf("App Repo config without volume details should return error")
 	}
@@ -749,7 +749,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	tmpVolume := AppFramework.Defaults.VolName
 	AppFramework.Defaults.VolName = "UnknownVolume"
 
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err == nil || !strings.HasPrefix(err.Error(), "invalid Volume Name for Defaults") {
 		t.Errorf("Volume referred in the defaults should be a valid volume")
 	}
@@ -762,7 +762,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	AppFramework.AppSources[1].VolName = AppFramework.AppSources[0].VolName
 	AppFramework.AppSources[1].Location = AppFramework.AppSources[0].Location
 
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err == nil || !strings.HasPrefix(err.Error(), "duplicate App Source configured") {
 		t.Errorf("Duplicate app sources should return an error")
 	}
@@ -770,7 +770,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	// Duplicate App Source locations across different scopes should not return an error
 	tmpScope := AppFramework.AppSources[1].Scope
 	AppFramework.AppSources[1].Scope = enterpriseApi.ScopeCluster
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err != nil {
 		t.Errorf("App Sources with different app scopes can have duplicate paths, but failed with error: %v", err)
 	}
@@ -783,7 +783,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	tmpAppSourceName := AppFramework.AppSources[1].Name
 	AppFramework.AppSources[1].Name = AppFramework.AppSources[0].Name
 
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err == nil || !strings.HasPrefix(err.Error(), "multiple app sources with the name adminApps is not allowed") {
 		t.Errorf("Failed to detect duplicate app source names")
 	}
@@ -794,14 +794,14 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	AppFramework.AppSources[0].VolName = ""
 	AppFramework.Defaults.VolName = ""
 
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err == nil || !strings.HasPrefix(err.Error(), "volumeName is missing for App Source") {
 		t.Errorf("If no default volume, App Source with missing volume info should return an error")
 	}
 
 	// If the AppSource doesn't have VolName, and if the defaults have it, shouldn't cause an error
 	AppFramework.Defaults.VolName = "msos_s2s3_vol"
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err != nil {
 		t.Errorf("If default volume, App Source with missing volume should not return an error, but got error %v", err)
 	}
@@ -809,7 +809,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	// Volume referenced from an index must be a valid volume
 	AppFramework.AppSources[0].VolName = "UnknownVolume"
 
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err == nil || !strings.HasPrefix(err.Error(), "invalid Volume Name for App Source") {
 		t.Errorf("Index with an invalid volume name should return error")
 	}
@@ -817,14 +817,14 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 
 	// if the CR supports only local apps, and if the app source scope is not local, should return error
 	AppFramework.AppSources[0].Scope = enterpriseApi.ScopeCluster
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, true)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, true, "")
 	if err == nil || !strings.HasPrefix(err.Error(), "invalid scope for App Source") {
 		t.Errorf("When called with App scope local, any app sources with the cluster scope should return an error")
 	}
 
 	// If the app scope value other than "local" or "cluster" should return an error
 	AppFramework.AppSources[0].Scope = "unknown"
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("scope for App Source: %s should be either %s or %s or %s", AppFramework.AppSources[0].Name, enterpriseApi.ScopeLocal, enterpriseApi.ScopeCluster, enterpriseApi.ScopePremiumApps)) {
 		t.Errorf("Unsupported app scope should be cause error, but failed to detect")
 	}
@@ -834,7 +834,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 
 	AppFramework.Defaults.Scope = enterpriseApi.ScopeCluster
 
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, true)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, true, "")
 	if err == nil || !strings.HasPrefix(err.Error(), "invalid scope for defaults config. Only local scope is supported for this kind of CR") {
 		t.Errorf("When called with App scope local, defaults with the cluster scope should return an error")
 	}
@@ -842,7 +842,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 
 	// Default scope should be either "local" OR "cluster"
 	AppFramework.Defaults.Scope = "unknown"
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err == nil || !strings.HasPrefix(err.Error(), "scope for defaults should be either local") {
 		t.Errorf("Unsupported default scope should be cause error, but failed to detect")
 	}
@@ -851,7 +851,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	// Missing scope, if the default scope is not specified should return error
 	AppFramework.Defaults.Scope = ""
 	AppFramework.AppSources[0].Scope = ""
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err == nil || !strings.HasPrefix(err.Error(), "app Source scope is missing for") {
 		t.Errorf("Missing scope should be detected, but failed")
 	}
@@ -862,7 +862,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 
 	AppFramework.Defaults.Scope = ""
 	AppFramework.AppSources[0].Scope = "clusterWithPreConfig"
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err != nil {
 		t.Errorf("Valid scope clusterWithPreConfig should not cause an error")
 	}
@@ -877,14 +877,14 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	}
 
 	AppFramework.AppsRepoPollInterval = 0
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err != nil {
 		t.Errorf("Got error on valid App Framework configuration. Error: %v", err)
 	}
 
 	// Check for minAppsRepoPollInterval
 	AppFramework.AppsRepoPollInterval = splcommon.MinAppsRepoPollInterval - 1
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err != nil {
 		t.Errorf("Got error on valid App Framework configuration. Error: %v", err)
 	} else if appFrameworkContext.AppsRepoStatusPollInterval != splcommon.MinAppsRepoPollInterval {
@@ -893,7 +893,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 
 	// Check for maxAppsRepoPollInterval
 	AppFramework.AppsRepoPollInterval = splcommon.MaxAppsRepoPollInterval + 1
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err != nil {
 		t.Errorf("Got error on valid App Framework configuration. Error: %v", err)
 	} else if appFrameworkContext.AppsRepoStatusPollInterval != splcommon.MaxAppsRepoPollInterval {
@@ -902,7 +902,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 
 	// Invalid volume name in defaults should return an error
 	AppFramework.Defaults.VolName = "unknownVolume"
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err == nil || !strings.HasPrefix(err.Error(), "invalid Volume Name for Defaults") {
 		t.Errorf("Configuring Defaults with invalid volume name should return an error, but failed to detect")
 	}
@@ -910,14 +910,14 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	AppFramework.Defaults.VolName = "msos_s2s3_vol"
 	// Invalid remote volume type should return error.
 	AppFramework.VolList[0].Type = "s4"
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err == nil || !strings.Contains(err.Error(), "storageType 's4' is invalid. Valid values are 's3' and 'blob'") {
 		t.Errorf("ValidateAppFrameworkSpec with invalid remote volume type should have returned error.")
 	}
 
 	AppFramework.VolList[0].Type = "s3"
 	AppFramework.VolList[0].Provider = "invalid-provider"
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err == nil || !strings.Contains(err.Error(), "provider 'invalid-provider' is invalid. Valid values are 'aws', 'minio' and 'azure'") {
 		t.Errorf("ValidateAppFrameworkSpec with invalid provider should have returned error.")
 	}
@@ -925,7 +925,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	// Validate s3 and azure are not right combination
 	AppFramework.VolList[0].Type = "s3"
 	AppFramework.VolList[0].Provider = "azure"
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err == nil || !strings.Contains(err.Error(), "storageType 's3' cannot be used with provider 'azure'. Valid combinations are (s3,aws), (s3,minio) and (blob,azure)") {
 		t.Errorf("ValidateAppFrameworkSpec with s3 and azure combination should have returned error.")
 	}
@@ -933,7 +933,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	// Validate blob and azure are right combination
 	AppFramework.VolList[0].Type = "blob"
 	AppFramework.VolList[0].Provider = "azure"
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err != nil {
 		t.Errorf("ValidateAppFrameworkSpec with blob and azure combination should not have returned error.")
 	}
@@ -941,7 +941,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	// Validate s3 and aws are right combination
 	AppFramework.VolList[0].Type = "s3"
 	AppFramework.VolList[0].Provider = "aws"
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err != nil {
 		t.Errorf("ValidateAppFrameworkSpec with s3 and aws combination should not have returned error.")
 	}
@@ -949,7 +949,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	// Validate s3 and aws are right combination
 	AppFramework.VolList[0].Type = "s3"
 	AppFramework.VolList[0].Provider = "minio"
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err != nil {
 		t.Errorf("ValidateAppFrameworkSpec with s3 and minio combination should not have returned error.")
 	}
@@ -957,7 +957,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	// Validate blob and aws are not right combination
 	AppFramework.VolList[0].Type = "blob"
 	AppFramework.VolList[0].Provider = "aws"
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err == nil || !strings.Contains(err.Error(), "storageType 'blob' cannot be used with provider 'aws'. Valid combinations are (s3,aws), (s3,minio) and (blob,azure)") {
 		t.Errorf("ValidateAppFrameworkSpec with blob and aws combination should have returned error.")
 	}
@@ -965,7 +965,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	// Validate blob and minio are not right combination
 	AppFramework.VolList[0].Type = "blob"
 	AppFramework.VolList[0].Provider = "minio"
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, false, "")
 	if err == nil || !strings.Contains(err.Error(), "storageType 'blob' cannot be used with provider 'minio'. Valid combinations are (s3,aws), (s3,minio) and (blob,azure)") {
 		t.Errorf("ValidateAppFrameworkSpec with blob and minio combination should have returned error.")
 	}
@@ -981,7 +981,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	AppFramework.Defaults.Scope = ""
 	AppFramework.AppSources[0].Scope = enterpriseApi.ScopePremiumApps
 	AppFramework.AppSources[0].PremiumAppsProps.Type = enterpriseApi.PremiumAppsTypeEs
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, true)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, true, "")
 	if err != nil {
 		t.Errorf("Valid scope premiumApps should not cause an error")
 	}
@@ -997,7 +997,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	AppFramework.AppSources[2].Scope = enterpriseApi.ScopePremiumApps
 	AppFramework.AppSources[2].PremiumAppsProps.Type = enterpriseApi.PremiumAppsTypeEs
 	AppFramework.AppSources[2].PremiumAppsProps.EsDefaults.SslEnablement = enterpriseApi.SslEnablementIgnore
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, true)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, true, "")
 	if err != nil {
 		t.Errorf("Valid SslEnablement flags should not cause an error")
 	}
@@ -1005,7 +1005,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	// unknown premiumApp type
 	AppFramework.AppSources[0].Scope = enterpriseApi.ScopePremiumApps
 	AppFramework.AppSources[0].PremiumAppsProps.Type = "unknowndPremiumType"
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, true)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, true, "")
 	if err == nil || !strings.HasPrefix(err.Error(), "invalid PremiumAppsProps. Valid value is enterpriseSecurity") {
 		t.Errorf("invalid premium app type should be detected, but failed")
 	}
@@ -1014,7 +1014,7 @@ func TestValidateAppFrameworkSpec(t *testing.T) {
 	AppFramework.AppSources[0].Scope = enterpriseApi.ScopePremiumApps
 	AppFramework.AppSources[0].PremiumAppsProps.Type = enterpriseApi.PremiumAppsTypeEs
 	AppFramework.AppSources[0].PremiumAppsProps.EsDefaults.SslEnablement = "invalidflag"
-	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, true)
+	err = ValidateAppFrameworkSpec(ctx, &AppFramework, &appFrameworkContext, true, "")
 	if err == nil || !strings.HasPrefix(err.Error(), "invalid sslEnablement. Valid values") {
 		t.Errorf("invalid sslEnablement flag should be detected, but failed")
 	}

--- a/pkg/splunk/enterprise/configuration_test.go
+++ b/pkg/splunk/enterprise/configuration_test.go
@@ -608,6 +608,38 @@ func TestValidateSplunkSmartstoreSpec(t *testing.T) {
 	}
 }
 
+func TestValidatePremiumAppsInputs(t *testing.T) {
+	appSrcSpec := enterpriseApi.AppSourceSpec{
+		Name: "testapp",
+		AppSourceDefaultSpec: enterpriseApi.AppSourceDefaultSpec{
+			PremiumAppsProps: enterpriseApi.PremiumAppsProps{
+				Type: "",
+			},
+		},
+	}
+
+	// Fails for invalid types, only ES allowed for now
+	err := validatePremiumAppsInputs(appSrcSpec, "")
+	if err == nil {
+		t.Errorf("Expected to see an error for invalid type, accepts only ES")
+	}
+
+	appSrcSpec.PremiumAppsProps.Type = enterpriseApi.PremiumAppsTypeEs
+	appSrcSpec.PremiumAppsProps.EsDefaults.SslEnablement = enterpriseApi.SslEnablementAuto
+
+	// Valid case
+	err = validatePremiumAppsInputs(appSrcSpec, "")
+	if err != nil {
+		t.Errorf("Should pass, valid config")
+	}
+
+	// invalid case, for SHC cannot use ssl_enablement auto
+	err = validatePremiumAppsInputs(appSrcSpec, "SearchHeadCluster")
+	if err == nil {
+		t.Errorf("Expected to see an error for invalid ssl_enablement for SHC in ES")
+	}
+}
+
 func TestValidateAppFrameworkSpec(t *testing.T) {
 	var err error
 	ctx := context.TODO()

--- a/pkg/splunk/enterprise/licensemanager.go
+++ b/pkg/splunk/enterprise/licensemanager.go
@@ -18,10 +18,11 @@ package enterprise
 import (
 	"context"
 	"fmt"
-	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
-	splutil "github.com/splunk/splunk-operator/pkg/splunk/util"
 	"reflect"
 	"time"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
+	splutil "github.com/splunk/splunk-operator/pkg/splunk/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -197,7 +198,7 @@ func getLicenseManagerStatefulSet(ctx context.Context, client splcommon.Controll
 func validateLicenseManagerSpec(ctx context.Context, c splcommon.ControllerClient, cr *enterpriseApi.LicenseManager) error {
 
 	if !reflect.DeepEqual(cr.Status.AppContext.AppFrameworkConfig, cr.Spec.AppFrameworkConfig) {
-		err := ValidateAppFrameworkSpec(ctx, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext, true)
+		err := ValidateAppFrameworkSpec(ctx, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext, true, cr.GetObjectKind().GroupVersionKind().Kind)
 		if err != nil {
 			return err
 		}

--- a/pkg/splunk/enterprise/licensemaster.go
+++ b/pkg/splunk/enterprise/licensemaster.go
@@ -18,9 +18,10 @@ package enterprise
 import (
 	"context"
 	"fmt"
-	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 	"reflect"
 	"time"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -198,7 +199,7 @@ func getLicenseMasterStatefulSet(ctx context.Context, client splcommon.Controlle
 func validateLicenseMasterSpec(ctx context.Context, c splcommon.ControllerClient, cr *enterpriseApiV3.LicenseMaster) error {
 
 	if !reflect.DeepEqual(cr.Status.AppContext.AppFrameworkConfig, cr.Spec.AppFrameworkConfig) {
-		err := ValidateAppFrameworkSpec(ctx, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext, true)
+		err := ValidateAppFrameworkSpec(ctx, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext, true, cr.GetObjectKind().GroupVersionKind().Kind)
 		if err != nil {
 			return err
 		}

--- a/pkg/splunk/enterprise/monitoringconsole.go
+++ b/pkg/splunk/enterprise/monitoringconsole.go
@@ -18,11 +18,12 @@ package enterprise
 import (
 	"context"
 	"fmt"
-	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 	"reflect"
 	"sort"
 	"strings"
 	"time"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 
 	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 	splctrl "github.com/splunk/splunk-operator/pkg/splunk/controller"
@@ -191,7 +192,7 @@ func getMonitoringConsoleStatefulSet(ctx context.Context, client splcommon.Contr
 // validateMonitoringConsoleSpec checks validity and makes default updates to a MonitoringConsole, and returns error if something is wrong.
 func validateMonitoringConsoleSpec(ctx context.Context, c splcommon.ControllerClient, cr *enterpriseApi.MonitoringConsole) error {
 	if !reflect.DeepEqual(cr.Status.AppContext.AppFrameworkConfig, cr.Spec.AppFrameworkConfig) {
-		err := ValidateAppFrameworkSpec(ctx, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext, true)
+		err := ValidateAppFrameworkSpec(ctx, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext, true, cr.GetObjectKind().GroupVersionKind().Kind)
 		if err != nil {
 			return err
 		}

--- a/pkg/splunk/enterprise/searchheadcluster.go
+++ b/pkg/splunk/enterprise/searchheadcluster.go
@@ -643,7 +643,7 @@ func validateSearchHeadClusterSpec(ctx context.Context, c splcommon.ControllerCl
 	}
 
 	if !reflect.DeepEqual(cr.Status.AppContext.AppFrameworkConfig, cr.Spec.AppFrameworkConfig) {
-		err := ValidateAppFrameworkSpec(ctx, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext, false)
+		err := ValidateAppFrameworkSpec(ctx, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext, false, cr.GetObjectKind().GroupVersionKind().Kind)
 		if err != nil {
 			return err
 		}

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -18,9 +18,10 @@ package enterprise
 import (
 	"context"
 	"fmt"
-	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 	"reflect"
 	"time"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 
 	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
 	splctrl "github.com/splunk/splunk-operator/pkg/splunk/controller"
@@ -284,7 +285,7 @@ func validateStandaloneSpec(ctx context.Context, c splcommon.ControllerClient, c
 	}
 
 	if !reflect.DeepEqual(cr.Status.AppContext.AppFrameworkConfig, cr.Spec.AppFrameworkConfig) {
-		err := ValidateAppFrameworkSpec(ctx, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext, true)
+		err := ValidateAppFrameworkSpec(ctx, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext, true, cr.GetObjectKind().GroupVersionKind().Kind)
 		if err != nil {
 			return err
 		}

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -1889,7 +1889,7 @@ func checkAndMigrateAppDeployStatus(ctx context.Context, client splcommon.Contro
 	// If needed, Migrate the app framework status
 	if isAppFrameworkMigrationNeeded(afwStatusContext) {
 		// Spec validation updates the status with some of the defaults, which may not be there in older app framework versions
-		err := ValidateAppFrameworkSpec(ctx, afwConf, afwStatusContext, isLocalScope)
+		err := ValidateAppFrameworkSpec(ctx, afwConf, afwStatusContext, isLocalScope, cr.GetObjectKind().GroupVersionKind().Kind)
 		if err != nil {
 			return err
 		}

--- a/pkg/splunk/util/messages.go
+++ b/pkg/splunk/util/messages.go
@@ -15,6 +15,22 @@
 
 package util
 
+// Suppression strings for certain splunk CLI commands
+// Splunk ES app has a lot of info strings marked as stderr, ignore them
+var splunkCliSuppressionStrings = []string{
+	"WARNING: Server Certificate Hostname Validation is disabled. Please see server.conf/[sslConfig]/cliVerifyServerName for details.\n",
+	"INFO: Initialization complete\nINFO: SSL enablement set to ignore, continuing...\n",
+	"INFO: Installation complete\nINFO: SSL enablement set to ignore, continuing...\n",
+	"INFO: Enabled SSL in system namespace\nINFO: Initialization complete\n",
+	"INFO: Enabled SSL in system namespace\nINFO: Installation complete\n",
+	"INFO: Initialization complete, please restart Splunk\nINFO: SSL enablement set to ignore, continuing...\n",
+	"INFO: Installation complete, please restart Splunk\nINFO: SSL enablement set to ignore, continuing...\n",
+	"INFO: Initialization complete\n",
+	"INFO: Installation complete\n",
+	"INFO: Init complete\n",
+	"App \"SplunkEnterpriseSecuritySuite\" already exists; use the \"update\" argument to install anyway\n",
+}
+
 const (
 	// Less than zero version error
 	lessThanOrEqualToZeroVersionError = "Versions shouldn't be <= 0"
@@ -39,23 +55,4 @@ const (
 
 	// emptySecretVolumeSource indicates an empty
 	emptySecretVolumeSource = "Didn't find secret volume source in any pod volume"
-
-	// splunkSSHWarningMessage Note: splunk 9.0 throws warning message "warning: server certificate hostname validation is disabled. please see server.conf/[sslconfig]/cliverifyservername for details.\n"
-	// we are supressing the message
-	splunkSSHWarningMessage = "WARNING: Server Certificate Hostname Validation is disabled. Please see server.conf/[sslConfig]/cliVerifyServerName for details.\n"
-
-	// splunkEsAppSSLWarning Note: The ES app post install spews out a harmless ES app message which can be ignored
-	splunkEsAppSSLWarning = "INFO: Installation complete\nINFO: SSL enablement set to ignore, continuing...\n"
-
-	// splunkEsAppSSLAutoWarning Note: The ES app post install spews out a harmless ES app message which can be ignored
-	splunkEsAppSSLAutoWarning = "INFO: Enabled SSL in system namespace\nINFO: Installation complete\n"
-
-	// splunkEsAppAlreadyExists Note: The ES app post install spews out a harmless ES app message which can be ignored
-	splunkEsAppAlreadyExists = "App \"SplunkEnterpriseSecuritySuite\" already exists; use the \"update\" argument to install anyway\n"
-
-	// splunkEsAppInstallationComplete
-	splunkEsAppInstallationComplete = "INFO: Installation complete\n"
-
-	// splunkEsAppSSLWarningRestart Note: The ES app post install spews out a harmless ES app message which can be ignored
-	splunkEsAppSSLWarningRestart = "INFO: Initialization complete, please restart Splunk\nINFO: SSL enablement set to ignore, continuing...\n"
 )

--- a/pkg/splunk/util/messages.go
+++ b/pkg/splunk/util/messages.go
@@ -46,4 +46,13 @@ const (
 
 	// splunkEsAppSSLWarning Note: The ES app post install spews out a harmless ES app message which can be ignored
 	splunkEsAppSSLWarning = "INFO: Installation complete\nINFO: SSL enablement set to ignore, continuing...\n"
+
+	// splunkEsAppSSLAutoWarning Note: The ES app post install spews out a harmless ES app message which can be ignored
+	splunkEsAppSSLAutoWarning = "INFO: Enabled SSL in system namespace\nINFO: Installation complete\n"
+
+	// splunkEsAppAlreadyExists Note: The ES app post install spews out a harmless ES app message which can be ignored
+	splunkEsAppAlreadyExists = "App \"SplunkEnterpriseSecuritySuite\" already exists; use the \"update\" argument to install anyway\n"
+
+	// splunkEsAppInstallationComplete
+	splunkEsAppInstallationComplete = "INFO: Installation complete\n"
 )

--- a/pkg/splunk/util/util.go
+++ b/pkg/splunk/util/util.go
@@ -236,30 +236,12 @@ func GetPodExecClient(client splcommon.ControllerClient, cr splcommon.MetaObject
 // suppressHarmlessErrorMessages suppresses harmless error messages
 func suppressHarmlessErrorMessages(values ...*string) {
 	for _, val := range values {
-		// Replace ssh warning message
-		if strings.Contains(*val, splunkSSHWarningMessage) {
-			*val = strings.ReplaceAll(*val, splunkSSHWarningMessage, "")
-		}
-
-		// Replace es app warnings
-		if strings.Contains(*val, splunkEsAppSSLWarning) {
-			*val = strings.ReplaceAll(*val, splunkEsAppSSLWarning, "")
-		}
-
-		if strings.Contains(*val, splunkEsAppSSLAutoWarning) {
-			*val = strings.ReplaceAll(*val, splunkEsAppSSLAutoWarning, "")
-		}
-
-		if strings.Contains(*val, splunkEsAppAlreadyExists) {
-			*val = strings.ReplaceAll(*val, splunkEsAppAlreadyExists, "")
-		}
-
-		if strings.Contains(*val, splunkEsAppInstallationComplete) {
-			*val = strings.ReplaceAll(*val, splunkEsAppInstallationComplete, "")
-		}
-
-		if strings.Contains(*val, splunkEsAppSSLWarningRestart) {
-			*val = strings.ReplaceAll(*val, splunkEsAppSSLWarningRestart, "")
+		// Replace each input string if it contains suppressions strings
+		for _, replStr := range splunkCliSuppressionStrings {
+			// Runs per suppression string
+			if strings.Contains(*val, replStr) {
+				*val = strings.ReplaceAll(*val, replStr, "")
+			}
 		}
 	}
 }

--- a/pkg/splunk/util/util.go
+++ b/pkg/splunk/util/util.go
@@ -241,9 +241,21 @@ func suppressHarmlessErrorMessages(values ...*string) {
 			*val = strings.ReplaceAll(*val, splunkSSHWarningMessage, "")
 		}
 
-		// Replace es app ssl warning
+		// Replace es app warnings
 		if strings.Contains(*val, splunkEsAppSSLWarning) {
 			*val = strings.ReplaceAll(*val, splunkEsAppSSLWarning, "")
+		}
+
+		if strings.Contains(*val, splunkEsAppSSLAutoWarning) {
+			*val = strings.ReplaceAll(*val, splunkEsAppSSLAutoWarning, "")
+		}
+
+		if strings.Contains(*val, splunkEsAppAlreadyExists) {
+			*val = strings.ReplaceAll(*val, splunkEsAppAlreadyExists, "")
+		}
+
+		if strings.Contains(*val, splunkEsAppInstallationComplete) {
+			*val = strings.ReplaceAll(*val, splunkEsAppInstallationComplete, "")
 		}
 	}
 }

--- a/pkg/splunk/util/util.go
+++ b/pkg/splunk/util/util.go
@@ -256,7 +256,7 @@ func suppressHarmlessErrorMessages(values ...*string) {
 
 		if strings.Contains(*val, splunkEsAppInstallationComplete) {
 			*val = strings.ReplaceAll(*val, splunkEsAppInstallationComplete, "")
-    }
+		}
 
 		if strings.Contains(*val, splunkEsAppSSLWarningRestart) {
 			*val = strings.ReplaceAll(*val, splunkEsAppSSLWarningRestart, "")

--- a/pkg/splunk/util/util_test.go
+++ b/pkg/splunk/util/util_test.go
@@ -236,10 +236,13 @@ func TestSuppressHarmlessErrorMessages(t *testing.T) {
 	string1 := splunkSSHWarningMessage
 	string2 := splunkEsAppSSLWarning
 	string3 := splunkEsAppSSLWarningRestart
+	string4 := splunkEsAppAlreadyExists
+	string5 := splunkEsAppSSLAutoWarning
+	string6 := splunkEsAppInstallationComplete
 
 	// Test replacement of strings
-	suppressHarmlessErrorMessages(&string1, &string2, &string3)
-	if string1 != "" || string2 != "" || string3 != "" {
+	suppressHarmlessErrorMessages(&string1, &string2, &string3, &string4, &string5, &string6)
+	if string1 != "" || string2 != "" || string3 != "" || string4 != "" || string5 != "" || string6 != "" {
 		t.Errorf("Known messages did not get suppressed.")
 	}
 }

--- a/pkg/splunk/util/util_test.go
+++ b/pkg/splunk/util/util_test.go
@@ -233,16 +233,16 @@ func TestGetSetTargetPodName(t *testing.T) {
 }
 
 func TestSuppressHarmlessErrorMessages(t *testing.T) {
-	string1 := splunkSSHWarningMessage
-	string2 := splunkEsAppSSLWarning
-	string3 := splunkEsAppSSLWarningRestart
-	string4 := splunkEsAppAlreadyExists
-	string5 := splunkEsAppSSLAutoWarning
-	string6 := splunkEsAppInstallationComplete
+	var finalStr string
+
+	// Create string containing all suppression strings
+	for _, replStr := range splunkCliSuppressionStrings {
+		finalStr += replStr
+	}
 
 	// Test replacement of strings
-	suppressHarmlessErrorMessages(&string1, &string2, &string3, &string4, &string5, &string6)
-	if string1 != "" || string2 != "" || string3 != "" || string4 != "" || string5 != "" || string6 != "" {
+	suppressHarmlessErrorMessages(&finalStr)
+	if finalStr != "" {
 		t.Errorf("Known messages did not get suppressed.")
 	}
 }


### PR DESCRIPTION
**Problem:**

As part of ES install operator executes following steps:

1. Download ES
2. Install ES app (extract to deployer apps directory)
3. Remove ES package from operator and deployer staging directory
4. Run ES post install commands like essinstall

What we saw that if step 4 fails, then Operator tries to install ES app again with following steps:

1. installAppAndCleanup is called which tries to find the app package on deployer (pod)
2. app package is not found and operator errors out.

**Solution:**

Broke down the installAppandCleanup method to separate methods install and cleanup called before and after post install.