### PR TITLE
Add wait in test cases after updating CR and before checking status

### DIFF
--- a/test/appframework_aws/c3/manager_appframework_test.go
+++ b/test/appframework_aws/c3/manager_appframework_test.go
@@ -427,6 +427,9 @@ var _ = Describe("c3appfw test", func() {
 			err = deployment.UpdateCR(ctx, idxc)
 			Expect(err).To(Succeed(), "Failed upgrade Indexer Cluster image")
 
+			// Allow time for update to take effect
+			time.Sleep(1 * time.Second)
+
 			// Ensure Cluster Manager goes to Ready phase
 			testenv.ClusterManagerReady(ctx, deployment, testcaseEnvInst)
 

--- a/test/appframework_aws/s1/appframework_aws_test.go
+++ b/test/appframework_aws/s1/appframework_aws_test.go
@@ -1066,6 +1066,9 @@ var _ = Describe("s1appfw test", func() {
 			err = deployment.UpdateCR(ctx, config)
 			Expect(err).To(Succeed(), "Unable to update config map")
 
+			// Allow time for update to take effect
+			time.Sleep(1 * time.Second)
+
 			// Wait for Standalone to be in READY status
 			testenv.StandaloneReady(ctx, deployment, deployment.GetName(), standalone, testcaseEnvInst)
 


### PR DESCRIPTION
### Description

This pull request introduces wait times after updating a CR in a test case and before checking the status. In the internal GitLab pipelines, these two test cases fail much more often than others. This is due to the fact that the "Ready" state of the CR from before the update is found before the update is applied, and the test case thinks that the "Ready" turns to an "Error". In reality, waiting even .5 seconds before checking the state will allow the CR to update and wait for the new "Ready" state to take effect and be consistent. I added a 1 second wait to be sure.

This is possibly related to similar fixes being done on the event emitting for test cases, but this small PR will be a quick fix for these specific tests.

### Key Changes

test/appframework_aws/c3/manager_appframework_test.go and test/appframework_aws/s1/appframework_aws_test.go
- Add a wait of 1 second to allow for the update to take effect before checking the state of the pod.
- I considered adding this wait in the UpdateCR() function, but that would greatly increase the amount of time needed to run the test suites, and seems to be stable on most test cases.

### Testing and Verification

These tests both passed locally after adding this wait.

### Related Issues

N/A

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [X] Relevant unit and integration tests are included.
- [X] Documentation has been updated accordingly.
- [X] All tests pass locally.
- [X] The PR description follows the project's guidelines.