### PR TITLE
CSPL-2574 - Fix nil map error in appFramework validation

### DIFF
--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -1425,10 +1425,9 @@ func validateSplunkAppSources(appFramework *enterpriseApi.AppFrameworkSpec, loca
 	duplicateAppSourceStorageChecker[enterpriseApi.ScopeLocal] = make(map[string]bool)
 	duplicateAppSourceStorageChecker[enterpriseApi.ScopePremiumApps] = make(map[string]bool)
 
-	if !localOrPremScope {
-		duplicateAppSourceStorageChecker[enterpriseApi.ScopeCluster] = make(map[string]bool)
-		duplicateAppSourceStorageChecker[enterpriseApi.ScopeClusterWithPreConfig] = make(map[string]bool)
-	}
+        // CSPL-2574 - Assign just in case invalid scope is passed through!
+	duplicateAppSourceStorageChecker[enterpriseApi.ScopeCluster] = make(map[string]bool)
+	duplicateAppSourceStorageChecker[enterpriseApi.ScopeClusterWithPreConfig] = make(map[string]bool)
 
 	duplicateAppSourceNameChecker := make(map[string]bool)
 


### PR DESCRIPTION
Operator 2.5.2, Standalone with the following config with cluster scope crashes operator:





```
apiVersion: enterprise.splunk.com/v4
kind: Standalone
metadata:
  name: ido
  finalizers:
  - enterprise.splunk.com/delete-pvc
spec:
  replicas: 1
  appRepo:
    appsRepoPollIntervalSeconds: 900
    defaults:
      volumeName: volume_app_repo_us
      scope: cluster
    appSources:
      - name: cspl_1250_apps
        location: cspl_1250_apps/
    volumes:
      - name: volume_app_repo_us
        storageType: s3
        provider: aws
        path: akondur-appframework-test/
        endpoint: https://s3-us-west-2.amazonaws.com
        region: us-west-2
        secretRef: s3-secret

```

Error log:

```
2024-03-27T23:27:50.760455704Z  INFO    ValidateAppFrameworkSpec        Invalid value of maxConcurrentAppDownloads      {"controller": "standalone", "controllerGroup": "enterprise.splunk.com", "controllerKind": "Standalone", "Standalone": {"name":"ido","namespace":"splunk-operator"}, "namespace": "splunk-operator", "name": "ido", "reconcileID": "4840474f-f041-485f-816e-a196a1766d5b", "configured value": 0, "Setting it to default value": 5}
2024-03-27T23:27:50.760497498Z  INFO    Observed a panic in reconciler: assignment to entry in nil map  {"controller": "standalone", "controllerGroup": "enterprise.splunk.com", "controllerKind": "Standalone", "Standalone": {"name":"ido","namespace":"splunk-operator"}, "namespace": "splunk-operator", "name": "ido", "reconcileID": "4840474f-f041-485f-816e-a196a1766d5b"}
panic: assignment to entry in nil map [recovered]
        panic: assignment to entry in nil map

goroutine 763 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:119 +0x1e5
panic({0x19bc0e0?, 0x2050100?})
        /usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/splunk/splunk-operator/pkg/splunk/enterprise.validateSplunkAppSources(0xc000d9dcc8, 0x1, {0x1c12e02, 0xa})
        /workspace/pkg/splunk/enterprise/configuration.go:1492 +0x305
github.com/splunk/splunk-operator/pkg/splunk/enterprise.ValidateAppFrameworkSpec({0x206ea98, 0xc000d14480}, 0xc000d9dcc8, 0xc000d9de18, 0x1, {0x1c12e02, 0xa})
        /workspace/pkg/splunk/enterprise/configuration.go:1593 +0x72f
github.com/splunk/splunk-operator/pkg/splunk/enterprise.validateStandaloneSpec({0x206ea98, 0xc000d14480}, {0x7ffb05b36360, 0xc00090f020}, 0xc000d9d500)
        /workspace/pkg/splunk/enterprise/standalone.go:289 +0x1ce
github.com/splunk/splunk-operator/pkg/splunk/enterprise.ApplyStandalone({0x206ea98, 0xc000d14480}, {0x7ffb05b36360?, 0xc00090f020}, 0xc000d9d500)
        /workspace/pkg/splunk/enterprise/standalone.go:55 +0x1cf
github.com/splunk/splunk-operator/controllers.glob..func8({0x206ea98, 0xc000d14480}, {0x20767d8?, 0xc00090f020}, 0x5?)
        /workspace/controllers/standalone_controller.go:119 +0x52
github.com/splunk/splunk-operator/controllers.(*StandaloneReconciler).Reconcile(0xc0000105a0, {0x206ea98, 0xc000d14480}, {{{0xc0001576c0, 0xf}, {0xc0001576b0, 0x3}}})
        /workspace/controllers/standalone_controller.go:109 +0x55b
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x206ea98?, {0x206ea98?, 0xc000d14480?}, {{{0xc0001576c0?, 0x18ee8e0?}, {0xc0001576b0?, 0x412095?}}})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:122 +0xb7
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000136c80, {0x206ead0, 0xc000673090}, {0x1a2a380?, 0xc0005ff9c0?})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:323 +0x365
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000136c80, {0x206ead0, 0xc000673090})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:274 +0x1c9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:235 +0x79
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 186
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:231 +0x565
```

After fix - logs correctly showing invalid scope, no crash observed with the operator main routine:

```
2024-03-28T00:04:23.705093728Z  INFO    Requeued        {"controller": "standalone", "controllerGroup": "enterprise.splunk.com", "controllerKind": "Standalone", "Standalone": {"name":"ido","namespace":"splunk-operator"}, "namespace": "splunk-operator", "name": "ido", "reconcileID": "a2070d99-8572-4ef8-b66e-d121ffac5574", "standalone": "splunk-operator/ido", "period(seconds)": 5}
2024-03-28T00:04:23.705122996Z  ERROR   Reconciler error        {"controller": "standalone", "controllerGroup": "enterprise.splunk.com", "controllerKind": "Standalone", "Standalone": {"name":"ido","namespace":"splunk-operator"}, "namespace": "splunk-operator", "name": "ido", "reconcileID": "a2070d99-8572-4ef8-b66e-d121ffac5574", "error": "invalid scope for defaults config. Only local scope is supported for this kind of CR"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:329
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:274
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:235
```