### PR TITLE
CSPL-3784: Update base image to latest ubi8-minimal version

### DIFF
--- a/.github/workflows/int-test-workflow.yml
+++ b/.github/workflows/int-test-workflow.yml
@@ -5,7 +5,6 @@ on:
       - develop
       - main
       - feature**
-      - CSPL_3784_ubiminimal
 jobs:
   build-operator-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/int-test-workflow.yml
+++ b/.github/workflows/int-test-workflow.yml
@@ -5,6 +5,7 @@ on:
       - develop
       - main
       - feature**
+      - CSPL_3784_ubiminimal
 jobs:
   build-operator-image:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG PLATFORMS=linux/amd64
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # This sha relates to ubi minimal version 8.10-1255, which is tagged as 8.10 and latest as of Apr 25, 2025
 ARG BASE_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal@sha256
-ARG BASE_IMAGE_VERSION=b2a1bec3dfbc7a14a1d84d98934dfe8fdde6eb822a211286601cf109cbccb075
+ARG BASE_IMAGE_VERSION=3b0f20d81f5fc0dfb3f96cbe9912e02959d1e508411e0e46fad52520208a651c
 
 # Build the manager binary
 FROM golang:1.23.0 AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG PLATFORMS=linux/amd64
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-# This sha relates to ubi minimal version 8.10-1255, which is tagged as 8.10 and latest as of Apr 25, 2025
+# This sha relates to ubi minimal version 8.10-1295.1749680713, which is tagged as 8.10 and latest as of Jun 23, 2025
 ARG BASE_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal@sha256
 ARG BASE_IMAGE_VERSION=3b0f20d81f5fc0dfb3f96cbe9912e02959d1e508411e0e46fad52520208a651c
 

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ docker-push: ## Push docker image with the manager.
 # Defaults:
 #   Build Platform: linux/amd64
 #   Build Base OS: registry.access.redhat.com/ubi8/ubi-minimal@sha256
-#   Build Base OS Version: 3b0f20d81f5fc0dfb3f96cbe9912e02959d1e508411e0e46fad52520208a651c (corresponds to tag 8.10-1295.1749680713) trigger
+#   Build Base OS Version: 3b0f20d81f5fc0dfb3f96cbe9912e02959d1e508411e0e46fad52520208a651c (corresponds to tag 8.10-1295.1749680713)
 # Pass only what is required, the rest will be defaulted
 # Setup defaults for build arguments
 PLATFORMS ?= linux/amd64

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ docker-push: ## Push docker image with the manager.
 # Defaults:
 #   Build Platform: linux/amd64
 #   Build Base OS: registry.access.redhat.com/ubi8/ubi-minimal@sha256
-#   Build Base OS Version: 3b0f20d81f5fc0dfb3f96cbe9912e02959d1e508411e0e46fad52520208a651c (corresponds to tag 8.10-1295.1749680713)
+#   Build Base OS Version: 3b0f20d81f5fc0dfb3f96cbe9912e02959d1e508411e0e46fad52520208a651c (corresponds to tag 8.10-1295.1749680713) trigger
 # Pass only what is required, the rest will be defaulted
 # Setup defaults for build arguments
 PLATFORMS ?= linux/amd64

--- a/Makefile
+++ b/Makefile
@@ -153,12 +153,12 @@ docker-push: ## Push docker image with the manager.
 # Defaults:
 #   Build Platform: linux/amd64
 #   Build Base OS: registry.access.redhat.com/ubi8/ubi-minimal@sha256
-#   Build Base OS Version: b2a1bec3dfbc7a14a1d84d98934dfe8fdde6eb822a211286601cf109cbccb075 (corresponds to tag 8.10-1255)
+#   Build Base OS Version: 3b0f20d81f5fc0dfb3f96cbe9912e02959d1e508411e0e46fad52520208a651c (corresponds to tag 8.10-1295.1749680713)
 # Pass only what is required, the rest will be defaulted
 # Setup defaults for build arguments
 PLATFORMS ?= linux/amd64
 BASE_IMAGE ?= registry.access.redhat.com/ubi8/ubi-minimal@sha256
-BASE_IMAGE_VERSION ?= b2a1bec3dfbc7a14a1d84d98934dfe8fdde6eb822a211286601cf109cbccb075
+BASE_IMAGE_VERSION ?= 3b0f20d81f5fc0dfb3f96cbe9912e02959d1e508411e0e46fad52520208a651c
 
 docker-buildx:
 	@if [ -z "${IMG}" ]; then \


### PR DESCRIPTION
### Description

This PR updates the manifest for the latest ubi8-minimal image to use as the base image in the Makefile and Dockerfile. This new version includes vulnerability fixes for included packages.

### Key Changes

* Dockerfile: Update the BASE_IMAGE_VERSION to use to build the image
* Makefile: Update the BASE_IMAGE_VERSION to use to build the image

### Testing and Verification

All unit, smoke, and integration tests were run.

### Related Issues

- https://splunk.atlassian.net/browse/CSPL-3784
- https://splunk.atlassian.net/browse/VULN-35964
- https://splunk.atlassian.net/browse/VULN-35965
- https://splunk.atlassian.net/browse/VULN-35966

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [x] All tests pass locally.
- [X] The PR description follows the project's guidelines.
