### PR TITLE
CSPL-2304 - Modify smartstore documentation for repFactor in internal indexes

### DIFF
--- a/api/v4/common_types.go
+++ b/api/v4/common_types.go
@@ -128,13 +128,13 @@ const (
 	// PhaseUpdating means a custom resource is in the process of updating to a new desired state (spec)
 	PhaseUpdating Phase = "Updating"
 
-	// PhaseScalingUp means a customer resource is in the process of scaling up
+	// PhaseScalingUp means a custom resource is in the process of scaling up
 	PhaseScalingUp Phase = "ScalingUp"
 
-	// PhaseScalingDown means a customer resource is in the process of scaling down
+	// PhaseScalingDown means a custom resource is in the process of scaling down
 	PhaseScalingDown Phase = "ScalingDown"
 
-	// PhaseTerminating means a customer resource is in the process of being removed
+	// PhaseTerminating means a custom resource is in the process of being removed
 	PhaseTerminating Phase = "Terminating"
 
 	// PhaseError means an error occured with custom resource management

--- a/docs/Helm.md
+++ b/docs/Helm.md
@@ -94,7 +94,7 @@ If the operator is already installed then you will need to disable the dependenc
 ```
 helm install --set splunk-operator.enabled=false <RELEASE_NAME> splunk/splunk-enterprise -n <RELEASE_NAMESPACE>
 ```
-Installing ```splunk/splunk-enterprise``` will deploy Splunk Enterprise customer resources according to your configuration, the following ```new_values.yaml``` file specifies override configurations to deploy a Cluster Manager, an Indexer Cluster and a Search Head Cluster.
+Installing ```splunk/splunk-enterprise``` will deploy Splunk Enterprise custom resources according to your configuration, the following ```new_values.yaml``` file specifies override configurations to deploy a Cluster Manager, an Indexer Cluster and a Search Head Cluster.
 
 ```
 clusterMaster:

--- a/docs/SmartStore.md
+++ b/docs/SmartStore.md
@@ -1,6 +1,6 @@
 # SmartStore Resource Guide
 
-*NOTE: The below method is a temporary way of installing SmartStore configuration & indexes. Starting from the Splunk Operator release 1.0.2, an enhanced App installation framework is introduced which is the recommended method to install SmartStore indexes & configuration. The below method can still be used if the customer wants to avoid storing the S3 secret and access keys in the S3 buckets(via the App installation framework)*
+*NOTE: The below method is a temporary way of installing SmartStore configuration & indexes. Starting from the Splunk Operator release 1.0.2, an enhanced App installation framework is introduced which is the recommended method to install SmartStore indexes & configuration. The below method may still be used to specify the S3 access keys, which avoids storing them in the S3 buckets (via the App installation framework)*
 
 The Splunk Operator includes a method for configuring a SmartStore remote storage volume with index support using a [Custom Resource](https://splunk.github.io/splunk-operator/CustomResources.html). The SmartStore integration is not implemented as a StorageClass. This feature and its settings rely on support integrated into Splunk Enterprise. See [SmartStore](https://docs.splunk.com/Documentation/Splunk/latest/Indexer/AboutSmartStore) for information on the feature and implementation considerations.
 
@@ -268,4 +268,4 @@ remote.s3.encryption = sse-s3
 
 ## Special Internal Indexes
 
-The `_cluster` app sets the `repFactor` to `0` for internal indexes such as `_metrics`, `_introspection`, `_telemetry`, `_metrics_rollup`, `_configtracker`. If replication of these indexes are desired please use the method specified in [Additional Configuration section](#additional-configuration) to set the `repFactor` to `auto`
+For Indexer Cluster, all Smartstore enabled indexes must have a `repFactor` set to `auto`. However, by default, the Cluster Manager's `_cluster` app(by default) sets the repFactor to `0` for internal indexes like `_metrics`, `_introspection`, `_telemetry`, `_metrics_rollup`, and `_configtracker`. If you want to replicate these indexes, please follow the instructions in the [Additional Configuration section](#additional-configuration) to set the repFactor to `auto`.

--- a/docs/SmartStore.md
+++ b/docs/SmartStore.md
@@ -1,6 +1,6 @@
 # SmartStore Resource Guide
 
-*NOTE: The below method is a temporary way of installing SmartStore configuration & indexes. Starting from the Splunk Operator release 1.0.2, an enhanced App installation framework is introduced which is the recommended method to install SmartStore indexes & configuration.*
+*NOTE: The below method is a temporary way of installing SmartStore configuration & indexes. Starting from the Splunk Operator release 1.0.2, an enhanced App installation framework is introduced which is the recommended method to install SmartStore indexes & configuration. The below method can still be used if the customer wants to avoid storing the S3 secret and access keys in the S3 buckets(via the App installation framework)*
 
 The Splunk Operator includes a method for configuring a SmartStore remote storage volume with index support using a [Custom Resource](https://splunk.github.io/splunk-operator/CustomResources.html). The SmartStore integration is not implemented as a StorageClass. This feature and its settings rely on support integrated into Splunk Enterprise. See [SmartStore](https://docs.splunk.com/Documentation/Splunk/latest/Indexer/AboutSmartStore) for information on the feature and implementation considerations.
 
@@ -265,3 +265,7 @@ remote.s3.encryption = sse-s3
 ```
 2. Apply the CR with the necessary & supported Smartstore and Index related configs
 3. Install the App created using the [currently supported methods](https://splunk.github.io/splunk-operator/Examples.html#installing-splunk-apps) (*Note: This can be combined with the previous step*)
+
+## Special Internal Indexes
+
+The `_cluster` app sets the `repFactor` to `0` for internal indexes such as `_metrics`, `_introspection`, `_telemetry`, `_metrics_rollup`, `_configtracker`. If replication of these indexes are desired please use the method specified in [Additional Configuration section](#additional-configuration) to set the `repFactor` to `auto`

--- a/docs/SmartStore.md
+++ b/docs/SmartStore.md
@@ -266,6 +266,6 @@ remote.s3.encryption = sse-s3
 2. Apply the CR with the necessary & supported Smartstore and Index related configs
 3. Install the App created using the [currently supported methods](https://splunk.github.io/splunk-operator/Examples.html#installing-splunk-apps) (*Note: This can be combined with the previous step*)
 
-## Special Internal Indexes
+## RepFactor for Internal Indexes
 
 For Indexer Cluster, all Smartstore enabled indexes must have a `repFactor` set to `auto`. However, by default, the Cluster Manager's `_cluster` app(by default) sets the repFactor to `0` for internal indexes like `_metrics`, `_introspection`, `_telemetry`, `_metrics_rollup`, and `_configtracker`. If you want to replicate these indexes, please follow the instructions in the [Additional Configuration section](#additional-configuration) to set the repFactor to `auto`.

--- a/docs/SmartStore.md
+++ b/docs/SmartStore.md
@@ -25,8 +25,8 @@ Example: `kubectl create secret generic s3-secret --from-literal=s3_access_key=i
    * Create a Secret object with Secret & Access credentials, as explained in [Storing SmartStore Secrets](#storing-smartstore-secrets)
 2. Confirm your S3-based storage volume path and URL.
 3. Confirm the name of the Splunk indexes being used with the SmartStore volume. 
-4. Create/Update the Standalone Customer Resource specification with volume and index configuration (see Example below)
-5. Apply the Customer Resource specification: kubectl -f apply Standalone.yaml
+4. Create/Update the Standalone custom resource specification with volume and index configuration (see Example below)
+5. Apply the custom resource specification: kubectl -f apply Standalone.yaml
 
 
 Example. Standalone.yaml:
@@ -73,8 +73,8 @@ Note: Custom apps with higher precedence can potentially overwrite the index and
    * Create a Secret object with Secret & Access credentials, as explained in [Storing SmartStore Secrets](#storing-smartstore-secrets)
 2. Confirm your S3-based storage volume path and URL.
 3. Confirm the name of the Splunk indexes being used with the SmartStore volume. 
-4. Create/Update the Cluster Manager Customer Resource specification with volume and index configuration (see Example below)
-5. Apply the Customer Resource specification: kubectl -f apply Clustermanager.yaml
+4. Create/Update the Cluster Manager custom resource specification with volume and index configuration (see Example below)
+5. Apply the custom resource specification: kubectl -f apply Clustermanager.yaml
 6. Follow the rest of the steps to Create an Indexer Cluster. See [Examples](Examples.md)
 
 
@@ -268,4 +268,4 @@ remote.s3.encryption = sse-s3
 
 ## RepFactor for Internal Indexes
 
-For Indexer Cluster, all Smartstore enabled indexes must have a `repFactor` set to `auto`. However, by default, the Cluster Manager's `_cluster` app(by default) sets the repFactor to `0` for internal indexes like `_metrics`, `_introspection`, `_telemetry`, `_metrics_rollup`, and `_configtracker`. If you want to replicate these indexes, please follow the instructions in the [Additional Configuration section](#additional-configuration) to set the repFactor to `auto`.
+For Indexer Cluster, all Smartstore enabled indexes must have `repFactor` set to `auto`. However, by default, the Cluster Manager's `_cluster` app(by default) sets the repFactor to `0` for internal indexes like `_metrics`, `_introspection`, `_telemetry`, `_metrics_rollup`, and `_configtracker`. If you want to replicate these indexes, please follow the instructions in the [Additional Configuration section](#additional-configuration) to set the repFactor to `auto`.


### PR DESCRIPTION
Splunk Operator via the smartstore feature, sets the repFactor to auto in the [default] stanza of the splunk-operator app in order to help with the requirements [here](https://docs.splunk.com/Documentation/Splunk/9.0.4/Indexer/ConfigureSmartStore). This setting was applied to all indexes except for certain internal indexes such as metrics, introspection, telemetry, _metrics_rollup, _configtracker which have specific stanzas in the _cluster app with repFactor as 0.

Modifying the documentation to:

- Inform the Splunk Admin of repFactor being set to `0` by default and a solution to override it. 
- Inform the Splunk Admin that the SmartStore method is still usable if they prefer not set their keys on S3 buckets.(To be changed with OIDC) 