### PR TITLE
CSPL-2199: Fix Nightly integration tests flakiness

### DIFF
--- a/test/appframework_aws/s1/appframework_aws_test.go
+++ b/test/appframework_aws/s1/appframework_aws_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 
@@ -1353,6 +1354,16 @@ var _ = Describe("s1appfw test", func() {
 			testcaseEnvInst.Log.Info("Get config map for livenessProbe and readinessProbe")
 			ConfigMapName := enterprise.GetProbeConfigMapName(testcaseEnvInst.GetName())
 			_, err = testenv.GetConfigMap(ctx, deployment, testcaseEnvInst.GetName(), ConfigMapName)
+			if err != nil {
+				for i := 1; i < 10; i++ {
+					_, err = testenv.GetConfigMap(ctx, deployment, testcaseEnvInst.GetName(), ConfigMapName)
+					if err == nil {
+						continue
+					} else {
+						time.Sleep(1 * time.Second)
+					}
+				}
+			}
 			Expect(err).To(Succeed(), "Unable to get config map for livenessProbe and readinessProbe", "ConfigMap name", ConfigMapName)
 
 			// Verify App installation is in progress on Standalone


### PR DESCRIPTION
This PR addresses the following flaky issues:
- tests failing with "Unable to get app status on pod" : This is most likely by timing issue, fix proposed here is to retry to get the pod install status several times
-  test failing with "Unable to get config map for livenessProbe and readinessProbe" : This is a similar kind of issue, with a similar proposed fix: try to get the configmap several times more before failing

Note: 
Tests failing with the pod status issue:
- can deploy a C3 SVA with App Framework enabled, install an app, then disable it by using a disabled version of the app and then remove it from app source
- can deploy a M4 SVA and have apps installed and updated locally on Cluster Manager and Deployer via manual poll

Test failing with the configmap issue:
- Deploy a Standalone instance with App Framework enabled and reset operator pod while app install is in progress


