### PR TITLE
CSPL-3580: Fix: Update Variable Formatting in deploy-eks-cluster.sh to Use ${variablename} for EBS Service Name Annotations

### DIFF
--- a/test/deploy-eks-cluster.sh
+++ b/test/deploy-eks-cluster.sh
@@ -122,8 +122,8 @@ function createCluster() {
     rolename=$(echo ${TEST_CLUSTER_NAME} | awk -F- '{print "EBS_" $(NF-1) "_" $(NF)}')
     aws iam create-role --role-name ${rolename} --assume-role-policy-document file://aws-ebs-csi-driver-trust-policy.json --description "irsa role for ${TEST_CLUSTER_NAME}"
     aws iam attach-role-policy  --policy-arn arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy  --role-name ${rolename}
-    kubectl annotate serviceaccount -n $namespace $service_account eks.amazonaws.com/role-arn=arn:aws:iam::$account_id:role/${rolename}
-    eksctl create addon --name aws-ebs-csi-driver --cluster ${TEST_CLUSTER_NAME} --service-account-role-arn arn:aws:iam::$account_id:role/${rolename} --force
+    kubectl annotate serviceaccount -n ${namespace} ${service_account} eks.amazonaws.com/role-arn=arn:aws:iam::${account_id}:role/${rolename}
+    eksctl create addon --name aws-ebs-csi-driver --cluster ${TEST_CLUSTER_NAME} --service-account-role-arn arn:aws:iam::${account_id}:role/${rolename} --force
     eksctl utils update-cluster-logging --cluster ${TEST_CLUSTER_NAME}
     # CSPL-2887 - Patch the default storage class to gp2
     kubectl patch storageclass gp2 -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'


### PR DESCRIPTION
**Title:** Fix: Update Variable Formatting in `deploy-eks-cluster.sh` to Use `${variablename}` for EBS Service Name Annotations

**Description:**

This PR addresses the bug in the `deploy-eks-cluster.sh` script where the incorrect formatting of variables was causing failures when adding IAM roles to the service account. Specifically, the issue stemmed from using `$variablename` instead of `${variablename}` for variable references, leading to incorrectly formatted values in the EBS service name annotations.

### Changes Made:
- Updated the variable formatting in `deploy-eks-cluster.sh` from `$variablename` to `${variablename}` to ensure proper handling in different shells.

### Impact:
- This fix ensures that the correct variable references are used, preventing incorrect formatting and ensuring that IAM roles, EBS volumes, and role policies are correctly applied.
- The issue of the wrong name being added to the EBS service name annotations is resolved.

### How to Test:
1. Run the `make cluster-up` command.
2. Verify that the cluster is created successfully without failures related to the incorrect formatting of variables.
3. Ensure that the correct names are added to the EBS service name annotations.

**Related Jira Ticket:** CSPL-3580 - Incorrect Formatting of IAM Role for Service Account

**Expected Outcome:**  
- The script should run successfully and add the IAM role and EBS volume correctly, with accurate service name annotations.
