### PR TITLE
CSPL-3798: Add more logs around invalid phase and downloadPending

### DIFF
--- a/pkg/splunk/enterprise/afwscheduler.go
+++ b/pkg/splunk/enterprise/afwscheduler.go
@@ -565,6 +565,7 @@ downloadWork:
 				// create the sub-directories on the volume for downloading scoped apps
 				localPath, err := downloadWorker.createDownloadDirOnOperator(ctx)
 				if err != nil {
+					scopedLog.Error(err, "unable to create download directory on operator", "appSrcName", downloadWorker.appSrcName, "appName", appDeployInfo.AppName)
 
 					// increment the retry count and mark this app as download pending
 					updatePplnWorkerPhaseInfo(ctx, appDeployInfo, appDeployInfo.PhaseInfo.FailCount+1, enterpriseApi.AppPkgDownloadPending)
@@ -1385,12 +1386,12 @@ func validatePhaseInfo(ctx context.Context, phaseInfo *enterpriseApi.PhaseInfo) 
 			enterpriseApi.PhaseInstall)
 
 	if !strings.Contains(phases, string(phaseInfo.Phase)) {
-		scopedLog.Error(nil, "Invalid phase in PhaseInfo")
+		scopedLog.Error(nil, "Invalid phase in PhaseInfo", "phase", string(phaseInfo.Phase))
 		return false
 	}
 
 	if ok := appPhaseInfoStatuses[phaseInfo.Status]; !ok {
-		scopedLog.Error(nil, "Invalid status in PhaseInfo")
+		scopedLog.Error(nil, "Invalid status in PhaseInfo", "phase", string(phaseInfo.Phase), "status", phaseInfo.Status)
 		return false
 	}
 	return true


### PR DESCRIPTION
### Description

As a response to a few community group discussions, this PR adds more logging around the app framework download work logic.

### Key Changes

- Add error log for unable to create download directory.
- Update error log with more information for invalid statuses and phases.

### Testing and Verification

N/A

### Related Issues

- https://splunk.atlassian.net/browse/CSPL-3798

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [X] All tests pass locally.
- [X] The PR description follows the project's guidelines.
