### PR TITLE
upgrade aws sdk go to enable eks pod identity work

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/splunk/splunk-operator
 go 1.21
 
 require (
-	github.com/aws/aws-sdk-go v1.42.16
+	github.com/aws/aws-sdk-go v1.53.12
 	github.com/go-logr/logr v1.4.1
 	github.com/google/go-cmp v0.6.0
 	github.com/minio/minio-go/v7 v7.0.16


### PR DESCRIPTION
Issue: https://github.com/splunk/splunk-operator/issues/1326