### PR TITLE
bugfix: add extraEnvs to splunk-operator helm-chart

### DIFF
--- a/helm-chart/splunk-operator/templates/deployment.yaml
+++ b/helm-chart/splunk-operator/templates/deployment.yaml
@@ -79,7 +79,6 @@ spec:
 {{- else }}
             value: {{ .Release.Namespace }}
 {{- end }}
-
           - name: POD_NAME
             valueFrom:
               fieldRef:
@@ -90,6 +89,9 @@ spec:
             value: "{{ .Values.image.repository }}"
           - name: CLUSTER_DOMAIN
             value: {{ .Values.splunkOperator.clusterDomain | default "cluster.local" }}
+{{- with .Values.extraEnvs }}
+{{- toYaml . | trim | nindent 10 }}
+{{- end }}
           ports:
             {{- range .Values.splunkOperator.service.ports }}
             - containerPort: {{ .port }}

--- a/helm-chart/splunk-operator/values.yaml
+++ b/helm-chart/splunk-operator/values.yaml
@@ -174,3 +174,11 @@ extraManifests: []
 #    spec:
 #      securityPolicy:
 #        name: "gcp-cloud-armor-policy-test"
+
+# Additional envs to the splunk-operator container
+extraEnvs: []
+# extraEnvs
+#  - name: POD_IP
+#    valueFrom:
+#      fieldRef:
+#        fieldPath: status.podIP


### PR DESCRIPTION
Linked issue #1478 

This PR introduces `extraEnvs` list to `splunk-operator`'s values.yaml. This field is used by `deployment.yaml` template to inject custom envs provided by users.