### PR TITLE
CSPL-3706: Default imagePullPolicy in Helm Chart 

### DIFF
--- a/helm-chart/splunk-enterprise/values.yaml
+++ b/helm-chart/splunk-enterprise/values.yaml
@@ -2,7 +2,7 @@
 # Overrides RELATED_IMAGE_SPLUNK_ENTERPRISE environment variable in Splunk Operator manager container
 image:
   repository: ""
-  imagePullPolicy: ""
+  imagePullPolicy: "IfNotPresent"
   imagePullSecrets: []
 
 # Deploy Splunk Operator chart


### PR DESCRIPTION
### Description

This pull request sets a default value for the imagePullPolicy in the splunk/splunk-enterprise helm chart. The CRs require the imagePullPolicy to be "Always" or "IfNotPresent", so setting this default removes unnecessary errors without requiring the user to update the value. "IfNotPresent" is used as default in other places in the code.

### Key Changes

- helm-chart/splunk-enterprise/values.yaml: Set default value for `image.imagePullPolicy`

### Testing and Verification

- Tested by installing a c3 instance on an AWS EKS cluster.
- Before the changes, kubectl events show `Could not update annotations. Reason ClusterManager.enterprise.splunk.com "cm" is invalid: spec.imagePullPolicy: Unsupported value: "": supported values: "Always", "IfNotPresent"`
- After the changes, these events are now shown.

### Related Issues

- https://splunk.atlassian.net/browse/CSPL-3706
- https://github.com/splunk/splunk-operator/issues/1475

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [X] Relevant unit and integration tests are included.
- [X] Documentation has been updated accordingly.
- [X] All tests pass locally.
- [X] The PR description follows the project's guidelines.
