### PR TITLE
Revert "CSPL-2187 - Make ssl_enablement ignore as default, disable strict for shc"

### DIFF
--- a/api/v4/common_types.go
+++ b/api/v4/common_types.go
@@ -387,11 +387,11 @@ type EsDefaults struct {
 	//     strict: Ensure that SSL is enabled
 	//             in the web.conf configuration file to use
 	//             this mode. Otherwise, the installer exists
-	//	     	   with an error.
+	//	     	   with an error. This is the DEFAULT mode used
+	//             by the operator if left empty.
 	//     auto: Enables SSL in the etc/system/local/web.conf
 	//           configuration file.
 	//     ignore: Ignores whether SSL is enabled or disabled.
-	//             This is the DEFAULT mode used by the operator if left empty.
 	//
 	// +optional
 	SslEnablement string `json:"sslEnablement,omitempty"`

--- a/config/crd/bases/enterprise.splunk.com_clustermanagers.yaml
+++ b/config/crd/bases/enterprise.splunk.com_clustermanagers.yaml
@@ -928,10 +928,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -976,11 +976,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -3755,11 +3755,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -3806,10 +3806,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:

--- a/config/crd/bases/enterprise.splunk.com_clustermasters.yaml
+++ b/config/crd/bases/enterprise.splunk.com_clustermasters.yaml
@@ -928,10 +928,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -976,11 +976,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -3755,11 +3755,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -3806,10 +3806,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:

--- a/config/crd/bases/enterprise.splunk.com_licensemanagers.yaml
+++ b/config/crd/bases/enterprise.splunk.com_licensemanagers.yaml
@@ -918,10 +918,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -966,11 +966,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -3629,11 +3629,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -3680,10 +3680,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:

--- a/config/crd/bases/enterprise.splunk.com_licensemasters.yaml
+++ b/config/crd/bases/enterprise.splunk.com_licensemasters.yaml
@@ -917,10 +917,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -965,11 +965,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -3628,11 +3628,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -3679,10 +3679,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:

--- a/config/crd/bases/enterprise.splunk.com_monitoringconsoles.yaml
+++ b/config/crd/bases/enterprise.splunk.com_monitoringconsoles.yaml
@@ -924,10 +924,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -972,11 +972,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -3634,11 +3634,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -3685,10 +3685,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:
@@ -4812,10 +4813,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -4860,11 +4861,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -7522,11 +7523,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -7573,10 +7574,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:

--- a/config/crd/bases/enterprise.splunk.com_searchheadclusters.yaml
+++ b/config/crd/bases/enterprise.splunk.com_searchheadclusters.yaml
@@ -930,10 +930,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -978,11 +978,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -3657,11 +3657,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -3708,10 +3708,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:
@@ -4905,10 +4906,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -4953,11 +4954,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -7632,11 +7633,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -7683,10 +7684,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:

--- a/config/crd/bases/enterprise.splunk.com_standalones.yaml
+++ b/config/crd/bases/enterprise.splunk.com_standalones.yaml
@@ -925,10 +925,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -973,11 +973,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -3757,11 +3757,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -3808,10 +3808,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:
@@ -5057,10 +5058,10 @@ spec:
                                     app installation strict: Ensure that SSL is enabled
                                     in the web.conf configuration file to use this
                                     mode. Otherwise, the installer exists with an
-                                    error. auto: Enables SSL in the etc/system/local/web.conf
+                                    error. This is the DEFAULT mode used by the operator
+                                    if left empty. auto: Enables SSL in the etc/system/local/web.conf
                                     configuration file. ignore: Ignores whether SSL
-                                    is enabled or disabled. This is the DEFAULT mode
-                                    used by the operator if left empty.'
+                                    is enabled or disabled.'
                                   type: string
                               type: object
                             type:
@@ -5105,11 +5106,11 @@ spec:
                                 description: 'Sets the sslEnablement value for ES
                                   app installation strict: Ensure that SSL is enabled
                                   in the web.conf configuration file to use this mode.
-                                  Otherwise, the installer exists with an error. auto:
-                                  Enables SSL in the etc/system/local/web.conf configuration
-                                  file. ignore: Ignores whether SSL is enabled or
-                                  disabled. This is the DEFAULT mode used by the operator
-                                  if left empty.'
+                                  Otherwise, the installer exists with an error. This
+                                  is the DEFAULT mode used by the operator if left
+                                  empty. auto: Enables SSL in the etc/system/local/web.conf
+                                  configuration file. ignore: Ignores whether SSL
+                                  is enabled or disabled.'
                                 type: string
                             type: object
                           type:
@@ -7889,11 +7890,11 @@ spec:
                                         ES app installation strict: Ensure that SSL
                                         is enabled in the web.conf configuration file
                                         to use this mode. Otherwise, the installer
-                                        exists with an error. auto: Enables SSL in
-                                        the etc/system/local/web.conf configuration
-                                        file. ignore: Ignores whether SSL is enabled
-                                        or disabled. This is the DEFAULT mode used
-                                        by the operator if left empty.'
+                                        exists with an error. This is the DEFAULT
+                                        mode used by the operator if left empty. auto:
+                                        Enables SSL in the etc/system/local/web.conf
+                                        configuration file. ignore: Ignores whether
+                                        SSL is enabled or disabled.'
                                       type: string
                                   type: object
                                 type:
@@ -7940,10 +7941,11 @@ spec:
                                       ES app installation strict: Ensure that SSL
                                       is enabled in the web.conf configuration file
                                       to use this mode. Otherwise, the installer exists
-                                      with an error. auto: Enables SSL in the etc/system/local/web.conf
-                                      configuration file. ignore: Ignores whether
-                                      SSL is enabled or disabled. This is the DEFAULT
-                                      mode used by the operator if left empty.'
+                                      with an error. This is the DEFAULT mode used
+                                      by the operator if left empty. auto: Enables
+                                      SSL in the etc/system/local/web.conf configuration
+                                      file. ignore: Ignores whether SSL is enabled
+                                      or disabled.'
                                     type: string
                                 type: object
                               type:

--- a/pkg/splunk/enterprise/afwscheduler.go
+++ b/pkg/splunk/enterprise/afwscheduler.go
@@ -1932,14 +1932,15 @@ func (idxcPlaybookContext *IdxcPlaybookContext) runPlaybook(ctx context.Context)
 }
 
 // getSslCliOption gets the ssl cli option for installing ES app.
-// Returns `ignore` if not configured. Note: Validation of spec done already
+// Returns `strict` if not configured. Note: Validation of spec done already
+// Reference: https://docs.splunk.com/Documentation/ES/latest/Install/InstallEnterpriseSecuritySHC
 func getSslCliOption(appSrcSpec *enterpriseApi.AppSourceSpec) string {
 	sslEn := appSrcSpec.PremiumAppsProps.EsDefaults.SslEnablement
 	if sslEn != "" {
 		return sslEn
 	}
 
-	return enterpriseApi.SslEnablementIgnore
+	return enterpriseApi.SslEnablementStrict
 }
 
 // Handles ES app post install steps

--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -1489,8 +1489,8 @@ func validatePremiumAppsInputs(appSrc enterpriseApi.AppSourceSpec, crKind string
 	// SHC ES app cannot use ssl_enablement auto, product doesn't support it
 	if crKind == "SearchHeadCluster" {
 		if appSrc.PremiumAppsProps.Type == enterpriseApi.PremiumAppsTypeEs {
-			if sslEnablementValue == enterpriseApi.SslEnablementAuto || sslEnablementValue == enterpriseApi.SslEnablementStrict {
-				return fmt.Errorf("scope for app source: %s search head cluster can have an ES app installed only with ssl_enablement ignore", appSrc.Name)
+			if appSrc.AppSourceDefaultSpec.PremiumAppsProps.EsDefaults.SslEnablement == enterpriseApi.SslEnablementAuto {
+				return fmt.Errorf("scope for app source: %s search head cluster cannot have an ES app installed with ssl_enablement auto", appSrc.Name)
 			}
 		}
 	}

--- a/pkg/splunk/enterprise/configuration_test.go
+++ b/pkg/splunk/enterprise/configuration_test.go
@@ -638,13 +638,6 @@ func TestValidatePremiumAppsInputs(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected to see an error for invalid ssl_enablement for SHC in ES")
 	}
-
-	appSrcSpec.PremiumAppsProps.EsDefaults.SslEnablement = enterpriseApi.SslEnablementStrict
-	// invalid case, for SHC cannot use ssl_enablement auto
-	err = validatePremiumAppsInputs(appSrcSpec, "SearchHeadCluster")
-	if err == nil {
-		t.Errorf("Expected to see an error for invalid ssl_enablement for SHC in ES")
-	}
 }
 
 func TestValidateAppFrameworkSpec(t *testing.T) {


### PR DESCRIPTION
Per the security requirements, reverting splunk/splunk-operator#1006 . Making strict as default again.