### PR TITLE
Bugfix/CSPL-3547 add app migration step to bias language script

### DIFF
--- a/docs/BiasLanguageMigration.md
+++ b/docs/BiasLanguageMigration.md
@@ -79,6 +79,7 @@ The `updated` folder has all of the files needed for the migration. The next ste
 10) Apply IndexerCluster CR
 11) Apply SearchHeadCluster CR
 12) Apply Standalone CR
+13) Migrate apps from master-app to manager-app directory
 
 Once you validate your environment, you can delete the CM and LM CRs using the files in the folder `to_remove_CRs`. 
 Example: `kubectl delete -f ./to_remove_CRs/<filename>`

--- a/docs/BiasLanguageMigration.md
+++ b/docs/BiasLanguageMigration.md
@@ -79,7 +79,7 @@ The `updated` folder has all of the files needed for the migration. The next ste
 10) Apply IndexerCluster CR
 11) Apply SearchHeadCluster CR
 12) Apply Standalone CR
-13) Migrate apps from master-app to manager-app directory
+13) Migrate apps from master-apps to manager-apps directory
 
 Once you validate your environment, you can delete the CM and LM CRs using the files in the folder `to_remove_CRs`. 
 Example: `kubectl delete -f ./to_remove_CRs/<filename>`


### PR DESCRIPTION
Bias language migration script should also contains step for migrating apps from directory master-apps to directory manager-app. 

This script adds an additional function to `tools/bias_lang_migration.sh` that is executing migration command on `cluster-manager` pods. Command's result is successfully performed migration to `manager-apps`
New function is only used in `migration` mode of migration script.

New revision of the script has been tested on V3->V4 `migrate` mode migrations, as well as manually.