### PR TITLE
feat: add option to add extra labels to operator pods

### DIFF
--- a/helm-chart/splunk-operator/templates/deployment.yaml
+++ b/helm-chart/splunk-operator/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
 {{- end }}
       labels:
 {{- include "splunk-operator.selectorLabels" . | nindent 8 }}
+{{- if .Values.splunkOperator.podLabels }}
+{{ toYaml .Values.splunkOperator.podLabels | indent 8 }}
+{{- end }}
     spec:
 {{- with .Values.splunkOperator.imagePullSecrets }}
       imagePullSecrets:

--- a/helm-chart/splunk-operator/values.yaml
+++ b/helm-chart/splunk-operator/values.yaml
@@ -51,6 +51,9 @@ splunkOperator:
   # Add pod annotations to Splunk Operator deployment pod
   podAnnotations: {}
 
+  # Add pod labels to Splunk Operator deployment pod
+  podLabels: {}
+
   # Set security context for manager container, default ensures that no child process of manager can gain more privileges than manager
   # reference: https://kubernetes.io/docs/concepts/security/pod-security-policy/#privilege-escalation
   containerSecurityContext:


### PR DESCRIPTION
## Intent

- Partially address https://github.com/splunk/splunk-operator/issues/1116 where we are required to set the pod's labels to make use of extra features from cloud provider - in the case is managed identity binding in Azure.

## Test

Values:

```
# values.yaml - different from the default:
splunkOperator:
  podLabels:
    aadpodidbinding: dummy
```

Generated:

```
# Source: splunk-operator/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: splunk-operator-controller-manager
  namespace: default
  labels:
    helm.sh/chart: splunk-operator-2.3.0
    control-plane: controller-manager
    app.kubernetes.io/name: splunk-operator
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "2.3.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      control-plane: controller-manager
      app.kubernetes.io/name: splunk-operator
      app.kubernetes.io/instance: release-name
  strategy:
    type: Recreate
  template:
    metadata:
      labels:
        control-plane: controller-manager
        app.kubernetes.io/name: splunk-operator
        app.kubernetes.io/instance: release-name
        aadpodidbinding: dummy
...
```
