### PR TITLE
CSPL-2206 - update splunk version and remove requirement to use extraEnv for SHC

### DIFF
--- a/.github/workflows/prodsec-workflow.yml
+++ b/.github/workflows/prodsec-workflow.yml
@@ -4,6 +4,7 @@ on:
     branches:
     - main
     - develop
+    - es_appfw_doc
 name: Prodsec Workflow
 jobs:
   semgrep:

--- a/.github/workflows/prodsec-workflow.yml
+++ b/.github/workflows/prodsec-workflow.yml
@@ -5,6 +5,7 @@ on:
     - main
     - develop
     - es_appfw_doc
+    - feature/es_appfw
 name: Prodsec Workflow
 jobs:
   semgrep:

--- a/.github/workflows/prodsec-workflow.yml
+++ b/.github/workflows/prodsec-workflow.yml
@@ -4,8 +4,6 @@ on:
     branches:
     - main
     - develop
-    - es_appfw_doc
-    - feature/es_appfw
 name: Prodsec Workflow
 jobs:
   semgrep:

--- a/docs/PremiumApps.md
+++ b/docs/PremiumApps.md
@@ -10,7 +10,7 @@ Installing Enterprise Security in a Kubernetes cluster with the Splunk Operator 
 
 * Ability to utilize the Splunk Operator [app framework](https://splunk.github.io/splunk-operator/AppFramework.html) method of installation.
 * Access to the [Splunk Enterprise Security (ES)](https://splunkbase.splunk.com/app/263/) app package.
-* Splunk Enterprise Security version 7.1.0, 7.0.2, 7.0.1, 7.0.0 or 6.6.2 as ES support in Splunk Operator is starting from Splunk Operator Release 2.2 which requires Splunk Enterprise 9.0.3 or later. For more information regarding Splunk Enterprise and Enterprise Security compatibility, see the [version compatibility matrix](https://docs.splunk.com/Documentation/VersionCompatibility/current/Matrix/CompatMatrix).
+* Splunk Enterprise Security version 7.1.0, 7.0.2, 7.0.1, 7.0.0 or 6.6.2 as ES support in Splunk Operator is starting from Splunk Operator Release 2.2.0 which requires Splunk Enterprise 9.0.3 or later. For more information regarding Splunk Enterprise and Enterprise Security compatibility, see the [version compatibility matrix](https://docs.splunk.com/Documentation/VersionCompatibility/current/Matrix/CompatMatrix).
 * Pod resource specs that meet the [Enterprise Security hardware requirements](https://docs.splunk.com/Documentation/ES/latest/Install/DeploymentPlanning#Hardware_requirements).
 * In the following sections, AWS S3 remote bucket is used for placing the splunk apps, but as given in the [app framework doc](https://splunk.github.io/splunk-operator/AppFramework.html), you can use Azure Blob remote buckets also.
 

--- a/docs/PremiumApps.md
+++ b/docs/PremiumApps.md
@@ -118,7 +118,7 @@ spec:
         secretRef: splunk-s3-secret
 ```
 
-In order to use strict mode of sslEnablment, you can enable SSL on splunkd using the extraEnv variable SPLUNK_HTTP_ENABLESSL as shown below: 
+In order to use strict mode of sslEnablement, you can enable SSL on splunkd using the extraEnv variable SPLUNK_HTTP_ENABLESSL as shown below:
 
 ```yaml
 apiVersion: enterprise.splunk.com/v4
@@ -241,7 +241,7 @@ spec:
   replicas: 3
 ```
 
-#### Consideration when using strict mode for "sslEnablment" in SHC
+#### Consideration when using strict mode for "sslEnablement" in SHC
 
 When using strict mode, the following additional steps are required so that the "splunk web ssl" is enabled for the SHC. These steps are necessary before you can install ES app with the strict mode of sslEnablement. Alternatively, if you are managing enableSplunkWebSSL setting outside of the Operator scope by pushing an app bundle through the deployer, then you can skip these steps.
 
@@ -287,10 +287,7 @@ spec:
 
 1. Ensure that the Enterprise Security app package is present in the specified AppFramework S3 location with the correct appSources scope. Additionally, if configuring an indexer cluster, ensure that the Splunk_TA_ForIndexers app is present in the ClusterManager AppFramework S3 location with the appSources "cluster" scope.
    
-2. Apply the specified custom resource(s), the Splunk Operator will handle installation and the environment will be ready to use once all pods are in the "Ready" state. Please refer to the examples above for creating your YAML files.
-   
-**Important Considerations**
-* Installation may take upwards of 30 minutes.
+2. Apply the specified custom resource(s), the Splunk Operator will handle installation and the environment will be ready to use once all pods are in the "Ready" state which may take upto 30 minutes. Please refer to the examples above for creating your YAML files.
 
 #### Post Installation Configuration
 
@@ -337,7 +334,7 @@ Example of error when you strict mode for sslEnablement and Splunk web is not SS
 ```
 To fix this error, you have one of the following options:
 1) Enable splunk web SSL- details on the section [Special consideration while using ssl enabled mode of strict in SHC](#special-consideration-while-using-ssl-enabled-mode-of-strict-in-shc)
-2) Or, use sslEnablment=ignore
+2) Or, use sslEnablement=ignore
 
 Example of a connection timeout error:
 

--- a/docs/PremiumApps.md
+++ b/docs/PremiumApps.md
@@ -1,6 +1,6 @@
 # Premium App Installation Guide
 
-The Splunk Operator currently provides support for automating the installation of Enterprise Security with support for other premium apps coming in the future. This page documents the prerequisites, installation steps, and limitations of deploying premium apps using the Splunk Operator.
+The Splunk Operator automates the installation of Enterprise Security with support for other premium apps coming in the future. This page documents the prerequisites, installation steps, and limitations of deploying premium apps using the Splunk Operator.
 
 ## Enterprise Security
 
@@ -27,14 +27,14 @@ Notably, if deploying a distributed search environment, the use of indexer clust
 
 ### What is and what is not automated by the Splunk Operator
 
-The Splunk Operator will install the necessary Enterprise Security components depending on the architecture specified by the applied CRDs.
+The Splunk Operator installs the necessary Enterprise Security components depending on the architecture specified by the applied CRDs.
 
-#### Standalone / Standalone Search Heads
-For standalones and standalone search heads the Operator will install Splunk Enterprise Security and all associated domain add-ons (DAs), and supporting add-ons (SAs).
+#### Standalone Splunk Instance/ Standalone Search Heads
+For standalone splunk instances and standalone search heads the Operator will install Splunk Enterprise Security and all associated domain add-ons (DAs), and supporting add-ons (SAs).
 
 #### Search Head Cluster
 When installing Enterprise Security in a Search Head Cluster, the Operator will perform the following tasks: 
-1) Install the splunk enterprise app in Deployer's etc/apps directory
+1) Install the splunk enterprise app in Deployer's etc/apps directory.
 2) Run the ES post install command `essinstall` that stages the Splunk Enterprise Security and all associated domain add-ons (DAs) and supporting add-ons (SAs) to the etc/shcapps.
 3) Push the shc cluster bundle from the deployer to all the SHs.
 
@@ -122,7 +122,7 @@ spec:
         secretRef: splunk-s3-secret
 ```
 
-In order to use strict mode of sslEnablment, you can enable SSL on splunkd using extraEnv variable SPLUNK_HTTP_ENABLESSL as given below: 
+In order to use strict mode of sslEnablment, you can enable SSL on splunkd using the extraEnv variable SPLUNK_HTTP_ENABLESSL as shown below: 
 
 ```yaml
 apiVersion: enterprise.splunk.com/v4
@@ -170,13 +170,13 @@ Assumption: you have downloaded ES app from https://splunkbase.splunk.com/app/26
 2. Apply the following YAML file
 2. Wait for the SHC, CM, and Indexers to be up and running. 
 3. Verify that the ES app is installed in SH. 
-3. Login to a SH, and extract the Splunk_TA_ForIndexers using the steps given here: [https://docs.splunk.com/Documentation/ES/7.0.2/Install/InstallTechnologyAdd-ons]
+3. Login to an SH, and extract the Splunk_TA_ForIndexers using the steps given here: [https://docs.splunk.com/Documentation/ES/7.0.2/Install/InstallTechnologyAdd-ons]
 4. Place the extracted Splunk_TA_ForIndexers package in the s3 bucket folder named "es_app_indexer_ta"
 
 The operator will poll this bucket after configured appsRepoPollIntervalSeconds and install the Splunk_TA_ForIndexers also.
  
-In this example for SHC, scope=premiumApps, type=EnterpriseSecurity, sslEnablement=ignore
-and for ClusterManager, scope=cluster, type and sslEnablement are not applicable.
+Following example shows creating a Splunk deployment with a SHC, ClusterManager and a IndexerCluster.
+Note the difference between the values of "scope" property for the SHC and ClusterManager. For the SHC, scope is set to "premiumApps" whereas for the ClusterManager, scope is set to "cluster"
 
 ```yaml
 apiVersion: enterprise.splunk.com/v4
@@ -247,9 +247,9 @@ spec:
   replicas: 3
 ```
 
-#### Special consideration while using ssl enabled mode of strict in SHC
+#### Consideration when using strict mode for "sslEnablment" in SHC
 
-For using the strict mode, the following additional steps are required so that SHC has Splunk Web SSL enabled. These steps are necessary before you can install ES app with the strict mode of sslEnablement. Alternatively, if you are managing enableSplunkWebSSL setting outside of the Operator scope by pushing an app bundle through the deployer, then you can skip these steps.
+When using strict mode, the following additional steps are required so that the "splunk web ssl" is enabled for the SHC. These steps are necessary before you can install ES app with the strict mode of sslEnablement. Alternatively, if you are managing enableSplunkWebSSL setting outside of the Operator scope by pushing an app bundle through the deployer, then you can skip these steps.
 
 Steps:
 1. Create a shc app (e.g., shccoreapp.spl) that contains a local/web.conf setting with `enableSplunkWebSSL=true`

--- a/docs/PremiumApps.md
+++ b/docs/PremiumApps.md
@@ -20,8 +20,8 @@ Currently there are only a subset of architectures that support automated deploy
 
 Supported Architectures Include:
 * Standalone Splunk Instance
-* Standalone Search Head with Indexer Cluster.
-* Search Head Cluster with Indexer Cluster.
+* Standalone Search Head with Indexer Cluster
+* Search Head Cluster with Indexer Cluster
 
 Notably, if deploying a distributed search environment, the use of indexer clustering is required to ensure that the necessary Enterprise Security specific configuration is pushed to the indexers via the Cluster Manager.
 

--- a/docs/PremiumApps.md
+++ b/docs/PremiumApps.md
@@ -34,7 +34,7 @@ For Standalone Splunk instances and standalone search heads the Operator will in
 #### Search Head Cluster
 When installing Enterprise Security in a Search Head Cluster, the Operator will perform the following tasks: 
 1) Install the splunk enterprise app in Deployer's etc/apps directory.
-2) Run the ES post install command `essinstall` that stages the Splunk Enterprise Security and all associated domain add-ons (DAs) and supporting add-ons (SAs) to the etc/shcapps.
+2) Run the ES post install command `essinstall` that stages the Splunk Enterprise Security and all associated domain add-ons (DAs) and supporting add-ons (SAs) to the etc/shcluster/apps.
 3) Push the Search Head Cluster bundle from the deployer to all the SHs.
 
 #### Indexer Cluster

--- a/docs/PremiumApps.md
+++ b/docs/PremiumApps.md
@@ -9,10 +9,10 @@ The Splunk Operator automates the installation of Enterprise Security with suppo
 Installing Enterprise Security in a Kubernetes cluster with the Splunk Operator requires the following:
 
 * Ability to utilize the Splunk Operator [app framework](https://splunk.github.io/splunk-operator/AppFramework.html) method of installation.
-* Access to the [Splunk Enterprise Security](https://splunkbase.splunk.com/app/263/) app package.
-* Splunk Enterprise Security version compatible to the Splunk Enterprise version used in your Splunk Operator installation. For more information regarding Splunk Enterprise and Enterprise Security compatibility, see the [version compatibility matrix](https://docs.splunk.com/Documentation/VersionCompatibility/current/Matrix/CompatMatrix). Note that Splunk Operator requires Splunk Enterprise 8.2.2 or later.
+* Access to the [Splunk Enterprise Security (ES)](https://splunkbase.splunk.com/app/263/) app package.
+* Splunk Enterprise Security version 7.1.0, 7.0.2, 7.0.1, 7.0.0 or 6.6.2 as ES support in Splunk Operator is starting from Splunk Operator Release 2.2 which requires Splunk Enterprise 9.0.3 or later. For more information regarding Splunk Enterprise and Enterprise Security compatibility, see the [version compatibility matrix](https://docs.splunk.com/Documentation/VersionCompatibility/current/Matrix/CompatMatrix).
 * Pod resource specs that meet the [Enterprise Security hardware requirements](https://docs.splunk.com/Documentation/ES/latest/Install/DeploymentPlanning#Hardware_requirements).
-* In the following sections, aws s3 remote bucket is used for placing the splunk apps, but as given in the [app framework doc](https://splunk.github.io/splunk-operator/AppFramework.html), you can use Azure blob remote buckets also.
+* In the following sections, AWS S3 remote bucket is used for placing the splunk apps, but as given in the [app framework doc](https://splunk.github.io/splunk-operator/AppFramework.html), you can use Azure Blob remote buckets also.
 
 ### Supported Deployment Types
 
@@ -247,7 +247,7 @@ When using strict mode, the following additional steps are required so that the 
 
 Steps:
 1. Create a SHC app (e.g., shccoreapp.spl) that contains a local/web.conf setting with `enableSplunkWebSSL=true`
-2. Place this app under security-team-apps/coreapps in your s3 bucket.
+2. Place this app under security-team-apps/coreapps in your S3 bucket.
 3. Use the following YAML file as an example to deploy this app through app framework. 
 4. Note: you also need to include the extraEnv:SPLUNK_HTTP_ENABLESSL with the value true in the YAML. This step will be revised in upcoming releases so it may not be needed as you are already pushing a web.conf with ssl setting.
 
@@ -285,7 +285,7 @@ spec:
 
 #### Installation steps
 
-1. Ensure that the Enterprise Security app package is present in the specified AppFramework S3 location with the correct appSources scope. Additionally, if configuring an indexer cluster, ensure that the Splunk_TA_ForIndexers app is present in the ClusterManager AppFramework s3 location with the appSources "cluster" scope.
+1. Ensure that the Enterprise Security app package is present in the specified AppFramework S3 location with the correct appSources scope. Additionally, if configuring an indexer cluster, ensure that the Splunk_TA_ForIndexers app is present in the ClusterManager AppFramework S3 location with the appSources "cluster" scope.
    
 2. Apply the specified custom resource(s), the Splunk Operator will handle installation and the environment will be ready to use once all pods are in the "Ready" state. Please refer to the examples above for creating your YAML files.
    

--- a/docs/PremiumApps.md
+++ b/docs/PremiumApps.md
@@ -1,0 +1,348 @@
+# Premium App Installation Guide
+
+The Splunk Operator currently provides support for automating installation of Enterprise Security with support for other premium apps coming in the future. This page documents the prerequisites, installation steps, and limitations of deploying premium apps using the Splunk Operator. 
+
+
+## Enterprise Security
+
+
+### Prerequisites
+
+Installing Enterprise Security in a Kubernetes cluster with the Splunk Operator requires the following:
+
+* Ability to utilize the Splunk Operator [app framework](https://splunk.github.io/splunk-operator/AppFramework.html) method of installation.
+* Access to the [Splunk Enterprise Security](https://splunkbase.splunk.com/app/263/) app package.
+* Splunk Enterprise Security version 6.4.1 or 6.6.0 as Splunk Operator requires Splunk Enterprise 8.2.2 or later. For more information regarding Splunk Enterprise and Enterprise Security compatibility, see the [version compatibility matrix](https://docs.splunk.com/Documentation/VersionCompatibility/current/Matrix/CompatMatrix).
+* If installing to an Indexer Cluster, access to the corresponding Splunk_TA_ForIndexers app from the Enterprise Security package. This app can be extracted using the procedure available at [Splunk ES app installation on Indexer Cluster](https://docs.splunk.com/Documentation/ES/7.0.2/Install/InstallTechnologyAdd-ons). After the Splunk_TA_ForIndexers is available, place it in a S3 bucket and use "cluster" scope in the YAML file to push the package via the cluster manager to the indexers. A Splunk_TA_ForIndexers package is also shipped with in the SplunkEnterpriseSecutitySuite package (can be found in the ES app package at SplunkEnterpriseSecuritySuite/install/splunkcloud/splunk_app_es/Splunk_TA_ForIndexers-\<version\>.spl).  
+* Pod resource specs that meet the [Enterprise Security hardware requirements](https://docs.splunk.com/Documentation/ES/latest/Install/DeploymentPlanning#Hardware_requirements).
+* In the following sections, aws s3 remote bucket is used for placing the splunk apps, but as given in the [app framework doc](https://splunk.github.io/splunk-operator/AppFramework.html), you can use Azure blob remote buckets also.
+
+### Supported Deployment Types
+
+Currently there are only a subset of architectures that support automated deployment of Enterprise Security through the Splunk Operator.
+
+Supported Architectures Include:
+* Standalone Splunk Instances 
+* Standalone Search Head(s) which search any number of Indexer Clusters.
+* Search Head Cluster(s) which search any number of Indexer Clusters. 
+
+Notably, if deploying a distributed search environment, the use of indexer clustering is required to ensure that the necessary Enterprise Security specific configuration is pushed to the indexers via the Cluster Manager.
+
+### What is and what is not automated by the Splunk Operator
+
+The Splunk Operator will install the necessary Enterprise Security components depending on the architecture specified by the applied CRDs.
+
+#### Standalone / Standalone Search Heads
+For standalones and standalone search heads the Operator will install Splunk Enterprise Security and all associated domain add-ons (DAs), and supporting add-ons (SAs).
+
+#### Search Head Cluster
+When installing Enterprise Security in a Search Head Cluster, the Operator will perform the following tasks: 
+1) Install the splunk enterprise app in Deployer's etc/apps directory
+2) Run the ES post install command `essinstall` that stages the Splunk Enterprise Security and all associated domain add-ons (DAs), and supporting add-ons (SAs) to the etc/shcapps.
+3) Push the shc cluster bundle from deployer to all the SHs.
+
+#### Indexer Cluster
+When installing ES in an indexer clustering environment through the Splunk Operator it is necessary to deploy the supplemental [Splunk_TA_ForIndexers](https://docs.splunk.com/Documentation/ES/latest/Install/InstallTechnologyAdd-ons#Create_the_Splunk_TA_ForIndexers_and_manage_deployment_manually) app from the ES package to the indexer cluster members. This can be achieved using the AppFramework app deployent steps using appSources scope of "cluster".
+
+
+### How to Install Enterprise Security using the Splunk Operator
+
+
+#### Necessary Configuration
+
+When crafting your Custom Resource to create a Splunk Enterprise Deployment it is necessary to take the following configurations into account.
+
+##### [appSources](https://splunk.github.io/splunk-operator/AppFramework.html#appsources) scope
+   
+   - When deploying ES to a Standalone or to a Search Head Cluster, it must be configured with an appSources scope of "premiumApps".
+   - When deploying the Splunk_TA_ForIndexers app to an Indexer Cluster, it must be configured with an appSources scope of "cluster".
+
+#####  SSL Enablement
+
+When installing ES versions 6.3.0+ is necessary to supply a value for the parameter ssl_enablement that is required by the ES post installation command `essinstall`. By default the value of strict is used which requires Splunk to have SSL enabled in web.conf (refer to setting `enableSplunkWebSSL`). The below table can be used for reference of available values of ssl enablement. 
+
+| SSL mode	| Description | 
+| --------- | ----------- | 
+|strict     |	Default mode. Ensure that SSL is enabled in the web.conf configuration file to use this mode. Otherwise, the installer exists with an error. Note that for the SHC, the ES post install command `essinstall` is run in deployer, and this command looks into web.conf files under etc/shcapps to validate that enableSplunkWebSSL is set to true or not.| 
+| auto	   | Enables SSL in the etc/system/local/web.conf configuration file. This mode is not supported by SHC |
+| ignore	   | Ignores whether SSL is enabled or disabled. |
+
+The Operator passes the ssl_enablement parameter through `sslEnablement` parameter withn `premiumAppsProps` configuration. The following snippet of a YAML file shows using `ignore` mode for ssl_enablement
+
+```yaml
+  appSources:
+        - name: esApp
+          location: es_app/
+          scope: premiumApps             <-------- setting scope as premiumApps to install ES
+          premiumAppsProps:
+            type: enterpriseSecurity
+            esDefaults:
+              sslEnablement: ignore       <--------- setting ssl_enablement to ignore
+```
+
+##### Search Head Cluster server.conf timeouts
+
+It may be necessary to increase the value of the default Search Head Clustering network timeouts to ensure that the connections made from the deployer to the Search Heads while pushing apps do not timeout. 
+
+These timeouts can be set through defaults.yaml
+```yaml
+  defaults: |-
+    splunk:
+      conf:
+        - key: server
+          value:
+            directory: /opt/splunk/etc/system/local
+            content:
+              shclustering:         
+                rcv_timeout: 300
+                send_timeeout: 300
+                cxn_timeeout: 300
+```
+
+##### splunkdConnectionTimeout
+Increasing the value of splunkdConnectionTimeout in web.conf will help ensure that all API calls made by the installer script will not timeout and prevent installation from succeeding.
+```yaml
+  defaults: |-
+    splunk:
+      conf:
+        - key: web
+          value:
+            directory: /opt/splunk/etc/system/local
+            content:
+              settings:
+                splunkdConnectionTimeout: 300
+```
+
+### Example YAML
+
+#### Install ES on a standalone splunk deployment
+
+Here is an example of a standalone CR with the spec(scope=premiumApps, type=EnterpriseSecurity, sslEnablement=ignore)
+
+Assuming the ES app tarball exists in an s3 bucket folder named "es_app" under the parent folder "security-team-apps" in your s3 bucket
+
+```yaml
+apiVersion: enterprise.splunk.com/v4
+kind: Standalone
+metadata:
+  name: example
+  finalizers:
+  - enterprise.splunk.com/delete-pvc
+spec:
+  replicas: 1
+  appRepo:
+    appsRepoPollIntervalSeconds: 60
+    defaults:
+      volumeName: volume_app_repo
+      scope: local
+    appSources:
+      - name: esApp
+        location: es_app/
+        scope: premiumApps
+        premiumAppsProps:
+          type: enterpriseSecurity
+          esDefaults:
+             sslEnablement: ignore
+    volumes:
+      - name: volume_app_repo
+        storageType: s3
+        provider: aws
+        path: security-team-apps/
+        endpoint: https://s3-us-west-2.amazonaws.com
+        region: us-west-2
+        secretRef: splunk-s3-secret
+```
+
+#### Install ES on a Search Head Cluster splunk deployment
+
+The below yaml will configure ES on a Search Head Cluster which searches an Indexer Cluster. 
+
+ Assumptions made are that:
+ 1. The ES app tarball exists in an s3 bucket folder named "es_app"
+ 2. Optional: The Splunk_TA_ForIndexers app exists in an s3 bucket folder named "es_app_indexer_ta".  
+ 
+ If you choose to extract Splunk_TA_ForIndexers instead of using the pre-shipped Splunk_TA_ForIndexers package (SplunkEnterpriseSecuritySuite/install/splunkcloud/splunk_app_es/Splunk_TA_ForIndexers-\<version\>.spl), the SHC should be up and running with Splunk Enterprise Secutiry Suite first. Then, the steps given at https://docs.splunk.com/Documentation/ES/7.0.2/Install/InstallTechnologyAdd-ons can be used to extract and deploy the Splunk_TA_ForIndexers to indexers.
+
+Steps:
+1. Apply the following YAML file
+2. Wait for the SHC, CM and Indexers and up and running
+3. Login to a SH, and extract the Splunk_TA_ForIndexers (steps given here)[https://docs.splunk.com/Documentation/ES/7.0.2/Install/InstallTechnologyAdd-ons]
+4. Place the extracted Splunk_TA_ForIndexers package in the s3 bucket folder named "es_app_indexer_ta"
+The operator will poll this bucket after configured appsRepoPollIntervalSeconds and install the Splunk_TA_ForIndexers also.
+ 
+In this example scope=premiumApps, type=EnterpriseSecurity, sslEnablement=ignore
+ 
+```yaml
+apiVersion: enterprise.splunk.com/v4
+kind: SearchHeadCluster
+metadata:
+  name: shc-es
+  finalizers:
+  - enterprise.splunk.com/delete-pvc
+spec:
+  appRepo:
+    appsRepoPollIntervalSeconds: 60
+    defaults:
+      volumeName: volume_app_repo
+      scope: local
+    appSources:
+      - name: esApp
+        location: es_app/
+        scope: premiumApps
+        premiumAppsProps:
+          type: enterpriseSecurity
+          esDefaults:
+             sslEnablement: ignore
+    volumes:
+      - name: volume_app_repo
+        storageType: s3
+        provider: aws
+        path: security-team-apps/
+        endpoint: https://s3-us-west-2.amazonaws.com
+        region: us-west-2
+        secretRef: splunk-s3-secret
+  clusterMasterRef:
+    name: cm-es
+---
+apiVersion: enterprise.splunk.com/v4
+kind: ClusterMaster
+metadata:
+  name: cm-es
+  finalizers:
+  - enterprise.splunk.com/delete-pvc
+spec:
+  appRepo:
+    appsRepoPollIntervalSeconds: 60
+    defaults:
+      volumeName: volume_app_repo
+      scope: local
+    appSources:
+      - name: esAppIndexer
+        location: es_app_indexer_ta/
+        scope: cluster
+    volumes:
+      - name: volume_app_repo
+        storageType: s3
+        provider: aws
+        path: security-team-apps/
+        endpoint: https://s3-us-west-2.amazonaws.com
+        region: us-west-2
+        secretRef: splunk-s3-secret
+---
+apiVersion: enterprise.splunk.com/v2
+kind: IndexerCluster
+metadata:
+  name: idc-es
+  finalizers:
+  - enterprise.splunk.com/delete-pvc
+spec:
+  clusterMasterRef:
+    name: cm-es
+  replicas: 3
+```
+
+#### Special consideration while using ssl enabled mode of strict
+
+In this example scope=premiumApps, type=EnterpriseSecurity, sslEnablement=strict
+
+For using the strict mode, a SHC bootstrap step is required so the SHC has Splunk Web SSL enabled.
+Steps:
+1. Create a shc app that contain an app with its local/web.conf setting enableSplunkWebSSL=true
+2. Deploy this app through app framework cluster scope. 
+3. Use the extraEnv:SPLUNK_HTTP_ENABLESSL with value true
+
+Following is an example to enable Splunk Web SSL through operator on SHC:
+
+```yaml
+apiVersion: enterprise.splunk.com/v4
+kind: SearchHeadCluster
+metadata:
+  name: shcssl
+  finalizers:
+  - enterprise.splunk.com/delete-pvc
+spec:
+  extraEnv:
+    - name: SPLUNK_HTTP_ENABLESSL
+      value : "true"
+  appRepo:
+    appsRepoPollIntervalSeconds: 60
+    defaults:
+      volumeName: volume_app_repo
+      scope: local
+    appSources:
+      - name: coreapps
+        scope: cluster
+        location: coreapps/
+    volumes:
+      - name: volume_app_repo
+        storageType: s3
+        provider: aws
+        path: security-team-apps/
+        endpoint: https://s3-us-west-2.amazonaws.com
+        region: us-west-2
+        secretRef: splunk-s3-secret
+```
+
+
+#### Installation steps
+
+1. Ensure that the Enterprise Security app tarball is present in the specified AppFramework s3 location with the correct appSources scope. Additionally, if configuring an indexer cluster, ensure that the Splunk_TA_ForIndexers app is present in the ClusterManager AppFramework s3 location with the appSources "cluster" scope.
+   
+2. Apply the specified custom resource(s), the Splunk Operator will handle installation and the environment will be ready to use once all pods are in the "Ready" state.
+   
+**Important Considerations**
+* Installation may take upwards of 30 minutes.
+
+#### Post Installation Configuration
+
+After installing Enterprise Security :
+
+* [Deploy add-ons to Splunk Enterprise Security](https://docs.splunk.com/Documentation/ES/latest/Install/InstallTechnologyAdd-ons) - Technology add-ons (TAs) which need to be installed to indexers can be installed via AppFramework, while TAs that reside on forwarders will need to be installed manually or via third party configuration management.
+
+* [Setup Integration with Splunk Stream](https://docs.splunk.com/Documentation/ES/latest/Install/IntegrateSplunkStream) (optional)
+
+* [Configure and deploy indexes](https://docs.splunk.com/Documentation/ES/latest/Install/Indexes) - The indexes associated with the packaged DAs and SAs will automatically be pushed to indexers when using indexer clustering, this step is only necessary if it is desired to configure any [custom index configuration](https://docs.splunk.com/Documentation/ES/latest/Install/Indexes#Index_configuration). Additionally, any newly installed technical ad-ons which are not included with the ES package may require index deployment.
+
+* [Configure Users and Roles as desired](https://docs.splunk.com/Documentation/ES/latest/Install/ConfigureUsersRoles)
+
+* [Configure Datamodels](https://docs.splunk.com/Documentation/ES/latest/Install/Datamodels)
+
+
+### Upgrade Steps
+
+To upgrade ES, all that is required is to move the new ES package into the specified AppFramework bucket. This will initiate a pod reset and begin the process of upgrading the new version. In indexer clustering environments, it is also necessary to move the new Splunk_TA_ForIndexers app to the Cluster Manager's AppFramework bucket that deploys apps to cluster members.
+
+* The upgrade process will preserve any knowledge objects that exist in app local directories.
+
+* Be sure to check the [ES upgrade notes](https://docs.splunk.com/Documentation/ES/latest/Install/Upgradetonewerversion#Version-specific_upgrade_notes) for any version specific changes.
+
+### Troubleshooting
+
+Following logs can be useful to check the ES app installation progress:
+
+Splunk operator log:
+
+```
+kubectl logs <operator_pod_name>
+```
+
+Logs of the respective pods:
+
+```
+kubectl logs <pod_name>
+```
+
+
+Common issues that may be encountered are : 
+* ES installation failed as you used default sslEnablement mode ("strict") - enable Splunk Web SSL in web.conf.
+* Ansible task timeouts - raise associated timeout (splunkdConnectionTimeout, rcvTimeout, etc.)
+* Pod Recycles - raise livenessProbe value
+
+
+### Current Limitations
+
+* For indexer clustering environments, need to manually extract Splunk_TA_ForIndexers app and place in Cluster Manager AppFramework bucket to be deployed to indexers.
+
+* Need to deploy add-ons to forwarders manually (or through your own methods).
+
+* Need to deploy Stream App Manually

--- a/docs/PremiumApps.md
+++ b/docs/PremiumApps.md
@@ -10,7 +10,7 @@ Installing Enterprise Security in a Kubernetes cluster with the Splunk Operator 
 
 * Ability to utilize the Splunk Operator [app framework](https://splunk.github.io/splunk-operator/AppFramework.html) method of installation.
 * Access to the [Splunk Enterprise Security](https://splunkbase.splunk.com/app/263/) app package.
-* Splunk Enterprise Security version 6.4.1 or 6.6.0 as Splunk Operator requires Splunk Enterprise 8.2.2 or later. For more information regarding Splunk Enterprise and Enterprise Security compatibility, see the [version compatibility matrix](https://docs.splunk.com/Documentation/VersionCompatibility/current/Matrix/CompatMatrix).
+* Splunk Enterprise Security version compatible to the Splunk Enterprise version used in your Splunk Operator installation. For more information regarding Splunk Enterprise and Enterprise Security compatibility, see the [version compatibility matrix](https://docs.splunk.com/Documentation/VersionCompatibility/current/Matrix/CompatMatrix). Note that Splunk Operator requires Splunk Enterprise 8.2.2 or later.
 * Pod resource specs that meet the [Enterprise Security hardware requirements](https://docs.splunk.com/Documentation/ES/latest/Install/DeploymentPlanning#Hardware_requirements).
 * In the following sections, aws s3 remote bucket is used for placing the splunk apps, but as given in the [app framework doc](https://splunk.github.io/splunk-operator/AppFramework.html), you can use Azure blob remote buckets also.
 
@@ -29,13 +29,13 @@ Notably, if deploying a distributed search environment, the use of indexer clust
 The Splunk Operator installs the necessary Enterprise Security components depending on the architecture specified by the applied CRDs.
 
 #### Standalone Splunk Instance/ Standalone Search Heads
-For standalone splunk instances and standalone search heads the Operator will install Splunk Enterprise Security and all associated domain add-ons (DAs), and supporting add-ons (SAs).
+For Standalone Splunk instances and standalone search heads the Operator will install Splunk Enterprise Security and all associated domain add-ons (DAs), and supporting add-ons (SAs).
 
 #### Search Head Cluster
 When installing Enterprise Security in a Search Head Cluster, the Operator will perform the following tasks: 
 1) Install the splunk enterprise app in Deployer's etc/apps directory.
 2) Run the ES post install command `essinstall` that stages the Splunk Enterprise Security and all associated domain add-ons (DAs) and supporting add-ons (SAs) to the etc/shcapps.
-3) Push the shc cluster bundle from the deployer to all the SHs.
+3) Push the Search Head Cluster bundle from the deployer to all the SHs.
 
 #### Indexer Cluster
 When installing ES in an indexer clustering environment through the Splunk Operator it is necessary to deploy the supplemental [Splunk_TA_ForIndexers](https://docs.splunk.com/Documentation/ES/latest/Install/InstallTechnologyAdd-ons#Create_the_Splunk_TA_ForIndexers_and_manage_deployment_manually) app from the ES package to the indexer cluster members. This can be achieved using the AppFramework app deployment steps using appSources scope of "cluster".
@@ -324,7 +324,7 @@ Splunk operator log:
 kubectl logs <operator_pod_name>
 ```
 
-Checking if there were any errors is ES install
+Checking if there were any errors during ES install
 
 ES post install failures:
 Log shows one or more entries with the following content:

--- a/docs/PremiumApps.md
+++ b/docs/PremiumApps.md
@@ -201,7 +201,7 @@ spec:
         endpoint: https://s3-us-west-2.amazonaws.com
         region: us-west-2
         secretRef: splunk-s3-secret
-  ClusterManagerRef:
+  clusterManagerRef:
     name: cm-es
 ---
 apiVersion: enterprise.splunk.com/v4
@@ -236,7 +236,7 @@ metadata:
   finalizers:
   - enterprise.splunk.com/delete-pvc
 spec:
-  ClusterManagerRef:
+  clusterManagerRef:
     name: cm-es
   replicas: 3
 ```

--- a/docs/PremiumApps.md
+++ b/docs/PremiumApps.md
@@ -1,10 +1,8 @@
 # Premium App Installation Guide
 
-The Splunk Operator currently provides support for automating installation of Enterprise Security with support for other premium apps coming in the future. This page documents the prerequisites, installation steps, and limitations of deploying premium apps using the Splunk Operator. 
-
+The Splunk Operator currently provides support for automating the installation of Enterprise Security with support for other premium apps coming in the future. This page documents the prerequisites, installation steps, and limitations of deploying premium apps using the Splunk Operator.
 
 ## Enterprise Security
-
 
 ### Prerequisites
 
@@ -38,15 +36,13 @@ For standalones and standalone search heads the Operator will install Splunk Ent
 #### Search Head Cluster
 When installing Enterprise Security in a Search Head Cluster, the Operator will perform the following tasks: 
 1) Install the splunk enterprise app in Deployer's etc/apps directory
-2) Run the ES post install command `essinstall` that stages the Splunk Enterprise Security and all associated domain add-ons (DAs), and supporting add-ons (SAs) to the etc/shcapps.
-3) Push the shc cluster bundle from deployer to all the SHs.
+2) Run the ES post install command `essinstall` that stages the Splunk Enterprise Security and all associated domain add-ons (DAs) and supporting add-ons (SAs) to the etc/shcapps.
+3) Push the shc cluster bundle from the deployer to all the SHs.
 
 #### Indexer Cluster
-When installing ES in an indexer clustering environment through the Splunk Operator it is necessary to deploy the supplemental [Splunk_TA_ForIndexers](https://docs.splunk.com/Documentation/ES/latest/Install/InstallTechnologyAdd-ons#Create_the_Splunk_TA_ForIndexers_and_manage_deployment_manually) app from the ES package to the indexer cluster members. This can be achieved using the AppFramework app deployent steps using appSources scope of "cluster".
-
+When installing ES in an indexer clustering environment through the Splunk Operator it is necessary to deploy the supplemental [Splunk_TA_ForIndexers](https://docs.splunk.com/Documentation/ES/latest/Install/InstallTechnologyAdd-ons#Create_the_Splunk_TA_ForIndexers_and_manage_deployment_manually) app from the ES package to the indexer cluster members. This can be achieved using the AppFramework app deployment steps using appSources scope of "cluster".
 
 ### How to Install Enterprise Security using the Splunk Operator
-
 
 #### Necessary Configuration
 
@@ -61,11 +57,11 @@ When crafting your Custom Resource to create a Splunk Enterprise Deployment it i
 
 When installing ES versions 6.3.0+ is necessary to supply a value for the parameter ssl_enablement that is required by the ES post installation command `essinstall`. By default, if you don't set any value for ssl_enablement, the value of `strict` is used which requires Splunk to have SSL enabled in web.conf (refer to setting `enableSplunkWebSSL`). The below table can be used for reference of available values of ssl enablement. 
 
-| SSL mode	| Description | 
+| SSL mode  | Description | 
 | --------- | ----------- | 
-|strict     |	Default mode. Ensure that SSL is enabled in the web.conf configuration file to use this mode. Otherwise, the installer exists with an error. Note that for the SHC, the ES post install command `essinstall` is run on the deployer, and this command looks into web.conf files under etc/shcapps to validate that enableSplunkWebSSL is set to true or not. This is done with assumption that you have already pushed a web.conf through etc/shcapps to all the SHC members.| 
-| auto	   | Enables SSL in the etc/system/local/web.conf configuration file. This mode is not supported by SHC |
-| ignore	   | Ignores whether SSL is enabled or disabled. This option may be handy if you don't want operator and essinstall to check SSL is enabled for Splunk web and continue ES installation without intruption. For example, you may have some processes outside of operator where you are already checking that your Splunk deployement is web SSL enabled.|
+|strict     | `Default mode`. Ensure that SSL is enabled in the web.conf configuration file to use this mode. Otherwise, the installer exists with an error. Note that for the SHC, the ES post install command `essinstall` is run on the deployer, and this command looks into web.conf files under etc/shcapps to validate that enableSplunkWebSSL is set to true or not. This is done with the assumption that you have already pushed a web.conf through etc/shcapps to all the SHC members.| 
+| auto     | Enables SSL in the etc/system/local/web.conf configuration file. This mode is not supported by SHC |
+| ignore     | Ignores whether SSL is enabled or disabled. This option may be handy if you don't want operator and essinstall to check SSL is enabled for Splunk web and continue ES installation without interruption. For example, you may have some processes outside of the operator where you are already checking that your Splunk deployment is web SSL enabled.|
 
 The operator passes the ES specific premium apps properties through the following properties:
 scope - use `premiumApps`
@@ -103,7 +99,7 @@ These timeouts can be set through defaults.yaml
 ```
 
 ##### splunkdConnectionTimeout
-Increasing the value of splunkdConnectionTimeout in web.conf will help ensure that all API calls made by the installer script will not timeout and prevent installation from succeeding.
+Increasing the value of splunkdConnectionTimeout in the web.conf will help ensure that all API calls made by the installer script will not timeout and prevent the installation from succeeding.
 ```yaml
   defaults: |-
     splunk:
@@ -162,7 +158,7 @@ spec:
 
 #### Install ES on a standalone splunk deployment with sslEnablement value strict
 
-Here is example of a standalone CR with the `sslEnablement=strict`. 
+Here is an example of a standalone CR with the `sslEnablement=strict`. 
 
 Assumption: the ES app tarball exists in an s3 bucket folder named "es_app" under the parent folder "security-team-apps" in your s3 bucket.
 
@@ -281,7 +277,7 @@ Assumption: you have downloaded ES app from https://splunkbase.splunk.com/app/26
 
 1. Place the ES app package at s3 path security-team-apps/es-app
 2. Apply the following YAML file
-2. Wait for the SHC, CM and Indexers to be up and running. 
+2. Wait for the SHC, CM, and Indexers to be up and running. 
 3. Verify that the ES app is installed in SH. 
 3. Login to a SH, and extract the Splunk_TA_ForIndexers using the steps given here: [https://docs.splunk.com/Documentation/ES/7.0.2/Install/InstallTechnologyAdd-ons]
 4. Place the extracted Splunk_TA_ForIndexers package in the s3 bucket folder named "es_app_indexer_ta"
@@ -289,7 +285,7 @@ Assumption: you have downloaded ES app from https://splunkbase.splunk.com/app/26
 The operator will poll this bucket after configured appsRepoPollIntervalSeconds and install the Splunk_TA_ForIndexers also.
  
 In this example for SHC, scope=premiumApps, type=EnterpriseSecurity, sslEnablement=ignore
-and for ClusterManager scope=cluster, type and sslEnablement are not applicable.
+and for ClusterManager, scope=cluster, type and sslEnablement are not applicable.
 
 ```yaml
 apiVersion: enterprise.splunk.com/v4
@@ -362,13 +358,13 @@ spec:
 
 #### Special consideration while using ssl enabled mode of strict in SHC
 
-For using the strict mode, following additional steps are required so that SHC has Splunk Web SSL enabled. This step is necessary before you can install ES app with strict mode of sslEnablement. Alternatively, if you are managing enableSplunkWebSSL setting outside of Operator scope by pushing an app bundle through deployer, then you can skip all these steps.
+For using the strict mode, the following additional steps are required so that SHC has Splunk Web SSL enabled. These steps are necessary before you can install ES app with the strict mode of sslEnablement. Alternatively, if you are managing enableSplunkWebSSL setting outside of the Operator scope by pushing an app bundle through the deployer, then you can skip all these steps.  
 
 Steps:
-1. Create a shc app (call it shccoreapp.spl) that contains a local/web.conf setting with `enableSplunkWebSSL=true`
-2. Plase this app under security-team-apps/coreapps in your s3 bucket.
+1. Create a shc app (e.g., shccoreapp.spl) that contains a local/web.conf setting with `enableSplunkWebSSL=true`
+2. Place this app under security-team-apps/coreapps in your s3 bucket.
 3. Use the following YAML file as an example to deploy this app through app framework. 
-4. Note: you also need to include the extraEnv:SPLUNK_HTTP_ENABLESSL with value true in the YAML. This step will be revised in upcoming releases so it may not be needed as you are already pushing a web.conf with ssl setting.
+4. Note: you also need to include the extraEnv:SPLUNK_HTTP_ENABLESSL with the value true in the YAML. This step will be revised in upcoming releases so it may not be needed as you are already pushing a web.conf with ssl setting.
 
 Following is an example to enable Splunk Web SSL through operator on SHC:
 
@@ -402,12 +398,11 @@ spec:
         secretRef: splunk-s3-secret
 ```
 
-
 #### Installation steps
 
 1. Ensure that the Enterprise Security app tarball is present in the specified AppFramework s3 location with the correct appSources scope. Additionally, if configuring an indexer cluster, ensure that the Splunk_TA_ForIndexers app is present in the ClusterManager AppFramework s3 location with the appSources "cluster" scope.
    
-2. Apply the specified custom resource(s), the Splunk Operator will handle installation and the environment will be ready to use once all pods are in the "Ready" state.
+2. Apply the specified custom resource(s), the Splunk Operator will handle installation and the environment will be ready to use once all pods are in the "Ready" state. Please refer to the examples above for creating your YAML files.
    
 **Important Considerations**
 * Installation may take upwards of 30 minutes.
@@ -426,7 +421,6 @@ After installing Enterprise Security :
 
 * [Configure Datamodels](https://docs.splunk.com/Documentation/ES/latest/Install/Datamodels)
 
-
 ### Upgrade Steps
 
 To upgrade ES, all that is required is to move the new ES package into the specified AppFramework bucket. This will initiate a pod reset and begin the process of upgrading the new version. In indexer clustering environments, it is also necessary to move the new Splunk_TA_ForIndexers app to the Cluster Manager's AppFramework bucket that deploys apps to cluster members.
@@ -437,7 +431,7 @@ To upgrade ES, all that is required is to move the new ES package into the speci
 
 ### Troubleshooting
 
-Following logs can be useful to check the ES app installation progress:
+The following logs can be useful to check the ES app installation progress:
 
 Splunk operator log:
 
@@ -451,12 +445,10 @@ Logs of the respective pods:
 kubectl logs <pod_name>
 ```
 
-
 Common issues that may be encountered are : 
-* ES installation failed as you used default sslEnablement mode ("strict") - enable Splunk Web SSL in web.conf. See the secton [Special consideration while using ssl enabled mode of strict in SHC](#special-consideration-while-using-ssl-enabled-mode-of-strict-in-shc)
+* ES installation failed as you used default sslEnablement mode ("strict") - enable Splunk Web SSL in web.conf. See the section [Special consideration while using ssl enabled mode of strict in SHC](#special-consideration-while-using-ssl-enabled-mode-of-strict-in-shc)
 * Ansible task timeouts - raise associated timeout (splunkdConnectionTimeout, rcvTimeout, etc.)
-* Pod Recycles - raise livenessProbe value.
-
+* Pod Recycles - raise livenessProbe value. More details on this at [Health Check doc](HealthCheck.md)
 
 ### Current Limitations
 

--- a/docs/PremiumApps.md
+++ b/docs/PremiumApps.md
@@ -439,11 +439,40 @@ Splunk operator log:
 kubectl logs <operator_pod_name>
 ```
 
+Checking if there were any errors is ES install
+
+ES post install failures:
+Log shows one ore more entries with the following content:
+"premium scoped app package install failed" -- (specific failure reasons show up here)
+
+Example of error when you strict mode for sslEnablement and Splunk web is not SSL enabled 
+
+```
+2022-12-07T00:17:36.780549729Z  ERROR   handleEsappPostinstall  premium scoped app package install failed   {"controller": "searchheadcluster", "controllerGroup": "enterprise.splunk.com", "controllerKind": "SearchHeadCluster", "SearchHeadCluster": {"name":"shc1","namespace":"default"}, "namespace": "default", "name": "shc1", "reconcileID": "83133a29-ca0d-46cc-9ae5-6f26385d4506", "name": "shc1", "namespace": "default", "pod": "splunk-shc1-deployer-0", "app name": "splunk-enterprise-security_702.spl", "stdout": "", "stderr": "FATAL: Error in 'essinstall' command: You must have SSL enabled to continue\n", "post install command": "/opt/splunk/bin/splunk search '| essinstall --ssl_enablement strict --deployment_type shc_deployer' -auth admin:`cat /mnt/splunk-secrets/password`", "failCount": 1, "error": "command terminated with exit code 17"}
+```
+To fix this error, you have one of the following options:
+1) Enable splunk web SSL- details on the section [Special consideration while using ssl enabled mode of strict in SHC](#special-consideration-while-using-ssl-enabled-mode-of-strict-in-shc)
+2) Or, use sslEnablment=ignore
+
+Example of a connection timeout error:
+
+```
+2022-12-07T00:48:11.542927588Z	ERROR	handleEsappPostinstall	premium scoped app package install failed	{"controller": "searchheadcluster", "controllerGroup": "enterprise.splunk.com", "controllerKind": "SearchHeadCluster", "SearchHeadCluster": {"name":"shc1it","namespace":"default"}, "namespace": "default", "name": "shc1it", "reconcileID": "b34966a2-e716-428f-a0c6-7611812e6b24", "name": "shc1it", "namespace": "default", "pod": "splunk-shc1it-deployer-0", "app name": "splunk-enterprise-security_702.spl", "stdout": "", "stderr": "FATAL: Error in 'essinstall' command: (InstallException) \"install_apps\" stage failed - Splunkd daemon is not responding: ('Error connecting to /services/apps/shc/es_deployer: The read operation timed out',)\n", "post install command": "/opt/splunk/bin/splunk search '| essinstall --ssl_enablement ignore --deployment_type shc_deployer' -auth admin:`cat /mnt/splunk-secrets/password`", "failCount": 2, "error": "command terminated with exit code 17"}
+```
+
+To fix this error, check the following areas:
+1) Check the splunkd log in the deployer pod for any issues.
+2) Check the splunkdConnectionTimeout setting in web.conf. More details at [setting connnection timeouts](#splunkdconnectiontimeout)
+
+
 Logs of the respective pods:
 
 ```
 kubectl logs <pod_name>
 ```
+
+Check the pod log (e.g deployer pod) in case you want to monitor the pod while it is coming up to ready state or it has gone to an error state.
+
 
 Common issues that may be encountered are : 
 * ES installation failed as you used default sslEnablement mode ("strict") - enable Splunk Web SSL in web.conf. See the section [Special consideration while using ssl enabled mode of strict in SHC](#special-consideration-while-using-ssl-enabled-mode-of-strict-in-shc)

--- a/docs/PremiumApps.md
+++ b/docs/PremiumApps.md
@@ -1,6 +1,6 @@
-# Premium App Installation Guide
+# Premium Apps Installation Guide
 
-The Splunk Operator automates the installation of Enterprise Security with support for other premium apps coming in the future. This page documents the prerequisites, installation steps, and limitations of deploying premium apps using the Splunk Operator.
+The Splunk Operator automates the installation of Enterprise Security with support for other premium apps coming in the future releases. This page documents the prerequisites, installation steps, troublshooting steps, and limitations of deploying premium apps using the Splunk Operator.
 
 ## Enterprise Security
 
@@ -283,7 +283,7 @@ spec:
         secretRef: splunk-s3-secret
 ```
 
-#### Installation steps
+#### Summary of Installation Steps
 
 1. Ensure that the Enterprise Security app package is present in the specified AppFramework S3 location with the correct appSources scope. Additionally, if configuring an indexer cluster, ensure that the Splunk_TA_ForIndexers app is present in the ClusterManager AppFramework S3 location with the appSources "cluster" scope.
    


### PR DESCRIPTION
---Changed to draft to remove the extra commits.---

As  @gaurav-splunk 's [ ansible fix](https://github.com/splunk/splunk-ansible/pull/704) is merged, so this PR will take care of the following items:

1. Remove requirement for adding extraEnv:SPLUNK_HTTP_ENAGBLESSL from SHC when sslEnablement is strict mode as now (given ansible fix is available) the web.conf bundle push will be sufficient alone for `esinstall` to work as well as having web.conf with `enableSplunkWebSSL=true` in the SHC.

2. Update the splunk enterprise release to right version (which 9.0.3-a1)

