### PR TITLE
Cspl-2489: GITHUG-1153 - Fix indexer deletion in upgrade scenario

### DIFF
--- a/pkg/splunk/enterprise/indexercluster_test.go
+++ b/pkg/splunk/enterprise/indexercluster_test.go
@@ -1875,3 +1875,21 @@ func TestIndexerClusterWithReadyState(t *testing.T) {
 		debug.PrintStack()
 	}
 }
+
+func TestImageUpdatedTo9(t *testing.T) {
+	if !imageUpdatedTo9("splunk/splunk:8.2.6", "splunk/splunk:9.0.0") {
+		t.Errorf("Should have detected an upgrade from 8 to 9")
+	}
+	if imageUpdatedTo9("splunk/splunk:9.0.3", "splunk/splunk:9.0.4") {
+		t.Errorf("Should not have detected an upgrade from 8 to 9")
+	}
+	if imageUpdatedTo9("splunk/splunk:8.2.6", "splunk/splunk:latest") {
+		t.Errorf("Should not have detected an upgrade from 8 to 9, latest doesn't allow to know the version")
+	}
+	if imageUpdatedTo9("splunk/splunk", "splunk/splunk") {
+		t.Errorf("Should not have detected an upgrade from 8 to 9, there is no colon and version")
+	}
+	if imageUpdatedTo9("splunk/splunk:", "splunk/splunk:") {
+		t.Errorf("Should not have detected an upgrade from 8 to 9, there is no version")
+	}
+}


### PR DESCRIPTION
This PR test GITHUT -1153 issue

addresses issue https://github.com/splunk/splunk-operator/issues/1151.
There are 2 changes:

Make sure that the fix of PR https://github.com/splunk/splunk-operator/pull/1041 is applied in the cluster-manager usecase
Fix the check on the image version. The format of the image field being like splunk/splunk-operator:8.2.0, it is needed to get the version that is after the colon. The previous check was only checking if the image was starting with 8 or 9, which is always false.