### PR TITLE
[draft]: add support for pre-created PVs - admin-managed-pv annotation

### DIFF
--- a/docs/CustomResources.md
+++ b/docs/CustomResources.md
@@ -403,6 +403,45 @@ spec:
   replicas: 1
 ```
 
+#### admin-managed-pv Annotations
+The admin-managed-pv annotation in the splunk-operator's Custom Resource allows the admin to control whether Persistent Volumes (PVs) are dynamically created for the StatefulSet associated with the CR. If set to `true`, no PVs will be created, and the Persistent Volume Claim templates in the StatefulSet manifest will include a selector block to match `app.kubernetes.io/instance` and `app.kubernetes.io/name` labels for pre-created PVs. This means that `/opt/splunk/etc` and `/opt/splunk/var` related PVCs will contain code block like below 
+
+```
+apiVersion: v1
+kind: PersistentVolumeClaim
+...
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: splunk-cm-cluster-manager
+      app.kubernetes.io/name: cluster-manager
+```
+
+To match selector definition like this, Persistent Volume must set labels accordingly 
+
+```
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-example-etc
+  labels:
+    app.kubernetes.io/instance: splunk-cm-cluster-manager
+    app.kubernetes.io/name: cluster-manager
+```
+
+When admin-managed-pv is set to `false`, PVs will be dynamically created as usual, providing dedicated persistent storage for the StatefulSet.
+
+Here is an example of a Standalone with the admin-managed-pv annotation set. After 
+```
+apiVersion: enterprise.splunk.com/v4
+kind: Standalone
+metadata:
+  name: single
+  finalizers:
+  - enterprise.splunk.com/delete-pvc
+  annotations:
+    enterprise.splunk.com/admin-managed-pv: "true"
+```
+
 #### Container Logs
 The Splunk Enterprise CRDs deploy Splunkd in Kubernetes pods running [docker-splunk](https://github.com/splunk/docker-splunk) container images. Adding a couple of environment variables to the CR spec as follows produces `detailed container logs`:
 


### PR DESCRIPTION
### Description

This PR adds support for using pre-created PVs in splunk-operator CRs. 
CRs that has `admin-managed-pv` annotation set on `true` won't create dynamically PVs and will include `matchLabel` selector block in related PVCs to match pre-created PVs
Except that Documentation is updated accordingly   

### Key Changes

`pkg/splunk/enterprise/configuration.go` - add logic for handling `admin-managed-pv` annotiation
`docs/CustomResources.md` - documentation update

### Testing and Verification

locally + via GH pipeline

### Related Issues

#1269 

### PR Checklist

- [x] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [x] Documentation has been updated accordingly.
- [x] All tests pass locally.
- [x] The PR description follows the project's guidelines.
