### PR TITLE
Clean Up AWS Resources After Cluster Deletion

### DIFF
--- a/test/deploy-eks-cluster.sh
+++ b/test/deploy-eks-cluster.sh
@@ -22,6 +22,7 @@ fi
 
 function deleteCluster() {
   echo "Cleanup role, security-group, open-id ${TEST_CLUSTER_NAME}"
+  account_id=$(aws sts get-caller-identity --query "Account" --output text)
   rolename=$(echo ${TEST_CLUSTER_NAME} | awk -F- '{print "EBS_" $(NF-1) "_" $(NF)}')
   role_attached_policies=$(aws iam list-attached-role-policies --role-name $rolename --query 'AttachedPolicies[*].PolicyArn' --output text)
   for policy_arn in ${role_attached_policies};

--- a/test/deploy-eks-cluster.sh
+++ b/test/deploy-eks-cluster.sh
@@ -34,7 +34,6 @@ function deleteCluster() {
   oidc_id=$(aws eks describe-cluster --name ${TEST_CLUSTER_NAME} --query "cluster.identity.oidc.issuer" --output text | cut -d '/' -f 5)
   aws iam delete-open-id-connect-provider --open-id-connect-provider-arn arn:aws:iam::${account_id}:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/${oidc_id}
   security_group_id=$(aws eks describe-cluster --name ${TEST_CLUSTER_NAME} --query "cluster.resourcesVpcConfig.securityGroupIds[0]" --output text)
-  aws ec2 delete-security-group --group-id ${security_group_id}
   echo "Cleanup remaining PVC on the EKS Cluster ${TEST_CLUSTER_NAME}"
 
   echo "Cleanup remaining PVC on the EKS Cluster ${TEST_CLUSTER_NAME}"
@@ -51,6 +50,7 @@ function deleteCluster() {
     echo "Unable to delete cluster - ${TEST_CLUSTER_NAME}"
     return 1
   fi
+  aws ec2 delete-security-group --group-id ${security_group_id}
 
   return 0
 }

--- a/test/deploy-eks-cluster.sh
+++ b/test/deploy-eks-cluster.sh
@@ -32,7 +32,7 @@ function deleteCluster() {
 
   aws iam delete-role --role-name ${rolename}
   oidc_id=$(aws eks describe-cluster --name ${TEST_CLUSTER_NAME} --query "cluster.identity.oidc.issuer" --output text | cut -d '/' -f 5)
-  aws iam delete-open-id-connect-provider --open-id-connect-provider-arn arn:aws:iam::${account_id}:oidc-provider/${oidc_id}
+  aws iam delete-open-id-connect-provider --open-id-connect-provider-arn arn:aws:iam::${account_id}:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/${oidc_id}
   security_group_id=$(aws eks describe-cluster --name ${TEST_CLUSTER_NAME} --query "cluster.resourcesVpcConfig.securityGroupIds[0]" --output text)
   aws ec2 delete-security-group --group-id ${security_group_id}
   echo "Cleanup remaining PVC on the EKS Cluster ${TEST_CLUSTER_NAME}"


### PR DESCRIPTION
### Clean Up AWS Resources After Cluster Deletion

#### Description
This PR introduces automation to clean up any remaining AWS resources, specifically **Security Groups** and **OIDC IDs**, after a Kubernetes cluster deletion. The objective is to ensure no orphaned resources are left behind once the pipeline completes, preventing unnecessary resource usage and avoiding potential security risks associated with leftover configurations.

#### Changes
- Implemented logic to delete **AWS Security Groups** associated with the cluster after deletion.
- Added cleanup for **OIDC ID** to remove any lingering identity provider configurations post-cluster deletion.
- Ensured the cleanup process runs at the end of the pipeline to capture any residual resources after all steps have completed.

#### Why This Is Needed
Leaving behind AWS Security Groups and OIDC configurations can lead to:
- **Increased Costs**: Unused resources incur costs if not removed.
- **Security Risks**: Unused Security Groups and identity configurations may expose the account to unauthorized access.
- **Resource Clutter**: Keeping a clean environment is crucial for maintaining accurate and effective resource management.

#### Testing
- Verified that Security Groups are correctly identified and deleted after cluster deletion.
- Tested OIDC ID removal in different scenarios to ensure compatibility with existing workflows.
- Confirmed no resources remain after pipeline completion.

#### Additional Notes
Please review the resource deletion logic to ensure it aligns with existing resource tagging conventions and does not inadvertently delete in-use resources in shared environments.

---

This PR will help maintain a clean AWS environment and improve resource efficiency in our CI/CD pipeline.