### PR TITLE
Splunk STS bug workaround

### DIFF
--- a/tools/k8_probes/livenessProbe.sh
+++ b/tools/k8_probes/livenessProbe.sh
@@ -44,7 +44,16 @@ liveness_probe_check_splunkd_process() {
   case "$state" in
   running|started)
       if [[ "" != "$SPLUNK_PROCESS_ID" ]]; then
-         exit 0
+        rsyncError=$(grep "Failed to execute runSync()" /opt/splunk/var/log/splunk/splunkd.log | tail -1)
+        if [[ "" != "$rsyncError" ]]; then
+            echo "Failed to execute runSync()"
+            echo "$rsyncError"
+            echo "going to recycle the pod."
+            exit 1
+        else
+            echo "No issues with STS service."
+        fi
+        exit 0
       fi
 
       # Goes to the the pod event
@@ -67,6 +76,15 @@ liveness_probe_default() {
     running|started)
         curl --max-time 30 --fail --insecure $HTTP_SCHEME://localhost:8089/
         if [[ $? == 0 ]]; then
+            rsyncError=$(grep "Failed to execute runSync()" /opt/splunk/var/log/splunk/splunkd.log | tail -1)
+            if [[ "" != "$rsyncError" ]]; then
+                echo "Failed to execute runSync()"
+                echo "$rsyncError"
+                echo "going to recycle the pod."
+                exit 1
+            else
+                echo "No issues with STS service."
+            fi
             exit 0
         fi
 


### PR DESCRIPTION
Splunkd is not able to refresh STS token after 36hr and that is bring the pod in a wierd state.. Where it is reporting as down to CM but the Splunkd process is not down..

We tried restarting Splunkd on a cadence via the app here but that doesnt seem to be working.

Adding this liveliness probe update which will check for the same error and if the error exists it will just kill the pod ( something that we are doing today to manually fix this issue.