### PR TITLE
CSPL-3529 Disable ARM Tests for Develop Branch

### DIFF
--- a/.github/workflows/arm-AL2023-build-test-push-workflow-AL2023.yml
+++ b/.github/workflows/arm-AL2023-build-test-push-workflow-AL2023.yml
@@ -1,9 +1,6 @@
 name: Arm AL2023 Smoke Test WorkFlow
 on:
-  push:
-    branches:
-      - develop
-      - main
+  workflow_dispatch:  
 jobs:
   check-formating:
     runs-on: ubuntu-latest

--- a/.github/workflows/arm-AL2023-int-test-workflow.yml
+++ b/.github/workflows/arm-AL2023-int-test-workflow.yml
@@ -1,9 +1,6 @@
 name: Arm AL2023 Integration Test WorkFlow
 on:
-  push:
-    branches:
-      - develop
-      - main
+  workflow_dispatch:
 jobs:
   build-operator-image-arm-al2023:
     runs-on: ubuntu-latest

--- a/.github/workflows/arm-Ubuntu-build-test-push-workflow.yml
+++ b/.github/workflows/arm-Ubuntu-build-test-push-workflow.yml
@@ -1,9 +1,6 @@
 name: Arm Ubuntu Smoke Test WorkFlow
 on:
-  push:
-    branches:
-      - develop
-      - main
+  workflow_dispatch:
 jobs:
   check-formating:
     runs-on: ubuntu-latest

--- a/.github/workflows/arm-Ubuntu-int-test-workflow.yml
+++ b/.github/workflows/arm-Ubuntu-int-test-workflow.yml
@@ -1,9 +1,6 @@
 name: Arm Ubuntu Integration Test WorkFlow Ubuntu
 on:
-  push:
-    branches:
-      - develop
-      - main
+  workflow_dispatch:
 jobs:
   build-operator-image-arm-ubuntu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

This PR disables ARM AL2023 tests run for develop branch since these tests should only run for release of ARM version. Otherwise, they fail.

### Key Changes

Removing `develop` branch name from a list of branches that are used to run ARM AL2023 tests.

### Testing and Verification

No automated or manual tests are required. Once this PR gets merged to main, it will be validated automatically. 

### Related Issues
**Github issue:** https://splunk.atlassian.net/browse/CSPL-3535

### PR Checklist
- [x] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [ ] All tests pass locally.
- [x] The PR description follows the project's guidelines.
