### PR TITLE
CSPL-3768 Adding inputs to Graviton pipelines and tests

### DIFF
--- a/.github/workflows/arm-AL2023-build-test-push-workflow-AL2023.yml
+++ b/.github/workflows/arm-AL2023-build-test-push-workflow-AL2023.yml
@@ -1,4 +1,9 @@
 name: Arm AL2023 Smoke Test WorkFlow
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  pull-requests: write
 on:
   workflow_dispatch:  
     inputs:

--- a/.github/workflows/arm-AL2023-build-test-push-workflow-AL2023.yml
+++ b/.github/workflows/arm-AL2023-build-test-push-workflow-AL2023.yml
@@ -2,8 +2,8 @@ name: Arm AL2023 Smoke Test WorkFlow
 on:
   workflow_dispatch:  
     inputs:
-      splunk_image_ecr_uri:
-        description: 'ECR URI of Splunk AL2023-based Docker Image'
+      splunk_image_repository_tag:
+        description: 'Splunk AL2023-based Docker Image repository and image tag (e.g. repository-name:tag)'
         required: true
 jobs:
   check-formating:
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-tests
     env:
-      SPLUNK_ENTERPRISE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
       S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -122,8 +122,8 @@ jobs:
     env:
       CLUSTER_NODES: 1
       CLUSTER_WORKERS: 3
-      SPLUNK_ENTERPRISE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
-      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       SPLUNK_OPERATOR_IMAGE_FILENAME: splunk-operator
       TEST_FOCUS: "${{ matrix.test }}"

--- a/.github/workflows/arm-AL2023-build-test-push-workflow-AL2023.yml
+++ b/.github/workflows/arm-AL2023-build-test-push-workflow-AL2023.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:  
     inputs:
       splunk_image_repository_tag:
-        description: 'Splunk AL2023-based Docker Image repository and image tag (e.g. repository-name:tag)'
+        description: 'Splunk AL2023-based Docker Image repository and tag (e.g. repository-name:tag)'
         required: true
 jobs:
   check-formating:

--- a/.github/workflows/arm-AL2023-build-test-push-workflow-AL2023.yml
+++ b/.github/workflows/arm-AL2023-build-test-push-workflow-AL2023.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-tests
     env:
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_PREFIX }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
       S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -122,8 +122,8 @@ jobs:
     env:
       CLUSTER_NODES: 1
       CLUSTER_WORKERS: 3
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
-      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_PREFIX }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.ECR_PREFIX }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       SPLUNK_OPERATOR_IMAGE_FILENAME: splunk-operator
       TEST_FOCUS: "${{ matrix.test }}"

--- a/.github/workflows/arm-AL2023-build-test-push-workflow-AL2023.yml
+++ b/.github/workflows/arm-AL2023-build-test-push-workflow-AL2023.yml
@@ -1,6 +1,10 @@
 name: Arm AL2023 Smoke Test WorkFlow
 on:
   workflow_dispatch:  
+    inputs:
+      splunk_image_ecr_uri:
+        description: 'ECR URI of Splunk AL2023-based Docker Image'
+        required: true
 jobs:
   check-formating:
     runs-on: ubuntu-latest
@@ -50,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-tests
     env:
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
       S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -118,8 +122,8 @@ jobs:
     env:
       CLUSTER_NODES: 1
       CLUSTER_WORKERS: 3
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE_ARM64 }}
-      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE_ARM64 }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
+      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       SPLUNK_OPERATOR_IMAGE_FILENAME: splunk-operator
       TEST_FOCUS: "${{ matrix.test }}"
@@ -138,6 +142,7 @@ jobs:
       CLUSTER_WIDE: "true"
       DEPLOYMENT_TYPE: ""
       ARM64: "true"
+      GRAVITON_TESTING: "true"
     steps:
       - name: Set Test Cluster Name
         run: |

--- a/.github/workflows/arm-AL2023-int-test-workflow.yml
+++ b/.github/workflows/arm-AL2023-int-test-workflow.yml
@@ -2,15 +2,15 @@ name: Arm AL2023 Integration Test WorkFlow
 on:
   workflow_dispatch:
     inputs:
-      splunk_image_ecr_uri:
-        description: 'ECR URI of Splunk AL2023-based Docker Image'
+      splunk_image_repository_tag:
+        description: 'Splunk AL2023-based Docker Image repository and image tag (e.g. repository-name:tag)'
         required: true
 jobs:
   build-operator-image-arm-al2023:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     env:
-      SPLUNK_ENTERPRISE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
       S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -71,8 +71,8 @@ jobs:
     env:
       CLUSTER_NODES: 1
       CLUSTER_WORKERS: 3
-      SPLUNK_ENTERPRISE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
-      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       SPLUNK_OPERATOR_IMAGE_FILENAME: splunk-operator
       TEST_FOCUS: "${{ matrix.test }}"

--- a/.github/workflows/arm-AL2023-int-test-workflow.yml
+++ b/.github/workflows/arm-AL2023-int-test-workflow.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     env:
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_PREFIX }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
       S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -71,8 +71,8 @@ jobs:
     env:
       CLUSTER_NODES: 1
       CLUSTER_WORKERS: 3
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
-      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_PREFIX }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.ECR_PREFIX }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       SPLUNK_OPERATOR_IMAGE_FILENAME: splunk-operator
       TEST_FOCUS: "${{ matrix.test }}"

--- a/.github/workflows/arm-AL2023-int-test-workflow.yml
+++ b/.github/workflows/arm-AL2023-int-test-workflow.yml
@@ -1,4 +1,9 @@
 name: Arm AL2023 Integration Test WorkFlow
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  pull-requests: write
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/arm-AL2023-int-test-workflow.yml
+++ b/.github/workflows/arm-AL2023-int-test-workflow.yml
@@ -1,12 +1,16 @@
 name: Arm AL2023 Integration Test WorkFlow
 on:
   workflow_dispatch:
+    inputs:
+      splunk_image_ecr_uri:
+        description: 'ECR URI of Splunk AL2023-based Docker Image'
+        required: true
 jobs:
   build-operator-image-arm-al2023:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     env:
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
       S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -67,8 +71,8 @@ jobs:
     env:
       CLUSTER_NODES: 1
       CLUSTER_WORKERS: 3
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE_ARM64 }}
-      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE_ARM64 }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
+      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       SPLUNK_OPERATOR_IMAGE_FILENAME: splunk-operator
       TEST_FOCUS: "${{ matrix.test }}"
@@ -86,6 +90,7 @@ jobs:
       CLUSTER_WIDE: "true"
       DEPLOYMENT_TYPE: ""
       ARM64: "true"
+      GRAVITON_TESTING: "true"
     steps:
       - name: Set Test Cluster Name
         run: |

--- a/.github/workflows/arm-AL2023-int-test-workflow.yml
+++ b/.github/workflows/arm-AL2023-int-test-workflow.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       splunk_image_repository_tag:
-        description: 'Splunk AL2023-based Docker Image repository and image tag (e.g. repository-name:tag)'
+        description: 'Splunk AL2023-based Docker Image repository and tag (e.g. repository-name:tag)'
         required: true
 jobs:
   build-operator-image-arm-al2023:

--- a/.github/workflows/arm-RHEL-build-test-push-workflow.yml
+++ b/.github/workflows/arm-RHEL-build-test-push-workflow.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
           splunk_image_repository_tag:
-            description: 'Splunk RHEL-based Docker Image repository and image tag (e.g. repository-name:tag)'
+            description: 'Splunk RHEL-based Docker Image repository and tag (e.g. repository-name:tag)'
             required: true
 jobs:
   build-operator-image-arm-rhel:
@@ -46,7 +46,7 @@ jobs:
       run: |
         export PLATFORMS=linux/arm64,linux/amd64
         export BASE_IMAGE=redhat/ubi9-minimal
-        export BASE_IMAGE_VERSION=9.5-1747111267
+        export BASE_IMAGE_VERSION=9.5
         export IMG=${{ secrets.ECR_REPOSITORY }}/${{ env.SPLUNK_OPERATOR_IMAGE_NAME }}:$GITHUB_SHA
         make docker-buildx PLATFORMS=$PLATFORMS BASE_IMAGE=$BASE_IMAGE BASE_IMAGE_VERSION=$BASE_IMAGE_VERSION IMG=$IMG
   int-tests-arm-rhel:
@@ -56,8 +56,6 @@ jobs:
         test:
           [
             appframeworksS1,
-            managerappframeworkc3,
-            managerappframeworkm4,
             managersecret,
             managersmartstore,
             managermc1,

--- a/.github/workflows/arm-RHEL-build-test-push-workflow.yml
+++ b/.github/workflows/arm-RHEL-build-test-push-workflow.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     env:
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_PREFIX }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
       S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -71,8 +71,8 @@ jobs:
     env:
       CLUSTER_NODES: 1
       CLUSTER_WORKERS: 3
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
-      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_PREFIX }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.ECR_PREFIX }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       SPLUNK_OPERATOR_IMAGE_FILENAME: splunk-operator
       TEST_FOCUS: "${{ matrix.test }}"

--- a/.github/workflows/arm-RHEL-build-test-push-workflow.yml
+++ b/.github/workflows/arm-RHEL-build-test-push-workflow.yml
@@ -1,4 +1,9 @@
 name: ARM RHEL Integration Test WorkFlow
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  pull-requests: write
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/arm-RHEL-build-test-push-workflow.yml
+++ b/.github/workflows/arm-RHEL-build-test-push-workflow.yml
@@ -1,12 +1,12 @@
-name: Arm AL2023 Integration Test WorkFlow
+name: ARM RHEL Integration Test WorkFlow
 on:
   workflow_dispatch:
     inputs:
-      splunk_image_repository_tag:
-        description: 'Splunk AL2023-based Docker Image repository and image tag (e.g. repository-name:tag)'
-        required: true
+          splunk_image_repository_tag:
+            description: 'Splunk RHEL-based Docker Image repository and image tag (e.g. repository-name:tag)'
+            required: true
 jobs:
-  build-operator-image-arm-al2023:
+  build-operator-image-arm-rhel:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     env:
@@ -45,11 +45,11 @@ jobs:
     - name: Build and push Splunk Operator Image
       run: |
         export PLATFORMS=linux/arm64,linux/amd64
-        export BASE_IMAGE=public.ecr.aws/amazonlinux/amazonlinux
-        export BASE_IMAGE_VERSION=2023
+        export BASE_IMAGE=redhat/ubi9-minimal
+        export BASE_IMAGE_VERSION=9.5-1747111267
         export IMG=${{ secrets.ECR_REPOSITORY }}/${{ env.SPLUNK_OPERATOR_IMAGE_NAME }}:$GITHUB_SHA
         make docker-buildx PLATFORMS=$PLATFORMS BASE_IMAGE=$BASE_IMAGE BASE_IMAGE_VERSION=$BASE_IMAGE_VERSION IMG=$IMG
-  int-tests-arm-al2023:
+  int-tests-arm-rhel:
     strategy:
       fail-fast: false
       matrix:
@@ -67,7 +67,7 @@ jobs:
             managerdeletecr,
           ]
     runs-on: ubuntu-latest
-    needs: build-operator-image-arm-al2023
+    needs: build-operator-image-arm-rhel
     env:
       CLUSTER_NODES: 1
       CLUSTER_WORKERS: 3

--- a/.github/workflows/arm-RHEL-int-test-workflow.yml
+++ b/.github/workflows/arm-RHEL-int-test-workflow.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     env:
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_PREFIX }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
       S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -71,8 +71,8 @@ jobs:
     env:
       CLUSTER_NODES: 1
       CLUSTER_WORKERS: 3
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
-      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_PREFIX }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.ECR_PREFIX }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       SPLUNK_OPERATOR_IMAGE_FILENAME: splunk-operator
       TEST_FOCUS: "${{ matrix.test }}"

--- a/.github/workflows/arm-RHEL-int-test-workflow.yml
+++ b/.github/workflows/arm-RHEL-int-test-workflow.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
           splunk_image_repository_tag:
-            description: 'Splunk RHEL-based Docker Image repository and image tag (e.g. repository-name:tag)'
+            description: 'Splunk RHEL-based Docker Image repository and tag (e.g. repository-name:tag)'
             required: true
 jobs:
   build-operator-image-arm-rhel:
@@ -56,8 +56,6 @@ jobs:
         test:
           [
             appframeworksS1,
-            managerappframeworkc3,
-            managerappframeworkm4,
             managersecret,
             managersmartstore,
             managermc1,

--- a/.github/workflows/arm-RHEL-int-test-workflow.yml
+++ b/.github/workflows/arm-RHEL-int-test-workflow.yml
@@ -1,12 +1,12 @@
-name: Arm AL2023 Integration Test WorkFlow
+name: ARM RHEL Integration Test WorkFlow
 on:
   workflow_dispatch:
     inputs:
-      splunk_image_repository_tag:
-        description: 'Splunk AL2023-based Docker Image repository and image tag (e.g. repository-name:tag)'
-        required: true
+          splunk_image_repository_tag:
+            description: 'Splunk RHEL-based Docker Image repository and image tag (e.g. repository-name:tag)'
+            required: true
 jobs:
-  build-operator-image-arm-al2023:
+  build-operator-image-arm-rhel:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     env:
@@ -45,11 +45,11 @@ jobs:
     - name: Build and push Splunk Operator Image
       run: |
         export PLATFORMS=linux/arm64,linux/amd64
-        export BASE_IMAGE=public.ecr.aws/amazonlinux/amazonlinux
-        export BASE_IMAGE_VERSION=2023
+        export BASE_IMAGE=redhat/ubi9-minimal
+        export BASE_IMAGE_VERSION=9.5
         export IMG=${{ secrets.ECR_REPOSITORY }}/${{ env.SPLUNK_OPERATOR_IMAGE_NAME }}:$GITHUB_SHA
         make docker-buildx PLATFORMS=$PLATFORMS BASE_IMAGE=$BASE_IMAGE BASE_IMAGE_VERSION=$BASE_IMAGE_VERSION IMG=$IMG
-  int-tests-arm-al2023:
+  int-tests-arm-rhel:
     strategy:
       fail-fast: false
       matrix:
@@ -67,7 +67,7 @@ jobs:
             managerdeletecr,
           ]
     runs-on: ubuntu-latest
-    needs: build-operator-image-arm-al2023
+    needs: build-operator-image-arm-rhel
     env:
       CLUSTER_NODES: 1
       CLUSTER_WORKERS: 3

--- a/.github/workflows/arm-RHEL-int-test-workflow.yml
+++ b/.github/workflows/arm-RHEL-int-test-workflow.yml
@@ -1,4 +1,9 @@
 name: ARM RHEL Integration Test WorkFlow
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  pull-requests: write
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/arm-Ubuntu-build-test-push-workflow.yml
+++ b/.github/workflows/arm-Ubuntu-build-test-push-workflow.yml
@@ -2,8 +2,8 @@ name: Arm Ubuntu Smoke Test WorkFlow
 on:
   workflow_dispatch:
     inputs:
-      splunk_image_ecr_uri:
-        description: 'ECR URI of Splunk Ubuntu-based Docker Image'
+      splunk_image_repository_tag:
+        description: 'Splunk AL2023-based Docker Image repository and image tag (e.g. repository-name:tag)'
         required: true
 jobs:
   check-formating:
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-tests
     env:
-      SPLUNK_ENTERPRISE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
       S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -122,8 +122,8 @@ jobs:
     env:
       CLUSTER_NODES: 1
       CLUSTER_WORKERS: 3
-      SPLUNK_ENTERPRISE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
-      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       SPLUNK_OPERATOR_IMAGE_FILENAME: splunk-operator
       TEST_FOCUS: "${{ matrix.test }}"

--- a/.github/workflows/arm-Ubuntu-build-test-push-workflow.yml
+++ b/.github/workflows/arm-Ubuntu-build-test-push-workflow.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       splunk_image_repository_tag:
-        description: 'Splunk Ubuntu-based Docker Image repository and image tag (e.g. repository-name:tag)'
+        description: 'Splunk Ubuntu-based Docker Image repository and tag (e.g. repository-name:tag)'
         required: true
 jobs:
   check-formating:

--- a/.github/workflows/arm-Ubuntu-build-test-push-workflow.yml
+++ b/.github/workflows/arm-Ubuntu-build-test-push-workflow.yml
@@ -1,4 +1,9 @@
 name: Arm Ubuntu Smoke Test WorkFlow
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  pull-requests: write
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/arm-Ubuntu-build-test-push-workflow.yml
+++ b/.github/workflows/arm-Ubuntu-build-test-push-workflow.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-tests
     env:
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_PREFIX }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
       S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -122,8 +122,8 @@ jobs:
     env:
       CLUSTER_NODES: 1
       CLUSTER_WORKERS: 3
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
-      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_PREFIX }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.ECR_PREFIX }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       SPLUNK_OPERATOR_IMAGE_FILENAME: splunk-operator
       TEST_FOCUS: "${{ matrix.test }}"

--- a/.github/workflows/arm-Ubuntu-build-test-push-workflow.yml
+++ b/.github/workflows/arm-Ubuntu-build-test-push-workflow.yml
@@ -1,6 +1,10 @@
 name: Arm Ubuntu Smoke Test WorkFlow
 on:
   workflow_dispatch:
+    inputs:
+      splunk_image_ecr_uri:
+        description: 'ECR URI of Splunk Ubuntu-based Docker Image'
+        required: true
 jobs:
   check-formating:
     runs-on: ubuntu-latest
@@ -50,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-tests
     env:
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
       S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -118,8 +122,8 @@ jobs:
     env:
       CLUSTER_NODES: 1
       CLUSTER_WORKERS: 3
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE_ARM64 }}
-      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE_ARM64 }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
+      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       SPLUNK_OPERATOR_IMAGE_FILENAME: splunk-operator
       TEST_FOCUS: "${{ matrix.test }}"
@@ -138,6 +142,7 @@ jobs:
       CLUSTER_WIDE: "true"
       DEPLOYMENT_TYPE: ""
       ARM64: "true"
+      GRAVITON_TESTING: "true"
     steps:
       - name: Set Test Cluster Name
         run: |

--- a/.github/workflows/arm-Ubuntu-build-test-push-workflow.yml
+++ b/.github/workflows/arm-Ubuntu-build-test-push-workflow.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       splunk_image_repository_tag:
-        description: 'Splunk AL2023-based Docker Image repository and image tag (e.g. repository-name:tag)'
+        description: 'Splunk Ubuntu-based Docker Image repository and image tag (e.g. repository-name:tag)'
         required: true
 jobs:
   check-formating:

--- a/.github/workflows/arm-Ubuntu-int-test-workflow.yml
+++ b/.github/workflows/arm-Ubuntu-int-test-workflow.yml
@@ -1,15 +1,16 @@
 name: Arm Ubuntu Integration Test WorkFlow Ubuntu
 on:
   workflow_dispatch:
-      splunk_image_ecr_uri:
-        description: 'ECR URI of Splunk Ubuntu-based Docker Image'
-        required: true
+    inputs:
+          splunk_image_repository_tag:
+            description: 'Splunk AL2023-based Docker Image repository and image tag (e.g. repository-name:tag)'
+            required: true
 jobs:
   build-operator-image-arm-ubuntu:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     env:
-      SPLUNK_ENTERPRISE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
       S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -70,8 +71,8 @@ jobs:
     env:
       CLUSTER_NODES: 1
       CLUSTER_WORKERS: 3
-      SPLUNK_ENTERPRISE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
-      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       SPLUNK_OPERATOR_IMAGE_FILENAME: splunk-operator
       TEST_FOCUS: "${{ matrix.test }}"

--- a/.github/workflows/arm-Ubuntu-int-test-workflow.yml
+++ b/.github/workflows/arm-Ubuntu-int-test-workflow.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     env:
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_PREFIX }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
       S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -71,8 +71,8 @@ jobs:
     env:
       CLUSTER_NODES: 1
       CLUSTER_WORKERS: 3
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
-      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.ECR_REPOSITORY }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.ECR_PREFIX }}/${{ github.event.inputs.splunk_image_repository_tag }}
+      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.ECR_PREFIX }}/${{ github.event.inputs.splunk_image_repository_tag }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       SPLUNK_OPERATOR_IMAGE_FILENAME: splunk-operator
       TEST_FOCUS: "${{ matrix.test }}"

--- a/.github/workflows/arm-Ubuntu-int-test-workflow.yml
+++ b/.github/workflows/arm-Ubuntu-int-test-workflow.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
           splunk_image_repository_tag:
-            description: 'Splunk AL2023-based Docker Image repository and image tag (e.g. repository-name:tag)'
+            description: 'Splunk Ubuntu-based Docker Image repository and image tag (e.g. repository-name:tag)'
             required: true
 jobs:
   build-operator-image-arm-ubuntu:

--- a/.github/workflows/arm-Ubuntu-int-test-workflow.yml
+++ b/.github/workflows/arm-Ubuntu-int-test-workflow.yml
@@ -1,4 +1,9 @@
 name: Arm Ubuntu Integration Test WorkFlow Ubuntu
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  pull-requests: write
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/arm-Ubuntu-int-test-workflow.yml
+++ b/.github/workflows/arm-Ubuntu-int-test-workflow.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
           splunk_image_repository_tag:
-            description: 'Splunk Ubuntu-based Docker Image repository and image tag (e.g. repository-name:tag)'
+            description: 'Splunk Ubuntu-based Docker Image repository and tag (e.g. repository-name:tag)'
             required: true
 jobs:
   build-operator-image-arm-ubuntu:

--- a/.github/workflows/arm-Ubuntu-int-test-workflow.yml
+++ b/.github/workflows/arm-Ubuntu-int-test-workflow.yml
@@ -1,12 +1,15 @@
 name: Arm Ubuntu Integration Test WorkFlow Ubuntu
 on:
   workflow_dispatch:
+      splunk_image_ecr_uri:
+        description: 'ECR URI of Splunk Ubuntu-based Docker Image'
+        required: true
 jobs:
   build-operator-image-arm-ubuntu:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     env:
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
       S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -67,8 +70,8 @@ jobs:
     env:
       CLUSTER_NODES: 1
       CLUSTER_WORKERS: 3
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE_ARM64 }}
-      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE_ARM64 }}
+      SPLUNK_ENTERPRISE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
+      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ github.event.inputs.splunk_image_ecr_uri }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
       SPLUNK_OPERATOR_IMAGE_FILENAME: splunk-operator
       TEST_FOCUS: "${{ matrix.test }}"
@@ -86,6 +89,7 @@ jobs:
       CLUSTER_WIDE: "true"
       DEPLOYMENT_TYPE: ""
       ARM64: "true"
+      GRAVITON_TESTING: "true"
     steps:
       - name: Set Test Cluster Name
         run: |

--- a/test/appframework_aws/c3/appframework_aws_test.go
+++ b/test/appframework_aws/c3/appframework_aws_test.go
@@ -139,6 +139,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -359,6 +360,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1495,6 +1497,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -2130,6 +2133,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -2258,6 +2262,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -3053,6 +3058,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					ClusterMasterRef: corev1.ObjectReference{
@@ -3163,6 +3169,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -3183,6 +3190,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					ClusterMasterRef: corev1.ObjectReference{

--- a/test/appframework_aws/c3/manager_appframework_test.go
+++ b/test/appframework_aws/c3/manager_appframework_test.go
@@ -136,6 +136,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -329,7 +330,7 @@ var _ = Describe("c3appfw test", func() {
 
 			// Upload V1 apps to S3 for Monitoring Console
 			oldImage := "Refer to RELATED_SPLUNK_IMAGE_ENTERPRISE"
-			newImage := "splunk/splunk:latest"
+			newImage := testcaseEnvInst.GetSplunkImage()
 
 			lm, err := deployment.DeployLicenseManager(ctx, deployment.GetName())
 			cm, err := deployment.DeployClusterManager(ctx, deployment.GetName(), lm.GetName(), "", "")
@@ -338,6 +339,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					ClusterManagerRef: corev1.ObjectReference{
@@ -500,6 +502,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1636,6 +1639,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -2271,6 +2275,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -2399,6 +2404,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -3194,6 +3200,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					ClusterManagerRef: corev1.ObjectReference{
@@ -3304,6 +3311,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -3324,6 +3332,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					ClusterManagerRef: corev1.ObjectReference{

--- a/test/appframework_aws/c3/manager_appframework_test.go
+++ b/test/appframework_aws/c3/manager_appframework_test.go
@@ -330,7 +330,7 @@ var _ = Describe("c3appfw test", func() {
 
 			// Upload V1 apps to S3 for Monitoring Console
 			oldImage := "Refer to RELATED_SPLUNK_IMAGE_ENTERPRISE"
-			newImage := testcaseEnvInst.GetSplunkImage()
+			newImage := "splunk/splunk:latest"
 
 			lm, err := deployment.DeployLicenseManager(ctx, deployment.GetName())
 			cm, err := deployment.DeployClusterManager(ctx, deployment.GetName(), lm.GetName(), "", "")

--- a/test/appframework_aws/m4/appframework_aws_test.go
+++ b/test/appframework_aws/m4/appframework_aws_test.go
@@ -137,6 +137,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -355,6 +356,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -968,6 +970,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1620,6 +1623,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1753,6 +1757,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},

--- a/test/appframework_aws/m4/manager_appframework_test.go
+++ b/test/appframework_aws/m4/manager_appframework_test.go
@@ -136,6 +136,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -354,6 +355,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -967,6 +969,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1619,6 +1622,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1752,6 +1756,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},

--- a/test/appframework_aws/s1/appframework_aws_test.go
+++ b/test/appframework_aws/s1/appframework_aws_test.go
@@ -131,6 +131,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -164,6 +165,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -309,6 +311,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -331,6 +334,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -478,6 +482,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -506,6 +511,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -663,6 +669,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -781,6 +788,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -886,6 +894,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -966,6 +975,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -994,6 +1004,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -1146,6 +1157,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1160,6 +1172,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1229,6 +1242,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1266,6 +1280,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -1342,6 +1357,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1438,6 +1454,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1511,6 +1528,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1620,6 +1638,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1739,6 +1758,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1834,6 +1854,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1896,6 +1917,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1967,6 +1989,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -2004,6 +2027,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{

--- a/test/appframework_az/c3/appframework_azure_test.go
+++ b/test/appframework_az/c3/appframework_azure_test.go
@@ -135,6 +135,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -349,6 +350,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -978,6 +980,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -998,6 +1001,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					ClusterMasterRef: corev1.ObjectReference{
@@ -1653,6 +1657,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -2291,6 +2296,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -2420,6 +2426,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -3219,6 +3226,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					ClusterMasterRef: corev1.ObjectReference{

--- a/test/appframework_az/c3/manager_appframework_azure_test.go
+++ b/test/appframework_az/c3/manager_appframework_azure_test.go
@@ -134,6 +134,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -347,6 +348,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -976,6 +978,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -996,6 +999,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					ClusterManagerRef: corev1.ObjectReference{
@@ -1653,6 +1657,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -2291,6 +2296,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -2420,6 +2426,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -3219,6 +3226,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					ClusterManagerRef: corev1.ObjectReference{

--- a/test/appframework_az/m4/appframework_azure_test.go
+++ b/test/appframework_az/m4/appframework_azure_test.go
@@ -137,6 +137,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -344,6 +345,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -941,6 +943,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1595,6 +1598,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1729,6 +1733,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},

--- a/test/appframework_az/m4/manager_appframework_azure_test.go
+++ b/test/appframework_az/m4/manager_appframework_azure_test.go
@@ -136,6 +136,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -343,6 +344,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -940,6 +942,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1594,6 +1597,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1728,6 +1732,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},

--- a/test/appframework_az/s1/appframework_azure_test.go
+++ b/test/appframework_az/s1/appframework_azure_test.go
@@ -134,6 +134,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -165,6 +166,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -300,6 +302,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -322,6 +325,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -472,6 +476,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -501,6 +506,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -641,6 +647,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -762,6 +769,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -865,6 +873,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -945,6 +954,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -973,6 +983,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -1124,6 +1135,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1138,6 +1150,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1207,6 +1220,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1245,6 +1259,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -1323,6 +1338,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1393,6 +1409,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1467,6 +1484,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1578,6 +1596,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1698,6 +1717,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1792,6 +1812,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1855,6 +1876,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1926,6 +1948,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1963,6 +1986,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{

--- a/test/appframework_gcp/c3/appframework_gcs_test.go
+++ b/test/appframework_gcp/c3/appframework_gcs_test.go
@@ -140,6 +140,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -360,6 +361,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},

--- a/test/appframework_gcp/c3/manager_appframework_test.go
+++ b/test/appframework_gcp/c3/manager_appframework_test.go
@@ -137,6 +137,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -344,6 +345,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					ClusterManagerRef: corev1.ObjectReference{
@@ -503,6 +505,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1639,6 +1642,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -2274,6 +2278,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -2402,6 +2407,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -3197,6 +3203,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					ClusterManagerRef: corev1.ObjectReference{
@@ -3307,6 +3314,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -3327,6 +3335,7 @@ var _ = Describe("c3appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					ClusterManagerRef: corev1.ObjectReference{

--- a/test/appframework_gcp/m4/appframework_gcs_test.go
+++ b/test/appframework_gcp/m4/appframework_gcs_test.go
@@ -137,6 +137,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -355,6 +356,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -968,6 +970,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1620,6 +1623,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1753,6 +1757,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},

--- a/test/appframework_gcp/m4/manager_appframework_test.go
+++ b/test/appframework_gcp/m4/manager_appframework_test.go
@@ -136,6 +136,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -354,6 +355,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -967,6 +969,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1619,6 +1622,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1752,6 +1756,7 @@ var _ = Describe("m4appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},

--- a/test/appframework_gcp/s1/appframework_gcs_test.go
+++ b/test/appframework_gcp/s1/appframework_gcs_test.go
@@ -131,6 +131,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -164,6 +165,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -309,6 +311,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -331,6 +334,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -478,6 +482,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -506,6 +511,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -663,6 +669,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -781,6 +788,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -886,6 +894,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -966,6 +975,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -994,6 +1004,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -1143,6 +1154,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1157,6 +1169,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1226,6 +1239,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1263,6 +1277,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -1339,6 +1354,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1435,6 +1451,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1508,6 +1525,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1617,6 +1635,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1736,6 +1755,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1831,6 +1851,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1893,6 +1914,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -1964,6 +1986,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},
@@ -2001,6 +2024,7 @@ var _ = Describe("s1appfw test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{

--- a/test/delete_cr/deletecr_test.go
+++ b/test/delete_cr/deletecr_test.go
@@ -62,6 +62,7 @@ var _ = Describe("DeleteCR test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 				},

--- a/test/licensemanager/manager_lm_c3_test.go
+++ b/test/licensemanager/manager_lm_c3_test.go
@@ -257,6 +257,7 @@ var _ = Describe("Licensemanager test", func() {
 					LicenseURL: "/mnt/licenses/enterprise.lic",
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 				},
 				AppFrameworkConfig: appFrameworkSpec,

--- a/test/licensemaster/lm_c3_test.go
+++ b/test/licensemaster/lm_c3_test.go
@@ -255,6 +255,7 @@ var _ = Describe("licensemaster test", func() {
 					LicenseURL: "/mnt/licenses/enterprise.lic",
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 				},
 				AppFrameworkConfig: appFrameworkSpec,

--- a/test/monitoring_console/manager_monitoring_console_test.go
+++ b/test/monitoring_console/manager_monitoring_console_test.go
@@ -92,6 +92,7 @@ var _ = Describe("Monitoring Console test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -190,6 +191,7 @@ var _ = Describe("Monitoring Console test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -235,6 +237,7 @@ var _ = Describe("Monitoring Console test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 						Resources: corev1.ResourceRequirements{
 							Limits: corev1.ResourceList{
 								"cpu":    resource.MustParse("2"),
@@ -341,6 +344,7 @@ var _ = Describe("Monitoring Console test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -529,6 +533,7 @@ var _ = Describe("Monitoring Console test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -972,6 +977,7 @@ var _ = Describe("Monitoring Console test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{
@@ -1013,6 +1019,7 @@ var _ = Describe("Monitoring Console test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 						Resources: corev1.ResourceRequirements{
 							Limits: corev1.ResourceList{
 								"cpu":    resource.MustParse("2"),

--- a/test/monitoring_console/monitoring_console_test.go
+++ b/test/monitoring_console/monitoring_console_test.go
@@ -168,6 +168,7 @@ var _ = Describe("Monitoring Console test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{

--- a/test/secret/manager_secret_s1_test.go
+++ b/test/secret/manager_secret_s1_test.go
@@ -280,6 +280,7 @@ var _ = Describe("Secret Test for SVA S1", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{

--- a/test/secret/secret_s1_test.go
+++ b/test/secret/secret_s1_test.go
@@ -280,6 +280,7 @@ var _ = Describe("Secret Test for SVA S1", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					MonitoringConsoleRef: corev1.ObjectReference{

--- a/test/smartstore/smartstore_test.go
+++ b/test/smartstore/smartstore_test.go
@@ -294,6 +294,7 @@ var _ = Describe("Smartstore test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					EtcVolumeStorageConfig: enterpriseApi.StorageClassSpec{
@@ -330,6 +331,7 @@ var _ = Describe("Smartstore test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "Always",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes: []corev1.Volume{},
 					VarVolumeStorageConfig: enterpriseApi.StorageClassSpec{

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -140,6 +140,7 @@ var _ = Describe("Smoke test", func() {
 				CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 					Spec: enterpriseApi.Spec{
 						ImagePullPolicy: "IfNotPresent",
+						Image:           testcaseEnvInst.GetSplunkImage(),
 					},
 					Volumes:        []corev1.Volume{},
 					ServiceAccount: serviceAccountName,

--- a/test/testenv/testcaseenv.go
+++ b/test/testenv/testcaseenv.go
@@ -62,7 +62,11 @@ func (testenv *TestCaseEnv) GetKubeClient() client.Client {
 
 // NewDefaultTestCaseEnv creates a default test environment
 func NewDefaultTestCaseEnv(kubeClient client.Client, name string) (*TestCaseEnv, error) {
-	return NewTestCaseEnv(kubeClient, name, specifiedOperatorImage, specifiedSplunkImage, specifiedLicenseFilePath)
+	if os.Getenv("GRAVITON_TESTING") == "true" {
+		return NewTestCaseEnv(kubeClient, name, specifiedOperatorImage, os.Getenv("SPLUNK_ENTERPRISE_IMAGE"), specifiedLicenseFilePath)
+	} else {
+		return NewTestCaseEnv(kubeClient, name, specifiedOperatorImage, specifiedSplunkImage, specifiedLicenseFilePath)
+	}
 }
 
 // NewTestCaseEnv creates a new test environment to run tests againsts
@@ -105,6 +109,11 @@ func NewTestCaseEnv(kubeClient client.Client, name string, operatorImage string,
 // GetName returns the name of the testenv
 func (testenv *TestCaseEnv) GetName() string {
 	return testenv.name
+}
+
+// GetName returns the Splunk image of the testenv
+func (testenv *TestCaseEnv) GetSplunkImage() string {
+	return testenv.splunkImage
 }
 
 // IsOperatorInstalledClusterWide returns if operator is installed clusterwide

--- a/test/testenv/testenv.go
+++ b/test/testenv/testenv.go
@@ -185,7 +185,11 @@ func init() {
 
 	flag.StringVar(&specifiedLicenseFilePath, "license-file", "", "Enterprise license file to use")
 	flag.StringVar(&specifiedOperatorImage, "operator-image", defaultOperatorImage, "Splunk Operator image to use")
-	flag.StringVar(&specifiedSplunkImage, "splunk-image", defaultSplunkImage, "Splunk Enterprise (splunkd) image to use")
+	if os.Getenv("GRAVITON_TESTING") == "true" {
+		flag.StringVar(&specifiedSplunkImage, "splunk-image", os.Getenv("SPLUNK_ENTERPRISE_IMAGE"), "Splunk Enterprise (splunkd) image to use")
+	} else {
+		flag.StringVar(&specifiedSplunkImage, "splunk-image", defaultSplunkImage, "Splunk Enterprise (splunkd) image to use")
+	}
 	flag.BoolVar(&specifiedSkipTeardown, "skip-teardown", false, "True to skip tearing down the test env after use")
 	flag.IntVar(&SpecifiedTestTimeout, "test-timeout", defaultTestTimeout, "Max test timeout in seconds to use")
 	flag.StringVar(&specifiedCommitHash, "commit-hash", "", "commit hash string to use as part of the name")
@@ -199,7 +203,11 @@ func (testenv *TestEnv) GetKubeClient() client.Client {
 
 // NewDefaultTestEnv creates a default test environment
 func NewDefaultTestEnv(name string) (*TestEnv, error) {
-	return NewTestEnv(name, specifiedCommitHash, specifiedOperatorImage, specifiedSplunkImage, specifiedLicenseFilePath)
+	if os.Getenv("GRAVITON_TESTING") == "true" {
+		return NewTestEnv(name, specifiedCommitHash, specifiedOperatorImage, os.Getenv("SPLUNK_ENTERPRISE_IMAGE"), specifiedLicenseFilePath)
+	} else {
+		return NewTestEnv(name, specifiedCommitHash, specifiedOperatorImage, specifiedSplunkImage, specifiedLicenseFilePath)
+	}
 }
 
 // NewTestEnv creates a new test environment to run tests againsts

--- a/test/testenv/util.go
+++ b/test/testenv/util.go
@@ -72,7 +72,7 @@ func RandomDNSName(n int) string {
 }
 
 // newStandalone creates and initializes CR for Standalone Kind
-func newStandalone(name, ns string) *enterpriseApi.Standalone {
+func newStandalone(name, ns, splunkImage string) *enterpriseApi.Standalone {
 
 	new := enterpriseApi.Standalone{
 		TypeMeta: metav1.TypeMeta{
@@ -88,6 +88,7 @@ func newStandalone(name, ns string) *enterpriseApi.Standalone {
 			CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 				Spec: enterpriseApi.Spec{
 					ImagePullPolicy: "Always",
+					Image:           splunkImage,
 				},
 				Volumes: []corev1.Volume{},
 			},
@@ -115,7 +116,7 @@ func newStandaloneWithGivenSpec(name, ns string, spec enterpriseApi.StandaloneSp
 	return &new
 }
 
-func newLicenseManager(name, ns, licenseConfigMapName string) *enterpriseApi.LicenseManager {
+func newLicenseManager(name, ns, licenseConfigMapName, splunkImage string) *enterpriseApi.LicenseManager {
 	new := enterpriseApi.LicenseManager{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "LicenseManager",
@@ -144,6 +145,7 @@ func newLicenseManager(name, ns, licenseConfigMapName string) *enterpriseApi.Lic
 				LicenseURL: "/mnt/licenses/enterprise.lic",
 				Spec: enterpriseApi.Spec{
 					ImagePullPolicy: "Always",
+					Image:           splunkImage,
 				},
 			},
 		},
@@ -152,7 +154,7 @@ func newLicenseManager(name, ns, licenseConfigMapName string) *enterpriseApi.Lic
 	return &new
 }
 
-func newLicenseMaster(name, ns, licenseConfigMapName string) *enterpriseApiV3.LicenseMaster {
+func newLicenseMaster(name, ns, licenseConfigMapName, splunkImage string) *enterpriseApiV3.LicenseMaster {
 	new := enterpriseApiV3.LicenseMaster{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "LicenseMaster",
@@ -181,6 +183,7 @@ func newLicenseMaster(name, ns, licenseConfigMapName string) *enterpriseApiV3.Li
 				LicenseURL: "/mnt/licenses/enterprise.lic",
 				Spec: enterpriseApi.Spec{
 					ImagePullPolicy: "Always",
+					Image:           splunkImage,
 				},
 			},
 		},
@@ -208,7 +211,7 @@ func swapLicenseManager(name string, licenseManagerName string) (string, string)
 }
 
 // newClusterManager creates and initialize the CR for ClusterManager Kind
-func newClusterManager(name, ns, licenseManagerName string, ansibleConfig string) *enterpriseApi.ClusterManager {
+func newClusterManager(name, ns, licenseManagerName, ansibleConfig, splunkImage string) *enterpriseApi.ClusterManager {
 
 	licenseMasterRef, licenseManagerRef := swapLicenseManager(name, licenseManagerName)
 
@@ -227,6 +230,7 @@ func newClusterManager(name, ns, licenseManagerName string, ansibleConfig string
 				Volumes: []corev1.Volume{},
 				Spec: enterpriseApi.Spec{
 					ImagePullPolicy: "Always",
+					Image:           splunkImage,
 				},
 				LicenseManagerRef: corev1.ObjectReference{
 					Name: licenseManagerRef,
@@ -243,7 +247,7 @@ func newClusterManager(name, ns, licenseManagerName string, ansibleConfig string
 }
 
 // newClusterManager creates and initialize the CR for ClusterManager Kind
-func newClusterMaster(name, ns, licenseManagerName string, ansibleConfig string) *enterpriseApiV3.ClusterMaster {
+func newClusterMaster(name, ns, licenseManagerName, ansibleConfig, splunkImage string) *enterpriseApiV3.ClusterMaster {
 
 	licenseMasterRef, licenseManagerRef := swapLicenseManager(name, licenseManagerName)
 
@@ -262,6 +266,7 @@ func newClusterMaster(name, ns, licenseManagerName string, ansibleConfig string)
 				Volumes: []corev1.Volume{},
 				Spec: enterpriseApi.Spec{
 					ImagePullPolicy: "Always",
+					Image:           splunkImage,
 				},
 				LicenseManagerRef: corev1.ObjectReference{
 					Name: licenseManagerRef,
@@ -278,7 +283,7 @@ func newClusterMaster(name, ns, licenseManagerName string, ansibleConfig string)
 }
 
 // newClusterManager creates and initialize the CR for ClusterManager Kind
-func newClusterManagerWithGivenIndexes(name, ns, licenseManagerName string, ansibleConfig string, smartstorespec enterpriseApi.SmartStoreSpec) *enterpriseApi.ClusterManager {
+func newClusterManagerWithGivenIndexes(name, ns, licenseManagerName, ansibleConfig, splunkImage string, smartstorespec enterpriseApi.SmartStoreSpec) *enterpriseApi.ClusterManager {
 
 	licenseMasterRef, licenseManagerRef := swapLicenseManager(name, licenseManagerName)
 
@@ -298,6 +303,7 @@ func newClusterManagerWithGivenIndexes(name, ns, licenseManagerName string, ansi
 				Volumes: []corev1.Volume{},
 				Spec: enterpriseApi.Spec{
 					ImagePullPolicy: "Always",
+					Image:           splunkImage,
 				},
 				LicenseManagerRef: corev1.ObjectReference{
 					Name: licenseManagerRef,
@@ -314,7 +320,7 @@ func newClusterManagerWithGivenIndexes(name, ns, licenseManagerName string, ansi
 }
 
 // newClusterManager creates and initialize the CR for ClusterManager Kind
-func newClusterMasterWithGivenIndexes(name, ns, licenseManagerName string, ansibleConfig string, smartstorespec enterpriseApi.SmartStoreSpec) *enterpriseApiV3.ClusterMaster {
+func newClusterMasterWithGivenIndexes(name, ns, licenseManagerName, ansibleConfig, splunkImage string, smartstorespec enterpriseApi.SmartStoreSpec) *enterpriseApiV3.ClusterMaster {
 
 	licenseMasterRef, licenseManagerRef := swapLicenseManager(name, licenseManagerName)
 
@@ -334,6 +340,7 @@ func newClusterMasterWithGivenIndexes(name, ns, licenseManagerName string, ansib
 				Volumes: []corev1.Volume{},
 				Spec: enterpriseApi.Spec{
 					ImagePullPolicy: "Always",
+					Image:           splunkImage,
 				},
 				LicenseManagerRef: corev1.ObjectReference{
 					Name: licenseManagerRef,
@@ -350,7 +357,7 @@ func newClusterMasterWithGivenIndexes(name, ns, licenseManagerName string, ansib
 }
 
 // newIndexerCluster creates and initialize the CR for IndexerCluster Kind
-func newIndexerCluster(name, ns, licenseManagerName string, replicas int, clusterManagerRef string, ansibleConfig string) *enterpriseApi.IndexerCluster {
+func newIndexerCluster(name, ns, licenseManagerName string, replicas int, clusterManagerRef, ansibleConfig, splunkImage string) *enterpriseApi.IndexerCluster {
 
 	licenseMasterRef, licenseManagerRef := swapLicenseManager(name, licenseManagerName)
 	clusterMasterRef, clusterManagerRef := swapClusterManager(name, clusterManagerRef)
@@ -370,6 +377,7 @@ func newIndexerCluster(name, ns, licenseManagerName string, replicas int, cluste
 				Volumes: []corev1.Volume{},
 				Spec: enterpriseApi.Spec{
 					ImagePullPolicy: "Always",
+					Image:           splunkImage,
 				},
 				ClusterManagerRef: corev1.ObjectReference{
 					Name: clusterManagerRef,
@@ -392,7 +400,7 @@ func newIndexerCluster(name, ns, licenseManagerName string, replicas int, cluste
 	return &new
 }
 
-func newSearchHeadCluster(name, ns, clusterManagerRef, licenseManagerName string, ansibleConfig string) *enterpriseApi.SearchHeadCluster {
+func newSearchHeadCluster(name, ns, clusterManagerRef, licenseManagerName, ansibleConfig, splunkImage string) *enterpriseApi.SearchHeadCluster {
 
 	licenseMasterRef, licenseManagerRef := swapLicenseManager(name, licenseManagerName)
 	clusterMasterRef, clusterManagerRef := swapClusterManager(name, clusterManagerRef)
@@ -412,6 +420,7 @@ func newSearchHeadCluster(name, ns, clusterManagerRef, licenseManagerName string
 				Volumes: []corev1.Volume{},
 				Spec: enterpriseApi.Spec{
 					ImagePullPolicy: "Always",
+					Image:           splunkImage,
 				},
 				ClusterManagerRef: corev1.ObjectReference{
 					Name: clusterManagerRef,
@@ -601,7 +610,7 @@ func newOperator(name, ns, account, operatorImageAndTag, splunkEnterpriseImageAn
 }
 
 // newStandaloneWithLM creates and initializes CR for Standalone Kind with License Manager
-func newStandaloneWithLM(name, ns string, licenseManagerName string) *enterpriseApi.Standalone {
+func newStandaloneWithLM(name, ns, licenseManagerName, splunkImage string) *enterpriseApi.Standalone {
 
 	licenseMasterRef, licenseManagerRef := swapLicenseManager(name, licenseManagerName)
 
@@ -619,6 +628,7 @@ func newStandaloneWithLM(name, ns string, licenseManagerName string) *enterprise
 			CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 				Spec: enterpriseApi.Spec{
 					ImagePullPolicy: "Always",
+					Image:           splunkImage,
 				},
 				LicenseManagerRef: corev1.ObjectReference{
 					Name: licenseManagerRef,
@@ -670,7 +680,7 @@ func newStandaloneWithSpec(name, ns string, spec enterpriseApi.StandaloneSpec) *
 }
 
 // newMonitoringConsoleSpec returns MC Spec with given name, namespace and license manager Ref
-func newMonitoringConsoleSpec(name string, ns string, LicenseManagerRef string) *enterpriseApi.MonitoringConsole {
+func newMonitoringConsoleSpec(name, ns, LicenseManagerRef, splunkImage string) *enterpriseApi.MonitoringConsole {
 
 	licenseMasterRef, licenseManagerRef := swapLicenseManager(name, LicenseManagerRef)
 
@@ -688,6 +698,7 @@ func newMonitoringConsoleSpec(name string, ns string, LicenseManagerRef string) 
 			CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
 				Spec: enterpriseApi.Spec{
 					ImagePullPolicy: "Always",
+					Image:           splunkImage,
 				},
 				LicenseManagerRef: corev1.ObjectReference{
 					Name: licenseManagerRef,


### PR DESCRIPTION
### Description

It adds inputs to Github actions for Graviton builds not to create branches with temporary image changes or replace secret values temporarily.

### Key Changes

- Introducing Github inputs.
- Enhancing tests to use Github inputs.

### Testing and Verification

Tested by automation. Neither manual tests nor new automated tests required.
Integ tests run: https://github.com/splunk/splunk-operator/pull/1522
RHEL smoke run: https://github.com/splunk/splunk-operator/actions/runs/15587504408
RHEL integ run: https://github.com/splunk/splunk-operator/actions/runs/15587498696

### Related Issues

Jira: https://splunk.atlassian.net/browse/CSPL-3756

### PR Checklist

- [x] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [x] All tests pass locally.
- [x] The PR description follows the project's guidelines.
