### PR TITLE
CSPL-2178: es post install failure should not trigger update of app install

### DIFF
--- a/api/v4/common_types.go
+++ b/api/v4/common_types.go
@@ -447,6 +447,8 @@ type AppFrameworkSpec struct {
 
 // AppDeploymentInfo represents a single App deployment information
 type AppDeploymentInfo struct {
+	// AppName is the name of app archive retrieved from the
+	// remote bucket e.g app1.tgz or app2.spl
 	AppName          string              `json:"appName"`
 	LastModifiedTime string              `json:"lastModifiedTime,omitempty"`
 	ObjectHash       string              `json:"objectHash"`
@@ -454,7 +456,11 @@ type AppDeploymentInfo struct {
 	Size             uint64              `json:"Size,omitempty"`
 	RepoState        AppRepoState        `json:"repoState"`
 	DeployStatus     AppDeploymentStatus `json:"deployStatus"`
-	InstalledAppName string              `json:"installedAppName"`
+
+	// AppPackageTopFolder is the name of top folder when we untar the
+	// app archive, which is also assumed to be same as the name of the
+	// app after it is installed.
+	AppPackageTopFolder string `json:"appPackageTopFolder"`
 
 	// App phase info to track download, copy and install
 	PhaseInfo PhaseInfo `json:"phaseInfo,omitempty"`

--- a/api/v4/common_types.go
+++ b/api/v4/common_types.go
@@ -454,6 +454,7 @@ type AppDeploymentInfo struct {
 	Size             uint64              `json:"Size,omitempty"`
 	RepoState        AppRepoState        `json:"repoState"`
 	DeployStatus     AppDeploymentStatus `json:"deployStatus"`
+	InstalledAppName string              `json:"installedAppName"`
 
 	// App phase info to track download, copy and install
 	PhaseInfo PhaseInfo `json:"phaseInfo,omitempty"`

--- a/config/crd/bases/enterprise.splunk.com_clustermanagers.yaml
+++ b/config/crd/bases/enterprise.splunk.com_clustermanagers.yaml
@@ -3914,6 +3914,8 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
+                              installedAppName:
+                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:

--- a/config/crd/bases/enterprise.splunk.com_clustermanagers.yaml
+++ b/config/crd/bases/enterprise.splunk.com_clustermanagers.yaml
@@ -3887,6 +3887,14 @@ spec:
                                 format: int64
                                 type: integer
                               appName:
+                                description: AppName is the name of app archive retrieved
+                                  from the remote bucket e.g app1.tgz or app2.spl
+                                type: string
+                              appPackageTopFolder:
+                                description: AppPackageTopFolder is the name of top
+                                  folder when we untar the app archive, which is also
+                                  assumed to be same as the name of the app after
+                                  it is installed.
                                 type: string
                               auxPhaseInfo:
                                 description: Used to track the copy and install status
@@ -3914,8 +3922,6 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
-                              installedAppName:
-                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:

--- a/config/crd/bases/enterprise.splunk.com_clustermasters.yaml
+++ b/config/crd/bases/enterprise.splunk.com_clustermasters.yaml
@@ -3914,6 +3914,8 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
+                              installedAppName:
+                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:

--- a/config/crd/bases/enterprise.splunk.com_clustermasters.yaml
+++ b/config/crd/bases/enterprise.splunk.com_clustermasters.yaml
@@ -3887,6 +3887,14 @@ spec:
                                 format: int64
                                 type: integer
                               appName:
+                                description: AppName is the name of app archive retrieved
+                                  from the remote bucket e.g app1.tgz or app2.spl
+                                type: string
+                              appPackageTopFolder:
+                                description: AppPackageTopFolder is the name of top
+                                  folder when we untar the app archive, which is also
+                                  assumed to be same as the name of the app after
+                                  it is installed.
                                 type: string
                               auxPhaseInfo:
                                 description: Used to track the copy and install status
@@ -3914,8 +3922,6 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
-                              installedAppName:
-                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:

--- a/config/crd/bases/enterprise.splunk.com_licensemanagers.yaml
+++ b/config/crd/bases/enterprise.splunk.com_licensemanagers.yaml
@@ -3788,6 +3788,8 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
+                              installedAppName:
+                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:

--- a/config/crd/bases/enterprise.splunk.com_licensemanagers.yaml
+++ b/config/crd/bases/enterprise.splunk.com_licensemanagers.yaml
@@ -3761,6 +3761,14 @@ spec:
                                 format: int64
                                 type: integer
                               appName:
+                                description: AppName is the name of app archive retrieved
+                                  from the remote bucket e.g app1.tgz or app2.spl
+                                type: string
+                              appPackageTopFolder:
+                                description: AppPackageTopFolder is the name of top
+                                  folder when we untar the app archive, which is also
+                                  assumed to be same as the name of the app after
+                                  it is installed.
                                 type: string
                               auxPhaseInfo:
                                 description: Used to track the copy and install status
@@ -3788,8 +3796,6 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
-                              installedAppName:
-                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:

--- a/config/crd/bases/enterprise.splunk.com_licensemasters.yaml
+++ b/config/crd/bases/enterprise.splunk.com_licensemasters.yaml
@@ -3787,6 +3787,8 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
+                              installedAppName:
+                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:

--- a/config/crd/bases/enterprise.splunk.com_licensemasters.yaml
+++ b/config/crd/bases/enterprise.splunk.com_licensemasters.yaml
@@ -3760,6 +3760,14 @@ spec:
                                 format: int64
                                 type: integer
                               appName:
+                                description: AppName is the name of app archive retrieved
+                                  from the remote bucket e.g app1.tgz or app2.spl
+                                type: string
+                              appPackageTopFolder:
+                                description: AppPackageTopFolder is the name of top
+                                  folder when we untar the app archive, which is also
+                                  assumed to be same as the name of the app after
+                                  it is installed.
                                 type: string
                               auxPhaseInfo:
                                 description: Used to track the copy and install status
@@ -3787,8 +3795,6 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
-                              installedAppName:
-                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:

--- a/config/crd/bases/enterprise.splunk.com_monitoringconsoles.yaml
+++ b/config/crd/bases/enterprise.splunk.com_monitoringconsoles.yaml
@@ -3766,6 +3766,14 @@ spec:
                                 format: int64
                                 type: integer
                               appName:
+                                description: AppName is the name of app archive retrieved
+                                  from the remote bucket e.g app1.tgz or app2.spl
+                                type: string
+                              appPackageTopFolder:
+                                description: AppPackageTopFolder is the name of top
+                                  folder when we untar the app archive, which is also
+                                  assumed to be same as the name of the app after
+                                  it is installed.
                                 type: string
                               auxPhaseInfo:
                                 description: Used to track the copy and install status
@@ -3793,8 +3801,6 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
-                              installedAppName:
-                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:
@@ -7649,6 +7655,14 @@ spec:
                                 format: int64
                                 type: integer
                               appName:
+                                description: AppName is the name of app archive retrieved
+                                  from the remote bucket e.g app1.tgz or app2.spl
+                                type: string
+                              appPackageTopFolder:
+                                description: AppPackageTopFolder is the name of top
+                                  folder when we untar the app archive, which is also
+                                  assumed to be same as the name of the app after
+                                  it is installed.
                                 type: string
                               auxPhaseInfo:
                                 description: Used to track the copy and install status
@@ -7676,8 +7690,6 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
-                              installedAppName:
-                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:

--- a/config/crd/bases/enterprise.splunk.com_monitoringconsoles.yaml
+++ b/config/crd/bases/enterprise.splunk.com_monitoringconsoles.yaml
@@ -3793,6 +3793,8 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
+                              installedAppName:
+                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:
@@ -7674,6 +7676,8 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
+                              installedAppName:
+                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:

--- a/config/crd/bases/enterprise.splunk.com_searchheadclusters.yaml
+++ b/config/crd/bases/enterprise.splunk.com_searchheadclusters.yaml
@@ -3789,6 +3789,14 @@ spec:
                                 format: int64
                                 type: integer
                               appName:
+                                description: AppName is the name of app archive retrieved
+                                  from the remote bucket e.g app1.tgz or app2.spl
+                                type: string
+                              appPackageTopFolder:
+                                description: AppPackageTopFolder is the name of top
+                                  folder when we untar the app archive, which is also
+                                  assumed to be same as the name of the app after
+                                  it is installed.
                                 type: string
                               auxPhaseInfo:
                                 description: Used to track the copy and install status
@@ -3816,8 +3824,6 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
-                              installedAppName:
-                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:
@@ -7759,6 +7765,14 @@ spec:
                                 format: int64
                                 type: integer
                               appName:
+                                description: AppName is the name of app archive retrieved
+                                  from the remote bucket e.g app1.tgz or app2.spl
+                                type: string
+                              appPackageTopFolder:
+                                description: AppPackageTopFolder is the name of top
+                                  folder when we untar the app archive, which is also
+                                  assumed to be same as the name of the app after
+                                  it is installed.
                                 type: string
                               auxPhaseInfo:
                                 description: Used to track the copy and install status
@@ -7786,8 +7800,6 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
-                              installedAppName:
-                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:

--- a/config/crd/bases/enterprise.splunk.com_searchheadclusters.yaml
+++ b/config/crd/bases/enterprise.splunk.com_searchheadclusters.yaml
@@ -3816,6 +3816,8 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
+                              installedAppName:
+                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:
@@ -7784,6 +7786,8 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
+                              installedAppName:
+                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:

--- a/config/crd/bases/enterprise.splunk.com_standalones.yaml
+++ b/config/crd/bases/enterprise.splunk.com_standalones.yaml
@@ -3889,6 +3889,14 @@ spec:
                                 format: int64
                                 type: integer
                               appName:
+                                description: AppName is the name of app archive retrieved
+                                  from the remote bucket e.g app1.tgz or app2.spl
+                                type: string
+                              appPackageTopFolder:
+                                description: AppPackageTopFolder is the name of top
+                                  folder when we untar the app archive, which is also
+                                  assumed to be same as the name of the app after
+                                  it is installed.
                                 type: string
                               auxPhaseInfo:
                                 description: Used to track the copy and install status
@@ -3916,8 +3924,6 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
-                              installedAppName:
-                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:
@@ -8016,6 +8022,14 @@ spec:
                                 format: int64
                                 type: integer
                               appName:
+                                description: AppName is the name of app archive retrieved
+                                  from the remote bucket e.g app1.tgz or app2.spl
+                                type: string
+                              appPackageTopFolder:
+                                description: AppPackageTopFolder is the name of top
+                                  folder when we untar the app archive, which is also
+                                  assumed to be same as the name of the app after
+                                  it is installed.
                                 type: string
                               auxPhaseInfo:
                                 description: Used to track the copy and install status
@@ -8043,8 +8057,6 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
-                              installedAppName:
-                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:

--- a/config/crd/bases/enterprise.splunk.com_standalones.yaml
+++ b/config/crd/bases/enterprise.splunk.com_standalones.yaml
@@ -3916,6 +3916,8 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
+                              installedAppName:
+                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:
@@ -8041,6 +8043,8 @@ spec:
                                 description: AppDeploymentStatus represents the status
                                   of an App on the Pod
                                 type: integer
+                              installedAppName:
+                                type: string
                               isUpdate:
                                 type: boolean
                               lastModifiedTime:

--- a/pkg/splunk/enterprise/afwscheduler_test.go
+++ b/pkg/splunk/enterprise/afwscheduler_test.go
@@ -2866,6 +2866,16 @@ func TestRunLocalScopedPlaybook(t *testing.T) {
 		t.Errorf("Expected app install failed")
 	}
 
+	mockPodExecReturnContexts[2].StdOut = "1" //app is not yet installed or it is not enabled
+	mockPodExecReturnContexts[2].StdErr = "Could not find object"
+
+	localInstallCtxt.sem <- struct{}{}
+	waiter.Add(1)
+	err = localInstallCtxt.runPlaybook(ctx)
+	if err == nil {
+		t.Errorf("Expected app install failed")
+	}
+
 	// Test5: install app should be successful
 
 	mockPodExecReturnContexts[3].StdErr = "" //no error for app install

--- a/pkg/splunk/enterprise/afwscheduler_test.go
+++ b/pkg/splunk/enterprise/afwscheduler_test.go
@@ -2761,9 +2761,11 @@ func TestRunLocalScopedPlaybook(t *testing.T) {
 	c.AddObject(pod)
 
 	podExecCommands := []string{
-		"test -f",
-		"/opt/splunk/bin/splunk install app",
-		"rm -f",
+		"test -f",                            //check if app archive is present
+		"tar tf",                             // gather installed app name
+		"/opt/splunk/bin/splunk list app",    // check if app is already installed
+		"/opt/splunk/bin/splunk install app", // install app
+		"rm -f",                              //remove app arhive
 	}
 
 	mockPodExecReturnContexts := []*spltest.MockPodExecReturnContext{
@@ -2773,10 +2775,20 @@ func TestRunLocalScopedPlaybook(t *testing.T) {
 			StdErr: "",
 			Err:    fmt.Errorf("some dummy error"),
 		},
+		// this is for getting installed app name
+		{
+			StdOut: "",
+			StdErr: "random dummy error1",
+		},
+		// this is for checking if app is already installed
+		{
+			StdOut: "",
+			StdErr: "random dummy error2",
+		},
 		// this is for installing the app
 		{
 			StdOut: "",
-			StdErr: "random dummy error",
+			StdErr: "random dummy error3",
 		},
 		// this is for removing the app package from pod
 		{
@@ -2825,26 +2837,48 @@ func TestRunLocalScopedPlaybook(t *testing.T) {
 		t.Errorf("Failed to detect missingApp pkg: err: %s", err.Error())
 	}
 
-	// Test2: checkIfFileExistsOnPod passes but install command returns error
+	// Test2: checkIfFileExistsOnPod passes but get installed app name returns error
 	mockPodExecReturnContexts[0].Err = nil
 	localInstallCtxt.sem <- struct{}{}
 	waiter.Add(1)
 	err = localInstallCtxt.runPlaybook(ctx)
 	if err == nil {
-		t.Errorf("Failed to detect missingApp pkg: err: %s", err.Error())
+		t.Errorf("Failed to detect that steps to get installed app failed: err: %s", err.Error())
 	}
 
-	// Test3: install command passes but removing app package from pod returns error
+	// Test3: get installed app name passes but getting installed app name failed
 	mockPodExecReturnContexts[1].StdErr = ""
 	localInstallCtxt.sem <- struct{}{}
 	waiter.Add(1)
 	err = localInstallCtxt.runPlaybook(ctx)
 	if err == nil {
-		t.Errorf("Failed to detect missingApp pkg: err: %s", err.Error())
+		t.Errorf("Failed to detect not able to get installed app name: err: %s", err.Error())
 	}
 
-	// Test4: successful scenario where everything succeeds
-	mockPodExecReturnContexts[2].StdErr = ""
+	// Test4: get installed app command passes but installing app fails
+	mockPodExecReturnContexts[2].StdOut = "1" //app is not yet installed or it is not enabled
+	mockPodExecReturnContexts[2].StdErr = ""  //no error thrown
+
+	localInstallCtxt.sem <- struct{}{}
+	waiter.Add(1)
+	err = localInstallCtxt.runPlaybook(ctx)
+	if err == nil {
+		t.Errorf("Expected app install failed")
+	}
+
+	// Test5: install app should be successful
+
+	mockPodExecReturnContexts[3].StdErr = "" //no error for app install
+
+	localInstallCtxt.sem <- struct{}{}
+	waiter.Add(1)
+	err = localInstallCtxt.runPlaybook(ctx)
+	if err == nil {
+		t.Errorf("Expected app install succeeded but app arhive deletion failed")
+	}
+
+	// Test6: successful scenario where everything succeeds
+	mockPodExecReturnContexts[4].StdErr = ""
 	localInstallCtxt.sem <- struct{}{}
 	waiter.Add(1)
 	err = localInstallCtxt.runPlaybook(ctx)
@@ -2942,10 +2976,12 @@ func TestPremiumAppScopedPlaybook(t *testing.T) {
 	c.AddObject(pod)
 
 	podExecCommands := []string{
-		"test -f",
-		"/opt/splunk/bin/splunk install app",
-		"/opt/splunk/bin/splunk search",
-		"rm -f",
+		"test -f",                            //check if app archive is present
+		"tar tf",                             // gather installed app name
+		"/opt/splunk/bin/splunk list app",    // check if app is already installed
+		"/opt/splunk/bin/splunk install app", // install app
+		"/opt/splunk/bin/splunk search",      // es post install : essinstall command
+		"rm -f",                              //remove app arhive
 	}
 
 	mockPodExecReturnContexts := []*spltest.MockPodExecReturnContext{
@@ -2955,20 +2991,30 @@ func TestPremiumAppScopedPlaybook(t *testing.T) {
 			StdErr: "",
 			Err:    fmt.Errorf("some dummy error"),
 		},
+		// this is for getting installed app name
+		{
+			StdOut: "",
+			StdErr: "random dummy error1",
+		},
+		// this is for checking if app is already installed
+		{
+			StdOut: "",
+			StdErr: "random dummy error2",
+		},
 		// this is for installing the app
 		{
 			StdOut: "",
-			StdErr: "Random Error",
+			StdErr: "random dummy error3",
+		},
+		// this is for running es post install command
+		{
+			StdOut: "",
+			StdErr: "random dummy error4",
 		},
 		// this is for removing the app package from pod
 		{
 			StdOut: "",
 			StdErr: "dummyError",
-		},
-		// this is for es post install pod exec error
-		{
-			StdOut: "",
-			StdErr: "dummyError2",
 		},
 	}
 
@@ -3018,47 +3064,67 @@ func TestPremiumAppScopedPlaybook(t *testing.T) {
 	waiter.Add(1)
 	err := pCtx.runPlaybook(ctx)
 	if err == nil {
-		t.Errorf("Failed to detect missingApp pkg: err: %s", err.Error())
+		t.Errorf("Failed to detect missingApp pkg")
 	}
 
-	// Test2: checkIfFileExistsOnPod passes but install command returns error
+	// Test2: checkIfFileExistsOnPod passes but get installed app name returns error
 	mockPodExecReturnContexts[0].Err = nil
 	localInstallCtxt.sem <- struct{}{}
 	waiter.Add(1)
 	err = pCtx.runPlaybook(ctx)
 	if err == nil {
-		t.Errorf("Failed to detect missingApp pkg: err: %s", err.Error())
+		t.Errorf("Failed to detect that steps to get installed app failed")
 	}
 
-	// Test3: failure in es post install pod exec command
+	// Test3: get installed app name passes but getting installed app name failed
 	mockPodExecReturnContexts[1].StdErr = ""
 	localInstallCtxt.sem <- struct{}{}
 	waiter.Add(1)
 	err = pCtx.runPlaybook(ctx)
-	if !strings.Contains(err.Error(), "premium scoped app package install failed") {
-		t.Errorf("Failed to detect missingApp pkg: err: %s", err.Error())
+	if err == nil {
+		t.Errorf("Failed to detect not able to get installed app name: err")
 	}
 
-	// Test4: install command passes but removing app package from pod returns error
-	mockPodExecReturnContexts[2].StdErr = ""
+	// Test4: get installed app command passes, it returns app is not enabled
+	// so app install will run and it should  fail
+	mockPodExecReturnContexts[2].StdOut = "1" //app is not yet installed or it is not enabled
+	mockPodExecReturnContexts[2].StdErr = ""  //no error thrown
+
 	localInstallCtxt.sem <- struct{}{}
 	waiter.Add(1)
 	err = pCtx.runPlaybook(ctx)
 	if err == nil {
-		t.Errorf("runPlayBook should have returned error")
+		t.Errorf("Expected app install failed")
 	}
 
+	// Test5: install app should be successful but es post install fails
+
+	mockPodExecReturnContexts[3].StdErr = "" //no error for app install
+
+	localInstallCtxt.sem <- struct{}{}
+	waiter.Add(1)
+	err = pCtx.runPlaybook(ctx)
 	if err == nil {
-		t.Errorf("runPlayBook did not return `premium scoped app package install failed` got %v", err.Error())
+		t.Errorf("Expected app install succeeded but es post install failed")
+	}
+	// Test6: es post install is successfull but remove archive fails
+
+	mockPodExecReturnContexts[4].StdErr = "" //no error for es post install
+
+	localInstallCtxt.sem <- struct{}{}
+	waiter.Add(1)
+	err = pCtx.runPlaybook(ctx)
+	if err == nil {
+		t.Errorf("Expected es post  install succeeded but app arhive deletion failed")
 	}
 
-	// Test5: everything passes
-	mockPodExecReturnContexts[3].StdErr = ""
+	// Test7: successful scenario where everything succeeds
+	mockPodExecReturnContexts[5].StdErr = ""
 	localInstallCtxt.sem <- struct{}{}
 	waiter.Add(1)
 	err = pCtx.runPlaybook(ctx)
 	if err != nil {
-		t.Errorf("runPlayBook should not have returned error")
+		t.Errorf("runPlayBook should not have returned error. err=%s", err.Error())
 	}
 
 	// Test 6: run for SHC


### PR DESCRIPTION
**Problem:**
As part of ES install in SHC, the operator executes the following steps:

1. Download ES
2. Install the ES app (`splunk install app <download_dir_on_pod>/splunk-enterprise-security_xxx.spl`)
3. Run ES post install commands `essinstall`
4. Cleanup the app archive

What we saw is that if step 3 fails, then the Operator Install worker thread tries run step 2 again that is -  install the ES app again with command `splunk install app <download_dir_on_pod>/splunk-enterprise-security_xxx.spl`

In this case, the App install command comes back with an error: `\nApp \"SplunkEnterpriseSecuritySuite\" already exists; use the \"update\" argument to install anyway\n", "err": "command terminated with exit code 22"`

This error comes back because the install worker thread does not know about the ES post-install failure and reruns step 2.

**Solution:**
In this fix, at step 2 above, the logic is enhanced so the install worker thread first checks if the app is already installed so it **_skips_** the install step.

Updated steps:
1. Download ES
2. Check if ES app is already installed and enabled (through splunk list app ...command)
3. If step 2 returns true, skip the app install ((`splunk install app <download_dir_on_pod>/splunk-enterprise-security_xxx.spl`)
5. Run ES post install commands `essinstall`
6. Cleanup the app archive
