### PR TITLE
[Draft] CSPL-2304 - Added smartstore documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -99,7 +99,11 @@ information.
 ### What Storage Type To Use?
 
 The Kubernetes infrastructure must have access to storage that meets or exceeds the recommendations provided in the Splunk Enterprise storage type recommendations at [Reference Hardware documentation - what storage type to use for a given role?](https://docs.splunk.com/Documentation/Splunk/latest/Capacity/Referencehardware#What_storage_type_should_I_use_for_a_role.3F) In summary, Indexers with SmartStore need NVMe or SSD storage to provide the necessary IOPs for a successful Splunk Enterprise environment.
- 
+
+### Splunk SmartStore Required
+
+For production environments, we are requiring the use of Splunk SmartStore. As a Splunk Enterprise deployment's data volume increases, demand for storage typically outpaces demand for compute resources. [Splunk's SmartStore Feature](https://docs.splunk.com/Documentation/Splunk/latest/Indexer/AboutSmartStore) allows you to manage your indexer storage and compute resources in a ___cost-effective___ manner by scaling those resources separately. SmartStore utilizes a fast storage cache on each indexer node to keep recent data locally available for search and keep other data in a remote object store. Look into the [SmartStore Resource Guide](SmartStore.md) document for configuring and using SmartStore through operator.
+
 ## Installing the Splunk Operator
 
 A Kubernetes cluster administrator can install and start the Splunk Operator for specific namespace by running:

--- a/docs/SmartStore.md
+++ b/docs/SmartStore.md
@@ -1,6 +1,6 @@
 # SmartStore Resource Guide
 
-*NOTE: The below method is a temporary way of installing SmartStore configuration & indexes. Starting from the Splunk Operator release 1.0.2, an enhanced App installation framework is introduced which is the recommended method to install SmartStore indexes & configuration. The below method can still be used if the customer wants to store the secret and access keys within the Kubernetes Customer Resource Spec*
+*NOTE: The below method is a temporary way of installing SmartStore configuration & indexes. Starting from the Splunk Operator release 1.0.2, an enhanced App installation framework is introduced which is the recommended method to install SmartStore indexes & configuration. The below method can still be used if the customer wants to avoid storing the S3 secret and access keys in the S3 buckets(via the App installation framework)*
 
 The Splunk Operator includes a method for configuring a SmartStore remote storage volume with index support using a [Custom Resource](https://splunk.github.io/splunk-operator/CustomResources.html). The SmartStore integration is not implemented as a StorageClass. This feature and its settings rely on support integrated into Splunk Enterprise. See [SmartStore](https://docs.splunk.com/Documentation/Splunk/latest/Indexer/AboutSmartStore) for information on the feature and implementation considerations.
 

--- a/docs/SmartStore.md
+++ b/docs/SmartStore.md
@@ -1,6 +1,6 @@
 # SmartStore Resource Guide
 
-*NOTE: The below method is a temporary way of installing SmartStore configuration & indexes. Starting from the Splunk Operator release 1.0.2, an enhanced App installation framework is introduced which is the recommended method to install SmartStore indexes & configuration.*
+*NOTE: The below method is a temporary way of installing SmartStore configuration & indexes. Starting from the Splunk Operator release 1.0.2, an enhanced App installation framework is introduced which is the recommended method to install SmartStore indexes & configuration. The below method can still be used if the customer wants to store the secret and access keys within the Kubernetes Customer Resource Spec*
 
 The Splunk Operator includes a method for configuring a SmartStore remote storage volume with index support using a [Custom Resource](https://splunk.github.io/splunk-operator/CustomResources.html). The SmartStore integration is not implemented as a StorageClass. This feature and its settings rely on support integrated into Splunk Enterprise. See [SmartStore](https://docs.splunk.com/Documentation/Splunk/latest/Indexer/AboutSmartStore) for information on the feature and implementation considerations.
 
@@ -265,3 +265,7 @@ remote.s3.encryption = sse-s3
 ```
 2. Apply the CR with the necessary & supported Smartstore and Index related configs
 3. Install the App created using the [currently supported methods](https://splunk.github.io/splunk-operator/Examples.html#installing-splunk-apps) (*Note: This can be combined with the previous step*)
+
+## Special Internal Indexes
+
+The `_cluster` app sets the `repFactor` to `0` for internal indexes such as `_metrics`, `_introspection`, `_telemetry`, `_metrics_rollup`, `_configtracker`. If replication of these indexes are desired please use the method specified in [Additional Configuration section](#additional-configuration) to set the `repFactor` to `auto`


### PR DESCRIPTION
Splunk Operator via the smartstore feature, sets the `repFactor` to `auto` in the `[default]` stanza of the `splunk-operator` app in order to help with the requirements [here](https://docs.splunk.com/Documentation/Splunk/9.0.4/Indexer/ConfigureSmartStore). This setting was applied to all indexes except for certain internal indexes such as `metrics`, `introspection`, `telemetry`, `_metrics_rollup`, `_configtracker` which have specific stanzas in the `_cluster` app with `repFactor` as `0`.

Modifying the documentation to:
- Inform the Splunk Admin of the default settings by the Splunk Operator and potential overrides of configuration
- README.md has smartstore as a required feature incorrectly. AppFramework is the way to go starting 1.0.2.