### PR TITLE
chore: allow creation of additional arbitrary k8s manifests

### DIFF
--- a/helm-chart/splunk-enterprise/templates/extra-manifests.yaml
+++ b/helm-chart/splunk-enterprise/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/helm-chart/splunk-enterprise/values.yaml
+++ b/helm-chart/splunk-enterprise/values.yaml
@@ -586,3 +586,14 @@ standalone:
   tolerations: []
 
   affinity: {}
+
+# Array with extra yaml to deploy with the chart. Evaluated as a template
+extraManifests: []
+# extraManifests:
+#  - apiVersion: cloud.google.com/v1beta1
+#    kind: BackendConfig
+#    metadata:
+#      name: "{{ .Release.Name }}-test"
+#    spec:
+#      securityPolicy:
+#        name: "gcp-cloud-armor-policy-test"

--- a/helm-chart/splunk-operator/templates/extra-manifests.yaml
+++ b/helm-chart/splunk-operator/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/helm-chart/splunk-operator/values.yaml
+++ b/helm-chart/splunk-operator/values.yaml
@@ -139,3 +139,14 @@ splunkOperator:
     name: app-staging
 # - mountPath:
 #   name:
+
+# Array with extra yaml to deploy with the chart. Evaluated as a template
+extraManifests: []
+# extraManifests:
+#  - apiVersion: cloud.google.com/v1beta1
+#    kind: BackendConfig
+#    metadata:
+#      name: "{{ .Release.Name }}-test"
+#    spec:
+#      securityPolicy:
+#        name: "gcp-cloud-armor-policy-test"


### PR DESCRIPTION
hi @vivekr-splunk @gaurav-splunk @pdhanoya-splunk @tpereirasplunk 

the [operator documentation provides references to istio and nginx ingress](https://github.com/splunk/splunk-operator/blob/11b9ed2b7e6dfbf63b69f720e94e9880d7fa5fe8/docs/Ingress.md) resources, but the helm chart provides no interface to create these resources.

this PR makes use of a flexible and [commonly-used](https://github.com/runatlantis/helm-charts/blob/main/charts/atlantis/templates/extra-manifests.yaml) pattern to create arbitrary k8s resources. use cases include the above and things like

- grafana dashboards
- prometheus configuration
- alertmanager rules
- additional k8s service accounts
- k8s [external secrets](https://github.com/external-secrets/external-secrets) objects
- configmaps for secret injection via bank-vaults/vault operator