### PR TITLE
Add support for multi indexer clusters for a multi site env. 

### DIFF
--- a/helm-chart/splunk-enterprise/templates/_helpers.tpl
+++ b/helm-chart/splunk-enterprise/templates/_helpers.tpl
@@ -72,11 +72,15 @@ Define namespace of release and allow for namespace override
 Define the list of Cluster Maaster internal URI used for multisite config
 */}}
 {{- define "cmlist" -}}
+{{- if and .Values.existingClusterManager .Values.existingClusterManager.name }}
+{{- $cm_name = printf "splunk-%s-cluster-manager-service" .Values.existingClusterManager.name -}}
+{{- else }}
 {{- $cm_name := list -}}
 {{- range default (default (until 1)) .Values.sva.m4.totalCluster }}
 {{- $cm_name = printf "splunk-%s-cluster-manager-service" .name | append $cm_name -}}
 {{- end -}}
 {{- join ","  $cm_name }}
+{{- end }}
 {{- end -}}
 
 

--- a/helm-chart/splunk-enterprise/templates/_helpers.tpl
+++ b/helm-chart/splunk-enterprise/templates/_helpers.tpl
@@ -67,3 +67,24 @@ Define namespace of release and allow for namespace override
 {{- define "splunk-enterprise.namespace" -}}
 {{- default .Release.Namespace .Values.namespaceOverride }}
 {{- end }}
+
+{{/*
+Define the list of Cluster Maaster internal URI used for multisite config
+*/}}
+{{- define "cmlist" -}}
+{{- $cm_name := list -}}
+{{- range default (default (until 1)) .Values.sva.m4.totalCluster }}
+{{- $cm_name = printf "splunk-%s-cluster-manager-service" .name | append $cm_name -}}
+{{- end -}}
+{{- join ","  $cm_name }}
+{{- end -}}
+
+
+{{/*
+Return the first value from the list of indexer clusters to be configured for outputs.conf
+*/}}
+{{- define "cm_name_first" -}}
+{{- with (first .Values.sva.m4.totalCluster) }}
+{{- .name  }}
+{{- end }}
+{{- end -}}

--- a/helm-chart/splunk-enterprise/templates/enterprise_v4_clustermanager.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v4_clustermanager.yaml
@@ -1,157 +1,162 @@
 {{- if or .Values.clusterManager.enabled ( and (not $.Values.existingClusterManager) ( or .Values.sva.c3.enabled .Values.sva.m4.enabled ) )}}
-apiVersion:  enterprise.splunk.com/v4
-kind: ClusterManager
-metadata:
-  name: {{ .Values.clusterManager.name }}
-  namespace: {{ default (include "splunk-enterprise.namespace" . ) .Values.clusterManager.namespaceOverride }}
+apiVersion: v1
+kind: List
+items:
+{{- range default (default (until 1)) .Values.sva.m4.totalCluster }}
+- apiVersion:  enterprise.splunk.com/v4
+  kind: ClusterManager
+  metadata:
+    name: {{ .Values.clusterManager.name }}
+    namespace: {{ default (include "splunk-enterprise.namespace" . ) .Values.clusterManager.namespaceOverride }}
 {{- with .Values.clusterManager.additionalLabels }}
-  labels:
-{{ toYaml . | indent 4 }}
+    labels:
+{{ toYaml . | indent 6 }}
 {{- end }}
 {{- with .Values.clusterManager.additionalAnnotations }}
-  annotations:
-{{ toYaml . | indent 4 }}
+    annotations:
+{{ toYaml . | indent 6 }}
 {{- end }}
-spec:
+  spec:
 {{- with .Values.clusterManager.appRepo }}
-  appRepo: 
-{{ toYaml . | indent 4 }}
+    appRepo: 
+{{ toYaml . | indent 6 }}
 {{- end }}
 {{- with .Values.clusterManager.smartstore }}
-  smartstore:
-{{ toYaml . | indent 4 }}
+    smartstore:
+{{ toYaml . | indent 6 }}
 {{- end }}
 {{- if .Values.existingLicenseManager }}
-  licenseManagerRef:
-    name: {{ .Values.existingLicenseManager.name }}
+    licenseManagerRef:
+      name: {{ .Values.existingLicenseManager.name }}
   {{- if .Values.existingLicenseManager.namespace }}
-    namespace: {{ .Values.existingLicenseManager.namespace }}
+      namespace: {{ .Values.existingLicenseManager.namespace }}
   {{- end }}
 {{- else if .Values.licenseManager.enabled }}
-  licenseManagerRef:
-    name: {{ .Values.licenseManager.name }}
+    licenseManagerRef:
+      name: {{ .Values.licenseManager.name }}
   {{- if .Values.licenseManager.namespaceOverride }}
-    namespace: {{ .Values.licenseManager.namespaceOverride }}
+      namespace: {{ .Values.licenseManager.namespaceOverride }}
   {{- end }}
 {{- end }}
 {{- if .Values.existingMonitoringConsole }}
-  monitoringConsoleRef:
-    name: {{ .Values.existingMonitoringConsole.name }}
+    monitoringConsoleRef:
+      name: {{ .Values.existingMonitoringConsole.name }}
   {{- if .Values.existingMonitoringConsole.namespace }}
-    namespace: {{ .Values.existingMonitoringConsole.namespace }}
+      namespace: {{ .Values.existingMonitoringConsole.namespace }}
   {{- end }}
 {{- else if .Values.monitoringConsole.enabled }}
-  monitoringConsoleRef:
-    name: {{ .Values.monitoringConsole.name }}
+    monitoringConsoleRef:
+      name: {{ .Values.monitoringConsole.name }}
   {{- if .Values.monitoringConsole.namespaceOverride }}
-    namespace: {{ .Values.monitoringConsole.namespaceOverride }}
+      namespace: {{ .Values.monitoringConsole.namespaceOverride }}
   {{- end }}
 {{- end }}
 {{- if .Values.image.repository }}
-  image: {{ .Values.image.repository }}
+    image: {{ .Values.image.repository }}
 {{- end }}
 {{- if .Values.image.imagePullPolicy }}
-  imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+    imagePullPolicy: {{ .Values.image.imagePullPolicy }}
 {{- end }}
 {{- with .Values.image.imagePullSecrets }}
-  imagePullSecrets:
-{{ toYaml . | indent 4 }}
+    imagePullSecrets:
+{{ toYaml . | indent 6 }}
 {{- end }}
 {{- with .Values.clusterManager.volumes }}      
-  volumes:
-{{ toYaml . | indent 4 }}
+    volumes:
+{{ toYaml . | indent 6 }}
 {{- end }}
 {{- if .Values.clusterManager.licenseUrl }}
-  licenseUrl: {{ .Values.clusterManager.licenseUrl }}
+    licenseUrl: {{ .Values.clusterManager.licenseUrl }}
 {{- end }}
 {{- if .Values.clusterManager.defaultsUrl }}
-  defaultsUrl: {{ .Values.clusterManager.defaultsUrl }}
+    defaultsUrl: {{ .Values.clusterManager.defaultsUrl }}
 {{- end }}
 {{- if .Values.sva.m4.enabled }}
-  defaults: |-
-    splunk:
-      site: {{ .Values.sva.m4.clusterManager.site }}
-      multisite_master: localhost
-      all_sites: {{ .Values.sva.m4.clusterManager.allSites }}
-      multisite_replication_factor_origin: 1
-      multisite_replication_factor_total: 2
-      multisite_search_factor_origin: 1
-      multisite_search_factor_total: 2
-      idxc:
-        search_factor: 2
-        replication_factor: 2
+    defaults: |-
+      splunk:
+        site: {{ .Values.sva.m4.clusterManager.site }}
+        multisite_master: localhost
+        all_sites: {{ .Values.sva.m4.clusterManager.allSites }}
+        multisite_replication_factor_origin: 1
+        multisite_replication_factor_total: 2
+        multisite_search_factor_origin: 1
+        multisite_search_factor_total: 2
+        idxc:
+          search_factor: 2
+          replication_factor: 2
 {{- else if .Values.clusterManager.defaults }}
-  defaults: |-
-{{ toYaml .Values.clusterManager.defaults | indent 4 }}
+    defaults: |-
+{{ toYaml .Values.clusterManager.defaults | indent 6 }}
 {{- end }}
 {{- if .Values.clusterManager.defaultsUrlApps }}
-  defaultsUrlApps: {{ .Values.clusterManager.defaultsUrlApps }}
+    defaultsUrlApps: {{ .Values.clusterManager.defaultsUrlApps }}
 {{- end }}
 {{- with .Values.clusterManager.extraEnv }}
-  extraEnv:
-{{ toYaml . | indent 4 }}
+    extraEnv:
+{{ toYaml . | indent 6 }}
 {{- end }}
 {{- if .Values.clusterManager.livenessInitialDelaySeconds }}
-  livenessInitialDelaySeconds: {{ .Values.clusterManager.livenessInitialDelaySeconds }}
+    livenessInitialDelaySeconds: {{ .Values.clusterManager.livenessInitialDelaySeconds }}
 {{- end }}
 {{- if .Values.clusterManager.readinessInitialDelaySeconds }}
-  readinessInitialDelaySeconds: {{ .Values.clusterManager.readinessInitialDelaySeconds }}
+    readinessInitialDelaySeconds: {{ .Values.clusterManager.readinessInitialDelaySeconds }}
 {{- end }}
 {{- if .Values.clusterManager.startupProbe }}
-  startupProbe:
-{{ toYaml .Values.clusterManager.startupProbe | indent 4 }}
+    startupProbe:
+{{ toYaml .Values.clusterManager.startupProbe | indent 6 }}
 {{- end }}
 {{- if .Values.clusterManager.livenessProbe }}
-  livenessProbe:
-{{ toYaml .Values.clusterManager.livenessProbe | indent 4 }}
+    livenessProbe:
+{{ toYaml .Values.clusterManager.livenessProbe | indent 6 }}
 {{- end }}
 {{- if .Values.clusterManager.readinessProbe }}
-  readinessProbe:
-{{ toYaml .Values.clusterManager.readinessProbe | indent 4 }}
+    readinessProbe:
+{{ toYaml .Values.clusterManager.readinessProbe | indent 6 }}
 {{- end }}
 {{- with .Values.clusterManager.etcVolumeStorageConfig }}
-  etcVolumeStorageConfig:
-{{ toYaml . | indent 4 }}
+    etcVolumeStorageConfig:
+{{ toYaml . | indent 6 }}
 {{- end }}
 {{- with .Values.clusterManager.varVolumeStorageConfig }}
-  varVolumeStorageConfig:
-{{ toYaml . | indent 4 }}
+    varVolumeStorageConfig:
+{{ toYaml . | indent 6 }}
 {{- end }}
 {{- with .Values.clusterManager.resources }}
-  resources:
-{{ toYaml . | indent 4 }}
+    resources:
+{{ toYaml . | indent 6 }}
 {{- end }}
 {{- if .Values.clusterManager.serviceAccount }}
-  serviceAccount: {{ .Values.clusterManager.serviceAccount }}
+    serviceAccount: {{ .Values.clusterManager.serviceAccount }}
 {{- end }}
 {{- with .Values.clusterManager.serviceTemplate }}
-  serviceTemplate:
-{{ toYaml . | indent 4 }}
+    serviceTemplate:
+{{ toYaml . | indent 6 }}
 {{- end }}
 {{- with .Values.clusterManager.tolerations }}
-  tolerations:
-{{ toYaml . | indent 4 }}
+    tolerations:
+{{ toYaml . | indent 6 }}
 {{- end }}
 {{- if .Values.clusterManager.topologySpreadConstraints }}
 {{- with .Values.clusterManager.topologySpreadConstraints }}
-  topologySpreadConstraints:
-{{ toYaml . | indent 4 }}
+    topologySpreadConstraints:
+{{ toYaml . | indent 6 }}
 {{- end }}
 {{- end }}
 {{- if and .Values.sva.m4.enabled  .Values.sva.m4.clusterManager.zone }}
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-        - matchExpressions:
-          - key: topology.kubernetes.io/zone
-            operator: In
-            values:
-            - {{ .Values.sva.m4.clusterManager.zone }}
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+              - {{ .Values.sva.m4.clusterManager.zone }}
 {{- else }}
   {{- with .Values.clusterManager.affinity }}
-  affinity:
-{{ toYaml . | indent 4 }}
+    affinity:
+{{ toYaml . | indent 6 }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm-chart/splunk-enterprise/templates/enterprise_v4_indexercluster.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v4_indexercluster.yaml
@@ -2,12 +2,14 @@
 apiVersion: v1
 kind: List
 items:
+{{- range default (default (until 1)) .Values.sva.m4.totalCluster }}
+{{ $cmname := .name }}
 {{- range default (default (until 1) .Values.sva.c3.indexerClusters) .Values.sva.m4.indexerClusters }}
 - apiVersion:  enterprise.splunk.com/v4
   kind: IndexerCluster
   metadata:
   {{- if or $.Values.sva.c3.enabled $.Values.sva.m4.enabled }}
-    name: {{ .name }}
+    name: {{ $cmname }}-}{{ .name }}
   {{- else if $.Values.indexerCluster.enabled }}
     name: {{ $.Values.indexerCluster.name }}
   {{- end }}
@@ -35,7 +37,7 @@ items:
     {{- end }}
   {{- else if or $.Values.clusterManager.enabled $.Values.sva.c3.enabled $.Values.sva.m4.enabled }}
     clusterManagerRef:
-      name: {{ $.Values.clusterManager.name }}
+      name: {{ $cmname }}
     {{- if $.Values.clusterManager.namespaceOverride }}
       namespace: {{ $.Values.clusterManager.namespaceOverride }}
     {{- end }}
@@ -93,7 +95,7 @@ items:
     {{- end }}
     defaults: |-
       splunk:
-        multisite_master: splunk-{{ $cm_name }}-cluster-manager-service
+        multisite_master: splunk-{{ $cmname }}-cluster-manager-service
         site: {{ .site }}
   {{- else if $.Values.indexerCluster.defaults }}
     defaults: |-
@@ -163,5 +165,6 @@ items:
 {{ toYaml . | indent 6 }}
     {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm-chart/splunk-enterprise/templates/enterprise_v4_licensemanager.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v4_licensemanager.yaml
@@ -23,9 +23,17 @@ spec:
   {{- if .Values.existingClusterManager.namespace }}
     namespace: {{ .Values.existingClusterManager.namespace }}
   {{- end }}
-{{- else if or .Values.clusterManager.enabled .Values.sva.c3.enabled .Values.sva.m4.enabled }}
+{{- else if or .Values.clusterManager.enabled .Values.sva.c3.enabled }}
   clusterManagerRef:
     name: {{ .Values.clusterManager.name }}
+  {{- if .Values.clusterManager.namespaceOverride }}
+    namespace: {{ .Values.clusterManager.namespaceOverride }}
+  {{- end }}
+{{- else if .Values.sva.m4.enabled }}
+  clusterManagerRef:
+    {{- with (first .Values.sva.m4.totalCluster) }}
+    name: {{ .name }}
+    {{- end }}
   {{- if .Values.clusterManager.namespaceOverride }}
     namespace: {{ .Values.clusterManager.namespaceOverride }}
   {{- end }}

--- a/helm-chart/splunk-enterprise/templates/enterprise_v4_licensemanager.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v4_licensemanager.yaml
@@ -31,9 +31,7 @@ spec:
   {{- end }}
 {{- else if .Values.sva.m4.enabled }}
   clusterManagerRef:
-    {{- with (first .Values.sva.m4.totalCluster) }}
-    name: {{ .name }}
-    {{- end }}
+    name: {{ include "cm_name_first" . }}
   {{- if .Values.clusterManager.namespaceOverride }}
     namespace: {{ .Values.clusterManager.namespaceOverride }}
   {{- end }}

--- a/helm-chart/splunk-enterprise/templates/enterprise_v4_monitoringconsole.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v4_monitoringconsole.yaml
@@ -23,9 +23,15 @@ spec:
   {{- if .Values.existingClusterManager.namespace }}
     namespace: {{ .Values.existingClusterManager.namespace }}
   {{- end }}
-{{- else if or .Values.clusterManager.enabled .Values.sva.c3.enabled .Values.sva.m4.enabled }}
+{{- else if or .Values.clusterManager.enabled .Values.sva.c3.enabled }}
   clusterManagerRef:
     name: {{ .Values.clusterManager.name }}
+  {{- if .Values.clusterManager.namespaceOverride }}
+    namespace: {{ .Values.clusterManager.namespaceOverride }}
+  {{- end }}
+{{- else if .Values.sva.m4.enabled }}
+  clusterManagerRef:
+    name: {{ include "cm_name_first" . }}
   {{- if .Values.clusterManager.namespaceOverride }}
     namespace: {{ .Values.clusterManager.namespaceOverride }}
   {{- end }}

--- a/helm-chart/splunk-enterprise/templates/enterprise_v4_monitoringconsole.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v4_monitoringconsole.yaml
@@ -72,6 +72,11 @@ spec:
 {{- if .Values.monitoringConsole.defaults }}
   defaults: |-
 {{ toYaml .Values.monitoringConsole.defaults | indent 4 }}
+{{- else if $.Values.sva.m4.enabled }}
+  defaults: |-
+    splunk:
+      multisite_master: {{ include "cmlist" . }}
+      site: {{ .site }}
 {{- end }}
 {{- if .Values.monitoringConsole.defaultsUrlApps }}
   defaultsUrlApps: {{ .Values.monitoringConsole.defaultsUrlApps }}

--- a/helm-chart/splunk-enterprise/templates/enterprise_v4_searchheadcluster.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v4_searchheadcluster.yaml
@@ -94,13 +94,9 @@ items:
     defaultsUrl: {{ $.Values.searchHeadCluster.defaultsUrl }}
   {{- end }}
   {{- if $.Values.sva.m4.enabled }}
-    {{- $cm_name := $.Values.clusterManager.name -}}
-    {{- if and $.Values.existingClusterManager $.Values.existingClusterManager.name }}
-      {{- $cm_name = $.Values.existingClusterManager.name -}}
-    {{- end }}
     defaults: |-
       splunk:
-        multisite_master: splunk-{{ $cm_name }}-cluster-manager-service
+        multisite_master: {{ include "cmlist" . }}
         site: {{ .site }}
   {{- else if $.Values.searchHeadCluster.defaults }}
     defaults: |-

--- a/helm-chart/splunk-enterprise/templates/enterprise_v4_searchheadcluster.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v4_searchheadcluster.yaml
@@ -34,11 +34,17 @@ items:
     {{- if $.Values.existingClusterManager.namespace }}
       namespace: {{ $.Values.existingClusterManager.namespace }}
     {{- end }}
-  {{- else if or $.Values.clusterManager.enabled $.Values.sva.c3.enabled $.Values.sva.m4.enabled }}
+  {{- else if or .Values.clusterManager.enabled .Values.sva.c3.enabled }}
     clusterManagerRef:
-      name: {{ $.Values.clusterManager.name }}
-    {{- if $.Values.clusterManager.namespaceOverride }}
-      namespace: {{ $.Values.clusterManager.namespaceOverride }}
+      name: {{ .Values.clusterManager.name }}
+    {{- if .Values.clusterManager.namespaceOverride }}
+      namespace: {{ .Values.clusterManager.namespaceOverride }}
+    {{- end }}
+  {{- else if .Values.sva.m4.enabled }}
+    clusterManagerRef:
+      name: {{ include "cm_name_first" . }}
+    {{- if .Values.clusterManager.namespaceOverride }}
+      namespace: {{ .Values.clusterManager.namespaceOverride }}
     {{- end }}
   {{- end }}
   {{- if $.Values.existingLicenseManager }}

--- a/helm-chart/splunk-enterprise/values.yaml
+++ b/helm-chart/splunk-enterprise/values.yaml
@@ -39,12 +39,16 @@ sva:
   m4:
 
     enabled: false
-
+    
     clusterManager: {}
       # allSites: "site1,site2"
       # site: site1
       # zone: us-west-1a
-
+    
+    totalCluster: []
+    # - name: cm-1
+    # - name: cm-2
+    
     indexerClusters: []
       # - name: idx1
       #   site: site1

--- a/helm-chart/splunk-enterprise/values.yaml
+++ b/helm-chart/splunk-enterprise/values.yaml
@@ -44,9 +44,10 @@ sva:
       # allSites: "site1,site2"
       # site: site1
       # zone: us-west-1a
-    
-    totalCluster: []
-    # - name: cm-1
+
+    #total number of indexer clusters needed in the deployment. 
+    totalCluster: 
+    - name: cm-1
     # - name: cm-2
     
     indexerClusters: []


### PR DESCRIPTION
Current helm charts dont support creating multiple indexer cluster and configuring SH/MC to support. 

This will add support to all create and configure multiple indexer clusters out of the box. 