### PR TITLE
CSPL-3518 Service Type default does not get overwritten if not set to ClusterIP

### DIFF
--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -326,10 +326,6 @@ func setServiceTemplateDefaults(spec *enterpriseApi.Spec) {
 			}
 		}
 	}
-
-	if spec.ServiceTemplate.Spec.Type == "" {
-		spec.ServiceTemplate.Spec.Type = corev1.ServiceTypeClusterIP
-	}
 }
 
 // validateCommonSplunkSpec checks validity and makes default updates to a CommonSplunkSpec, and returns error if something is wrong.


### PR DESCRIPTION
### Description

This PR makes sure that if the CRD template default value of serviceTemplate/properties/spec/properties/type is overwritten to NodePort, then SOK doesn't try to overwrite it back to ClusterIP. ClusterIP is a Kubernetes default value for ServiceType, so no extra effort is required from SOK.

### Key Changes

The following if condition is removed from the code. This way, SOK depends either on a Kubernetes default or on a user-provided default.
```
if spec.ServiceTemplate.Spec.Type == "" {
		spec.ServiceTemplate.Spec.Type = corev1.ServiceTypeClusterIP
	}
```

### Testing and Verification

The change doesn't impact already existing tests. 

The change doesn't require any automated tests update or new tests because the CRD template is provided by the SOK team as it is defining a guideline on how to setup resources and modifications are possible, but can not be fully validated and confirmed for all possible scenarios that might happen.

Below manual tests were performed to confirm the change.

1) Kubernetes operator provisioned with PR changes and IndexCluster CRD serviceTemplate/properties/spec/properties/type advanced with default: NodePort.

```
...
splunk-idxc-test-indexer-service         NodePort    10.100.70.138    <none>        8000:30719/TCP,8084:30742/TCP,8088:32310/TCP,8089:30162/TCP,9997:30414/TCP   3s
```

2. Kubernetes operator provisioned with PR changes and IndexCluster CRD serviceTemplate/properties/spec/properties/type with no default value.

```
...
splunk-idxc-test-indexer-service    ClusterIP   10.100.140.208   <none>        8000/TCP,8084/TCP,8088/TCP,8089/TCP,9997/TCP   1s
```

3. Kubernetes operator provisioned with PR changes and IndexCluster CRD serviceTemplate/properties/spec/properties/type with no default value, but YAML file contains service type set to NodePort.

```
...
splunk-idxc-test-indexer-service         NodePort    10.100.122.54   <none>        8000:30822/TCP,8084:31058/TCP,8088:31393/TCP,8089:32405/TCP,9997:31175/TCP   4s
```

4. Kubernetes operator provisioned with PR changes and IndexCluster CRD serviceTemplate/properties/spec/properties/type advanced with default: NodePort, but YAML file contains service type set to ClusterIP.

```
...
splunk-idxc-test-indexer-service         ClusterIP   10.100.142.144   <none>        8084/TCP,8000/TCP,8088/TCP,8089/TCP,9997/TCP   3s
```

5. Kubernetes operator provisioned with PR changes and IndexCluster CRD serviceTemplate/properties/spec/properties/type with no default value (Helm).

```
...
splunk-idxc-indexer-service         ClusterIP   10.100.232.225   <none>        8000/TCP,8084/TCP,8088/TCP,8089/TCP,9997/TCP   11s
```

6. Kubernetes operator provisioned with PR changes and IndexCluster CRD serviceTemplate/properties/spec/properties/type advanced with default: NodePort (Helm).

```
...
splunk-idxc-indexer-service         NodePort    10.100.243.226   <none>        8000:31735/TCP,8084:31944/TCP,8088:31481/TCP,8089:31573/TCP,9997:31824/TCP   62s
```

7. Kubernetes operator provisioned with PR changes and IndexCluster CRD serviceTemplate/properties/spec/properties/type with no default value, but YAML file contains service type set to NodePort. (Helm)

```
...
splunk-idxc-indexer-service         NodePort    10.100.14.184    <none>        8000:30807/TCP,8084:30214/TCP,8088:30438/TCP,8089:31477/TCP,9997:31215/TCP   17s
```

8. Kubernetes operator provisioned with PR changes and IndexCluster CRD serviceTemplate/properties/spec/properties/type advanced with default: NodePort, but YAML file contains service type set to ClusterIP. (Helm)

```
...
splunk-idxc-indexer-service         ClusterIP   10.100.245.213   <none>        8084/TCP,8000/TCP,8088/TCP,8089/TCP,9997/TCP   7s
```

### Related Issues
Github Issue: https://github.com/splunk/splunk-operator/issues/1211
Jira task: https://splunk.atlassian.net/browse/CSPL-3518

### PR Checklist

- [x] Code changes adhere to the project's coding standards.
- [x] All tests pass locally.
- [x] The PR description follows the project's guidelines.