### PR TITLE
Remove kube-rbac-proxy from Helm charts

### DIFF
--- a/helm-chart/splunk-operator/templates/deployment.yaml
+++ b/helm-chart/splunk-operator/templates/deployment.yaml
@@ -42,28 +42,14 @@ spec:
       hostPID: {{ .Values.splunkOperator.hostPID }}
       hostIPC: {{ .Values.splunkOperator.hostIPC }}
       containers:
-        - name: kube-rbac-proxy
-          image: "{{ .Values.kubeRbacProxy.image.repository }}:{{ .Values.kubeRbacProxy.image.tag }}"
-          imagePullPolicy: {{ .Values.kubeRbacProxy.image.pullPolicy }}
-          args:
-          - "--secure-listen-address=0.0.0.0:8443"
-          - "--upstream=http://127.0.0.1:8080/"
-          - "--logtostderr=true"
-          - "--v=10"
-          ports:
-          - containerPort: 8443
-            name: https
-            protocol: TCP
-          resources:
-{{- toYaml .Values.kubeRbacProxy.resources | nindent 12 }}
         - name: manager
           image: "{{ .Values.splunkOperator.image.repository}}"
           imagePullPolicy: {{ .Values.splunkOperator.image.pullPolicy }}
           args:
-          - --leader-elect
-          - --pprof
+            - --leader-elect
+            - --pprof
           command:
-          - /manager
+            - /manager
 {{- with .Values.splunkOperator.livenessProbe }}
           livenessProbe:
 {{- toYaml . | nindent 12 }}
@@ -73,22 +59,22 @@ spec:
 {{- toYaml . | nindent 12 }}
 {{- end }}
           env:
-          - name: WATCH_NAMESPACE
+            - name: WATCH_NAMESPACE
 {{- if .Values.splunkOperator.clusterWideAccess  }}
-            value: {{ .Values.splunkOperator.watchNamespaces }}
+              value: {{ .Values.splunkOperator.watchNamespaces }}
 {{- else }}
-            value: {{ .Release.Namespace }}
+              value: {{ .Release.Namespace }}
 {{- end }}
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: OPERATOR_NAME
-            value: {{ include "splunk-operator.operator.fullname" . }}
-          - name: RELATED_IMAGE_SPLUNK_ENTERPRISE
-            value: "{{ .Values.image.repository }}"
-          - name: CLUSTER_DOMAIN
-            value: {{ .Values.splunkOperator.clusterDomain | default "cluster.local" }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: {{ include "splunk-operator.operator.fullname" . }}
+            - name: RELATED_IMAGE_SPLUNK_ENTERPRISE
+              value: "{{ .Values.image.repository }}"
+            - name: CLUSTER_DOMAIN
+              value: {{ .Values.splunkOperator.clusterDomain | default "cluster.local" }}
 {{- with .Values.extraEnvs }}
 {{- toYaml . | trim | nindent 10 }}
 {{- end }}

--- a/helm-chart/splunk-operator/values.yaml
+++ b/helm-chart/splunk-operator/values.yaml
@@ -5,27 +5,6 @@ splunk-operator:
 image:
   repository: docker.io/splunk/splunk:9.4.1
 
-# The kube-rbac-proxy is a small HTTP proxy for a single upstream, that can perform RBAC
-# authorization against the Kubernetes API.
-# reference: https://github.com/brancz/kube-rbac-proxy
-kubeRbacProxy:
-
-  # Specify kube-rbac-proxy image
-  image:
-    repository: gcr.io/kubebuilder/kube-rbac-proxy
-    pullPolicy: IfNotPresent
-    tag: "v0.13.1"
-
-  # Set resource requests and limits for kube-rbac-proxy container
-  resources:
-    limits:
-      cpu: 500m
-      memory: 128Mi
-    requests:
-      cpu: 5m
-      memory: 64Mi
-
-
 # Splunk Operator configurations
 splunkOperator:
 


### PR DESCRIPTION
### Description

Removes kube-rbac proxy references from helm charts. It's been deprecated and the image gcr.io/kubebuilder/kube-rbac-proxy no longer exists.

