### PR TITLE
CSPL-3704 #1474 Secret Management: SOK deletes automatically smartstore secrets created

### DIFF
--- a/.github/workflows/int-test-gcp-workflow.yml
+++ b/.github/workflows/int-test-gcp-workflow.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - develop
       - main
-      - CSPL-3704_smartstore_secret_deletion
 jobs:
   build-operator-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/int-test-gcp-workflow.yml
+++ b/.github/workflows/int-test-gcp-workflow.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - develop
       - main
-
+      - CSPL-3704_smartstore_secret_deletion
 jobs:
   build-operator-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/int-test-workflow.yml
+++ b/.github/workflows/int-test-workflow.yml
@@ -5,6 +5,7 @@ on:
       - develop
       - main
       - feature**
+      - CSPL-3704_smartstore_secret_deletion
 jobs:
   build-operator-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/int-test-workflow.yml
+++ b/.github/workflows/int-test-workflow.yml
@@ -5,7 +5,6 @@ on:
       - develop
       - main
       - feature**
-      - CSPL-3704_smartstore_secret_deletion
 jobs:
   build-operator-image:
     runs-on: ubuntu-latest

--- a/pkg/splunk/enterprise/clustermanager.go
+++ b/pkg/splunk/enterprise/clustermanager.go
@@ -128,6 +128,9 @@ func ApplyClusterManager(ctx context.Context, client splcommon.ControllerClient,
 		return result, err
 	}
 
+	// Smart Store secrets get created manually and should not be managed by the Operator
+	DeleteOwnerReferencesForResources(ctx, client, cr, &cr.Spec.SmartStore, SplunkClusterManager)
+
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
 		if cr.Spec.MonitoringConsoleRef.Name != "" {
@@ -154,7 +157,6 @@ func ApplyClusterManager(ctx context.Context, client splcommon.ControllerClient,
 			return result, err
 		}
 
-		DeleteOwnerReferencesForResources(ctx, client, cr, &cr.Spec.SmartStore, SplunkClusterManager)
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after

--- a/pkg/splunk/enterprise/clustermanager.go
+++ b/pkg/splunk/enterprise/clustermanager.go
@@ -129,7 +129,9 @@ func ApplyClusterManager(ctx context.Context, client splcommon.ControllerClient,
 	}
 
 	// Smart Store secrets get created manually and should not be managed by the Operator
-	DeleteOwnerReferencesForResources(ctx, client, cr, &cr.Spec.SmartStore, SplunkClusterManager)
+	if &cr.Spec.SmartStore != nil {
+		_ = DeleteOwnerReferencesForS3SecretObjects(ctx, client, cr, &cr.Spec.SmartStore)
+	}
 
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
@@ -156,6 +158,8 @@ func ApplyClusterManager(ctx context.Context, client splcommon.ControllerClient,
 		if err != nil {
 			return result, err
 		}
+
+		DeleteOwnerReferencesForResources(ctx, client, cr, SplunkClusterManager)
 
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 

--- a/pkg/splunk/enterprise/clustermaster.go
+++ b/pkg/splunk/enterprise/clustermaster.go
@@ -126,7 +126,9 @@ func ApplyClusterMaster(ctx context.Context, client splcommon.ControllerClient, 
 	}
 
 	// Smart Store secrets get created manually and should not be managed by the Operator
-	DeleteOwnerReferencesForResources(ctx, client, cr, &cr.Spec.SmartStore, SplunkClusterMaster)
+	if &cr.Spec.SmartStore != nil {
+		_ = DeleteOwnerReferencesForS3SecretObjects(ctx, client, cr, &cr.Spec.SmartStore)
+	}
 
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
@@ -147,7 +149,9 @@ func ApplyClusterMaster(ctx context.Context, client splcommon.ControllerClient, 
 				return result, err
 			}
 		}
-		
+
+		DeleteOwnerReferencesForResources(ctx, client, cr, SplunkClusterMaster)
+
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after
 			cr.Status.Phase = enterpriseApi.PhaseTerminating

--- a/pkg/splunk/enterprise/clustermaster.go
+++ b/pkg/splunk/enterprise/clustermaster.go
@@ -125,6 +125,9 @@ func ApplyClusterMaster(ctx context.Context, client splcommon.ControllerClient, 
 		return result, err
 	}
 
+	// Smart Store secrets get created manually and should not be managed by the Operator
+	DeleteOwnerReferencesForResources(ctx, client, cr, &cr.Spec.SmartStore, SplunkClusterMaster)
+
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
 		if cr.Spec.MonitoringConsoleRef.Name != "" {
@@ -144,9 +147,8 @@ func ApplyClusterMaster(ctx context.Context, client splcommon.ControllerClient, 
 				return result, err
 			}
 		}
-		DeleteOwnerReferencesForResources(ctx, client, cr, &cr.Spec.SmartStore, SplunkClusterMaster)
+		
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
-
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after
 			cr.Status.Phase = enterpriseApi.PhaseTerminating
 		} else {

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -125,11 +125,9 @@ func ApplyIndexerClusterManager(ctx context.Context, client splcommon.Controller
 		}
 	}
 
-	// Smart Store secrets get created manually and should not be managed by the Operator
-	DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkIndexer)
-
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
+		DeleteOwnerReferencesForResources(ctx, client, cr, SplunkIndexer)
 
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after
@@ -382,11 +380,10 @@ func ApplyIndexerCluster(ctx context.Context, client splcommon.ControllerClient,
 		}
 	}
 
-	// Smart Store secrets get created manually and should not be managed by the Operator
-	DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkIndexer)
-
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
+		DeleteOwnerReferencesForResources(ctx, client, cr, SplunkIndexer)
+
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after
 			cr.Status.Phase = enterpriseApi.PhaseTerminating

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -125,9 +125,12 @@ func ApplyIndexerClusterManager(ctx context.Context, client splcommon.Controller
 		}
 	}
 
+	// Smart Store secrets get created manually and should not be managed by the Operator
+	DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkIndexer)
+
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
-		DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkIndexer)
+
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after
 			cr.Status.Phase = enterpriseApi.PhaseTerminating
@@ -379,9 +382,11 @@ func ApplyIndexerCluster(ctx context.Context, client splcommon.ControllerClient,
 		}
 	}
 
+	// Smart Store secrets get created manually and should not be managed by the Operator
+	DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkIndexer)
+
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
-		DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkIndexer)
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after
 			cr.Status.Phase = enterpriseApi.PhaseTerminating

--- a/pkg/splunk/enterprise/licensemanager.go
+++ b/pkg/splunk/enterprise/licensemanager.go
@@ -90,6 +90,9 @@ func ApplyLicenseManager(ctx context.Context, client splcommon.ControllerClient,
 		return result, err
 	}
 
+	// Smart Store secrets get created manually and should not be managed by the Operator
+	DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkLicenseManager)
+
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
 		if cr.Spec.MonitoringConsoleRef.Name != "" {
@@ -108,9 +111,7 @@ func ApplyLicenseManager(ctx context.Context, client splcommon.ControllerClient,
 			}
 		}
 
-		DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkLicenseManager)
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
-
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after
 			cr.Status.Phase = enterpriseApi.PhaseTerminating
 		} else {

--- a/pkg/splunk/enterprise/licensemanager.go
+++ b/pkg/splunk/enterprise/licensemanager.go
@@ -90,9 +90,6 @@ func ApplyLicenseManager(ctx context.Context, client splcommon.ControllerClient,
 		return result, err
 	}
 
-	// Smart Store secrets get created manually and should not be managed by the Operator
-	DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkLicenseManager)
-
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
 		if cr.Spec.MonitoringConsoleRef.Name != "" {
@@ -101,6 +98,7 @@ func ApplyLicenseManager(ctx context.Context, client splcommon.ControllerClient,
 				return result, err
 			}
 		}
+
 		// If this is the last of its kind getting deleted,
 		// remove the entry for this CR type from configMap or else
 		// just decrement the refCount for this CR type.
@@ -110,6 +108,8 @@ func ApplyLicenseManager(ctx context.Context, client splcommon.ControllerClient,
 				return result, err
 			}
 		}
+
+		DeleteOwnerReferencesForResources(ctx, client, cr, SplunkLicenseManager)
 
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after

--- a/pkg/splunk/enterprise/licensemaster.go
+++ b/pkg/splunk/enterprise/licensemaster.go
@@ -90,6 +90,9 @@ func ApplyLicenseMaster(ctx context.Context, client splcommon.ControllerClient, 
 		return result, err
 	}
 
+	// Smart Store secrets get created manually and should not be managed by the Operator
+	DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkLicenseMaster)
+
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
 		if cr.Spec.MonitoringConsoleRef.Name != "" {
@@ -108,9 +111,7 @@ func ApplyLicenseMaster(ctx context.Context, client splcommon.ControllerClient, 
 			}
 		}
 
-		DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkLicenseMaster)
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
-
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after
 			cr.Status.Phase = enterpriseApi.PhaseTerminating
 		} else {

--- a/pkg/splunk/enterprise/licensemaster.go
+++ b/pkg/splunk/enterprise/licensemaster.go
@@ -90,9 +90,6 @@ func ApplyLicenseMaster(ctx context.Context, client splcommon.ControllerClient, 
 		return result, err
 	}
 
-	// Smart Store secrets get created manually and should not be managed by the Operator
-	DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkLicenseMaster)
-
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
 		if cr.Spec.MonitoringConsoleRef.Name != "" {
@@ -101,6 +98,7 @@ func ApplyLicenseMaster(ctx context.Context, client splcommon.ControllerClient, 
 				return result, err
 			}
 		}
+
 		// If this is the last of its kind getting deleted,
 		// remove the entry for this CR type from configMap or else
 		// just decrement the refCount for this CR type.
@@ -110,6 +108,8 @@ func ApplyLicenseMaster(ctx context.Context, client splcommon.ControllerClient, 
 				return result, err
 			}
 		}
+
+		DeleteOwnerReferencesForResources(ctx, client, cr, SplunkLicenseMaster)
 
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after

--- a/pkg/splunk/enterprise/searchheadcluster.go
+++ b/pkg/splunk/enterprise/searchheadcluster.go
@@ -112,9 +112,6 @@ func ApplySearchHeadCluster(ctx context.Context, client splcommon.ControllerClie
 		cr.Status.AdminPasswordChangedSecrets = make(map[string]bool)
 	}
 
-	// Smart Store secrets get created manually and should not be managed by the Operator
-	DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkSearchHead)
-
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
 		if cr.Spec.MonitoringConsoleRef.Name != "" {
@@ -133,6 +130,8 @@ func ApplySearchHeadCluster(ctx context.Context, client splcommon.ControllerClie
 				return result, err
 			}
 		}
+
+		DeleteOwnerReferencesForResources(ctx, client, cr, SplunkSearchHead)
 
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after

--- a/pkg/splunk/enterprise/searchheadcluster.go
+++ b/pkg/splunk/enterprise/searchheadcluster.go
@@ -112,6 +112,9 @@ func ApplySearchHeadCluster(ctx context.Context, client splcommon.ControllerClie
 		cr.Status.AdminPasswordChangedSecrets = make(map[string]bool)
 	}
 
+	// Smart Store secrets get created manually and should not be managed by the Operator
+	DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkSearchHead)
+
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
 		if cr.Spec.MonitoringConsoleRef.Name != "" {
@@ -131,7 +134,6 @@ func ApplySearchHeadCluster(ctx context.Context, client splcommon.ControllerClie
 			}
 		}
 
-		DeleteOwnerReferencesForResources(ctx, client, cr, nil, SplunkSearchHead)
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after
 			cr.Status.Phase = enterpriseApi.PhaseTerminating

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -115,7 +115,9 @@ func ApplyStandalone(ctx context.Context, client splcommon.ControllerClient, cr 
 	}
 
 	// Smart Store secrets get created manually and should not be managed by the Operator
-	DeleteOwnerReferencesForResources(ctx, client, cr, &cr.Spec.SmartStore, SplunkStandalone)
+	if &cr.Spec.SmartStore != nil {
+		_ = DeleteOwnerReferencesForS3SecretObjects(ctx, client, cr, &cr.Spec.SmartStore)
+	}
 
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
@@ -126,6 +128,7 @@ func ApplyStandalone(ctx context.Context, client splcommon.ControllerClient, cr 
 				return result, err
 			}
 		}
+
 		// If this is the last of its kind getting deleted,
 		// remove the entry for this CR type from configMap or else
 		// just decrement the refCount for this CR type.
@@ -135,6 +138,8 @@ func ApplyStandalone(ctx context.Context, client splcommon.ControllerClient, cr 
 				return result, err
 			}
 		}
+
+		DeleteOwnerReferencesForResources(ctx, client, cr, SplunkStandalone)
 
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -114,6 +114,9 @@ func ApplyStandalone(ctx context.Context, client splcommon.ControllerClient, cr 
 		return result, err
 	}
 
+	// Smart Store secrets get created manually and should not be managed by the Operator
+	DeleteOwnerReferencesForResources(ctx, client, cr, &cr.Spec.SmartStore, SplunkStandalone)
+
 	// check if deletion has been requested
 	if cr.ObjectMeta.DeletionTimestamp != nil {
 		if cr.Spec.MonitoringConsoleRef.Name != "" {
@@ -132,7 +135,7 @@ func ApplyStandalone(ctx context.Context, client splcommon.ControllerClient, cr 
 				return result, err
 			}
 		}
-		DeleteOwnerReferencesForResources(ctx, client, cr, &cr.Spec.SmartStore, SplunkStandalone)
+
 		terminating, err := splctrl.CheckForDeletion(ctx, cr, client)
 
 		if terminating && err != nil { // don't bother if no error, since it will just be removed immmediately after

--- a/pkg/splunk/enterprise/util_test.go
+++ b/pkg/splunk/enterprise/util_test.go
@@ -566,7 +566,7 @@ func TestRemoveOwenerReferencesForSecretObjectsReferredBySmartstoreVolumes(t *te
 	}
 
 	// Smartstore volume config with non-existing secret objects
-	err = DeleteOwnerReferencesForResources(ctx, client, &cr, &cr.Spec.SmartStore, SplunkClusterMaster)
+	err = DeleteOwnerReferencesForResources(ctx, client, &cr, SplunkClusterMaster)
 	if err == nil {
 		t.Errorf("Should report an error, when the secret objects doesn't exist")
 	}


### PR DESCRIPTION
### Description

This PR fixes a bug where a Smart Store secret created manually gets removed by the operator on Splunk resources removal because owner references are set by the Operator on the Splunk resources creation for given secret while it should not be managed by SOK.

### Key Changes

Moving the DeleteOwnerReferencesForS3SecretObjects execution outside of DeleteOwnerReferencesForResources execution and outside of if cr.ObjectMeta.DeletionTimestamp != nil condition. Additionally, a small check needed to be added to the condition to make unit tests running since they rely on a namespaced secret, not a separate Smart Store secret.

### Testing and Verification

Tested manually for S1, C3, M4, S1 & LM & MC, C3 & LM & MC and M4 & LM & MC. Automated tests executed as a part of the process.

### Related Issues
https://splunk.atlassian.net/browse/CSPL-3704
https://github.com/splunk/splunk-operator/issues/1474

### PR Checklist
- [x] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [x] All tests pass locally.
- [x] The PR description follows the project's guidelines.