### PR TITLE
cspl-2177: added dockefile changes to fix CVE-2022-42898 vulnerability 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ ENV OPERATOR=/manager \
 
 RUN yum -y install shadow-utils
 RUN useradd -ms /bin/bash nonroot -u 1001
+RUN yum update -y krb5-libs && yum clean all
 RUN yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical
 RUN yum -y update-minimal --security --sec-severity=Moderate
 RUN yum -y update-minimal --security --sec-severity=Low
@@ -43,7 +44,7 @@ LABEL name="splunk" \
       description="The Splunk Operator for Kubernetes (SOK) makes it easy for Splunk Administrators to deploy and operate Enterprise deployments in a Kubernetes infrastructure. Packaged as a container, it uses the operator pattern to manage Splunk-specific custom resources, following best practices to manage all the underlying Kubernetes objects for you."
 
 WORKDIR /
-RUN mkdir /licenses 
+RUN mkdir /licenses
 RUN mkdir -p /tools/k8_probes
 
 COPY --from=builder /workspace/manager .

--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,7 @@ bundle: manifests kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
 	operator-sdk bundle validate ./bundle
+	operator-sdk bundle validate bundle --select-optional suite=operatorframework
 	cp bundle/manifests/enterprise.splunk.com* helm-chart/splunk-operator/crds
 
 .PHONY: bundle-build
@@ -315,6 +316,7 @@ run_clair_scan:
 generate-artifacts-namespace: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	mkdir -p release-${VERSION}
 	cp config/default/kustomization-namespace.yaml config/default/kustomization.yaml
+	cp config/rbac/kustomization-namespace.yaml config/rbac/kustomization.yaml
 	$(SED) "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
 	$(SED) "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
 	$(SED) "s/ClusterRole/Role/g"  config/rbac/role.yaml
@@ -329,6 +331,7 @@ generate-artifacts-namespace: manifests kustomize ## Deploy controller to the K8
 generate-artifacts-cluster: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	mkdir -p release-${VERSION}
 	cp config/default/kustomization-cluster.yaml config/default/kustomization.yaml
+	cp config/rbac/kustomization-cluster.yaml config/rbac/kustomization.yaml
 	$(SED) "s/namespace: splunk-operator/namespace: ${NAMESPACE}/g"  config/default/kustomization.yaml
 	$(SED) "s|SPLUNK_ENTERPRISE_IMAGE|${SPLUNK_ENTERPRISE_IMAGE}|g"  config/default/kustomization.yaml
 	$(SED) "s/WATCH_NAMESPACE_VALUE/\"${WATCH_NAMESPACE}\"/g"  config/default/kustomization.yaml

--- a/config/rbac/kustomization-cluster.yaml
+++ b/config/rbac/kustomization-cluster.yaml
@@ -1,0 +1,18 @@
+resources:
+# All RBAC will be applied under this service account in
+# the deployment namespace. You may comment out this resource
+# if your manager will use a service account that exists at
+# runtime. Be sure to update RoleBinding and ClusterRoleBinding
+# subjects if changing service account names.
+- service_account.yaml
+- role.yaml
+- role_binding.yaml
+- leader_election_role.yaml
+- leader_election_role_binding.yaml
+# Comment the following 4 lines if you want to disable
+# the auth proxy (https://github.com/brancz/kube-rbac-proxy)
+# which protects your /metrics endpoint.
+- auth_proxy_service.yaml
+- auth_proxy_role.yaml
+- auth_proxy_role_binding.yaml
+- auth_proxy_client_clusterrole.yaml

--- a/config/rbac/kustomization-namespace.yaml
+++ b/config/rbac/kustomization-namespace.yaml
@@ -1,0 +1,18 @@
+resources:
+# All RBAC will be applied under this service account in
+# the deployment namespace. You may comment out this resource
+# if your manager will use a service account that exists at
+# runtime. Be sure to update RoleBinding and ClusterRoleBinding
+# subjects if changing service account names.
+- service_account.yaml
+- role.yaml
+- role_binding.yaml
+- leader_election_role.yaml
+- leader_election_role_binding.yaml
+# Comment the following 4 lines if you want to disable
+# the auth proxy (https://github.com/brancz/kube-rbac-proxy)
+# which protects your /metrics endpoint.
+#- auth_proxy_service.yaml
+#- auth_proxy_role.yaml
+#- auth_proxy_role_binding.yaml
+#- auth_proxy_client_clusterrole.yaml

--- a/docs/SplunkOperatorUpgrade.md
+++ b/docs/SplunkOperatorUpgrade.md
@@ -20,7 +20,7 @@ A Splunk Operator for Kubernetes upgrade might include support for a later versi
 
 # Splunk Operator Upgrade
 
-## Steps to upgrade from version greater than 1.0.5 to 2.1.0
+## Steps to upgrade from version greater than 1.0.5 to latest
 
 1. Download the latest Splunk Operator installation yaml file.
 ​
@@ -51,7 +51,9 @@ If a Splunk Operator release includes an updated Splunk Enterprise Docker image,
 
 ## Steps to Upgrade from 1.0.5 or older version to latest
 
-Upgrading the Splunk Operator from 1.0.5 or older version to latest is a new installation rather than an upgrade from the current operator. The older Splunk Operator must be cleaned up before installing the new version. Script [operator-upgrade.sh](https://github.com/splunk/splunk-operator/releases/download/2.1.0/operator-upgrade.sh) helps you to do the cleanup. The script expects the current namespace where the operator is installed and the path to the latest operator deployment manifest file. The script performs the following steps
+Upgrading the Splunk Operator from 1.0.5 or older version to latest is a new installation rather than an upgrade from current operator installation. The older Splunk Operator must be cleaned up before installing the new version. You should upgrade operator to 1.1.0 first and then use [normal upgrade process from 1.1.0 to latest](#Steps-to-upgrade-from-version-greater-than-1.0.5-to-2.1.0).
+
+Script [operator-upgrade.sh](https://github.com/splunk/splunk-operator/releases/download/1.1.0/operator-upgrade.sh) helps you to do the cleanup, and install 1.1.0 Splunk operator. The script expects the current namespace where the operator is installed and the path to the latest operator deployment manifest file. The script performs the following steps
 
 * Backup of all the operator resources within the namespace like
 ** service-account, deployment, role, role-binding, cluster-role, cluster-role-binding
@@ -62,13 +64,13 @@ Upgrading the Splunk Operator from 1.0.5 or older version to latest is a new ins
 1. Download the upgrade script.
 
 ```
-wget -O operator-upgarde.sh https://github.com/splunk/splunk-operator/releases/download/2.1.0/operator-upgrade.sh
+wget -O operator-upgarde.sh https://github.com/splunk/splunk-operator/releases/download/1.1.0/operator-upgrade.sh
 ```
 
 2. Download the latest Splunk Operator installation yaml file.
 
 ```
-wget -O splunk-operator-install.yaml https://github.com/splunk/splunk-operator/releases/download/2.1.0/splunk-operator-install.yaml
+wget -O splunk-operator-install.yaml https://github.com/splunk/splunk-operator/releases/download/1.1.0/splunk-operator-install.yaml
 ```
 
 3. (Optional) Review the file and update it with your specific customizations used during your install. 
@@ -78,7 +80,7 @@ wget -O splunk-operator-install.yaml https://github.com/splunk/splunk-operator/r
 Set KUBECONFIG and run [operator-upgrade.sh](https://github.com/splunk/splunk-operator/releases/download/2.1.0/operator-upgrade.sh) script with the following mandatory arguments
 
 * `current_namespace` current namespace where operator is installed
-* `manifest_file`: path to 2.1.0 Splunk Operator manifest file
+* `manifest_file`: path to 1.1.0 Splunk Operator manifest file
 
 ### Example
 


### PR DESCRIPTION
- fix for vulnerability in base os image
- fix for namespace specific manifest file generation
tested both the fixes they both work on openshift cluster

Signed-off-by: vivekr-splunk <94569031+vivekr-splunk@users.noreply.github.com>