### PR TITLE
Update semgrep scanner to run on ubuntu latest

### DIFF
--- a/.github/workflows/prodsec-workflow.yml
+++ b/.github/workflows/prodsec-workflow.yml
@@ -8,7 +8,7 @@ name: Prodsec Workflow
 jobs:
   semgrep:
     name: Semgrep Scanner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:

--- a/.github/workflows/prodsec-workflow.yml
+++ b/.github/workflows/prodsec-workflow.yml
@@ -8,7 +8,7 @@ name: Prodsec Workflow
 jobs:
   semgrep:
     name: Semgrep Scanner
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:


### PR DESCRIPTION
Ubuntu-20.04 is deprecated and will be unsupported in less than 1 month. [This page](https://github.com/actions/runner-images/issues/11101) suggests using ubuntu-latest as another option.