### PR TITLE
adding add repo for main branch in pipeline test

### DIFF
--- a/.github/workflows/helm-test-workflow.yml
+++ b/.github/workflows/helm-test-workflow.yml
@@ -172,6 +172,10 @@ jobs:
       - name: install k8s dashboard
         run: |
           kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.5/aio/deploy/recommended.yaml
+      - name: Add splunk helm repo for main branch
+        if: github.ref == 'refs/heads/main'
+        run: |
+          helm repo add splunk https://splunk.github.io/splunk-operator/
       - name: Run helm test
         env:
           KUTTL_SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ env.SPLUNK_ENTERPRISE_IMAGE }}


### PR DESCRIPTION
only for main branch we need to run release helm workflow. instead of using helm chart directory to run test it will use github.io hosted splunk operator helm charts.

this can only be tested on main branch.  