### PR TITLE
Update distroless RC and release tags

### DIFF
--- a/.github/workflows/automated-release-workflow.yml
+++ b/.github/workflows/automated-release-workflow.yml
@@ -105,3 +105,28 @@ jobs:
       env:
         COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
 
+    - name: Pull Distroless RC Splunk Operator Image
+      run: |
+        docker pull splunk/splunk-operator-rc:${{ github.event.inputs.release_version }}-distroless-RC
+
+    - name: Promote Distroless RC Image to Release
+      run: |
+        docker tag splunk/splunk-operator-rc:${{ github.event.inputs.release_version }}-distroless-RC splunk/splunk-operator:${{ github.event.inputs.operator_image_tag }}-distroless
+
+    - name: Push Distroless Release Image
+      run: |
+        docker push splunk/splunk-operator:${{ github.event.inputs.operator_image_tag }}-distroless
+    
+    - name: Sign Distroless Splunk Operator image with a key
+      run: |
+        cosign sign --yes --key env://COSIGN_PRIVATE_KEY  splunk/splunk-operator:${{ github.event.inputs.operator_image_tag }}-distroless
+      env:
+        COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+    
+    - name: Verify Distroless Splunk Operator image with a key
+      run: |
+        cosign verify --key env://COSIGN_PUBLIC_KEY  splunk/splunk-operator:${{ github.event.inputs.operator_image_tag }}-distroless
+      env:
+        COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
+

--- a/.github/workflows/merge-develop-to-main-workflow.yml
+++ b/.github/workflows/merge-develop-to-main-workflow.yml
@@ -95,11 +95,11 @@ jobs:
       # Build and push Distroless image
       - name: Build Distroless Image
         run: |
-          make docker-build IMG=splunk/splunk-operator-distroless:${{ github.event.inputs.release_version }}-RC${{ github.event.inputs.release_candiate_version }} BASE_IMAGE=gcr.io/distroless/static BASE_IMAGE_VERSION=latest
+          make docker-build IMG=splunk/splunk-operator-rc:${{ github.event.inputs.release_version }}-distroless-RC${{ github.event.inputs.release_candiate_version }} BASE_IMAGE=gcr.io/distroless/static BASE_IMAGE_VERSION=latest
 
       - name: Push Distroless Image
         run: |
-          make docker-push IMG=splunk/splunk-operator-distroless:${{ github.event.inputs.release_version }}-RC${{ github.event.inputs.release_candiate_version }}
+          make docker-push IMG=splunk/splunk-operator-rc:${{ github.event.inputs.release_version }}-distroless-RC${{ github.event.inputs.release_candiate_version }}
 
       - name: Tag and Push Default UBI RC Image
         run: |
@@ -108,8 +108,8 @@ jobs:
 
       - name: Tag and Push Default Distroless RC Image
         run: |
-          docker tag splunk/splunk-operator:${{ github.event.inputs.release_version }}-RC${{ github.event.inputs.release_candiate_version }}-distroless splunk/splunk-operator-distroless:${{ github.event.inputs.release_version }}-RC-distroless
-          docker push splunk/splunk-operator:${{ github.event.inputs.release_version }}-RC-distroless
+          docker tag splunk/splunk-operator-rc:${{ github.event.inputs.release_version }}-distroless-RC${{ github.event.inputs.release_candiate_version }} splunk/splunk-operator-rc:${{ github.event.inputs.release_version }}-distroless-RC
+          docker push splunk/splunk-operator-rc:${{ github.event.inputs.release_version }}-distroless-RC
 
       - name: Generate Release Artifacts
         run: |


### PR DESCRIPTION
This change will make the distroless image build and push to dockerhub with the -distroless-RC tag in the splunk/splunk-operator-rc repository in the merge to main workflow, and the -distroless tag in the splunk/splunk-operator repository on the automated release workflow.