### PR TITLE
CSPL-2721: Upgrade Path : removed MC flow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi8/ubi:8.10
 
 ENV OPERATOR=/manager \
     USER_UID=1001 \

--- a/pkg/splunk/enterprise/upgrade.go
+++ b/pkg/splunk/enterprise/upgrade.go
@@ -160,40 +160,6 @@ MonitoringConsole:
 		}
 		return true, nil
 	} else {
-
-		// check if a MonitoringConsole is attached to the instance
-		monitoringConsoleRef := spec.MonitoringConsoleRef
-		if monitoringConsoleRef.Name == "" {
-			goto SearchHeadCluster
-		}
-
-		namespacedName := types.NamespacedName{Namespace: cr.GetNamespace(), Name: monitoringConsoleRef.Name}
-		monitoringConsole := &enterpriseApi.MonitoringConsole{}
-
-		// get the monitoring console referred in custom resource
-		err := c.Get(ctx, namespacedName, monitoringConsole)
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				goto SearchHeadCluster
-			}
-			eventPublisher.Warning(ctx, "UpgradePathValidation", fmt.Sprintf("Could not find the Monitoring Console. Reason %v", err))
-			scopedLog.Error(err, "Unable to get Monitoring Console")
-			return false, err
-		}
-
-		mcImage, err := getCurrentImage(ctx, c, monitoringConsole, SplunkMonitoringConsole)
-		if err != nil {
-			eventPublisher.Warning(ctx, "UpgradePathValidation", fmt.Sprintf("Could not get the Monitoring Console Image. Reason %v", err))
-			scopedLog.Error(err, "Unable to get Monitoring Console current image")
-			return false, err
-		}
-
-		// check if an image upgrade is happening and whether MC has finished updating yet, return false to stop
-		// further reconcile operations on custom resource until MC is ready
-		if monitoringConsole.Status.Phase != enterpriseApi.PhaseReady || mcImage != spec.Image {
-			return false, nil
-		}
-
 		goto SearchHeadCluster
 	}
 SearchHeadCluster:


### PR DESCRIPTION
Several customers have reported that the current upgrade flow of the Splunk Operator is causing delays in starting indexers and search head clusters due to the Monitoring Console (MC) container sometimes failing to start. The proposed new upgrade flow aims to speed up the process by altering the order in which components are started.

**Current Flow:**

- License Manager
- Cluster Manager
- MC
- Search Head
- Indexers

**Proposed New Flow:**

- License Manager
- Cluster Manager
- Search Head
- Indexers
