### PR TITLE
Fix faulty default FailureTreshold values

### DIFF
--- a/pkg/splunk/controller/util.go
+++ b/pkg/splunk/controller/util.go
@@ -211,17 +211,27 @@ func MergePodSpecUpdates(ctx context.Context, current *corev1.PodSpec, revised *
 				result = true
 			}
 
+			// check probes
 			if hasProbeChanged(current.Containers[idx].LivenessProbe, revised.Containers[idx].LivenessProbe) {
+				scopedLog.Info("Pod Container Liveness Probe differ",
+					"current", current.Containers[idx].LivenessProbe,
+					"revised", revised.Containers[idx].LivenessProbe)
 				current.Containers[idx].LivenessProbe = revised.Containers[idx].LivenessProbe
 				result = true
 			}
 
 			if hasProbeChanged(current.Containers[idx].ReadinessProbe, revised.Containers[idx].ReadinessProbe) {
+				scopedLog.Info("Pod Container ReadinessProbe Probe differ",
+					"current", current.Containers[idx].ReadinessProbe,
+					"revised", revised.Containers[idx].ReadinessProbe)
 				current.Containers[idx].ReadinessProbe = revised.Containers[idx].ReadinessProbe
 				result = true
 			}
 
 			if hasProbeChanged(current.Containers[idx].StartupProbe, revised.Containers[idx].StartupProbe) {
+				scopedLog.Info("Pod Container StartupProbe Probe differ",
+					"current", current.Containers[idx].StartupProbe,
+					"revised", revised.Containers[idx].StartupProbe)
 				current.Containers[idx].StartupProbe = revised.Containers[idx].StartupProbe
 				result = true
 			}

--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -1063,6 +1063,10 @@ func getProbeWithConfigUpdates(defaultProbe *corev1.Probe, configuredProbe *ente
 		if derivedProbe.PeriodSeconds == 0 {
 			derivedProbe.PeriodSeconds = defaultProbe.PeriodSeconds
 		}
+		// CSPL-2242 - Default value for FailureThreshold not being set forces unnecessary statefulSet updates
+		if derivedProbe.FailureThreshold == 0 {
+			derivedProbe.FailureThreshold = defaultProbe.FailureThreshold
+		}
 		// Always use defaultProbe Exec. At this time customer supported scripts are not supported.
 		derivedProbe.Exec = defaultProbe.Exec
 		return &derivedProbe


### PR DESCRIPTION
Default value for FailureThreshold not being set forces unnecessary statefulSet updates