### PR TITLE
[CSPL-3269] Change error log for clarification

### DIFF
--- a/pkg/splunk/enterprise/afwscheduler.go
+++ b/pkg/splunk/enterprise/afwscheduler.go
@@ -822,7 +822,7 @@ func getAppTopFolderFromPackage(rctx context.Context, cr splcommon.MetaObject, a
 		// The onus falls on the user to make sure the app packages are tarred appropriately
 		// to avoid the re-installation cycles as it is prudent to continue
 		// to the install step for harmless warnings
-		scopedLog.Info("Error in tar contents list, app can still be installed", "stdOut", stdOut, "stdErr", stdErr, "command", command, "appPkgPathOnPod", appPkgPathOnPod)
+		scopedLog.Info("Error in tar contents list, but app installation will continue", "stdOut", stdOut, "stdErr", stdErr, "command", command, "appPkgPathOnPod", appPkgPathOnPod)
 		if stdOut == "" {
 			return "Empty app package name, could not get installed app name", err
 		}

--- a/pkg/splunk/enterprise/afwscheduler.go
+++ b/pkg/splunk/enterprise/afwscheduler.go
@@ -822,7 +822,7 @@ func getAppTopFolderFromPackage(rctx context.Context, cr splcommon.MetaObject, a
 		// The onus falls on the user to make sure the app packages are tarred appropriately
 		// to avoid the re-installation cycles as it is prudent to continue
 		// to the install step for harmless warnings
-		scopedLog.Info("Error in tar contents list, but app installation will continue", "stdOut", stdOut, "stdErr", stdErr, "command", command, "appPkgPathOnPod", appPkgPathOnPod)
+		scopedLog.Error(err, "Error in tar contents list, but app installation will continue", "stdOut", stdOut, "stdErr", stdErr, "command", command, "appPkgPathOnPod", appPkgPathOnPod)
 		if stdOut == "" {
 			return "Empty app package name, could not get installed app name", err
 		}

--- a/pkg/splunk/enterprise/afwscheduler.go
+++ b/pkg/splunk/enterprise/afwscheduler.go
@@ -822,7 +822,7 @@ func getAppTopFolderFromPackage(rctx context.Context, cr splcommon.MetaObject, a
 		// The onus falls on the user to make sure the app packages are tarred appropriately
 		// to avoid the re-installation cycles as it is prudent to continue
 		// to the install step for harmless warnings
-		scopedLog.Error(err, "Error in tar contents list, but app installation will continue", "stdOut", stdOut, "stdErr", stdErr, "command", command, "appPkgPathOnPod", appPkgPathOnPod)
+		scopedLog.Error(err, "error in tar contents list, but app installation will continue", "stdOut", stdOut, "stdErr", stdErr, "command", command, "appPkgPathOnPod", appPkgPathOnPod)
 		if stdOut == "" {
 			return "Empty app package name, could not get installed app name", err
 		}

--- a/pkg/splunk/enterprise/afwscheduler.go
+++ b/pkg/splunk/enterprise/afwscheduler.go
@@ -822,7 +822,7 @@ func getAppTopFolderFromPackage(rctx context.Context, cr splcommon.MetaObject, a
 		// The onus falls on the user to make sure the app packages are tarred appropriately
 		// to avoid the re-installation cycles as it is prudent to continue
 		// to the install step for harmless warnings
-		scopedLog.Error(err, "could not get installed app name", "stdOut", stdOut, "stdErr", stdErr, "command", command, "appPkgPathOnPod", appPkgPathOnPod)
+		scopedLog.Info("Error in tar contents list, app can still be installed", "stdOut", stdOut, "stdErr", stdErr, "command", command, "appPkgPathOnPod", appPkgPathOnPod)
 		if stdOut == "" {
 			return "Empty app package name, could not get installed app name", err
 		}


### PR DESCRIPTION
GitHub Issue: https://github.com/splunk/splunk-operator/issues/1309

This issue was resolved in https://github.com/splunk/splunk-operator/pull/1327, but this error log makes it seem like app installation will still fail. Changing the log from error the info and updating the log should provide a better experience.