### PR TITLE
Add pvs.yaml template and remove empty lines from values.yaml

### DIFF
--- a/helm-chart/splunk-enterprise/templates/enterprise_v4_clustermanager.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v4_clustermanager.yaml
@@ -1,23 +1,23 @@
-{{- if or .Values.clusterManager.enabled ( and (not $.Values.existingClusterManager) ( or .Values.sva.c3.enabled .Values.sva.m4.enabled ) )}}
+{{- if or .Values.customResources.clusterManager.enabled ( and (not $.Values.existingClusterManager) ( or .Values.sva.c3.enabled .Values.sva.m4.enabled ) )}}
 apiVersion:  enterprise.splunk.com/v4
 kind: ClusterManager
 metadata:
-  name: {{ .Values.clusterManager.name }}
-  namespace: {{ default (include "splunk-enterprise.namespace" . ) .Values.clusterManager.namespaceOverride }}
-{{- with .Values.clusterManager.additionalLabels }}
+  name: {{ .Values.customResources.clusterManager.name }}
+  namespace: {{ default (include "splunk-enterprise.namespace" . ) .Values.customResources.clusterManager.namespaceOverride }}
+{{- with .Values.customResources.clusterManager.additionalLabels }}
   labels:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.clusterManager.additionalAnnotations }}
+{{- with .Values.customResources.clusterManager.additionalAnnotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- with .Values.clusterManager.appRepo }}
+{{- with .Values.customResources.clusterManager.appRepo }}
   appRepo: 
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.clusterManager.smartstore }}
+{{- with .Values.customResources.clusterManager.smartstore }}
   smartstore:
 {{ toYaml . | indent 4 }}
 {{- end }}
@@ -27,11 +27,11 @@ spec:
   {{- if .Values.existingLicenseManager.namespace }}
     namespace: {{ .Values.existingLicenseManager.namespace }}
   {{- end }}
-{{- else if .Values.licenseManager.enabled }}
+{{- else if .Values.customResources.licenseManager.enabled }}
   licenseManagerRef:
-    name: {{ .Values.licenseManager.name }}
-  {{- if .Values.licenseManager.namespaceOverride }}
-    namespace: {{ .Values.licenseManager.namespaceOverride }}
+    name: {{ .Values.customResources.licenseManager.name }}
+  {{- if .Values.customResources.licenseManager.namespaceOverride }}
+    namespace: {{ .Values.customResources.licenseManager.namespaceOverride }}
   {{- end }}
 {{- end }}
 {{- if .Values.existingMonitoringConsole }}
@@ -40,11 +40,11 @@ spec:
   {{- if .Values.existingMonitoringConsole.namespace }}
     namespace: {{ .Values.existingMonitoringConsole.namespace }}
   {{- end }}
-{{- else if .Values.monitoringConsole.enabled }}
+{{- else if .Values.customResources.monitoringConsole.enabled }}
   monitoringConsoleRef:
-    name: {{ .Values.monitoringConsole.name }}
-  {{- if .Values.monitoringConsole.namespaceOverride }}
-    namespace: {{ .Values.monitoringConsole.namespaceOverride }}
+    name: {{ .Values.customResources.monitoringConsole.name }}
+  {{- if .Values.customResources.monitoringConsole.namespaceOverride }}
+    namespace: {{ .Values.customResources.monitoringConsole.namespaceOverride }}
   {{- end }}
 {{- end }}
 {{- if .Values.image.repository }}
@@ -57,15 +57,15 @@ spec:
   imagePullSecrets:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.clusterManager.volumes }}      
+{{- with .Values.customResources.clusterManager.volumes }}
   volumes:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if .Values.clusterManager.licenseUrl }}
-  licenseUrl: {{ .Values.clusterManager.licenseUrl }}
+{{- if .Values.customResources.clusterManager.licenseUrl }}
+  licenseUrl: {{ .Values.customResources.clusterManager.licenseUrl }}
 {{- end }}
-{{- if .Values.clusterManager.defaultsUrl }}
-  defaultsUrl: {{ .Values.clusterManager.defaultsUrl }}
+{{- if .Values.customResources.clusterManager.defaultsUrl }}
+  defaultsUrl: {{ .Values.customResources.clusterManager.defaultsUrl }}
 {{- end }}
 {{- if .Values.sva.m4.enabled }}
   defaults: |-
@@ -80,60 +80,60 @@ spec:
       idxc:
         search_factor: 2
         replication_factor: 2
-{{- else if .Values.clusterManager.defaults }}
+{{- else if .Values.customResources.clusterManager.defaults }}
   defaults: |-
-{{ toYaml .Values.clusterManager.defaults | indent 4 }}
+{{ toYaml .Values.customResources.clusterManager.defaults | indent 4 }}
 {{- end }}
-{{- if .Values.clusterManager.defaultsUrlApps }}
-  defaultsUrlApps: {{ .Values.clusterManager.defaultsUrlApps }}
+{{- if .Values.customResources.clusterManager.defaultsUrlApps }}
+  defaultsUrlApps: {{ .Values.customResources.clusterManager.defaultsUrlApps }}
 {{- end }}
-{{- with .Values.clusterManager.extraEnv }}
+{{- with .Values.customResources.clusterManager.extraEnv }}
   extraEnv:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if .Values.clusterManager.livenessInitialDelaySeconds }}
-  livenessInitialDelaySeconds: {{ .Values.clusterManager.livenessInitialDelaySeconds }}
+{{- if .Values.customResources.clusterManager.livenessInitialDelaySeconds }}
+  livenessInitialDelaySeconds: {{ .Values.customResources.clusterManager.livenessInitialDelaySeconds }}
 {{- end }}
-{{- if .Values.clusterManager.readinessInitialDelaySeconds }}
-  readinessInitialDelaySeconds: {{ .Values.clusterManager.readinessInitialDelaySeconds }}
+{{- if .Values.customResources.clusterManager.readinessInitialDelaySeconds }}
+  readinessInitialDelaySeconds: {{ .Values.customResources.clusterManager.readinessInitialDelaySeconds }}
 {{- end }}
-{{- if .Values.clusterManager.startupProbe }}
+{{- if .Values.customResources.clusterManager.startupProbe }}
   startupProbe:
-{{ toYaml .Values.clusterManager.startupProbe | indent 4 }}
+{{ toYaml .Values.customResources.clusterManager.startupProbe | indent 4 }}
 {{- end }}
-{{- if .Values.clusterManager.livenessProbe }}
+{{- if .Values.customResources.clusterManager.livenessProbe }}
   livenessProbe:
-{{ toYaml .Values.clusterManager.livenessProbe | indent 4 }}
+{{ toYaml .Values.customResources.clusterManager.livenessProbe | indent 4 }}
 {{- end }}
-{{- if .Values.clusterManager.readinessProbe }}
+{{- if .Values.customResources.clusterManager.readinessProbe }}
   readinessProbe:
-{{ toYaml .Values.clusterManager.readinessProbe | indent 4 }}
+{{ toYaml .Values.customResources.clusterManager.readinessProbe | indent 4 }}
 {{- end }}
-{{- with .Values.clusterManager.etcVolumeStorageConfig }}
+{{- with .Values.customResources.clusterManager.etcVolumeStorageConfig }}
   etcVolumeStorageConfig:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.clusterManager.varVolumeStorageConfig }}
+{{- with .Values.customResources.clusterManager.varVolumeStorageConfig }}
   varVolumeStorageConfig:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.clusterManager.resources }}
+{{- with .Values.customResources.clusterManager.resources }}
   resources:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if .Values.clusterManager.serviceAccount }}
-  serviceAccount: {{ .Values.clusterManager.serviceAccount }}
+{{- if .Values.customResources.clusterManager.serviceAccount }}
+  serviceAccount: {{ .Values.customResources.clusterManager.serviceAccount }}
 {{- end }}
-{{- with .Values.clusterManager.serviceTemplate }}
+{{- with .Values.customResources.clusterManager.serviceTemplate }}
   serviceTemplate:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.clusterManager.tolerations }}
+{{- with .Values.customResources.clusterManager.tolerations }}
   tolerations:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if .Values.clusterManager.topologySpreadConstraints }}
-{{- with .Values.clusterManager.topologySpreadConstraints }}
+{{- if .Values.customResources.clusterManager.topologySpreadConstraints }}
+{{- with .Values.customResources.clusterManager.topologySpreadConstraints }}
   topologySpreadConstraints:
 {{ toYaml . | indent 4 }}
 {{- end }}
@@ -149,7 +149,7 @@ spec:
             values:
             - {{ .Values.sva.m4.clusterManager.zone }}
 {{- else }}
-  {{- with .Values.clusterManager.affinity }}
+  {{- with .Values.customResources.clusterManager.affinity }}
   affinity:
 {{ toYaml . | indent 4 }}
   {{- end }}

--- a/helm-chart/splunk-enterprise/templates/enterprise_v4_indexercluster.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v4_indexercluster.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.indexerCluster.enabled .Values.sva.c3.enabled .Values.sva.m4.enabled }}
+{{- if or .Values.customResources.indexerCluster.enabled .Values.sva.c3.enabled .Values.sva.m4.enabled }}
 apiVersion: v1
 kind: List
 items:
@@ -8,24 +8,24 @@ items:
   metadata:
   {{- if or $.Values.sva.c3.enabled $.Values.sva.m4.enabled }}
     name: {{ .name }}
-  {{- else if $.Values.indexerCluster.enabled }}
-    name: {{ $.Values.indexerCluster.name }}
+  {{- else if $.Values.customResources.indexerCluster.enabled }}
+    name: {{ $.Values.customResources.indexerCluster.name }}
   {{- end }}
-    namespace: {{ default $.Release.Namespace $.Values.indexerCluster.namespaceOverride }}
-  {{- with $.Values.indexerCluster.additionalLabels }}
+    namespace: {{ default $.Release.Namespace $.Values.customResources.indexerCluster.namespaceOverride }}
+  {{- with $.Values.customResources.indexerCluster.additionalLabels }}
     labels:
 {{ toYaml . | indent 6 }}
   {{- end }}
-  {{- with $.Values.indexerCluster.additionalAnnotations }}
+  {{- with $.Values.customResources.indexerCluster.additionalAnnotations }}
     annotations:
 {{ toYaml . | indent 6 }}
   {{- end }}
   spec:
-  {{- if $.Values.indexerCluster.serviceAccount }}
-    serviceAccount: {{ $.Values.indexerCluster.serviceAccount }}
+  {{- if $.Values.customResources.indexerCluster.serviceAccount }}
+    serviceAccount: {{ $.Values.customResources.indexerCluster.serviceAccount }}
   {{- end }}
-  {{- if $.Values.indexerCluster.replicaCount }}
-    replicas: {{ $.Values.indexerCluster.replicaCount }}
+  {{- if $.Values.customResources.indexerCluster.replicaCount }}
+    replicas: {{ $.Values.customResources.indexerCluster.replicaCount }}
   {{- end }}
   {{- if $.Values.existingClusterManager }}
     clusterManagerRef:
@@ -33,11 +33,11 @@ items:
     {{- if $.Values.existingClusterManager.namespace }}
       namespace: {{ $.Values.existingClusterManager.namespace }}
     {{- end }}
-  {{- else if or $.Values.clusterManager.enabled $.Values.sva.c3.enabled $.Values.sva.m4.enabled }}
+  {{- else if or $.Values.customResources.clusterManager.enabled $.Values.sva.c3.enabled $.Values.sva.m4.enabled }}
     clusterManagerRef:
-      name: {{ $.Values.clusterManager.name }}
-    {{- if $.Values.clusterManager.namespaceOverride }}
-      namespace: {{ $.Values.clusterManager.namespaceOverride }}
+      name: {{ $.Values.customResources.clusterManager.name }}
+    {{- if $.Values.customResources.clusterManager.namespaceOverride }}
+      namespace: {{ $.Values.customResources.clusterManager.namespaceOverride }}
     {{- end }}
   {{- end }}
   {{- if $.Values.existingLicenseManager }}
@@ -46,11 +46,11 @@ items:
     {{- if $.Values.existingLicenseManager.namespace }}
       namespace: {{ $.Values.existingLicenseManager.namespace }}
     {{- end }}
-  {{- else if $.Values.licenseManager.enabled }}
+  {{- else if $.Values.customResources.licenseManager.enabled }}
     licenseManagerRef:
-      name: {{ $.Values.licenseManager.name }}
-    {{- if $.Values.licenseManager.namespaceOverride }}
-      namespace: {{ $.Values.licenseManager.namespaceOverride }}
+      name: {{ $.Values.customResources.licenseManager.name }}
+    {{- if $.Values.customResources.licenseManager.namespaceOverride }}
+      namespace: {{ $.Values.customResources.licenseManager.namespaceOverride }}
     {{- end }}
   {{- end }}
   {{- if $.Values.existingMonitoringConsole }}
@@ -59,11 +59,11 @@ items:
     {{- if $.Values.existingMonitoringConsole.namespace }}
       namespace: {{ $.Values.existingMonitoringConsole.namespace }}
     {{- end }}
-  {{- else if $.Values.monitoringConsole.enabled }}
+  {{- else if $.Values.customResources.monitoringConsole.enabled }}
     monitoringConsoleRef:
-      name: {{ $.Values.monitoringConsole.name }}
-    {{- if $.Values.monitoringConsole.namespaceOverride }}
-      namespace: {{ $.Values.monitoringConsole.namespaceOverride }}
+      name: {{ $.Values.customResources.monitoringConsole.name }}
+    {{- if $.Values.customResources.monitoringConsole.namespaceOverride }}
+      namespace: {{ $.Values.customResources.monitoringConsole.namespaceOverride }}
     {{- end }}
   {{- end }}
   {{- if $.Values.image.repository }}
@@ -76,18 +76,18 @@ items:
     imagePullSecrets:
 {{ toYaml . | indent 6 }}
   {{- end }}
-  {{- with $.Values.indexerCluster.volumes }}
+  {{- with $.Values.customResources.indexerCluster.volumes }}
     volumes:
 {{ toYaml . | indent 6 }}
   {{- end }}
-  {{- if $.Values.indexerCluster.licenseUrl }}
-    licenseUrl: {{ $.Values.indexerCluster.licenseUrl }}
+  {{- if $.Values.customResources.indexerCluster.licenseUrl }}
+    licenseUrl: {{ $.Values.customResources.indexerCluster.licenseUrl }}
   {{- end }}
-  {{- if $.Values.indexerCluster.defaultsUrl }}
-    defaultsUrl: {{ $.Values.indexerCluster.defaultsUrl }}
+  {{- if $.Values.customResources.indexerCluster.defaultsUrl }}
+    defaultsUrl: {{ $.Values.customResources.indexerCluster.defaultsUrl }}
   {{- end }}
   {{- if $.Values.sva.m4.enabled }}
-    {{- $cm_name := $.Values.clusterManager.name -}}
+    {{- $cm_name := $.Values.customResources.clusterManager.name -}}
     {{- if $.Values.existingClusterManager }}
       {{- $cm_name = $.Values.existingClusterManager.name -}}
     {{- end }}
@@ -95,54 +95,54 @@ items:
       splunk:
         multisite_master: splunk-{{ $cm_name }}-cluster-manager-service
         site: {{ .site }}
-  {{- else if $.Values.indexerCluster.defaults }}
+  {{- else if $.Values.customResources.indexerCluster.defaults }}
     defaults: |-
-{{ toYaml $.Values.indexerCluster.defaults | indent 6 }}
+{{ toYaml $.Values.customResources.indexerCluster.defaults | indent 6 }}
   {{- end }}
-  {{- with $.Values.indexerCluster.extraEnv }}
+  {{- with $.Values.customResources.indexerCluster.extraEnv }}
     extraEnv:
 {{ toYaml . | indent 6 }}
   {{- end }}
-  {{- if $.Values.indexerCluster.livenessInitialDelaySeconds }}
-    livenessInitialDelaySeconds: {{ $.Values.indexerCluster.livenessInitialDelaySeconds }}
+  {{- if $.Values.customResources.indexerCluster.livenessInitialDelaySeconds }}
+    livenessInitialDelaySeconds: {{ $.Values.customResources.indexerCluster.livenessInitialDelaySeconds }}
   {{- end }}
-  {{- if $.Values.indexerCluster.readinessInitialDelaySeconds }}
-    readinessInitialDelaySeconds: {{ $.Values.indexerCluster.readinessInitialDelaySeconds }}
+  {{- if $.Values.customResources.indexerCluster.readinessInitialDelaySeconds }}
+    readinessInitialDelaySeconds: {{ $.Values.customResources.indexerCluster.readinessInitialDelaySeconds }}
   {{- end }}
-  {{- if $.Values.indexerCluster.startupProbe }}
+  {{- if $.Values.customResources.indexerCluster.startupProbe }}
     startupProbe:
-{{ toYaml $.Values.indexerCluster.startupProbe | indent 6 }}
+{{ toYaml $.Values.customResources.indexerCluster.startupProbe | indent 6 }}
   {{- end }}
-  {{- if $.Values.indexerCluster.livenessProbe }}
+  {{- if $.Values.customResources.indexerCluster.livenessProbe }}
     livenessProbe:
-{{ toYaml $.Values.indexerCluster.livenessProbe | indent 6 }}
+{{ toYaml $.Values.customResources.indexerCluster.livenessProbe | indent 6 }}
   {{- end }}
-  {{- if $.Values.indexerCluster.readinessProbe }}
+  {{- if $.Values.customResources.indexerCluster.readinessProbe }}
     readinessProbe:
-{{ toYaml $.Values.indexerCluster.readinessProbe | indent 6 }}
+{{ toYaml $.Values.customResources.indexerCluster.readinessProbe | indent 6 }}
   {{- end }}
-  {{- with $.Values.indexerCluster.etcVolumeStorageConfig }}
+  {{- with $.Values.customResources.indexerCluster.etcVolumeStorageConfig }}
     etcVolumeStorageConfig:
 {{ toYaml . | indent 6 }}
   {{- end }}
-  {{- with $.Values.indexerCluster.varVolumeStorageConfig }}
+  {{- with $.Values.customResources.indexerCluster.varVolumeStorageConfig }}
     varVolumeStorageConfig:
 {{ toYaml . | indent 6 }}
   {{- end }}
-  {{- with $.Values.indexerCluster.resources }}
+  {{- with $.Values.customResources.indexerCluster.resources }}
     resources:
 {{ toYaml . | indent 6 }}
   {{- end }}
-  {{- with $.Values.indexerCluster.serviceTemplate }}
+  {{- with $.Values.customResources.indexerCluster.serviceTemplate }}
     serviceTemplate:
 {{ toYaml . | indent 6 }}
   {{- end }}
-  {{- with $.Values.indexerCluster.tolerations }}
+  {{- with $.Values.customResources.indexerCluster.tolerations }}
     tolerations:
 {{ toYaml . | indent 6 }}
   {{- end }}
-{{- if $.Values.indexerCluster.topologySpreadConstraints }}
-  {{- with $.Values.indexerCluster.topologySpreadConstraints }}
+{{- if $.Values.customResources.indexerCluster.topologySpreadConstraints }}
+  {{- with $.Values.customResources.indexerCluster.topologySpreadConstraints }}
     topologySpreadConstraints:
 {{ toYaml . | indent 6 }}
 {{- end }}
@@ -158,7 +158,7 @@ items:
               values:
               - {{ .zone }}
   {{- else }}
-    {{- with $.Values.indexerCluster.affinity }}
+    {{- with $.Values.customResources.indexerCluster.affinity }}
     affinity:
 {{ toYaml . | indent 6 }}
     {{- end }}

--- a/helm-chart/splunk-enterprise/templates/enterprise_v4_licensemanager.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v4_licensemanager.yaml
@@ -1,19 +1,19 @@
-{{- if .Values.licenseManager.enabled }}
+{{- if .Values.customResources.licenseManager.enabled }}
 apiVersion:  enterprise.splunk.com/v4
 kind: LicenseManager
 metadata:
-  name: {{ .Values.licenseManager.name }}
-  namespace: {{ default (include "splunk-enterprise.namespace" . ) .Values.licenseManager.namespaceOverride }}
-{{- with .Values.licenseManager.additionalLabels }}
+  name: {{ .Values.customResources.licenseManager.name }}
+  namespace: {{ default (include "splunk-enterprise.namespace" . ) .Values.customResources.licenseManager.namespaceOverride }}
+{{- with .Values.customResources.licenseManager.additionalLabels }}
   labels:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.licenseManager.additionalAnnotations }}
+{{- with .Values.customResources.licenseManager.additionalAnnotations }}
   annotations:
 {{ toYaml . | indent 4 }}
   {{- end }}
 spec:
-{{- with .Values.licenseManager.appRepo }}
+{{- with .Values.customResources.licenseManager.appRepo }}
   appRepo:
 {{ toYaml . | indent 4 }}
 {{- end }}
@@ -23,11 +23,11 @@ spec:
   {{- if .Values.existingClusterManager.namespace }}
     namespace: {{ .Values.existingClusterManager.namespace }}
   {{- end }}
-{{- else if or .Values.clusterManager.enabled .Values.sva.c3.enabled .Values.sva.m4.enabled }}
+{{- else if or .Values.customResources.clusterManager.enabled .Values.sva.c3.enabled .Values.sva.m4.enabled }}
   clusterManagerRef:
-    name: {{ .Values.clusterManager.name }}
-  {{- if .Values.clusterManager.namespaceOverride }}
-    namespace: {{ .Values.clusterManager.namespaceOverride }}
+    name: {{ .Values.customResources.clusterManager.name }}
+  {{- if .Values.customResources.clusterManager.namespaceOverride }}
+    namespace: {{ .Values.customResources.clusterManager.namespaceOverride }}
   {{- end }}
 {{- end }}
 {{- if .Values.existingMonitoringConsole }}
@@ -36,11 +36,11 @@ spec:
   {{- if .Values.existingMonitoringConsole.namespace }}
     namespace: {{ .Values.existingMonitoringConsole.namespace }}
   {{- end }}
-{{- else if .Values.monitoringConsole.enabled }}
+{{- else if .Values.customResources.monitoringConsole.enabled }}
   monitoringConsoleRef:
-    name: {{ .Values.monitoringConsole.name }}
-  {{- if .Values.monitoringConsole.namespaceOverride }}
-    namespace: {{ .Values.monitoringConsole.namespaceOverride }}
+    name: {{ .Values.customResources.monitoringConsole.name }}
+  {{- if .Values.customResources.monitoringConsole.namespaceOverride }}
+    namespace: {{ .Values.customResources.monitoringConsole.namespaceOverride }}
   {{- end }}
 {{- end }}
 {{- if .Values.image.repository }}
@@ -53,75 +53,75 @@ spec:
   imagePullSecrets:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.licenseManager.volumes }}
+{{- with .Values.customResources.licenseManager.volumes }}
   volumes:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if .Values.licenseManager.licenseUrl }}
-  licenseUrl: {{ .Values.licenseManager.licenseUrl }}
+{{- if .Values.customResources.licenseManager.licenseUrl }}
+  licenseUrl: {{ .Values.customResources.licenseManager.licenseUrl }}
 {{- end }}
-{{- if .Values.licenseManager.defaultsUrl }}
-  defaultsUrl: {{ .Values.licenseManager.defaultsUrl }}
+{{- if .Values.customResources.licenseManager.defaultsUrl }}
+  defaultsUrl: {{ .Values.customResources.licenseManager.defaultsUrl }}
 {{- end }}
-{{- if .Values.licenseManager.defaults }}
+{{- if .Values.customResources.licenseManager.defaults }}
   defaults: |-
-{{ toYaml .Values.licenseManager.defaults | indent 4 }}
+{{ toYaml .Values.customResources.licenseManager.defaults | indent 4 }}
 {{- end }}
-{{- if .Values.licenseManager.defaultsUrlApps }}
-  defaultsUrlApps: {{ .Values.licenseManager.defaultsUrlApps }}
+{{- if .Values.customResources.licenseManager.defaultsUrlApps }}
+  defaultsUrlApps: {{ .Values.customResources.licenseManager.defaultsUrlApps }}
 {{- end }}
-{{- with .Values.licenseManager.extraEnv }}
+{{- with .Values.customResources.licenseManager.extraEnv }}
   extraEnv:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if .Values.licenseManager.livenessInitialDelaySeconds }}
-  livenessInitialDelaySeconds: {{ .Values.licenseManager.livenessInitialDelaySeconds }}
+{{- if .Values.customResources.licenseManager.livenessInitialDelaySeconds }}
+  livenessInitialDelaySeconds: {{ .Values.customResources.licenseManager.livenessInitialDelaySeconds }}
 {{- end }}
-{{- if .Values.licenseManager.readinessInitialDelaySeconds }}
-  readinessInitialDelaySeconds: {{ .Values.licenseManager.readinessInitialDelaySeconds }}
+{{- if .Values.customResources.licenseManager.readinessInitialDelaySeconds }}
+  readinessInitialDelaySeconds: {{ .Values.customResources.licenseManager.readinessInitialDelaySeconds }}
 {{- end }}
-{{- if .Values.licenseManager.startupProbe }}
+{{- if .Values.customResources.licenseManager.startupProbe }}
   startupProbe:
-{{ toYaml .Values.licenseManager.startupProbe | indent 4 }}
+{{ toYaml .Values.customResources.licenseManager.startupProbe | indent 4 }}
 {{- end }}
-{{- if .Values.licenseManager.livenessProbe }}
+{{- if .Values.customResources.licenseManager.livenessProbe }}
   livenessProbe:
-{{ toYaml .Values.licenseManager.livenessProbe | indent 4 }}
+{{ toYaml .Values.customResources.licenseManager.livenessProbe | indent 4 }}
 {{- end }}
-{{- if .Values.licenseManager.readinessProbe }}
+{{- if .Values.customResources.licenseManager.readinessProbe }}
   readinessProbe:
-{{ toYaml .Values.licenseManager.readinessProbe | indent 4 }}
+{{ toYaml .Values.customResources.licenseManager.readinessProbe | indent 4 }}
 {{- end }}
-{{- with .Values.licenseManager.etcVolumeStorageConfig }}
+{{- with .Values.customResources.licenseManager.etcVolumeStorageConfig }}
   etcVolumeStorageConfig:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.licenseManager.varVolumeStorageConfig }}
+{{- with .Values.customResources.licenseManager.varVolumeStorageConfig }}
   varVolumeStorageConfig:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.licenseManager.resources }}
+{{- with .Values.customResources.licenseManager.resources }}
   resources:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if .Values.licenseManager.serviceAccount }}
-  serviceAccount: {{ .Values.licenseManager.serviceAccount }}
+{{- if .Values.customResources.licenseManager.serviceAccount }}
+  serviceAccount: {{ .Values.customResources.licenseManager.serviceAccount }}
 {{- end }}
-{{- with .Values.licenseManager.serviceTemplate }}
+{{- with .Values.customResources.licenseManager.serviceTemplate }}
   serviceTemplate:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.licenseManager.tolerations }}
+{{- with .Values.customResources.licenseManager.tolerations }}
   tolerations:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if .Values.licenseManager.topologySpreadConstraints }}
-{{- with .Values.licenseManager.topologySpreadConstraints }}
+{{- if .Values.customResources.licenseManager.topologySpreadConstraints }}
+{{- with .Values.customResources.licenseManager.topologySpreadConstraints }}
   topologySpreadConstraints:
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- end }}
-{{- with .Values.licenseManager.affinity }}
+{{- with .Values.customResources.licenseManager.affinity }}
   affinity:
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/helm-chart/splunk-enterprise/templates/enterprise_v4_monitoringconsole.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v4_monitoringconsole.yaml
@@ -1,19 +1,19 @@
-{{- if .Values.monitoringConsole.enabled }}
+{{- if .Values.customResources.monitoringConsole.enabled }}
 apiVersion:  enterprise.splunk.com/v4
 kind: MonitoringConsole
 metadata:
-  name: {{ .Values.monitoringConsole.name }}
-  namespace: {{ default (include "splunk-enterprise.namespace" . ) .Values.monitoringConsole.namespaceOverride }}
-{{- with .Values.monitoringConsole.additionalLabels }}
+  name: {{ .Values.customResources.monitoringConsole.name }}
+  namespace: {{ default (include "splunk-enterprise.namespace" . ) .Values.customResources.monitoringConsole.namespaceOverride }}
+{{- with .Values.customResources.monitoringConsole.additionalLabels }}
   labels:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.monitoringConsole.additionalAnnotations }}
+{{- with .Values.customResources.monitoringConsole.additionalAnnotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- with .Values.monitoringConsole.appRepo }}
+{{- with .Values.customResources.monitoringConsole.appRepo }}
   appRepo: 
 {{ toYaml . | indent 4 }}
 {{- end }}
@@ -23,11 +23,11 @@ spec:
   {{- if .Values.existingClusterManager.namespace }}
     namespace: {{ .Values.existingClusterManager.namespace }}
   {{- end }}
-{{- else if or .Values.clusterManager.enabled .Values.sva.c3.enabled .Values.sva.m4.enabled }}
+{{- else if or .Values.customResources.clusterManager.enabled .Values.sva.c3.enabled .Values.sva.m4.enabled }}
   clusterManagerRef:
-    name: {{ .Values.clusterManager.name }}
-  {{- if .Values.clusterManager.namespaceOverride }}
-    namespace: {{ .Values.clusterManager.namespaceOverride }}
+    name: {{ .Values.customResources.clusterManager.name }}
+  {{- if .Values.customResources.clusterManager.namespaceOverride }}
+    namespace: {{ .Values.customResources.clusterManager.namespaceOverride }}
   {{- end }}
 {{- end }}
 {{- if .Values.existingLicenseManager }}
@@ -36,11 +36,11 @@ spec:
   {{- if .Values.existingLicenseManager.namespace }}
     namespace: {{ .Values.existingLicenseManager.namespace }}
   {{- end }}
-{{- else if .Values.licenseManager.enabled }}
+{{- else if .Values.customResources.licenseManager.enabled }}
   licenseManagerRef:
-    name: {{ .Values.licenseManager.name }}
-  {{- if .Values.licenseManager.namespaceOverride }}
-    namespace: {{ .Values.licenseManager.namespaceOverride }}
+    name: {{ .Values.customResources.licenseManager.name }}
+  {{- if .Values.customResources.licenseManager.namespaceOverride }}
+    namespace: {{ .Values.customResources.licenseManager.namespaceOverride }}
   {{- end }}
 {{- end }}
 {{- if .Values.image.repository }}
@@ -53,75 +53,75 @@ spec:
   imagePullSecrets:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.monitoringConsole.volumes }}      
+{{- with .Values.customResources.monitoringConsole.volumes }}
   volumes:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if .Values.monitoringConsole.licenseUrl }}
-  licenseUrl: {{ .Values.monitoringConsole.licenseUrl }}
+{{- if .Values.customResources.monitoringConsole.licenseUrl }}
+  licenseUrl: {{ .Values.customResources.monitoringConsole.licenseUrl }}
 {{- end }}
-{{- if .Values.monitoringConsole.defaultsUrl }}
-  defaultsUrl: {{ .Values.monitoringConsole.defaultsUrl }}
+{{- if .Values.customResources.monitoringConsole.defaultsUrl }}
+  defaultsUrl: {{ .Values.customResources.monitoringConsole.defaultsUrl }}
 {{- end }}
-{{- if .Values.monitoringConsole.defaults }}
+{{- if .Values.customResources.monitoringConsole.defaults }}
   defaults: |-
-{{ toYaml .Values.monitoringConsole.defaults | indent 4 }}
+{{ toYaml .Values.customResources.monitoringConsole.defaults | indent 4 }}
 {{- end }}
-{{- if .Values.monitoringConsole.defaultsUrlApps }}
-  defaultsUrlApps: {{ .Values.monitoringConsole.defaultsUrlApps }}
+{{- if .Values.customResources.monitoringConsole.defaultsUrlApps }}
+  defaultsUrlApps: {{ .Values.customResources.monitoringConsole.defaultsUrlApps }}
 {{- end }}
-{{- with .Values.monitoringConsole.extraEnv }}
+{{- with .Values.customResources.monitoringConsole.extraEnv }}
   extraEnv:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if .Values.monitoringConsole.livenessInitialDelaySeconds }}
-  livenessInitialDelaySeconds: {{ .Values.monitoringConsole.livenessInitialDelaySeconds }}
+{{- if .Values.customResources.monitoringConsole.livenessInitialDelaySeconds }}
+  livenessInitialDelaySeconds: {{ .Values.customResources.monitoringConsole.livenessInitialDelaySeconds }}
 {{- end }}
-{{- if .Values.monitoringConsole.readinessInitialDelaySeconds }}
-  readinessInitialDelaySeconds: {{ .Values.monitoringConsole.readinessInitialDelaySeconds }}
+{{- if .Values.customResources.monitoringConsole.readinessInitialDelaySeconds }}
+  readinessInitialDelaySeconds: {{ .Values.customResources.monitoringConsole.readinessInitialDelaySeconds }}
 {{- end }}
-{{- if .Values.monitoringConsole.startupProbe }}
+{{- if .Values.customResources.monitoringConsole.startupProbe }}
   startupProbe:
-{{ toYaml .Values.monitoringConsole.startupProbe | indent 4 }}
+{{ toYaml .Values.customResources.monitoringConsole.startupProbe | indent 4 }}
 {{- end }}
-{{- if .Values.monitoringConsole.livenessProbe }}
+{{- if .Values.customResources.monitoringConsole.livenessProbe }}
   livenessProbe:
-{{ toYaml .Values.monitoringConsole.livenessProbe | indent 4 }}
+{{ toYaml .Values.customResources.monitoringConsole.livenessProbe | indent 4 }}
 {{- end }}
-{{- if .Values.monitoringConsole.readinessProbe }}
+{{- if .Values.customResources.monitoringConsole.readinessProbe }}
   readinessProbe:
-{{ toYaml .Values.monitoringConsole.readinessProbe | indent 4 }}
+{{ toYaml .Values.customResources.monitoringConsole.readinessProbe | indent 4 }}
 {{- end }}
-{{- with .Values.monitoringConsole.etcVolumeStorageConfig }}
+{{- with .Values.customResources.monitoringConsole.etcVolumeStorageConfig }}
   etcVolumeStorageConfig:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.monitoringConsole.varVolumeStorageConfig }}
+{{- with .Values.customResources.monitoringConsole.varVolumeStorageConfig }}
   varVolumeStorageConfig:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.monitoringConsole.resources }}
+{{- with .Values.customResources.monitoringConsole.resources }}
   resources:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if .Values.monitoringConsole.serviceAccount }}
-  serviceAccount: {{ .Values.monitoringConsole.serviceAccount }}
+{{- if .Values.customResources.monitoringConsole.serviceAccount }}
+  serviceAccount: {{ .Values.customResources.monitoringConsole.serviceAccount }}
 {{- end }}
-{{- with .Values.monitoringConsole.serviceTemplate }}
+{{- with .Values.customResources.monitoringConsole.serviceTemplate }}
   serviceTemplate:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.monitoringConsole.tolerations }}
+{{- with .Values.customResources.monitoringConsole.tolerations }}
   tolerations:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if .Values.monitoringConsole.topologySpreadConstraints }}
-{{- with .Values.monitoringConsole.topologySpreadConstraints }}
+{{- if .Values.customResources.monitoringConsole.topologySpreadConstraints }}
+{{- with .Values.customResources.monitoringConsole.topologySpreadConstraints }}
   topologySpreadConstraints:
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- end }}
-{{- with .Values.monitoringConsole.affinity }}
+{{- with .Values.customResources.monitoringConsole.affinity }}
   affinity:
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/helm-chart/splunk-enterprise/templates/enterprise_v4_searchheadcluster.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v4_searchheadcluster.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.searchHeadCluster.enabled .Values.sva.c3.enabled .Values.sva.m4.enabled }}
+{{- if or .Values.customResources.searchHeadCluster.enabled .Values.sva.c3.enabled .Values.sva.m4.enabled }}
 apiVersion: v1
 kind: List
 items:
@@ -8,23 +8,23 @@ items:
   metadata:
   {{- if or $.Values.sva.c3.enabled $.Values.sva.m4.enabled }}
     name: {{ .name }}
-  {{- else if $.Values.searchHeadCluster.enabled }}
-    name: {{ $.Values.searchHeadCluster.name }}
+  {{- else if $.Values.customResources.searchHeadCluster.enabled }}
+    name: {{ $.Values.customResources.searchHeadCluster.name }}
   {{- end }}
-    namespace: {{ default $.Release.Namespace $.Values.searchHeadCluster.namespaceOverride }}
-  {{- with $.Values.searchHeadCluster.additionalLabels }}
+    namespace: {{ default $.Release.Namespace $.Values.customResources.searchHeadCluster.namespaceOverride }}
+  {{- with $.Values.customResources.searchHeadCluster.additionalLabels }}
     labels:
 {{ toYaml . | indent 6 }}
   {{- end }}
-  {{- with $.Values.searchHeadCluster.additionalAnnotations }}
+  {{- with $.Values.customResources.searchHeadCluster.additionalAnnotations }}
     annotations:
 {{ toYaml . | indent 6 }}
   {{- end }}
   spec:
-  {{- if $.Values.searchHeadCluster.replicaCount }}
-    replicas: {{ $.Values.searchHeadCluster.replicaCount }}
+  {{- if $.Values.customResources.searchHeadCluster.replicaCount }}
+    replicas: {{ $.Values.customResources.searchHeadCluster.replicaCount }}
   {{- end }}
-  {{- with $.Values.searchHeadCluster.appRepo }}
+  {{- with $.Values.customResources.searchHeadCluster.appRepo }}
     appRepo: 
 {{ toYaml . | indent 6 }}
   {{- end }}
@@ -34,11 +34,11 @@ items:
     {{- if $.Values.existingClusterManager.namespace }}
       namespace: {{ $.Values.existingClusterManager.namespace }}
     {{- end }}
-  {{- else if or $.Values.clusterManager.enabled $.Values.sva.c3.enabled $.Values.sva.m4.enabled }}
+  {{- else if or $.Values.customResources.clusterManager.enabled $.Values.sva.c3.enabled $.Values.sva.m4.enabled }}
     clusterManagerRef:
-      name: {{ $.Values.clusterManager.name }}
-    {{- if $.Values.clusterManager.namespaceOverride }}
-      namespace: {{ $.Values.clusterManager.namespaceOverride }}
+      name: {{ $.Values.customResources.clusterManager.name }}
+    {{- if $.Values.customResources.clusterManager.namespaceOverride }}
+      namespace: {{ $.Values.customResources.clusterManager.namespaceOverride }}
     {{- end }}
   {{- end }}
   {{- if $.Values.existingLicenseManager }}
@@ -47,11 +47,11 @@ items:
     {{- if $.Values.existingLicenseManager.namespace }}
       namespace: {{ $.Values.existingLicenseManager.namespace }}
     {{- end }}
-  {{- else if or $.Values.licenseManager.enabled }}
+  {{- else if or $.Values.customResources.licenseManager.enabled }}
     licenseManagerRef:
-      name: {{ $.Values.licenseManager.name }}
-    {{- if $.Values.licenseManager.namespaceOverride }}
-      namespace: {{ $.Values.licenseManager.namespaceOverride }}
+      name: {{ $.Values.customResources.licenseManager.name }}
+    {{- if $.Values.customResources.licenseManager.namespaceOverride }}
+      namespace: {{ $.Values.customResources.licenseManager.namespaceOverride }}
     {{- end }}
   {{- end }}
   {{- if $.Values.existingMonitoringConsole }}
@@ -60,11 +60,11 @@ items:
     {{- if $.Values.existingMonitoringConsole.namespace }}
       namespace: {{ $.Values.existingMonitoringConsole.namespace }}
     {{- end }}
-  {{- else if $.Values.monitoringConsole.enabled }}
+  {{- else if $.Values.customResources.monitoringConsole.enabled }}
     monitoringConsoleRef:
-      name: {{ $.Values.monitoringConsole.name }}
-    {{- if $.Values.monitoringConsole.namespaceOverride }}
-      namespace: {{ $.Values.monitoringConsole.namespaceOverride }}
+      name: {{ $.Values.customResources.monitoringConsole.name }}
+    {{- if $.Values.customResources.monitoringConsole.namespaceOverride }}
+      namespace: {{ $.Values.customResources.monitoringConsole.namespaceOverride }}
     {{- end }}
   {{- end }}
   {{- if $.Values.image.repository }}
@@ -77,18 +77,18 @@ items:
     imagePullSecrets:
 {{ toYaml . | indent 6 }}
   {{- end }}
-  {{- with $.Values.searchHeadCluster.volumes }}
+  {{- with $.Values.customResources.searchHeadCluster.volumes }}
     volumes:
 {{ toYaml . | indent 6 }}
   {{- end }}
-  {{- if $.Values.searchHeadCluster.licenseUrl }}
-    licenseUrl: {{ $.Values.searchHeadCluster.licenseUrl }}
+  {{- if $.Values.customResources.searchHeadCluster.licenseUrl }}
+    licenseUrl: {{ $.Values.customResources.searchHeadCluster.licenseUrl }}
   {{- end }}
-  {{- if $.Values.searchHeadCluster.defaultsUrl }}
-    defaultsUrl: {{ $.Values.searchHeadCluster.defaultsUrl }}
+  {{- if $.Values.customResources.searchHeadCluster.defaultsUrl }}
+    defaultsUrl: {{ $.Values.customResources.searchHeadCluster.defaultsUrl }}
   {{- end }}
   {{- if $.Values.sva.m4.enabled }}
-    {{- $cm_name := $.Values.clusterManager.name -}}
+    {{- $cm_name := $.Values.customResources.clusterManager.name -}}
     {{- if and $.Values.existingClusterManager $.Values.existingClusterManager.name }}
       {{- $cm_name = $.Values.existingClusterManager.name -}}
     {{- end }}
@@ -96,60 +96,60 @@ items:
       splunk:
         multisite_master: splunk-{{ $cm_name }}-cluster-manager-service
         site: {{ .site }}
-  {{- else if $.Values.searchHeadCluster.defaults }}
+  {{- else if $.Values.customResources.searchHeadCluster.defaults }}
     defaults: |-
-{{ toYaml $.Values.searchHeadCluster.defaults | indent 6 }}
+{{ toYaml $.Values.customResources.searchHeadCluster.defaults | indent 6 }}
   {{- end }}
-  {{- if $.Values.searchHeadCluster.defaultsUrlApps }}
-    defaultsUrlApps: {{ $.Values.searchHeadCluster.defaultsUrlApps }}
+  {{- if $.Values.customResources.searchHeadCluster.defaultsUrlApps }}
+    defaultsUrlApps: {{ $.Values.customResources.searchHeadCluster.defaultsUrlApps }}
   {{- end }}
-  {{- with $.Values.searchHeadCluster.extraEnv }}
+  {{- with $.Values.customResources.searchHeadCluster.extraEnv }}
     extraEnv:
 {{ toYaml . | indent 6 }}
   {{- end }}
-  {{- if $.Values.searchHeadCluster.livenessInitialDelaySeconds }}
-    livenessInitialDelaySeconds: {{ $.Values.searchHeadCluster.livenessInitialDelaySeconds }}
+  {{- if $.Values.customResources.searchHeadCluster.livenessInitialDelaySeconds }}
+    livenessInitialDelaySeconds: {{ $.Values.customResources.searchHeadCluster.livenessInitialDelaySeconds }}
   {{- end }}
-  {{- if $.Values.searchHeadCluster.readinessInitialDelaySeconds }}
-    readinessInitialDelaySeconds: {{ $.Values.searchHeadCluster.readinessInitialDelaySeconds }}
+  {{- if $.Values.customResources.searchHeadCluster.readinessInitialDelaySeconds }}
+    readinessInitialDelaySeconds: {{ $.Values.customResources.searchHeadCluster.readinessInitialDelaySeconds }}
   {{- end }}
-  {{- if $.Values.searchHeadCluster.startupProbe }}
+  {{- if $.Values.customResources.searchHeadCluster.startupProbe }}
     startupProbe:
-{{ toYaml $.Values.searchHeadCluster.startupProbe | indent 6 }}
+{{ toYaml $.Values.customResources.searchHeadCluster.startupProbe | indent 6 }}
   {{- end }}
-  {{- if $.Values.searchHeadCluster.livenessProbe }}
+  {{- if $.Values.customResources.searchHeadCluster.livenessProbe }}
     livenessProbe:
-{{ toYaml $.Values.searchHeadCluster.livenessProbe | indent 6 }}
+{{ toYaml $.Values.customResources.searchHeadCluster.livenessProbe | indent 6 }}
   {{- end }}
-  {{- if $.Values.searchHeadCluster.readinessProbe }}
+  {{- if $.Values.customResources.searchHeadCluster.readinessProbe }}
     readinessProbe:
-{{ toYaml $.Values.searchHeadCluster.readinessProbe | indent 6 }}
+{{ toYaml $.Values.customResources.searchHeadCluster.readinessProbe | indent 6 }}
   {{- end }}
-  {{- with $.Values.searchHeadCluster.etcVolumeStorageConfig }}
+  {{- with $.Values.customResources.searchHeadCluster.etcVolumeStorageConfig }}
     etcVolumeStorageConfig:
 {{ toYaml . | indent 6 }}
   {{- end }}
-  {{- with $.Values.searchHeadCluster.varVolumeStorageConfig }}
+  {{- with $.Values.customResources.searchHeadCluster.varVolumeStorageConfig }}
     varVolumeStorageConfig:
 {{ toYaml . | indent 6 }}
   {{- end }}
-  {{- with $.Values.searchHeadCluster.resources }}
+  {{- with $.Values.customResources.searchHeadCluster.resources }}
     resources:
 {{ toYaml . | indent 6 }}
   {{- end }}
-  {{- if $.Values.searchHeadCluster.serviceAccount }}
-    serviceAccount: {{ $.Values.searchHeadCluster.serviceAccount }}
+  {{- if $.Values.customResources.searchHeadCluster.serviceAccount }}
+    serviceAccount: {{ $.Values.customResources.searchHeadCluster.serviceAccount }}
   {{- end }}
-  {{- with $.Values.searchHeadCluster.serviceTemplate }}
+  {{- with $.Values.customResources.searchHeadCluster.serviceTemplate }}
     serviceTemplate:
 {{ toYaml . | indent 6 }}
   {{- end }}
-  {{- with $.Values.searchHeadCluster.tolerations }}
+  {{- with $.Values.customResources.searchHeadCluster.tolerations }}
     tolerations:
 {{ toYaml . | indent 6 }}
   {{- end }}
-  {{- if $.Values.searchHeadCluster.topologySpreadConstraints }}
-  {{- with $.Values.searchHeadCluster.topologySpreadConstraints }}
+  {{- if $.Values.customResources.searchHeadCluster.topologySpreadConstraints }}
+  {{- with $.Values.customResources.searchHeadCluster.topologySpreadConstraints }}
     topologySpreadConstraints:
 {{ toYaml . | indent 6 }}
   {{- end }}
@@ -165,7 +165,7 @@ items:
               values:
               - {{ .zone }}
   {{- else }}
-    {{- with $.Values.searchHeadCluster.affinity }}
+    {{- with $.Values.customResources.searchHeadCluster.affinity }}
     affinity:
 {{ toYaml . | indent 6 }}
     {{- end }}

--- a/helm-chart/splunk-enterprise/templates/enterprise_v4_standalone.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v4_standalone.yaml
@@ -1,31 +1,31 @@
-{{- if or .Values.standalone.enabled .Values.sva.s1.enabled }}
+{{- if or .Values.customResources.standalone.enabled .Values.sva.s1.enabled }}
 apiVersion:  enterprise.splunk.com/v4
 kind: Standalone
 metadata:
-  name: {{ .Values.standalone.name }}
-  namespace: {{ default (include "splunk-enterprise.namespace" . ) .Values.standalone.namespaceOverride }}
-{{- with .Values.standalone.additionalLabels }}
+  name: {{ .Values.customResources.standalone.name }}
+  namespace: {{ default (include "splunk-enterprise.namespace" . ) .Values.customResources.standalone.namespaceOverride }}
+{{- with .Values.customResources.standalone.additionalLabels }}
   labels:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.standalone.additionalAnnotations }}
+{{- with .Values.customResources.standalone.additionalAnnotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.standalone.serviceAccount }}
-  serviceAccount: {{ .Values.standalone.serviceAccount }}
+{{- if .Values.customResources.standalone.serviceAccount }}
+  serviceAccount: {{ .Values.customResources.standalone.serviceAccount }}
 {{- end }}
 {{- if and .Values.sva.s1.enabled .Values.sva.s1.standalones }}
   replicas: {{ .Values.sva.s1.standalones }}
-{{- else if and .Values.standalone.enabled .Values.standalone.replicaCount }}
-  replicas: {{ .Values.standalone.replicaCount }}
+{{- else if and .Values.customResources.standalone.enabled .Values.customResources.standalone.replicaCount }}
+  replicas: {{ .Values.customResources.standalone.replicaCount }}
 {{- end }}
-{{- with .Values.standalone.appRepo }}
+{{- with .Values.customResources.standalone.appRepo }}
   appRepo:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.standalone.smartstore }}
+{{- with .Values.customResources.standalone.smartstore }}
   smartstore:
 {{ toYaml . | indent 4 }}
 {{- end }}
@@ -35,11 +35,11 @@ spec:
   {{- if .Values.existingClusterManager.namespace }}
     namespace: {{ .Values.existingClusterManager.namespace }}
   {{- end }}
-{{- else if .Values.clusterManager.enabled }}
+{{- else if .Values.customResources.clusterManager.enabled }}
   clusterManagerRef:
-    name: {{ .Values.clusterManager.name }}
-  {{- if .Values.clusterManager.namespaceOverride }}
-    namespace: {{ .Values.clusterManager.namespaceOverride }}
+    name: {{ .Values.customResources.clusterManager.name }}
+  {{- if .Values.customResources.clusterManager.namespaceOverride }}
+    namespace: {{ .Values.customResources.clusterManager.namespaceOverride }}
   {{- end }}
 {{- end }}
 {{- if and .Values.existingLicenseManager .Values.existingLicenseManager.name }}
@@ -48,11 +48,11 @@ spec:
   {{- if .Values.existingLicenseManager.namespace }}
     namespace: {{ .Values.existingLicenseManager.namespace }}
   {{- end }}
-{{- else if .Values.licenseManager.enabled }}
+{{- else if .Values.customResources.licenseManager.enabled }}
   licenseManagerRef:
-    name: {{ .Values.licenseManager.name }}
-  {{- if .Values.licenseManager.namespaceOverride }}
-    namespace: {{ .Values.licenseManager.namespaceOverride }}
+    name: {{ .Values.customResources.licenseManager.name }}
+  {{- if .Values.customResources.licenseManager.namespaceOverride }}
+    namespace: {{ .Values.customResources.licenseManager.namespaceOverride }}
   {{- end }}
 {{- end }}
 {{- if and .Values.existingMonitoringConsole .Values.existingMonitoringConsole.name }}
@@ -61,11 +61,11 @@ spec:
   {{- if .Values.existingMonitoringConsole.namespace }}
     namespace: {{ .Values.existingMonitoringConsole.namespace }}
   {{- end }}
-{{- else if .Values.monitoringConsole.enabled }}
+{{- else if .Values.customResources.monitoringConsole.enabled }}
   monitoringConsoleRef:
-    name: {{ .Values.monitoringConsole.name }}
-  {{- if .Values.monitoringConsole.namespaceOverride }}
-    namespace: {{ .Values.monitoringConsole.namespaceOverride }}
+    name: {{ .Values.customResources.monitoringConsole.name }}
+  {{- if .Values.customResources.monitoringConsole.namespaceOverride }}
+    namespace: {{ .Values.customResources.monitoringConsole.namespaceOverride }}
   {{- end }}
 {{- end }}
 {{- if .Values.image.repository }}
@@ -78,72 +78,72 @@ spec:
   imagePullSecrets:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.standalone.volumes }}
+{{- with .Values.customResources.standalone.volumes }}
   volumes:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if .Values.standalone.licenseUrl }}
-  licenseUrl: {{ .Values.standalone.licenseUrl }}
+{{- if .Values.customResources.standalone.licenseUrl }}
+  licenseUrl: {{ .Values.customResources.standalone.licenseUrl }}
 {{- end }}
-{{- if .Values.standalone.defaultsUrl }}
-  defaultsUrl: {{ .Values.standalone.defaultsUrl }}
+{{- if .Values.customResources.standalone.defaultsUrl }}
+  defaultsUrl: {{ .Values.customResources.standalone.defaultsUrl }}
 {{- end }}
-{{- if .Values.standalone.defaults }}
+{{- if .Values.customResources.standalone.defaults }}
   defaults: |-
-{{ toYaml .Values.standalone.defaults | indent 4 }}
+{{ toYaml .Values.customResources.standalone.defaults | indent 4 }}
 {{- end }}
-{{- if .Values.standalone.defaultsUrlApps }}
-  defaultsUrlApps: {{ .Values.standalone.defaultsUrlApps }}
+{{- if .Values.customResources.standalone.defaultsUrlApps }}
+  defaultsUrlApps: {{ .Values.customResources.standalone.defaultsUrlApps }}
 {{- end }}
-{{- with .Values.standalone.extraEnv }}
+{{- with .Values.customResources.standalone.extraEnv }}
   extraEnv:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if .Values.standalone.livenessInitialDelaySeconds }}
-  livenessInitialDelaySeconds: {{ .Values.standalone.livenessInitialDelaySeconds }}
+{{- if .Values.customResources.standalone.livenessInitialDelaySeconds }}
+  livenessInitialDelaySeconds: {{ .Values.customResources.standalone.livenessInitialDelaySeconds }}
 {{- end }}
-{{- if .Values.standalone.readinessInitialDelaySeconds }}
-  readinessInitialDelaySeconds: {{ .Values.standalone.readinessInitialDelaySeconds }}
+{{- if .Values.customResources.standalone.readinessInitialDelaySeconds }}
+  readinessInitialDelaySeconds: {{ .Values.customResources.standalone.readinessInitialDelaySeconds }}
 {{- end }}
-{{- if .Values.standalone.startupProbe }}
+{{- if .Values.customResources.standalone.startupProbe }}
   startupProbe:
-{{ toYaml .Values.standalone.startupProbe | indent 4 }}
+{{ toYaml .Values.customResources.standalone.startupProbe | indent 4 }}
 {{- end }}
-{{- if .Values.standalone.livenessProbe }}
+{{- if .Values.customResources.standalone.livenessProbe }}
   livenessProbe:
-{{ toYaml .Values.standalone.livenessProbe | indent 4 }}
+{{ toYaml .Values.customResources.standalone.livenessProbe | indent 4 }}
 {{- end }}
-{{- if .Values.standalone.readinessProbe }}
+{{- if .Values.customResources.standalone.readinessProbe }}
   readinessProbe:
-{{ toYaml .Values.standalone.readinessProbe | indent 4 }}
+{{ toYaml .Values.customResources.standalone.readinessProbe | indent 4 }}
 {{- end }}
-{{- with .Values.standalone.etcVolumeStorageConfig }}
+{{- with .Values.customResources.standalone.etcVolumeStorageConfig }}
   etcVolumeStorageConfig:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.standalone.varVolumeStorageConfig }}
+{{- with .Values.customResources.standalone.varVolumeStorageConfig }}
   varVolumeStorageConfig:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.standalone.resources }}
+{{- with .Values.customResources.standalone.resources }}
   resources:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.standalone.serviceTemplate }}
+{{- with .Values.customResources.standalone.serviceTemplate }}
   serviceTemplate:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.standalone.tolerations }}
+{{- with .Values.customResources.standalone.tolerations }}
   tolerations:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if .Values.standalone.topologySpreadConstraints }}
-{{- with .Values.standalone.topologySpreadConstraints }}
+{{- if .Values.customResources.standalone.topologySpreadConstraints }}
+{{- with .Values.customResources.standalone.topologySpreadConstraints }}
   topologySpreadConstraints:
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- end }}
-{{- with .Values.standalone.affinity }}
+{{- with .Values.customResources.standalone.affinity }}
   affinity:
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/helm-chart/splunk-enterprise/templates/pvs.yaml
+++ b/helm-chart/splunk-enterprise/templates/pvs.yaml
@@ -1,0 +1,53 @@
+{{- range $section, $config := .Values.customResources }}
+{{- if $config.enablePersistentVolume }}
+{{- range $i := until (int (default 1 $config.replicaCount)) }}
+
+{{- if $config.persistence.etc }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: "{{ $config.kindName }}-{{ $.Release.Name }}-etc-pv-{{ $i }}"
+  labels:
+    app.kubernetes.io/name: {{ $config.kindName }}
+    app.kubernetes.io/instance: {{ printf "splunk-%s-%s" $config.name $config.kindName }}
+spec:
+  capacity: 
+    storage: {{ $config.persistence.etc.size | default "10Gi" }} # Default size if not set
+  accessModes:
+  {{- toYaml $config.persistence.etc.accessModes | nindent 4 }}
+  persistentVolumeReclaimPolicy: {{ $config.persistence.etc.reclaimPolicy }}
+  {{- if $config.persistence.etc.storageClass }}
+  storageClassName: {{ $config.persistence.etc.storageClass }}
+  {{- end }}
+  {{- if $config.persistence.etc.providerConfig }}
+  {{- toYaml $config.persistence.etc.providerConfig | nindent 2 }}
+  {{- end }}
+---
+{{- end }}
+
+{{- if $config.persistence.var }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: "{{ $config.kindName }}-{{ $.Release.Name }}-etc-pv-{{ $i }}"
+  labels:
+    app.kubernetes.io/name: {{ $config.kindName }}
+    app.kubernetes.io/instance: {{ printf "splunk-%s-%s" $config.name $config.kindName }}
+spec:
+  capacity:
+    storage: {{ $config.persistence.var.size | default "100Gi" }} # Default size if not set
+  accessModes:
+  {{- toYaml $config.persistence.var.accessModes | nindent 4 }}
+  persistentVolumeReclaimPolicy: {{ $config.persistence.var.reclaimPolicy }}
+  {{- if $config.persistence.var.storageClass }}
+  storageClassName: {{ $config.persistence.var.storageClass }}
+  {{- end }}
+  {{- if $config.persistence.var.providerConfig }}
+  {{- toYaml $config.persistence.var.providerConfig | nindent 2 }}
+  {{- end }}
+---
+{{- end }}
+
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm-chart/splunk-enterprise/values.yaml
+++ b/helm-chart/splunk-enterprise/values.yaml
@@ -4,47 +4,34 @@ image:
   repository: ""
   imagePullPolicy: ""
   imagePullSecrets: []
-
 # Deploy Splunk Operator chart
 # Disable if the Splunk Operator is already deployed
 splunk-operator:
   enabled: true
-
 sva:
-
   # Single Server Deployment (S1)
   # reference: https://www.splunk.com/pdfs/technical-briefs/splunk-validated-architectures.pdf#page=9
   s1:
-
     enabled: false
-
     standalones: 1
-
   # Distributed Clustered Deployment + SHC - Single Site (C3)
   # reference: https://www.splunk.com/pdfs/technical-briefs/splunk-validated-architectures.pdf#page=14
   c3:
-
     enabled: false
-
     indexerClusters: []
       # - name: idx1
       # - name: idx2
-
     searchHeadClusters: []
       # - name: shc1
       # - name: shc2
-
   # Distributed Clustered Deployment + SHC - Multi-Site (M4)
   # reference: https://www.splunk.com/pdfs/technical-briefs/splunk-validated-architectures.pdf#page=20
   m4:
-
     enabled: false
-
     clusterManager: {}
       # allSites: "site1,site2"
       # site: site1
       # zone: us-west-1a
-
     indexerClusters: []
       # - name: idx1
       #   site: site1
@@ -52,752 +39,737 @@ sva:
       # - name: idx2
       #   site: site2
       #   zone: us-west-1c
-
     searchHeadClusters: []
       # - name: shc1
       #   site: site2
       #   zone: us-west-1c
-
 # Set name reference if ClusterManager is already deployed
 # Namespace is optional, set if the resource exists outside of the release namespace
 existingClusterManager: {}
   # name:
   # namespace:
-
 # Set name reference if MonitoringConsole is already deployed
 # Namespace is optional, set if the resource exists outside of the release namespace
 existingMonitoringConsole: {}
   # name:
   # namespace:
-
 # Set name reference if LicenseManager is already deployed
 # Namespace is optional, set if the resource exists outside of the release namespace
 existingLicenseManager: {}
   # name:
   # namespace:
-
+customResources:
 # Configure a Splunk Cluster Manager instance
-clusterManager:
-
-  # Deploy a cluster manager instance
-  enabled: false
-
-  # Specify the custom resource name
-  name: "cm"
-
-  # Override the custom resource namespace
-  # Default deploys to the release namespace
-  namespaceOverride: ""
-
-  # Specify additional labels
-  additionalLabels: {}
-
-  additionalAnnotations: {}
-
-
-
-  # Splunk Enterprise App repository
-  # Specifies remote App location and scope for Splunk App management
-  # reference: https://github.com/splunk/splunk-operator/blob/develop/docs/AppFramework.md
-  appRepo: {}
-    ## Example: Deploy apps on cluster manager instance for local use
-    # appsRepoPollIntervalSeconds: 900
-    # appSources:
-    #   - name: networkApps
-    #     location: networkAppsLoc/
-    #   - name: clusterBase
-    #     location: clusterBaseLoc/
-    #   - name: adminApps
-    #     location: adminAppsLoc/
-    #     scope: local
-    # volumes:
-    #   - name: volume_app_repo_us
-    #     storageType: s3
-    #     provider: aws
-    #     path: bucket-app-framework-us-west-2/idxcAndCmApps/
-    #     endpoint: https://s3-us-west-2.amazonaws.com
-    #     region: us-west-2
-    #     secretRef: s3-secret
-
-  # Splunk Smartstore configuration
-  # reference: https://github.com/splunk/splunk-operator/blob/develop/docs/SmartStore.md
-  smartstore: {}
-    ## Example: Deploy smartstore to a clustermanager, distributes config to indexer peers
-    # volumes:
-    #   - name: <remote_volume_name>
-    #     path: <remote_volume_path>
-    #     endpoint: https://s3-<region>.amazonaws.com
-    #     secretRef: <secret_store_obj>
-    # indexes:
-    #   - name: <index_name_1>
-    #     remotePath: $_index_name
-    #     volumeName: <remote_volume_name>
-    #   - name: <index_name_2>
-    #     remotePath: $_index_name
-    #     volumeName: <remote_volume_name>
-    #   - name: <index_name_3>
-    #     remotePath: $_index_name
-    #     volumeName: <remote_volume_name>
-
-  # List volumes to be mounted in all pod containers
-  # reference: https://kubernetes.io/docs/concepts/storage/volumes/
-  volumes: []
-
-  # Full path or URL for a Splunk Enterprise license file
-  # Ignore if deploying a license manager instance
-  licenseUrl: ""
-
-  # Full path or URL for one or more default.yml files, separated by commas
-  defaultsUrl: ""
-
-  # Specify Splunk default.yaml to override intial environment config
-  defaults: {}
-    ## Example: Deploy a multi-site cluster manager
-    # splunk:
-    #   site: site1
-    #   multisite_manager: localhost
-    #   all_sites: site1,site2,site3
-    #   multisite_replication_factor_origin: 1
-    #   multisite_replication_factor_total: 2
-    #   multisite_search_factor_origin: 1
-    #   multisite_search_factor_total: 2
-    #   idxc:
-    #     search_factor: 2
-    #     replication_factor: 2
-
-  # Full path or URL for one or more defaults.yml files specific to App install, separated by commas
-  defaultsUrlApps: ""
-
-  # List additional environment variables to passed to the Splunk instance container
-  extraEnv: []
-  # - name:
-  #   value:
-
-  # Delay in seconds before probing liveness
-  # refernece: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command
-  livenessInitialDelaySeconds: 300
-
-  # Delay in seconds before probing readiness
-  # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command
-  readinessInitialDelaySeconds: 10
-
-  # Set Probes for Splunk instance pod containers
-  # reference: https://github.com/splunk/splunk-operator/blob/main/docs/HealthCheck.md
-  startupProbe: {}
-    # initialDelaySeconds: 40
-    # timeoutSeconds: 30
-    # periodSeconds: 30
-    # failureThreshold: 12
-  livenessProbe: {}
-    # initialDelaySeconds: 30
-    # timeoutSeconds: 30
-    # periodSeconds: 30
-    # failureThreshold: 3
-  readinessProbe: {}
-    # initialDelaySeconds: 10
-    # timeoutSeconds: 5
-    # periodSeconds: 5
-    # failureThreshold: 3
-
-  # Storage configuration for /opt/splunk/etc volume
-  # To use a StorageClass other than your default StorageClass, specify the storageClassName
-  # reference: https://github.com/splunk/splunk-operator/blob/develop/docs/StorageClass.md
-  etcVolumeStorageConfig:
-    ephemeralStorage: false
-    storageCapacity: 10Gi
-  # storageClassName: gp2
-
-  # Storage configuration for /opt/splunk/var volume
-  # To use a StorageClass other than your default StorageClass, specify the storageClassName
-  # reference: https://github.com/splunk/splunk-operator/blob/develop/docs/StorageClass.md
-  varVolumeStorageConfig:
-    ephemeralStorage: false
-    storageCapacity: 100Gi
-  # storageClassName: gp2
-
-  # Set resource requests and limits for Splunk instance pod containers
-  # reference: https://github.com/splunk/splunk-operator/blob/develop/docs/CustomResources.md#examples-of-guaranteed-and-burstable-qos
-  resources: {}
-    # requests:
-    #   memory: "2Gi"
-    #   cpu: "4"
-    # limits:
-    #   memory: "12Gi"
-    #   cpu: "24"
-
-  # Specify a service account used by the Splunk instance pods
-  # Default uses the Default Service Account to access the API server
-  # reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-  serviceAccount: ""
-
-  # ServiceTemplate is a template used to create Kubernetes services
-  serviceTemplate: {}
-
-  # Specify Splunk instance pod tolerations
-  # reference: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations: []
-
-  # Define affinity scheduling rules
-  # reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
-  affinity: {}
-    ## Example: schedule Splunk instance pod on a node in zone-1a
-    # nodeAffinity:
-    #   requiredDuringSchedulingIgnoredDuringExecution:
-    #     nodeSelectorTerms:
-    #     - matchExpressions:
-    #       - key: failure-domain.beta.kubernetes.io/zone
-    #         operator: In
-    #         values:
-    #         - zone-1a
-
-  # Configure a topology spread constraint
-  #  https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
-  topologySpreadConstraints: []
-  #  - maxSkew: <integer>
-  #    minDomains: <integer> # optional; beta since v1.25
-  #    topologyKey: <string>
-  #    whenUnsatisfiable: <string>
-  #    labelSelector: <object>
-  #    matchLabelKeys: <list> # optional; alpha since v1.25
-  #    nodeAffinityPolicy: [Honor|Ignore] # optional; beta since v1.26
-  #    nodeTaintsPolicy: [Honor|Ignore] # optional; beta since v1.26
-
-
-indexerCluster:
-
-  enabled: false
-
-  name: "idxc"
-
-  namespaceOverride: ""
-
-  additionalLabels: {}
-
-  additionalAnnotations: {}
-
-  replicaCount: 1
-
-  volumes: []
-
-  licenseUrl: ""
-
-  defaultsUrl: ""
-
-  defaults: {}
-
-  extraEnv: []
-  # - name:
-  #   value:
-
-  livenessInitialDelaySeconds: 300
-
-  readinessInitialDelaySeconds: 10
-
-  # Set Probes for Splunk instance pod containers
-  # reference: https://github.com/splunk/splunk-operator/blob/main/docs/HealthCheck.md
-  startupProbe: {}
-    # initialDelaySeconds: 40
-    # timeoutSeconds: 30
-    # periodSeconds: 30
-    # failureThreshold: 12
-  livenessProbe: {}
-    # initialDelaySeconds: 30
-    # timeoutSeconds: 30
-    # periodSeconds: 30
-    # failureThreshold: 3
-  readinessProbe: {}
-    # initialDelaySeconds: 10
-    # timeoutSeconds: 5
-    # periodSeconds: 5
-    # failureThreshold: 3
-
-  etcVolumeStorageConfig:
-    ephemeralStorage: false
-    storageCapacity: 10Gi
-  # storageClassName: gp2
-
-  varVolumeStorageConfig:
-    ephemeralStorage: false
-    storageCapacity: 100Gi
-  # storageClassName: gp2
-
-  resources: {}
-    # requests:
-    #   memory: "2Gi"
-    #   cpu: "4"
-    # limits:
-    #   memory: "12Gi"
-    #   cpu: "24"
-
-  serviceAccount: ""
-
-  # ServiceTemplate is a template used to create Kubernetes services
-  serviceTemplate: {}
-
-  tolerations: []
-
-  affinity: {}
-
-  # Configure a topology spread constraint
-  #  https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
-  topologySpreadConstraints: []
-  #  - maxSkew: <integer>
-  #    minDomains: <integer> # optional; beta since v1.25
-  #    topologyKey: <string>
-  #    whenUnsatisfiable: <string>
-  #    labelSelector: <object>
-  #    matchLabelKeys: <list> # optional; alpha since v1.25
-  #    nodeAffinityPolicy: [Honor|Ignore] # optional; beta since v1.26
-  #    nodeTaintsPolicy: [Honor|Ignore] # optional; beta since v1.26
-
-searchHeadCluster:
-
-  enabled: false
-
-  name: "shc"
-
-  namespaceOverride: ""
-
-  additionalLabels: {}
-
-  additionalAnnotations: {}
-
-  replicaCount: 1
-
-  appRepo: {}
-    # appsRepoPollIntervalSeconds:
-    # defaults:
-    #   volumeName:
-    #   scope:
-    # appSources:
-    #   - name:
-    #     location:
-    #     scope: # options (local|cluster|premiumApps) default local
-    #      premiumAppsProps: #only if scope is set to premiumApps
-    #        type: enterpriseSecurity
-    #        esDefaults:
-    #          sslEnablement: # options are ignore, strict, auto. default value is strict
-    # volumes:
-    #   - name:
-    #     storageType:
-    #     provider:
-    #     path:
-    #     endpoint:
-    #     region:
-    #     secretRef:
-
-  volumes: []
-
-  licenseUrl: ""
-
-  defaultsUrl: ""
-
-  defaults: {}
-
-  defaultsUrlApps: ""
-
-  extraEnv: []
-  # - name:
-  #   value:
-
-  livenessInitialDelaySeconds: 300
-
-  readinessInitialDelaySeconds: 10
-
-  # Set Probes for Splunk instance pod containers
-  # reference: https://github.com/splunk/splunk-operator/blob/main/docs/HealthCheck.md
-  startupProbe: {}
-    # initialDelaySeconds: 40
-    # timeoutSeconds: 30
-    # periodSeconds: 30
-    # failureThreshold: 12
-  livenessProbe: {}
-    # initialDelaySeconds: 30
-    # timeoutSeconds: 30
-    # periodSeconds: 30
-    # failureThreshold: 3
-  readinessProbe: {}
-    # initialDelaySeconds: 10
-    # timeoutSeconds: 5
-    # periodSeconds: 5
-    # failureThreshold: 3
-
-  etcVolumeStorageConfig:
-    ephemeralStorage: false
-    storageCapacity: 10Gi
-  # storageClassName: gp2
-
-  varVolumeStorageConfig:
-    ephemeralStorage: false
-    storageCapacity: 100Gi
-  # storageClassName: gp2
-
-  resources: {}
-    # requests:
-    #   memory: "2Gi"
-    #   cpu: "4"
-    # limits:
-    #   memory: "12Gi"
-    #   cpu: "24"
-
-  serviceAccount: ""
-
-  # ServiceTemplate is a template used to create Kubernetes services
-  serviceTemplate: {}
-
-  tolerations: []
-
-  affinity: {}
-
-  # Configure a topology spread constraint
-  #  https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
-  topologySpreadConstraints: []
-  #  - maxSkew: <integer>
-  #    minDomains: <integer> # optional; beta since v1.25
-  #    topologyKey: <string>
-  #    whenUnsatisfiable: <string>
-  #    labelSelector: <object>
-  #    matchLabelKeys: <list> # optional; alpha since v1.25
-  #    nodeAffinityPolicy: [Honor|Ignore] # optional; beta since v1.26
-  #    nodeTaintsPolicy: [Honor|Ignore] # optional; beta since v1.26
-
-monitoringConsole:
-
-  enabled: false
-
-  name: "mc"
-
-  namespaceOverride: ""
-
-  additionalLabels: {}
-
-  additionalAnnotations: {}
-
-  appRepo: {}
-    # appsRepoPollIntervalSeconds:
-    # defaults:
-    #   volumeName:
-    #   scope:
-    # appSources:
-    #   - name:
-    #     location:
-    # volumes:
-    #   - name:
-    #     storageType:
-    #     provider:
-    #     path:
-    #     endpoint:
-    #     region:
-    #     secretRef:
-
-  volumes: []
-
-  licenseUrl: ""
-
-  defaultsUrl: ""
-
-  defaults: {}
-
-  defaultsUrlApps: ""
-
-  extraEnv: []
-  # - name:
-  #   value:
-
-  livenessInitialDelaySeconds: 300
-
-  readinessInitialDelaySeconds: 10
-
-  # Set Probes for Splunk instance pod containers
-  # reference: https://github.com/splunk/splunk-operator/blob/main/docs/HealthCheck.md
-  startupProbe: {}
-    # initialDelaySeconds: 40
-    # timeoutSeconds: 30
-    # periodSeconds: 30
-    # failureThreshold: 12
-  livenessProbe: {}
-    # initialDelaySeconds: 30
-    # timeoutSeconds: 30
-    # periodSeconds: 30
-    # failureThreshold: 3
-  readinessProbe: {}
-    # initialDelaySeconds: 10
-    # timeoutSeconds: 5
-    # periodSeconds: 5
-    # failureThreshold: 3
-
-  etcVolumeStorageConfig:
-    ephemeralStorage: false
-    storageCapacity: 10Gi
-  # storageClassName: gp2
-
-  varVolumeStorageConfig:
-    ephemeralStorage: false
-    storageCapacity: 100Gi
-  # storageClassName: gp2
-
-  resources: {}
-    # requests:
-    #   memory: "2Gi"
-    #   cpu: "4"
-    # limits:
-    #   memory: "12Gi"
-    #   cpu: "24"
-
-  serviceAccount: ""
-
-  # ServiceTemplate is a template used to create Kubernetes services
-  serviceTemplate: {}
-
-  tolerations: []
-
-  affinity: {}
-
-  # Configure a topology spread constraint
-  #  https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
-  topologySpreadConstraints: []
-  #  - maxSkew: <integer>
-  #    minDomains: <integer> # optional; beta since v1.25
-  #    topologyKey: <string>
-  #    whenUnsatisfiable: <string>
-  #    labelSelector: <object>
-  #    matchLabelKeys: <list> # optional; alpha since v1.25
-  #    nodeAffinityPolicy: [Honor|Ignore] # optional; beta since v1.26
-  #    nodeTaintsPolicy: [Honor|Ignore] # optional; beta since v1.26
-
-licenseManager:
-
-  enabled: false
-
-  name: "lm"
-
-  namespaceOverride: ""
-
-  additionalLabels: {}
-
-  additionalAnnotations: {}
-
-  appRepo: {}
-    # appsRepoPollIntervalSeconds:
-    # defaults:
-    #   volumeName:
-    #   scope:
-    # appSources:
-    #   - name:
-    #     location:
-    #     scope: # options (local|cluster|premiumApps) default local
-    #      premiumAppsProps: #only if scope is set to premiumApps
-    #        type: enterpriseSecurity
-    #        esDefaults:
-    #          sslEnablement: # options are ignore, strict, auto. default value is strict
-    # volumes:
-    #   - name:
-    #     storageType:
-    #     provider:
-    #     path:
-    #     endpoint:
-    #     region:
-    #     secretRef:
-
-  volumes: []
-  ## Example: mounting volume containing license in Splunk instance pod container
-  # - name: licenses
-  #   configMap:
-  #     name: splunk-licenses
-
-  licenseUrl: ""
-  ## Example: using mounted volume to specify license file path
-  # licenseUrl: /mnt/licenses/enterprise.lic
-
-  defaultsUrl: ""
-
-  defaults: {}
-
-  defaultsUrlApps: ""
-
-  extraEnv: []
-  # - name:
-  #   value:
-
-  livenessInitialDelaySeconds: 300
-
-  readinessInitialDelaySeconds: 10
-
-  # Set Probes for Splunk instance pod containers
-  # reference: https://github.com/splunk/splunk-operator/blob/main/docs/HealthCheck.md
-  startupProbe: {}
-    # initialDelaySeconds: 40
-    # timeoutSeconds: 30
-    # periodSeconds: 30
-    # failureThreshold: 12
-  livenessProbe: {}
-    # initialDelaySeconds: 30
-    # timeoutSeconds: 30
-    # periodSeconds: 30
-    # failureThreshold: 3
-  readinessProbe: {}
-    # initialDelaySeconds: 10
-    # timeoutSeconds: 5
-    # periodSeconds: 5
-    # failureThreshold: 3
-
-  etcVolumeStorageConfig:
-    ephemeralStorage: false
-    storageCapacity: 10Gi
-  # storageClassName: gp2
-
-  varVolumeStorageConfig:
-    ephemeralStorage: false
-    storageCapacity: 100Gi
-  # storageClassName: gp2
-
-  resources: {}
-    # requests:
-    #   memory: "2Gi"
-    #   cpu: "4"
-    # limits:
-    #   memory: "12Gi"
-    #   cpu: "24"
-
-  serviceAccount: ""
-
-  # ServiceTemplate is a template used to create Kubernetes services
-  serviceTemplate: {}
-
-  tolerations: []
-
-  affinity: {}
-
-  # Configure a topology spread constraint
-  #  https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
-  topologySpreadConstraints: []
-  #  - maxSkew: <integer>
-  #    minDomains: <integer> # optional; beta since v1.25
-  #    topologyKey: <string>
-  #    whenUnsatisfiable: <string>
-  #    labelSelector: <object>
-  #    matchLabelKeys: <list> # optional; alpha since v1.25
-  #    nodeAffinityPolicy: [Honor|Ignore] # optional; beta since v1.26
-  #    nodeTaintsPolicy: [Honor|Ignore] # optional; beta since v1.26
-
-standalone:
-
-  enabled: false
-
-  name: "stdln"
-
-  namespaceOverride: ""
-
-  additionalLabels: {}
-
-  additionalAnnotations: {}
-
-  replicaCount: 1
-
-  appRepo: {}
-    # appsRepoPollIntervalSeconds:
-    # defaults:
-    #   volumeName:
-    #   scope:
-    # appSources:
-    #   - name:
-    #     location:
-    # volumes:
-    #   - name:
-    #     storageType:
-    #     provider:
-    #     path:
-    #     endpoint:
-    #     region:
-    #     secretRef:
-
-  smartstore: {}
-    # defaults:
-    #   volumeName:
-    # indexes:
-    #   - name:
-    #     volumeName:
-    #     remotePath:
-    # volumes:
-    #   - name:
-    #     path:
-    #     endpoint:
-    #     secretRef:
-  volumes: []
-
-  licenseUrl: ""
-
-  defaultsUrl: ""
-
-  defaults: {}
-
-  defaultsUrlApps: ""
-
-  extraEnv: []
-  # - name:
-  #   value:
-
-  livenessInitialDelaySeconds: 300
-
-  readinessInitialDelaySeconds: 10
-
-  # Set Probes for Splunk instance pod containers
-  # reference: https://github.com/splunk/splunk-operator/blob/main/docs/HealthCheck.md
-  startupProbe: {}
-    # initialDelaySeconds: 40
-    # timeoutSeconds: 30
-    # periodSeconds: 30
-    # failureThreshold: 12
-  livenessProbe: {}
-    # initialDelaySeconds: 30
-    # timeoutSeconds: 30
-    # periodSeconds: 30
-    # failureThreshold: 3
-  readinessProbe: {}
-    # initialDelaySeconds: 10
-    # timeoutSeconds: 5
-    # periodSeconds: 5
-    # failureThreshold: 3
-
-  etcVolumeStorageConfig:
-    ephemeralStorage: false
-    storageCapacity: 10Gi
-  # storageClassName: gp2
-
-  varVolumeStorageConfig:
-    ephemeralStorage: false
-    storageCapacity: 100Gi
-  # storageClassName: gp2
-
-  resources: {}
-    # requests:
-    #   memory: "2Gi"
-    #   cpu: "4"
-    # limits:
-    #   memory: "12Gi"
-    #   cpu: "24"
-
-  serviceAccount: ""
-
-  # ServiceTemplate is a template used to create Kubernetes services
-  serviceTemplate: {}
-
-  tolerations: []
-
-  affinity: {}
-
-  # Configure a topology spread constraint
-  #  https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
-  topologySpreadConstraints: []
-  #  - maxSkew: <integer>
-  #    minDomains: <integer> # optional; beta since v1.25
-  #    topologyKey: <string>
-  #    whenUnsatisfiable: <string>
-  #    labelSelector: <object>
-  #    matchLabelKeys: <list> # optional; alpha since v1.25
-  #    nodeAffinityPolicy: [Honor|Ignore] # optional; beta since v1.26
-  #    nodeTaintsPolicy: [Honor|Ignore] # optional; beta since v1.26
-
+  clusterManager:  # Deploy a cluster manager instance
+    enabled: false
+    # Specify the custom resource name
+    name: "cm"
+    # Override the custom resource namespace
+    # Default deploys to the release namespace
+    namespaceOverride: ""
+    # Specify additional labels
+    kindName: cluster-manager
+    additionalLabels: {}
+    additionalAnnotations: {}
+    # Splunk Enterprise App repository
+    # Specifies remote App location and scope for Splunk App management
+    # reference: https://github.com/splunk/splunk-operator/blob/develop/docs/AppFramework.md
+    appRepo: {}
+      ## Example: Deploy apps on cluster manager instance for local use
+      # appsRepoPollIntervalSeconds: 900
+      # appSources:
+      #   - name: networkApps
+      #     location: networkAppsLoc/
+      #   - name: clusterBase
+      #     location: clusterBaseLoc/
+      #   - name: adminApps
+      #     location: adminAppsLoc/
+      #     scope: local
+      # volumes:
+      #   - name: volume_app_repo_us
+      #     storageType: s3
+      #     provider: aws
+      #     path: bucket-app-framework-us-west-2/idxcAndCmApps/
+      #     endpoint: https://s3-us-west-2.amazonaws.com
+      #     region: us-west-2
+      #     secretRef: s3-secret
+    # Splunk Smartstore configuration
+    # reference: https://github.com/splunk/splunk-operator/blob/develop/docs/SmartStore.md
+    smartstore: {}
+      ## Example: Deploy smartstore to a clustermanager, distributes config to indexer peers
+      # volumes:
+      #   - name: <remote_volume_name>
+      #     path: <remote_volume_path>
+      #     endpoint: https://s3-<region>.amazonaws.com
+      #     secretRef: <secret_store_obj>
+      # indexes:
+      #   - name: <index_name_1>
+      #     remotePath: $_index_name
+      #     volumeName: <remote_volume_name>
+      #   - name: <index_name_2>
+      #     remotePath: $_index_name
+      #     volumeName: <remote_volume_name>
+      #   - name: <index_name_3>
+      #     remotePath: $_index_name
+      #     volumeName: <remote_volume_name>
+    # List volumes to be mounted in all pod containers
+    # reference: https://kubernetes.io/docs/concepts/storage/volumes/
+    volumes: []
+    # Full path or URL for a Splunk Enterprise license file
+    # Ignore if deploying a license manager instance
+    licenseUrl: ""
+    # Full path or URL for one or more default.yml files, separated by commas
+    defaultsUrl: ""
+    # Specify Splunk default.yaml to override intial environment config
+    defaults: {}
+      ## Example: Deploy a multi-site cluster manager
+      # splunk:
+      #   site: site1
+      #   multisite_manager: localhost
+      #   all_sites: site1,site2,site3
+      #   multisite_replication_factor_origin: 1
+      #   multisite_replication_factor_total: 2
+      #   multisite_search_factor_origin: 1
+      #   multisite_search_factor_total: 2
+      #   idxc:
+      #     search_factor: 2
+      #     replication_factor: 2
+    # Full path or URL for one or more defaults.yml files specific to App install, separated by commas
+    defaultsUrlApps: ""
+    # List additional environment variables to passed to the Splunk instance container
+    extraEnv: []
+    # - name:
+    #   value:
+    # Delay in seconds before probing liveness
+    # refernece: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command
+    livenessInitialDelaySeconds: 300
+    # Delay in seconds before probing readiness
+    # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command
+    readinessInitialDelaySeconds: 10
+    # Set Probes for Splunk instance pod containers
+    # reference: https://github.com/splunk/splunk-operator/blob/main/docs/HealthCheck.md
+    startupProbe: {}
+      # initialDelaySeconds: 40
+      # timeoutSeconds: 30
+      # periodSeconds: 30
+      # failureThreshold: 12
+    livenessProbe: {}
+      # initialDelaySeconds: 30
+      # timeoutSeconds: 30
+      # periodSeconds: 30
+      # failureThreshold: 3
+    readinessProbe: {}
+      # initialDelaySeconds: 10
+      # timeoutSeconds: 5
+      # periodSeconds: 5
+      # failureThreshold: 3
+    # Storage configuration for /opt/splunk/etc volume
+    # To use a StorageClass other than your default StorageClass, specify the storageClassName
+    # reference: https://github.com/splunk/splunk-operator/blob/develop/docs/StorageClass.md
+    enablePersistentVolume: false
+    persistence: {}
+      # etc:
+      #   reclaimPolicy: "Delete"
+      #   storageClass: "gp2"
+      #   size: 10Gi
+      #   accessModes:
+      #     - ReadWriteOnce
+      #   providerConfig:
+      #     awsElasticBlockStore:
+      #       volumeID: vol-xxxxxxxxxxxxxxxxxxx
+      #       fsType: ext4
+      # var:
+      #   reclaimPolicy: "Delete"
+      #   storageClass: "gp2"
+      #   size: 1000Gi
+      #   accessModes:
+      #     - ReadWriteOnce
+      #   providerConfig:
+      #     awsElasticBlockStore:
+      #       volumeID: vol-xxxxxxxxxxxxxxxxxxx
+      #       fsType: ext4
+    etcVolumeStorageConfig:
+      ephemeralStorage: false
+      storageCapacity: 10Gi
+    # storageClassName: gp2
+    # Storage configuration for /opt/splunk/var volume
+    # To use a StorageClass other than your default StorageClass, specify the storageClassName
+    # reference: https://github.com/splunk/splunk-operator/blob/develop/docs/StorageClass.md
+    varVolumeStorageConfig:
+      ephemeralStorage: false
+      storageCapacity: 100Gi
+    # storageClassName: gp2
+    # Set resource requests and limits for Splunk instance pod containers
+    # reference: https://github.com/splunk/splunk-operator/blob/develop/docs/CustomResources.md#examples-of-guaranteed-and-burstable-qos
+    resources: {}
+      # requests:
+      #   memory: "2Gi"
+      #   cpu: "4"
+      # limits:
+      #   memory: "12Gi"
+      #   cpu: "24"
+    # Specify a service account used by the Splunk instance pods
+    # Default uses the Default Service Account to access the API server
+    # reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    serviceAccount: ""
+    # ServiceTemplate is a template used to create Kubernetes services
+    serviceTemplate: {}
+    # Specify Splunk instance pod tolerations
+    # reference: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+    tolerations: []
+    # Define affinity scheduling rules
+    # reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
+    affinity: {}
+      ## Example: schedule Splunk instance pod on a node in zone-1a
+      # nodeAffinity:
+      #   requiredDuringSchedulingIgnoredDuringExecution:
+      #     nodeSelectorTerms:
+      #     - matchExpressions:
+      #       - key: failure-domain.beta.kubernetes.io/zone
+      #         operator: In
+      #         values:
+      #         - zone-1a
+    # Configure a topology spread constraint
+    #  https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+    topologySpreadConstraints: []
+    #  - maxSkew: <integer>
+    #    minDomains: <integer> # optional; beta since v1.25
+    #    topologyKey: <string>
+    #    whenUnsatisfiable: <string>
+    #    labelSelector: <object>
+    #    matchLabelKeys: <list> # optional; alpha since v1.25
+    #    nodeAffinityPolicy: [Honor|Ignore] # optional; beta since v1.26
+    #    nodeTaintsPolicy: [Honor|Ignore] # optional; beta since v1.26
+  indexerCluster:
+    enabled: false
+    name: "idxc"
+    namespaceOverride: ""
+    kindName: indexer-cluster
+    additionalLabels: {}
+    additionalAnnotations: {}
+    replicaCount: 2
+    volumes: []
+    licenseUrl: ""
+    defaultsUrl: ""
+    defaults: {}
+    extraEnv: []
+    # - name:
+    #   value:
+    livenessInitialDelaySeconds: 300
+    readinessInitialDelaySeconds: 10
+    # Set Probes for Splunk instance pod containers
+    # reference: https://github.com/splunk/splunk-operator/blob/main/docs/HealthCheck.md
+    startupProbe: {}
+      # initialDelaySeconds: 40
+      # timeoutSeconds: 30
+      # periodSeconds: 30
+      # failureThreshold: 12
+    livenessProbe: {}
+      # initialDelaySeconds: 30
+      # timeoutSeconds: 30
+      # periodSeconds: 30
+      # failureThreshold: 3
+    readinessProbe: {}
+      # initialDelaySeconds: 10
+      # timeoutSeconds: 5
+      # periodSeconds: 5
+      # failureThreshold: 3
+    enablePersistentVolume: false
+    persistence: {}
+      # etc:
+      #   reclaimPolicy: "Delete"
+      #   storageClass: "gp2"
+      #   size: 10Gi
+      #   accessModes:
+      #     - ReadWriteOnce
+      #   providerConfig:
+      #     awsElasticBlockStore:
+      #       volumeID: vol-xxxxxxxxxxxxxxxxxxx
+      #       fsType: ext4
+      # var:
+      #   reclaimPolicy: "Delete"
+      #   storageClass: "gp2"
+      #   size: 1000Gi
+      #   accessModes:
+      #     - ReadWriteOnce
+      #   providerConfig:
+      #     awsElasticBlockStore:
+      #       volumeID: vol-xxxxxxxxxxxxxxxxxxx
+      #       fsType: ext4
+    etcVolumeStorageConfig:
+      ephemeralStorage: false
+      storageCapacity: 10Gi
+    # storageClassName: gp2
+    varVolumeStorageConfig:
+      ephemeralStorage: false
+      storageCapacity: 100Gi
+    # storageClassName: gp2
+    resources: {}
+      # requests:
+      #   memory: "2Gi"
+      #   cpu: "4"
+      # limits:
+      #   memory: "12Gi"
+      #   cpu: "24"
+    serviceAccount: ""
+    # ServiceTemplate is a template used to create Kubernetes services
+    serviceTemplate: {}
+    tolerations: []
+    affinity: {}
+    # Configure a topology spread constraint
+    #  https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+    topologySpreadConstraints: []
+    #  - maxSkew: <integer>
+    #    minDomains: <integer> # optional; beta since v1.25
+    #    topologyKey: <string>
+    #    whenUnsatisfiable: <string>
+    #    labelSelector: <object>
+    #    matchLabelKeys: <list> # optional; alpha since v1.25
+    #    nodeAffinityPolicy: [Honor|Ignore] # optional; beta since v1.26
+    #    nodeTaintsPolicy: [Honor|Ignore] # optional; beta since v1.26
+  searchHeadCluster:
+    enabled: false
+    name: "shc"
+    namespaceOverride: ""
+    kindName: search-head
+    additionalLabels: {}
+    additionalAnnotations: {}
+    replicaCount: 1
+    appRepo: {}
+      # appsRepoPollIntervalSeconds:
+      # defaults:
+      #   volumeName:
+      #   scope:
+      # appSources:
+      #   - name:
+      #     location:
+      #     scope: # options (local|cluster|premiumApps) default local
+      #      premiumAppsProps: #only if scope is set to premiumApps
+      #        type: enterpriseSecurity
+      #        esDefaults:
+      #          sslEnablement: # options are ignore, strict, auto. default value is strict
+      # volumes:
+      #   - name:
+      #     storageType:
+      #     provider:
+      #     path:
+      #     endpoint:
+      #     region:
+      #     secretRef:
+    volumes: []
+    licenseUrl: ""
+    defaultsUrl: ""
+    defaults: {}
+    defaultsUrlApps: ""
+    extraEnv: []
+    # - name:
+    #   value:
+    livenessInitialDelaySeconds: 300
+    readinessInitialDelaySeconds: 10
+    # Set Probes for Splunk instance pod containers
+    # reference: https://github.com/splunk/splunk-operator/blob/main/docs/HealthCheck.md
+    startupProbe: {}
+      # initialDelaySeconds: 40
+      # timeoutSeconds: 30
+      # periodSeconds: 30
+      # failureThreshold: 12
+    livenessProbe: {}
+      # initialDelaySeconds: 30
+      # timeoutSeconds: 30
+      # periodSeconds: 30
+      # failureThreshold: 3
+    readinessProbe: {}
+      # initialDelaySeconds: 10
+      # timeoutSeconds: 5
+      # periodSeconds: 5
+      # failureThreshold: 3
+    enablePersistentVolume: false
+    persistence: {}
+      # etc:
+      #   reclaimPolicy: "Delete"
+      #   storageClass: "gp2"
+      #   size: 10Gi
+      #   accessModes:
+      #     - ReadWriteOnce
+      #   providerConfig:
+      #     awsElasticBlockStore:
+      #       volumeID: vol-xxxxxxxxxxxxxxxxxxx
+      #       fsType: ext4
+      # var:
+      #   reclaimPolicy: "Delete"
+      #   storageClass: "gp2"
+      #   size: 1000Gi
+      #   accessModes:
+      #     - ReadWriteOnce
+      #   providerConfig:
+      #     awsElasticBlockStore:
+      #       volumeID: vol-xxxxxxxxxxxxxxxxxxx
+      #       fsType: ext4
+    etcVolumeStorageConfig:
+      ephemeralStorage: false
+      storageCapacity: 10Gi
+    # storageClassName: gp2
+    varVolumeStorageConfig:
+      ephemeralStorage: false
+      storageCapacity: 100Gi
+    # storageClassName: gp2
+    resources: {}
+      # requests:
+      #   memory: "2Gi"
+      #   cpu: "4"
+      # limits:
+      #   memory: "12Gi"
+      #   cpu: "24"
+    serviceAccount: ""
+    # ServiceTemplate is a template used to create Kubernetes services
+    serviceTemplate: {}
+    tolerations: []
+    affinity: {}
+    # Configure a topology spread constraint
+    #  https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+    topologySpreadConstraints: []
+    #  - maxSkew: <integer>
+    #    minDomains: <integer> # optional; beta since v1.25
+    #    topologyKey: <string>
+    #    whenUnsatisfiable: <string>
+    #    labelSelector: <object>
+    #    matchLabelKeys: <list> # optional; alpha since v1.25
+    #    nodeAffinityPolicy: [Honor|Ignore] # optional; beta since v1.26
+    #    nodeTaintsPolicy: [Honor|Ignore] # optional; beta since v1.26
+  monitoringConsole:
+    enabled: true
+    name: "mc"
+    namespaceOverride: ""
+    kindName: monitoring-console
+    additionalLabels: {}
+    additionalAnnotations: {}
+    appRepo: {}
+      # appsRepoPollIntervalSeconds:
+      # defaults:
+      #   volumeName:
+      #   scope:
+      # appSources:
+      #   - name:
+      #     location:
+      # volumes:
+      #   - name:
+      #     storageType:
+      #     provider:
+      #     path:
+      #     endpoint:
+      #     region:
+      #     secretRef:
+    volumes: []
+    licenseUrl: ""
+    defaultsUrl: ""
+    defaults: {}
+    defaultsUrlApps: ""
+    extraEnv: []
+    # - name:
+    #   value:
+    livenessInitialDelaySeconds: 300
+    readinessInitialDelaySeconds: 10
+    # Set Probes for Splunk instance pod containers
+    # reference: https://github.com/splunk/splunk-operator/blob/main/docs/HealthCheck.md
+    startupProbe: {}
+      # initialDelaySeconds: 40
+      # timeoutSeconds: 30
+      # periodSeconds: 30
+      # failureThreshold: 12
+    livenessProbe: {}
+      # initialDelaySeconds: 30
+      # timeoutSeconds: 30
+      # periodSeconds: 30
+      # failureThreshold: 3
+    readinessProbe: {}
+      # initialDelaySeconds: 10
+      # timeoutSeconds: 5
+      # periodSeconds: 5
+      # failureThreshold: 3
+    enablePersistentVolume: true
+    persistence:
+      etc:
+        reclaimPolicy: "Delete"
+        storageClass: "gp2"
+        size: 10Gi
+        accessModes:
+          - ReadWriteOnce
+        providerConfig:
+          awsElasticBlockStore:
+            volumeID: vol-xxxxxxxxxxxxxxxxxxx
+            fsType: ext4
+      var:
+        reclaimPolicy: "Delete"
+        storageClass: "gp2"
+        size: 1000Gi
+        accessModes:
+          - ReadWriteOnce
+        providerConfig:
+          awsElasticBlockStore:
+            volumeID: vol-xxxxxxxxxxxxxxxxxxx
+            fsType: ext4
+    etcVolumeStorageConfig:
+      ephemeralStorage: false
+      storageCapacity: 10Gi
+    # storageClassName: gp2
+    varVolumeStorageConfig:
+      ephemeralStorage: false
+      storageCapacity: 100Gi
+    # storageClassName: gp2
+    resources: {}
+      # requests:
+      #   memory: "2Gi"
+      #   cpu: "4"
+      # limits:
+      #   memory: "12Gi"
+      #   cpu: "24"
+    serviceAccount: ""
+    # ServiceTemplate is a template used to create Kubernetes services
+    serviceTemplate: {}
+    tolerations: []
+    affinity: {}
+    # Configure a topology spread constraint
+    #  https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+    topologySpreadConstraints: []
+    #  - maxSkew: <integer>
+    #    minDomains: <integer> # optional; beta since v1.25
+    #    topologyKey: <string>
+    #    whenUnsatisfiable: <string>
+    #    labelSelector: <object>
+    #    matchLabelKeys: <list> # optional; alpha since v1.25
+    #    nodeAffinityPolicy: [Honor|Ignore] # optional; beta since v1.26
+    #    nodeTaintsPolicy: [Honor|Ignore] # optional; beta since v1.26
+  licenseManager:
+    enabled: false
+    name: "lm"
+    namespaceOverride: ""
+    kindName: license-manager
+    additionalLabels: {}
+    additionalAnnotations: {}
+    appRepo: {}
+      # appsRepoPollIntervalSeconds:
+      # defaults:
+      #   volumeName:
+      #   scope:
+      # appSources:
+      #   - name:
+      #     location:
+      #     scope: # options (local|cluster|premiumApps) default local
+      #      premiumAppsProps: #only if scope is set to premiumApps
+      #        type: enterpriseSecurity
+      #        esDefaults:
+      #          sslEnablement: # options are ignore, strict, auto. default value is strict
+      # volumes:
+      #   - name:
+      #     storageType:
+      #     provider:
+      #     path:
+      #     endpoint:
+      #     region:
+      #     secretRef:
+    volumes: []
+    ## Example: mounting volume containing license in Splunk instance pod container
+    # - name: licenses
+    #   configMap:
+    #     name: splunk-licenses
+    licenseUrl: ""
+    ## Example: using mounted volume to specify license file path
+    # licenseUrl: /mnt/licenses/enterprise.lic
+    defaultsUrl: ""
+    defaults: {}
+    defaultsUrlApps: ""
+    extraEnv: []
+    # - name:
+    #   value:
+    livenessInitialDelaySeconds: 300
+    readinessInitialDelaySeconds: 10
+    # Set Probes for Splunk instance pod containers
+    # reference: https://github.com/splunk/splunk-operator/blob/main/docs/HealthCheck.md
+    startupProbe: {}
+      # initialDelaySeconds: 40
+      # timeoutSeconds: 30
+      # periodSeconds: 30
+      # failureThreshold: 12
+    livenessProbe: {}
+      # initialDelaySeconds: 30
+      # timeoutSeconds: 30
+      # periodSeconds: 30
+      # failureThreshold: 3
+    readinessProbe: {}
+      # initialDelaySeconds: 10
+      # timeoutSeconds: 5
+      # periodSeconds: 5
+      # failureThreshold: 3
+    enablePersistentVolume: false
+    persistence: {}
+      # etc:
+      #   reclaimPolicy: "Delete"
+      #   storageClass: "gp2"
+      #   size: 10Gi
+      #   accessModes:
+      #     - ReadWriteOnce
+      #   providerConfig:
+      #     awsElasticBlockStore:
+      #       volumeID: vol-xxxxxxxxxxxxxxxxxxx
+      #       fsType: ext4
+      # var:
+      #   reclaimPolicy: "Delete"
+      #   storageClass: "gp2"
+      #   size: 1000Gi
+      #   accessModes:
+      #     - ReadWriteOnce
+      #   providerConfig:
+      #     awsElasticBlockStore:
+      #       volumeID: vol-xxxxxxxxxxxxxxxxxxx
+      #       fsType: ext4
+    etcVolumeStorageConfig:
+      ephemeralStorage: false
+      storageCapacity: 10Gi
+    # storageClassName: gp2
+    varVolumeStorageConfig:
+      ephemeralStorage: false
+      storageCapacity: 100Gi
+    # storageClassName: gp2
+
+    resources: {}
+      # requests:
+      #   memory: "2Gi"
+      #   cpu: "4"
+      # limits:
+      #   memory: "12Gi"
+      #   cpu: "24"
+    serviceAccount: ""
+    # ServiceTemplate is a template used to create Kubernetes services
+    serviceTemplate: {}
+    tolerations: []
+    affinity: {}
+    # Configure a topology spread constraint
+    #  https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+    topologySpreadConstraints: []
+    #  - maxSkew: <integer>
+    #    minDomains: <integer> # optional; beta since v1.25
+    #    topologyKey: <string>
+    #    whenUnsatisfiable: <string>
+    #    labelSelector: <object>
+    #    matchLabelKeys: <list> # optional; alpha since v1.25
+    #    nodeAffinityPolicy: [Honor|Ignore] # optional; beta since v1.26
+    #    nodeTaintsPolicy: [Honor|Ignore] # optional; beta since v1.26
+  standalone:
+    enabled: false
+    name: "stdln"
+    namespaceOverride: ""
+    kindName: standalone
+    additionalLabels: {}
+    additionalAnnotations: {}
+    replicaCount: 1
+    appRepo: {}
+      # appsRepoPollIntervalSeconds:
+      # defaults:
+      #   volumeName:
+      #   scope:
+      # appSources:
+      #   - name:
+      #     location:
+      # volumes:
+      #   - name:
+      #     storageType:
+      #     provider:
+      #     path:
+      #     endpoint:
+      #     region:
+      #     secretRef:
+    smartstore: {}
+      # defaults:
+      #   volumeName:
+      # indexes:
+      #   - name:
+      #     volumeName:
+      #     remotePath:
+      # volumes:
+      #   - name:
+      #     path:
+      #     endpoint:
+      #     secretRef:
+    volumes: []
+    licenseUrl: ""
+    defaultsUrl: ""
+    defaults: {}
+    defaultsUrlApps: ""
+    extraEnv: []
+    # - name:
+    #   value:
+    livenessInitialDelaySeconds: 300
+    readinessInitialDelaySeconds: 10
+    # Set Probes for Splunk instance pod containers
+    # reference: https://github.com/splunk/splunk-operator/blob/main/docs/HealthCheck.md
+    startupProbe: {}
+      # initialDelaySeconds: 40
+      # timeoutSeconds: 30
+      # periodSeconds: 30
+      # failureThreshold: 12
+    livenessProbe: {}
+      # initialDelaySeconds: 30
+      # timeoutSeconds: 30
+      # periodSeconds: 30
+      # failureThreshold: 3
+    readinessProbe: {}
+      # initialDelaySeconds: 10
+      # timeoutSeconds: 5
+      # periodSeconds: 5
+      # failureThreshold: 3
+    enablePersistentVolume: false
+    persistence: {}
+      # etc:
+      #   reclaimPolicy: "Delete"
+      #   storageClass: "gp2"
+      #   size: 10Gi
+      #   accessModes:
+      #     - ReadWriteOnce
+      #   providerConfig:
+      #     awsElasticBlockStore:
+      #       volumeID: vol-xxxxxxxxxxxxxxxxxxx
+      #       fsType: ext4
+      # var:
+      #   reclaimPolicy: "Delete"
+      #   storageClass: "gp2"
+      #   size: 1000Gi
+      #   accessModes:
+      #     - ReadWriteOnce
+      #   providerConfig:
+      #     awsElasticBlockStore:
+      #       volumeID: vol-xxxxxxxxxxxxxxxxxxx
+      #       fsType: ext4
+    etcVolumeStorageConfig:
+      ephemeralStorage: false
+      storageCapacity: 10Gi
+    # storageClassName: gp2
+    varVolumeStorageConfig:
+      ephemeralStorage: false
+      storageCapacity: 100Gi
+    # storageClassName: gp2
+    resources: {}
+      # requests:
+      #   memory: "2Gi"
+      #   cpu: "4"
+      # limits:
+      #   memory: "12Gi"
+      #   cpu: "24"
+    serviceAccount: ""
+    # ServiceTemplate is a template used to create Kubernetes services
+    serviceTemplate: {}
+    tolerations: []
+    affinity: {}
+    # Configure a topology spread constraint
+    #  https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+    topologySpreadConstraints: []
+    #  - maxSkew: <integer>
+    #    minDomains: <integer> # optional; beta since v1.25
+    #    topologyKey: <string>
+    #    whenUnsatisfiable: <string>
+    #    labelSelector: <object>
+    #    matchLabelKeys: <list> # optional; alpha since v1.25
+    #    nodeAffinityPolicy: [Honor|Ignore] # optional; beta since v1.26
+    #    nodeTaintsPolicy: [Honor|Ignore] # optional; beta since v1.26
 # Array with extra yaml to deploy with the chart. Evaluated as a template
 extraManifests: []
 # extraManifests:

--- a/helm-chart/splunk-operator/values.yaml
+++ b/helm-chart/splunk-operator/values.yaml
@@ -1,21 +1,17 @@
 splunk-operator:
   enabled: true
-
 # Splunk image
 image:
   repository: docker.io/splunk/splunk:9.4.1
-
 # The kube-rbac-proxy is a small HTTP proxy for a single upstream, that can perform RBAC
 # authorization against the Kubernetes API.
 # reference: https://github.com/brancz/kube-rbac-proxy
 kubeRbacProxy:
-
   # Specify kube-rbac-proxy image
   image:
     repository: gcr.io/kubebuilder/kube-rbac-proxy
     pullPolicy: IfNotPresent
     tag: "v0.13.1"
-
   # Set resource requests and limits for kube-rbac-proxy container
   resources:
     limits:
@@ -24,39 +20,28 @@ kubeRbacProxy:
     requests:
       cpu: 5m
       memory: 64Mi
-
-
 # Splunk Operator configurations
 splunkOperator:
-
   # Splunk operator image and pull policy
   # reference: https://github.com/splunk/splunk-operator
   image:
     repository: docker.io/splunk/splunk-operator:2.8.0
     pullPolicy: IfNotPresent
-
   # Set image pull secrets to pull image from a private registry
   imagePullSecrets: []
-
   # Give operator cluster-wide access, otherwise access is limited to operator namespace
   clusterWideAccess: true
-
   # List namespaces to be watched by Splunk Operator e.x "namespace1,namespace2", must have cluster-wide access
   # Default watches the entire cluster
   watchNamespaces: ""
-
   # Add labels to Splunk Operator deployment
   labels: {}
-
   # Add annotations to Splunk Operator deployment
   annotations: {}
-
   # Add pod annotations to Splunk Operator deployment pod
   podAnnotations: {}
-
   # Add pod labels to Splunk Operator deployment pod
   podLabels: {}
-
   # Set security context for manager container, default ensures that no child process of manager can gain more privileges than manager
   # reference: https://kubernetes.io/docs/concepts/security/pod-security-policy/#privilege-escalation
   containerSecurityContext:
@@ -70,7 +55,6 @@ splunkOperator:
         - "NET_BIND_SERVICE"
     seccompProfile:
       type: "RuntimeDefault"
-
   # Set security context for Splunk Operator pod
   # reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#podsecuritycontext-v1-core
   securityContext:
@@ -78,13 +62,11 @@ splunkOperator:
     fsGroup: 1001
     runAsNonRoot: true
     fsGroupChangePolicy: "OnRootMismatch"
-
   # Set usage of host networking and namespace
   # reference: https://kubernetes.io/docs/concepts/security/pod-security-policy/#host-namespaces
   hostNetwork: false
   hostPID: false
   hostIPC: false
-
   # Define liveness probe to check if manager container is running
   # reference: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#types-of-probe
   livenessProbe:
@@ -93,7 +75,6 @@ splunkOperator:
       port: 8081
     initialDelaySeconds: 15
     periodSeconds: 20
-
   # Define readiness probe to check if manager container is ready for requests
   # reference: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#types-of-probe
   readinessProbe:
@@ -102,7 +83,6 @@ splunkOperator:
       port: 8081
     initialDelaySeconds: 5
     periodSeconds: 10
-
   # Define splunk operator manager service ports
   # reference: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/
   service:
@@ -116,7 +96,6 @@ splunkOperator:
   #   port: 8080
   #   protocol: TCP
   #   targetPort: 8080
-
   # Set resource requests and limits for manager container
   resources:
     limits:
@@ -125,27 +104,21 @@ splunkOperator:
     requests:
       cpu: 1000m
       memory: 2000Mi
-
   # Specify nodes that can schedule the Splunk Operator pod
   # reference: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector: {}
-
   # Specify Splunk Operator pod tolerations
   # reference: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations: []
-
   # Define affinity scheduling rules
   # reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
   affinity: {}
-
   # Set duration in seconds the pod needs to terminate gracefully
   # reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#pod-v1-core
   terminationGracePeriodSeconds: 10
-
   # Set storageClassName for the PersistentVolumeClaim
   persistentVolumeClaim:
     storageClassName: ""
-
   # Specify volumes for Splunk Operator pod, append additional volumes to list
   # reference: https://kubernetes.io/docs/concepts/storage/volumes/
   volumes:
@@ -155,7 +128,6 @@ splunkOperator:
 # - name:
 #   persistentVolumeClaim:
 #     claimName:
-
   # Specify volume mounts for the manager container, append additional volume mounts to list
   # reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/
   volumeMounts:
@@ -163,7 +135,6 @@ splunkOperator:
     name: app-staging
 # - mountPath:
 #   name:
-
 # Array with extra yaml to deploy with the chart. Evaluated as a template
 extraManifests: []
 # extraManifests:
@@ -174,7 +145,6 @@ extraManifests: []
 #    spec:
 #      securityPolicy:
 #        name: "gcp-cloud-armor-policy-test"
-
 # Additional envs to the splunk-operator container
 extraEnvs: []
 # extraEnvs


### PR DESCRIPTION
### Description

This PR adds support for creation of PVs per CR to the helm deployments. This is a result of #1509 change, and should be merged after it.
As an addition I've also removed empty lines from `values.yaml` to adjust it to the universal standards of Helm-charts 

### Key Changes

- new template for creation of Persistent Volumes per CR - pvs.yaml
- move of CRs specific configs under `customResources` block in `values.yaml 
- adjustments of templates regarding previous point
- deletion of empty lines in `values.yaml`

### Testing and Verification

local tests
`helm template release-splunk  . -n splunk-operator --set customResources.standalone.enablePersistentVolume=true  --set splunk-operator.enabled=false  --set installCRDs=false
& addition of adjusted `values.yaml`

### Related Issues

- #1509

### PR Checklist

- [x] Code changes adhere to the project's coding standards.
- [N/A] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [x] All tests pass locally.
- [x] The PR description follows the project's guidelines.
