### PR TITLE
Removing App Framework Tests for C3 and M4 from ARM Pipelines

### DIFF
--- a/.github/workflows/arm-AL2023-build-test-push-workflow-AL2023.yml
+++ b/.github/workflows/arm-AL2023-build-test-push-workflow-AL2023.yml
@@ -109,8 +109,6 @@ jobs:
         test: [
                 basic,
                 appframeworksS1,
-                managerappframeworkc3,
-                managerappframeworkm4,
                 managersecret,
                 managermc,
                ]

--- a/.github/workflows/arm-AL2023-int-test-workflow.yml
+++ b/.github/workflows/arm-AL2023-int-test-workflow.yml
@@ -52,8 +52,6 @@ jobs:
         test:
           [
             appframeworksS1,
-            managerappframeworkc3,
-            managerappframeworkm4,
             managersecret,
             managersmartstore,
             managermc1,

--- a/.github/workflows/arm-Ubuntu-build-test-push-workflow.yml
+++ b/.github/workflows/arm-Ubuntu-build-test-push-workflow.yml
@@ -109,8 +109,6 @@ jobs:
         test: [
                 basic,
                 appframeworksS1,
-                managerappframeworkc3,
-                managerappframeworkm4,
                 managersecret,
                 managermc,
               ]

--- a/.github/workflows/arm-Ubuntu-int-test-workflow.yml
+++ b/.github/workflows/arm-Ubuntu-int-test-workflow.yml
@@ -52,8 +52,6 @@ jobs:
         test:
           [
             appframeworksS1,
-            managerappframeworkc3,
-            managerappframeworkm4,
             managersecret,
             managersmartstore,
             managermc1,


### PR DESCRIPTION
### Description

This PR removes App Framework tests for C3 and M4 SVAs from ARM pipelines because Search Heads are not supported for them, only Indexers are, so the tests can not pass.

### Key Changes

- Removing App Framework tests for C3 and M4 from ARM Pipelines

### Testing and Verification

N/A

### Related Issues

N/A

### PR Checklist

- [ ] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [ ] All tests pass locally.
- [ ] The PR description follows the project's guidelines.
