### PR TITLE
CSPL-2267 - Fix logging crash in AWS Client download app

### DIFF
--- a/pkg/splunk/client/awss3client.go
+++ b/pkg/splunk/client/awss3client.go
@@ -252,7 +252,7 @@ func (awsclient *AWSS3Client) DownloadApp(ctx context.Context, downloadRequest R
 			IfMatch: aws.String(downloadRequest.Etag),
 		})
 	if err != nil {
-		scopedLog.Error(err, "Unable to download item %s", downloadRequest.RemoteFile)
+		scopedLog.Error(err, "Unable to download item %s", "RemoteFile", downloadRequest.RemoteFile)
 		os.Remove(downloadRequest.RemoteFile)
 		return false, err
 	}


### PR DESCRIPTION
Fix logging crash in AWS Client download app