### PR TITLE
Upgrade golang.org/x/net version to v0.38.0

### DIFF
--- a/.github/workflows/int-test-workflow.yml
+++ b/.github/workflows/int-test-workflow.yml
@@ -5,6 +5,7 @@ on:
       - develop
       - main
       - feature**
+      - CSPL_3846_xnet
 jobs:
   build-operator-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/int-test-workflow.yml
+++ b/.github/workflows/int-test-workflow.yml
@@ -5,7 +5,6 @@ on:
       - develop
       - main
       - feature**
-      - CSPL_3846_xnet
 jobs:
   build-operator-image:
     runs-on: ubuntu-latest

--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect
-	golang.org/x/net v0.37.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/oauth2 v0.21.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -336,6 +336,8 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.37.0 h1:1zLorHbz+LYj7MQlSf1+2tPIIgibq2eL5xkrGk6f+2c=
 golang.org/x/net v0.37.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.21.0 h1:tsimM75w1tF/uws5rbeHzIWxEqElMehnc+iW793zsZs=

--- a/internal/controller/common/predicate.go
+++ b/internal/controller/common/predicate.go
@@ -30,7 +30,7 @@ func LabelChangedPredicate() predicate.Predicate {
 func GenerationChangedPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return  !reflect.DeepEqual(e.ObjectOld.GetGeneration(), e.ObjectNew.GetGeneration())
+			return !reflect.DeepEqual(e.ObjectOld.GetGeneration(), e.ObjectNew.GetGeneration())
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			// Evaluates to false if the object has been confirmed deleted.


### PR DESCRIPTION
### Description

This pull request updates the dependency version of golang.org/x/net dependencies to mitigate medium severity security vulnerabilities.

golang.org/x/net
- https://pkg.go.dev/vuln/GO-2025-3595
- Severity: SEC_MEDIUM
- The tokenizer incorrectly interprets tags with unquoted attribute values that end with a solidus character Check Mark as self-closing. When directly using Tokenizer, this can result in such tags incorrectly being marked as self-closing, and when using the Parse functions, this can result in content following such tags as being placed in the wrong scope during DOM construction, but only when tags are in foreign content (e.g. <math>, <svg>, etc contexts).

### Key Changes

go.mod and go.sum:
- Update versions of dependencies.

### Testing and Verification

Unit tests, smoke tests, and integration tests all run and are passing.

### Related Issues

- https://splunk.atlassian.net/browse/CSPL-3846
- https://splunk.atlassian.net/browse/VULN-38979

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [X] Relevant unit and integration tests are included.
- [X] Documentation has been updated accordingly.
- [X] All tests pass locally.
- [X] The PR description follows the project's guidelines.
