### PR TITLE
CSPL-3673: Update install docs with arguments

### DIFF
--- a/docs/Install.md
+++ b/docs/Install.md
@@ -18,7 +18,7 @@ By installing `splunk-operator-cluster.yaml` Operator will watch all the namespa
 
 ```
 wget -O splunk-operator-cluster.yaml https://github.com/splunk/splunk-operator/releases/download/2.7.1/splunk-operator-cluster.yaml
-kubectl apply -f splunk-operator-cluster.yaml
+kubectl apply -f splunk-operator-cluster.yaml --server-side
 ```
 
 ## Install operator to watch multiple namespaces
@@ -48,7 +48,7 @@ In order to install operator with restrictive permission to watch only single na
 
 ```
 wget -O splunk-operator-namespace.yaml https://github.com/splunk/splunk-operator/releases/download/2.7.1/splunk-operator-namespace.yaml
-kubectl apply -f splunk-operator-namespace.yaml
+kubectl apply -f splunk-operator-namespace.yaml --server-side
 ```
 
 ## Private Registries

--- a/docs/README.md
+++ b/docs/README.md
@@ -121,6 +121,8 @@ A Kubernetes cluster administrator can install and start the Splunk Operator for
 kubectl apply -f https://github.com/splunk/splunk-operator/releases/download/2.7.1/splunk-operator-cluster.yaml --server-side  --force-conflicts
 ```
 
+The reason for appending `--server-side` and `--force-conflicts` to the apply command is that some of the CRDs are getting to long according to the CRD standards. There are no real implications caused by this.
+
 The [Advanced Installation Instructions](Install.md) page offers guidance for advanced configurations, including the use of private image registries, installation at cluster scope, and installing the Splunk Operator as a user who is not a Kubernetes administrator. Users of Red Hat OpenShift should review the [Red Hat OpenShift](OpenShift.md) page.
 
 *Note: We recommended that the Splunk Enterprise Docker image is copied to a private registry, or directly onto your Kubernetes workers before creating large Splunk Enterprise deployments. See the [Required Images Documentation](Images.md) page, and the [Advanced Installation Instructions](Install.md) page for guidance on working with copies of the Docker images.*


### PR DESCRIPTION
### Description

This PR updates the Install document to include the --server-side option in the command to install the operator. It also updates the description on the README as to why the --server-side option is needed.

### Key Changes

docs/Install.md
- Add `--server-side` as argument to command to install the operator

docs/README.md
- Add explanation why `--server-side` and `--force-conflicts` are used

### Testing and Verification

N/A

### Related Issues

- https://github.com/splunk/splunk-operator/issues/1157
- https://splunk.atlassian.net/browse/CSPL-3673

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [X] Relevant unit and integration tests are included.
- [X] Documentation has been updated accordingly.
- [X] All tests pass locally.
- [X] The PR description follows the project's guidelines.