### PR TITLE
CSPL-3534 Fixing string processing in cluster script

### DIFF
--- a/test/deploy-eks-cluster.sh
+++ b/test/deploy-eks-cluster.sh
@@ -107,13 +107,13 @@ function createCluster() {
         {
           \"Effect\": \"Allow\",
           \"Principal\": {
-            \"Federated\": \"arn:aws:iam::$account_id:oidc-provider/$oidc_provider\"
+            \"Federated\": \"arn:aws:iam::${account_id}:oidc-provider/${oidc_provider}\"
           },
           \"Action\": \"sts:AssumeRoleWithWebIdentity\",
           \"Condition\": {
             \"StringEquals\": {
-              \"$oidc_provider:aud\": \"sts.amazonaws.com\",
-              \"$oidc_provider:sub\": \"system:serviceaccount:$namespace:$service_account\"
+              \"${oidc_provider}:aud\": \"sts.amazonaws.com\",
+              \"${oidc_provider}:sub\": \"system:serviceaccount:${namespace}:${service_account}\"
             }
           }
         }


### PR DESCRIPTION
### Description

This PR fixes string processing of the AWS policy for creating a cluster setup. Previously, running the policy related command in the terminal resulted in an incorrect output.

### Key Changes

Changing `$variable` to `${variable}`.

### Testing and Verification

Running the policy related command in a local setup resulted in a correct input. This is a helper script and doesn't require writing or updating automated tests.

### Related Issues
**Github issue:** https://splunk.atlassian.net/browse/CSPL-3534

### PR Checklist
- [x] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [x] All tests pass locally.
- [x] The PR description follows the project's guidelines.
