### PR TITLE
fix: correct syntax for annotations

### DIFF
--- a/helm-chart/splunk-enterprise/templates/enterprise_v4_licensemanager.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v4_licensemanager.yaml
@@ -9,7 +9,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- with .Values.licenseManager.additionalAnnotations }}
-    annotations:
+  annotations:
 {{ toYaml . | indent 4 }}
   {{- end }}
 spec:


### PR DESCRIPTION
Attempting to add annotations to LicenseManager pods results in the below error:

`Helm install failed: YAML parse error on splunk-enterprise/templates/enterprise_v4_licensemanager.yaml: error converting YAML to JSON: yaml: line 6: mapping values are not allowed in this context`

Due to additional indentation added to `annotations` line