### PR TITLE
Move pushing latest image from build test workflow to automated releasese workflow

### DIFF
--- a/.github/workflows/automated-release-workflow.yml
+++ b/.github/workflows/automated-release-workflow.yml
@@ -87,10 +87,12 @@ jobs:
     - name: Promote RC Image to Release
       run: |
         docker tag splunk/splunk-operator-rc:${{ github.event.inputs.release_version }}-RC splunk/splunk-operator:${{ github.event.inputs.operator_image_tag }}
+        docker tag splunk/splunk-operator:${{ github.event.inputs.operator_image_tag }} splunk/splunk-operator:latest
 
     - name: Push Release Image
       run: |
         docker push splunk/splunk-operator:${{ github.event.inputs.operator_image_tag }}
+        docker push splunk/splunk-operator:latest
     
     - name: Sign Splunk Operator image with a key
       run: |

--- a/.github/workflows/build-test-push-workflow.yml
+++ b/.github/workflows/build-test-push-workflow.yml
@@ -303,36 +303,3 @@ jobs:
       #    name: Integration Tests          # Name of the check run which will be created
       #    path: inttest-*.xml         # Path to test results
       #    reporter: jest-junit        # Format of test results
-  push-latest:
-    needs: smoke-tests
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    env:
-      SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
-      TAG: latest
-    steps:
-    - name: Checkout Code
-      uses: actions/checkout@v2
-    - name: Dotenv Action
-      id: dotenv
-      uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2.5.0
-    - name: Configure Docker Hub credentials
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PUSH_TOKEN}}
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-    - name: Login to Amazon ECR
-      uses: aws-actions/amazon-ecr-login@v1
-    - name: Re-tag Splunk Operator Image
-      run: |
-        docker tag ${{ secrets.ECR_REPOSITORY }}/${{ env.SPLUNK_OPERATOR_IMAGE_NAME }}:$GITHUB_SHA ${{ env.SPLUNK_OPERATOR_IMAGE_NAME }}:${{ env.TAG }}
-    - name: Push Splunk Operator Image to Docker Hub
-      run: docker push ${{ env.SPLUNK_OPERATOR_IMAGE_NAME }}:${{ env.TAG }}

--- a/.github/workflows/distroless-build-test-push-workflow.yml
+++ b/.github/workflows/distroless-build-test-push-workflow.yml
@@ -301,36 +301,3 @@ jobs:
       #    name: Integration Tests          # Name of the check run which will be created
       #    path: inttest-*.xml         # Path to test results
       #    reporter: jest-junit        # Format of test results
-  push-latest:
-    needs: smoke-tests
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    env:
-      SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
-      TAG: latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
-      - name: Dotenv Action
-        id: dotenv
-        uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.5.0
-      - name: Configure Docker Hub credentials
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PUSH_TOKEN}}
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v1
-      - name: Re-tag Splunk Operator Image
-        run: |
-          docker tag ${{ secrets.ECR_REPOSITORY }}/${{ env.SPLUNK_OPERATOR_IMAGE_NAME }}:$GITHUB_SHA-distroless ${{ env.SPLUNK_OPERATOR_IMAGE_NAME }}:${{ env.TAG }}-distroless
-      - name: Push Splunk Operator Image to Docker Hub
-        run: docker push ${{ env.SPLUNK_OPERATOR_IMAGE_NAME }}:${{ env.TAG }}


### PR DESCRIPTION
This change moves pushing the latest dockerhub tag from the build-test-push workflow to the automated-release workflow. The latest tag and the release tag should be the same image, so pushing both together is the best option instead of pushing two separate images.