### PR TITLE
CSPL-3867: SHC and CM Error Message Visibility

### DIFF
--- a/.github/workflows/build-test-push-workflow.yml
+++ b/.github/workflows/build-test-push-workflow.yml
@@ -3,58 +3,57 @@ on:
   pull_request: {}
   push:
     branches:
-      - main
-      - develop
-      - CSPL_3867_errors
+    - main
+    - develop
 jobs:
-  # check-formating:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Dotenv Action
-  #     id: dotenv
-  #     uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
-  #   - name: Setup Go
-  #     uses: actions/setup-go@v2
-  #     with:
-  #       go-version: ${{ steps.dotenv.outputs.GO_VERSION }}
-  #   - name: Check Source formatting
-  #     run: make fmt && if [[ $? -ne 0 ]]; then false; fi
-  #   - name: Lint source code
-  #     run: make vet && if [[ $? -ne 0 ]]; then false; fi
-  # unit-tests:
-  #   runs-on: ubuntu-latest
-  #   needs: check-formating
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Dotenv Action
-  #       id: dotenv
-  #       uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
-  #     - name: Setup Go
-  #       uses: actions/setup-go@v2
-  #       with:
-  #         go-version: ${{ steps.dotenv.outputs.GO_VERSION }}
-  #     - name: Install goveralls
-  #       run: |
-  #         go version
-  #         go install github.com/mattn/goveralls@latest
-  #     - name: Install Ginkgo
-  #       run: |
-  #         make setup/ginkgo
-  #         go mod tidy
-  #     - name: Run Unit Tests
-  #       run: |
-  #         make test
-  #     - name: Run Code Coverage
-  #       run: goveralls -coverprofile=coverage.out -service=circle-ci -repotoken ${{ secrets.COVERALLS_TOKEN }}
-  #     - name: Upload Coverage artifacts
-  #       uses: actions/upload-artifact@v4.4.0
-  #       with:
-  #         name: coverage.out
-  #         path: coverage.out
+  check-formating:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Dotenv Action
+      id: dotenv
+      uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ steps.dotenv.outputs.GO_VERSION }}
+    - name: Check Source formatting
+      run: make fmt && if [[ $? -ne 0 ]]; then false; fi
+    - name: Lint source code
+      run: make vet && if [[ $? -ne 0 ]]; then false; fi
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: check-formating
+    steps:
+      - uses: actions/checkout@v2
+      - name: Dotenv Action
+        id: dotenv
+        uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ steps.dotenv.outputs.GO_VERSION }}
+      - name: Install goveralls
+        run: |
+          go version
+          go install github.com/mattn/goveralls@latest
+      - name: Install Ginkgo
+        run: |
+          make setup/ginkgo
+          go mod tidy
+      - name: Run Unit Tests
+        run: |
+          make test
+      - name: Run Code Coverage
+        run: goveralls -coverprofile=coverage.out -service=circle-ci -repotoken ${{ secrets.COVERALLS_TOKEN }}
+      - name: Upload Coverage artifacts
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: coverage.out
+          path: coverage.out
   build-operator-image:
     runs-on: ubuntu-latest
-    # needs: unit-tests
+    needs: unit-tests
     env:
       SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
@@ -103,209 +102,209 @@ jobs:
       env:
         COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
         COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-  # vulnerability-scan:
-  #   permissions:
-  #     actions: read
-  #     contents: read
-  #     security-events: write
-  #   runs-on: ubuntu-latest
-  #   needs: build-operator-image
-  #   env:
-  #     SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE }}
-  #     SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
-  #     ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-  #     S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-  #     IMAGE_NAME: ${{ secrets.ECR_REPOSITORY }}/splunk/splunk-operator:${{ github.sha }}
-  #   steps:
-  #   - name: Set up cosign
-  #     uses: sigstore/cosign-installer@main
-  #   - uses: actions/checkout@v2
-  #   - name: Dotenv Action
-  #     id: dotenv
-  #     uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
-  #   - name: Set up Docker Buildx
-  #     uses: docker/setup-buildx-action@v2.5.0
-  #   - name: Configure AWS credentials
-  #     uses: aws-actions/configure-aws-credentials@v1
-  #     with:
-  #       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #       aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+  vulnerability-scan:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    runs-on: ubuntu-latest
+    needs: build-operator-image
+    env:
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE }}
+      SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
+      ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+      S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      IMAGE_NAME: ${{ secrets.ECR_REPOSITORY }}/splunk/splunk-operator:${{ github.sha }}
+    steps:
+    - name: Set up cosign
+      uses: sigstore/cosign-installer@main
+    - uses: actions/checkout@v2
+    - name: Dotenv Action
+      id: dotenv
+      uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2.5.0
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
-  #   - name: Login to Amazon ECR
-  #     uses: aws-actions/amazon-ecr-login@v1
-  #   - name: Pull Splunk Operator Image Locally
-  #     run: |
-  #       docker pull ${{ env.IMAGE_NAME }}
-  #   - name: Verify Signed Splunk Operator image 
-  #     run: |
-  #       cosign verify --key env://COSIGN_PUBLIC_KEY  ${{ env.IMAGE_NAME }}
-  #     env:
-  #       COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
-  #   - name: Run Trivy vulnerability scanner
-  #     uses: aquasecurity/trivy-action@master
-  #     with:
-  #       image-ref: '${{ env.IMAGE_NAME }}'
-  #       format: sarif
-  #       #exit-code: 1
-  #       severity: 'CRITICAL'
-  #       ignore-unfixed: true
-  #       output: 'trivy-results.sarif'
-  #   - name: Upload Trivy scan results to GitHub Security tab
-  #     uses: github/codeql-action/upload-sarif@v3
-  #     with:
-  #       sarif_file: 'trivy-results.sarif'
-  # smoke-tests:
-  #   needs: vulnerability-scan
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test: [
-  #               basic,
-  #               appframeworksS1,
-  #               managerappframeworkc3,
-  #               managerappframeworkm4,
-  #               managersecret,
-  #               managermc,
-  #              ]
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     CLUSTER_NODES: 1
-  #     CLUSTER_WORKERS: 3
-  #     SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE }}
-  #     SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_RELEASE_IMAGE }}
-  #     SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
-  #     SPLUNK_OPERATOR_IMAGE_FILENAME: splunk-operator
-  #     TEST_FOCUS: "${{ matrix.test }}"
-  #     # This regex matches any string not containing smoke keyword
-  #     TEST_TO_SKIP: "^(?:[^s]+|s(?:$|[^m]|m(?:$|[^o]|o(?:$|[^k]|k(?:$|[^e])))))*$"
-  #     TEST_CLUSTER_PLATFORM: eks
-  #     EKS_VPC_PRIVATE_SUBNET_STRING: ${{ secrets.EKS_VPC_PRIVATE_SUBNET_STRING }}
-  #     EKS_VPC_PUBLIC_SUBNET_STRING: ${{ secrets.EKS_VPC_PUBLIC_SUBNET_STRING }}
-  #     TEST_BUCKET: ${{ secrets.TEST_BUCKET }}
-  #     TEST_INDEXES_S3_BUCKET: ${{ secrets.TEST_INDEXES_S3_BUCKET }}
-  #     ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-  #     PRIVATE_REGISTRY: ${{ secrets.ECR_REPOSITORY }}
-  #     S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-  #     ENTERPRISE_LICENSE_LOCATION: ${{ secrets.ENTERPRISE_LICENSE_LOCATION }}
-  #     EKS_SSH_PUBLIC_KEY: ${{ secrets.EKS_SSH_PUBLIC_KEY }}
-  #     CLUSTER_WIDE: "true"
-  #     DEPLOYMENT_TYPE: ""
-  #   steps:
-  #     - name: Set Test Cluster Name
-  #       run: |
-  #         echo "TEST_CLUSTER_NAME=eks-integration-test-cluster-${{ matrix.test }}-$GITHUB_RUN_ID" >> $GITHUB_ENV
-  #     - name: Chekcout code
-  #       uses: actions/checkout@v2
-  #     - name: Dotenv Action
-  #       id: dotenv
-  #       uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
-  #     - name: Change splunk enterprise to release image on main branches
-  #       if: github.ref == 'refs/heads/main'
-  #       run: |
-  #         echo "SPLUNK_ENTERPRISE_IMAGE=${{ steps.dotenv.outputs.SPLUNK_ENTERPRISE_RELEASE_IMAGE }}" >> $GITHUB_ENV
-  #     - name: Install Kubectl
-  #       uses: Azure/setup-kubectl@v3
-  #       with:
-  #         version: ${{ steps.dotenv.outputs.KUBECTL_VERSION }}
-  #     - name: Install Python
-  #       uses: actions/setup-python@v2
-  #     - name: Install AWS CLI
-  #       run: |
-  #         curl "${{ steps.dotenv.outputs.AWSCLI_URL}}" -o "awscliv2.zip"
-  #         unzip awscliv2.zip
-  #         sudo ./aws/install --update
-  #         aws --version
-  #     - name: Setup Go
-  #       uses: actions/setup-go@v2
-  #       with:
-  #         go-version: ${{ steps.dotenv.outputs.GO_VERSION }}
-  #     - name: Install Ginkgo
-  #       run: |
-  #         make setup/ginkgo
-  #     - name: Install Helm
-  #       run: |
-  #         curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-  #         chmod 700 get_helm.sh
-  #         ./get_helm.sh
-  #         DESIRED_VERSION=v3.8.2 bash get_helm.sh
-  #     - name: Install EKS CTL
-  #       run: |
-  #         curl --silent --insecure --location "https://github.com/weaveworks/eksctl/releases/download/${{ steps.dotenv.outputs.EKSCTL_VERSION }}/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-  #         sudo mv /tmp/eksctl /usr/local/bin
-  #         eksctl version
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v2.5.0
-  #     - name: Install Operator SDK
-  #       run: |
-  #         sudo curl -L -o /usr/local/bin/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/${{ steps.dotenv.outputs.OPERATOR_SDK_VERSION }}/operator-sdk-${{ steps.dotenv.outputs.OPERATOR_SDK_VERSION }}-x86_64-linux-gnu
-  #         sudo chmod +x /usr/local/bin/operator-sdk
-  #     - name: Configure Docker Hub credentials
-  #       uses: docker/login-action@v1
-  #       with:
-  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         password: ${{ secrets.DOCKERHUB_TOKEN}}
-  #     - name: Set Splunk Operator image
-  #       run: |
-  #           echo "SPLUNK_OPERATOR_IMAGE=${{ env.SPLUNK_OPERATOR_IMAGE_NAME }}:$GITHUB_SHA" >> $GITHUB_ENV
-  #     - name: Pull Splunk Enterprise Image
-  #       run: docker pull ${{ env.SPLUNK_ENTERPRISE_IMAGE }}
-  #     - name: Configure AWS credentials
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-  #     - name: Login to Amazon ECR
-  #       id: login-ecr
-  #       uses: aws-actions/amazon-ecr-login@v1
-  #     - name: Tag and Push Splunk Enterprise Image to ECR
-  #       run: |
-  #         docker tag ${{ env.SPLUNK_ENTERPRISE_IMAGE }} ${{ secrets.ECR_REPOSITORY }}/${{ env.SPLUNK_ENTERPRISE_IMAGE }}
-  #         docker push ${{ secrets.ECR_REPOSITORY }}/${{ env.SPLUNK_ENTERPRISE_IMAGE }}
-  #     - name: Create EKS cluster
-  #       run: |
-  #          export EKS_CLUSTER_K8_VERSION=${{ steps.dotenv.outputs.EKS_CLUSTER_K8_VERSION }}
-  #          make cluster-up
-  #     - name: install metric server
-  #       run: |
-  #         kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
-  #     - name: install k8s dashboard
-  #       run: |
-  #         kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.5/aio/deploy/recommended.yaml
-  #     - name: Setup Kustomize
-  #       run: |
-  #         sudo snap install kustomize
-  #         mkdir -p ./bin
-  #         cp /snap/bin/kustomize ./bin/kustomize
-  #     - name: Run smoke test
-  #       id: smoketest
-  #       run: |
-  #         make int-test
-  #     - name: Collect Test Logs
-  #       if: ${{ always() }}
-  #       run: |
-  #         mkdir -p /tmp/pod_logs
-  #         find ./test -name "*.log" -exec cp {} /tmp/pod_logs \;
-  #     - name: Archive Pod Logs
-  #       if: ${{ always() }}
-  #       uses: actions/upload-artifact@v4.4.0
-  #       with:
-  #         name: "splunk-pods-logs--artifacts-${{ matrix.test }}"
-  #         path: "/tmp/pod_logs/**"
-  #     - name: Cleanup Test Case artifacts
-  #       if: ${{ always() }}
-  #       run: |
-  #         make cleanup
-  #         make clean
-  #     - name: Cleanup up EKS cluster
-  #       if: ${{ always() }}
-  #       run: |
-  #         make cluster-down
-  #     #- name: Test Report
-  #     #  uses: dorny/test-reporter@v1
-  #     #  if: success() || failure()    # run this step even if previous step failed
-  #     #  with:
-  #     #    name: Integration Tests          # Name of the check run which will be created
-  #     #    path: inttest-*.xml         # Path to test results
-  #     #    reporter: jest-junit        # Format of test results
+    - name: Login to Amazon ECR
+      uses: aws-actions/amazon-ecr-login@v1
+    - name: Pull Splunk Operator Image Locally
+      run: |
+        docker pull ${{ env.IMAGE_NAME }}
+    - name: Verify Signed Splunk Operator image 
+      run: |
+        cosign verify --key env://COSIGN_PUBLIC_KEY  ${{ env.IMAGE_NAME }}
+      env:
+        COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@master
+      with:
+        image-ref: '${{ env.IMAGE_NAME }}'
+        format: sarif
+        #exit-code: 1
+        severity: 'CRITICAL'
+        ignore-unfixed: true
+        output: 'trivy-results.sarif'
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: 'trivy-results.sarif'
+  smoke-tests:
+    needs: vulnerability-scan
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [
+                basic,
+                appframeworksS1,
+                managerappframeworkc3,
+                managerappframeworkm4,
+                managersecret,
+                managermc,
+               ]
+    runs-on: ubuntu-latest
+    env:
+      CLUSTER_NODES: 1
+      CLUSTER_WORKERS: 3
+      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE }}
+      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_RELEASE_IMAGE }}
+      SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
+      SPLUNK_OPERATOR_IMAGE_FILENAME: splunk-operator
+      TEST_FOCUS: "${{ matrix.test }}"
+      # This regex matches any string not containing smoke keyword
+      TEST_TO_SKIP: "^(?:[^s]+|s(?:$|[^m]|m(?:$|[^o]|o(?:$|[^k]|k(?:$|[^e])))))*$"
+      TEST_CLUSTER_PLATFORM: eks
+      EKS_VPC_PRIVATE_SUBNET_STRING: ${{ secrets.EKS_VPC_PRIVATE_SUBNET_STRING }}
+      EKS_VPC_PUBLIC_SUBNET_STRING: ${{ secrets.EKS_VPC_PUBLIC_SUBNET_STRING }}
+      TEST_BUCKET: ${{ secrets.TEST_BUCKET }}
+      TEST_INDEXES_S3_BUCKET: ${{ secrets.TEST_INDEXES_S3_BUCKET }}
+      ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+      PRIVATE_REGISTRY: ${{ secrets.ECR_REPOSITORY }}
+      S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      ENTERPRISE_LICENSE_LOCATION: ${{ secrets.ENTERPRISE_LICENSE_LOCATION }}
+      EKS_SSH_PUBLIC_KEY: ${{ secrets.EKS_SSH_PUBLIC_KEY }}
+      CLUSTER_WIDE: "true"
+      DEPLOYMENT_TYPE: ""
+    steps:
+      - name: Set Test Cluster Name
+        run: |
+          echo "TEST_CLUSTER_NAME=eks-integration-test-cluster-${{ matrix.test }}-$GITHUB_RUN_ID" >> $GITHUB_ENV
+      - name: Chekcout code
+        uses: actions/checkout@v2
+      - name: Dotenv Action
+        id: dotenv
+        uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
+      - name: Change splunk enterprise to release image on main branches
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo "SPLUNK_ENTERPRISE_IMAGE=${{ steps.dotenv.outputs.SPLUNK_ENTERPRISE_RELEASE_IMAGE }}" >> $GITHUB_ENV
+      - name: Install Kubectl
+        uses: Azure/setup-kubectl@v3
+        with:
+          version: ${{ steps.dotenv.outputs.KUBECTL_VERSION }}
+      - name: Install Python
+        uses: actions/setup-python@v2
+      - name: Install AWS CLI
+        run: |
+          curl "${{ steps.dotenv.outputs.AWSCLI_URL}}" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install --update
+          aws --version
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ steps.dotenv.outputs.GO_VERSION }}
+      - name: Install Ginkgo
+        run: |
+          make setup/ginkgo
+      - name: Install Helm
+        run: |
+          curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+          chmod 700 get_helm.sh
+          ./get_helm.sh
+          DESIRED_VERSION=v3.8.2 bash get_helm.sh
+      - name: Install EKS CTL
+        run: |
+          curl --silent --insecure --location "https://github.com/weaveworks/eksctl/releases/download/${{ steps.dotenv.outputs.EKSCTL_VERSION }}/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+          sudo mv /tmp/eksctl /usr/local/bin
+          eksctl version
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.5.0
+      - name: Install Operator SDK
+        run: |
+          sudo curl -L -o /usr/local/bin/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/${{ steps.dotenv.outputs.OPERATOR_SDK_VERSION }}/operator-sdk-${{ steps.dotenv.outputs.OPERATOR_SDK_VERSION }}-x86_64-linux-gnu
+          sudo chmod +x /usr/local/bin/operator-sdk
+      - name: Configure Docker Hub credentials
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN}}
+      - name: Set Splunk Operator image
+        run: |
+            echo "SPLUNK_OPERATOR_IMAGE=${{ env.SPLUNK_OPERATOR_IMAGE_NAME }}:$GITHUB_SHA" >> $GITHUB_ENV
+      - name: Pull Splunk Enterprise Image
+        run: docker pull ${{ env.SPLUNK_ENTERPRISE_IMAGE }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Tag and Push Splunk Enterprise Image to ECR
+        run: |
+          docker tag ${{ env.SPLUNK_ENTERPRISE_IMAGE }} ${{ secrets.ECR_REPOSITORY }}/${{ env.SPLUNK_ENTERPRISE_IMAGE }}
+          docker push ${{ secrets.ECR_REPOSITORY }}/${{ env.SPLUNK_ENTERPRISE_IMAGE }}
+      - name: Create EKS cluster
+        run: |
+           export EKS_CLUSTER_K8_VERSION=${{ steps.dotenv.outputs.EKS_CLUSTER_K8_VERSION }}
+           make cluster-up
+      - name: install metric server
+        run: |
+          kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+      - name: install k8s dashboard
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.5/aio/deploy/recommended.yaml
+      - name: Setup Kustomize
+        run: |
+          sudo snap install kustomize
+          mkdir -p ./bin
+          cp /snap/bin/kustomize ./bin/kustomize
+      - name: Run smoke test
+        id: smoketest
+        run: |
+          make int-test
+      - name: Collect Test Logs
+        if: ${{ always() }}
+        run: |
+          mkdir -p /tmp/pod_logs
+          find ./test -name "*.log" -exec cp {} /tmp/pod_logs \;
+      - name: Archive Pod Logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: "splunk-pods-logs--artifacts-${{ matrix.test }}"
+          path: "/tmp/pod_logs/**"
+      - name: Cleanup Test Case artifacts
+        if: ${{ always() }}
+        run: |
+          make cleanup
+          make clean
+      - name: Cleanup up EKS cluster
+        if: ${{ always() }}
+        run: |
+          make cluster-down
+      #- name: Test Report
+      #  uses: dorny/test-reporter@v1
+      #  if: success() || failure()    # run this step even if previous step failed
+      #  with:
+      #    name: Integration Tests          # Name of the check run which will be created
+      #    path: inttest-*.xml         # Path to test results
+      #    reporter: jest-junit        # Format of test results

--- a/.github/workflows/build-test-push-workflow.yml
+++ b/.github/workflows/build-test-push-workflow.yml
@@ -3,57 +3,58 @@ on:
   pull_request: {}
   push:
     branches:
-    - main
-    - develop
+      - main
+      - develop
+      - CSPL_3867_errors
 jobs:
-  check-formating:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Dotenv Action
-      id: dotenv
-      uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
-    - name: Setup Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ steps.dotenv.outputs.GO_VERSION }}
-    - name: Check Source formatting
-      run: make fmt && if [[ $? -ne 0 ]]; then false; fi
-    - name: Lint source code
-      run: make vet && if [[ $? -ne 0 ]]; then false; fi
-  unit-tests:
-    runs-on: ubuntu-latest
-    needs: check-formating
-    steps:
-      - uses: actions/checkout@v2
-      - name: Dotenv Action
-        id: dotenv
-        uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
-      - name: Setup Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ steps.dotenv.outputs.GO_VERSION }}
-      - name: Install goveralls
-        run: |
-          go version
-          go install github.com/mattn/goveralls@latest
-      - name: Install Ginkgo
-        run: |
-          make setup/ginkgo
-          go mod tidy
-      - name: Run Unit Tests
-        run: |
-          make test
-      - name: Run Code Coverage
-        run: goveralls -coverprofile=coverage.out -service=circle-ci -repotoken ${{ secrets.COVERALLS_TOKEN }}
-      - name: Upload Coverage artifacts
-        uses: actions/upload-artifact@v4.4.0
-        with:
-          name: coverage.out
-          path: coverage.out
+  # check-formating:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Dotenv Action
+  #     id: dotenv
+  #     uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
+  #   - name: Setup Go
+  #     uses: actions/setup-go@v2
+  #     with:
+  #       go-version: ${{ steps.dotenv.outputs.GO_VERSION }}
+  #   - name: Check Source formatting
+  #     run: make fmt && if [[ $? -ne 0 ]]; then false; fi
+  #   - name: Lint source code
+  #     run: make vet && if [[ $? -ne 0 ]]; then false; fi
+  # unit-tests:
+  #   runs-on: ubuntu-latest
+  #   needs: check-formating
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Dotenv Action
+  #       id: dotenv
+  #       uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
+  #     - name: Setup Go
+  #       uses: actions/setup-go@v2
+  #       with:
+  #         go-version: ${{ steps.dotenv.outputs.GO_VERSION }}
+  #     - name: Install goveralls
+  #       run: |
+  #         go version
+  #         go install github.com/mattn/goveralls@latest
+  #     - name: Install Ginkgo
+  #       run: |
+  #         make setup/ginkgo
+  #         go mod tidy
+  #     - name: Run Unit Tests
+  #       run: |
+  #         make test
+  #     - name: Run Code Coverage
+  #       run: goveralls -coverprofile=coverage.out -service=circle-ci -repotoken ${{ secrets.COVERALLS_TOKEN }}
+  #     - name: Upload Coverage artifacts
+  #       uses: actions/upload-artifact@v4.4.0
+  #       with:
+  #         name: coverage.out
+  #         path: coverage.out
   build-operator-image:
     runs-on: ubuntu-latest
-    needs: unit-tests
+    # needs: unit-tests
     env:
       SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE }}
       SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
@@ -102,209 +103,209 @@ jobs:
       env:
         COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
         COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-  vulnerability-scan:
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    runs-on: ubuntu-latest
-    needs: build-operator-image
-    env:
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE }}
-      SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
-      ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-      S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      IMAGE_NAME: ${{ secrets.ECR_REPOSITORY }}/splunk/splunk-operator:${{ github.sha }}
-    steps:
-    - name: Set up cosign
-      uses: sigstore/cosign-installer@main
-    - uses: actions/checkout@v2
-    - name: Dotenv Action
-      id: dotenv
-      uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2.5.0
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+  # vulnerability-scan:
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     security-events: write
+  #   runs-on: ubuntu-latest
+  #   needs: build-operator-image
+  #   env:
+  #     SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE }}
+  #     SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
+  #     ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+  #     S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+  #     IMAGE_NAME: ${{ secrets.ECR_REPOSITORY }}/splunk/splunk-operator:${{ github.sha }}
+  #   steps:
+  #   - name: Set up cosign
+  #     uses: sigstore/cosign-installer@main
+  #   - uses: actions/checkout@v2
+  #   - name: Dotenv Action
+  #     id: dotenv
+  #     uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
+  #   - name: Set up Docker Buildx
+  #     uses: docker/setup-buildx-action@v2.5.0
+  #   - name: Configure AWS credentials
+  #     uses: aws-actions/configure-aws-credentials@v1
+  #     with:
+  #       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #       aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
-    - name: Login to Amazon ECR
-      uses: aws-actions/amazon-ecr-login@v1
-    - name: Pull Splunk Operator Image Locally
-      run: |
-        docker pull ${{ env.IMAGE_NAME }}
-    - name: Verify Signed Splunk Operator image 
-      run: |
-        cosign verify --key env://COSIGN_PUBLIC_KEY  ${{ env.IMAGE_NAME }}
-      env:
-        COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
-    - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
-      with:
-        image-ref: '${{ env.IMAGE_NAME }}'
-        format: sarif
-        #exit-code: 1
-        severity: 'CRITICAL'
-        ignore-unfixed: true
-        output: 'trivy-results.sarif'
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v3
-      with:
-        sarif_file: 'trivy-results.sarif'
-  smoke-tests:
-    needs: vulnerability-scan
-    strategy:
-      fail-fast: false
-      matrix:
-        test: [
-                basic,
-                appframeworksS1,
-                managerappframeworkc3,
-                managerappframeworkm4,
-                managersecret,
-                managermc,
-               ]
-    runs-on: ubuntu-latest
-    env:
-      CLUSTER_NODES: 1
-      CLUSTER_WORKERS: 3
-      SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE }}
-      SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_RELEASE_IMAGE }}
-      SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
-      SPLUNK_OPERATOR_IMAGE_FILENAME: splunk-operator
-      TEST_FOCUS: "${{ matrix.test }}"
-      # This regex matches any string not containing smoke keyword
-      TEST_TO_SKIP: "^(?:[^s]+|s(?:$|[^m]|m(?:$|[^o]|o(?:$|[^k]|k(?:$|[^e])))))*$"
-      TEST_CLUSTER_PLATFORM: eks
-      EKS_VPC_PRIVATE_SUBNET_STRING: ${{ secrets.EKS_VPC_PRIVATE_SUBNET_STRING }}
-      EKS_VPC_PUBLIC_SUBNET_STRING: ${{ secrets.EKS_VPC_PUBLIC_SUBNET_STRING }}
-      TEST_BUCKET: ${{ secrets.TEST_BUCKET }}
-      TEST_INDEXES_S3_BUCKET: ${{ secrets.TEST_INDEXES_S3_BUCKET }}
-      ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-      PRIVATE_REGISTRY: ${{ secrets.ECR_REPOSITORY }}
-      S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      ENTERPRISE_LICENSE_LOCATION: ${{ secrets.ENTERPRISE_LICENSE_LOCATION }}
-      EKS_SSH_PUBLIC_KEY: ${{ secrets.EKS_SSH_PUBLIC_KEY }}
-      CLUSTER_WIDE: "true"
-      DEPLOYMENT_TYPE: ""
-    steps:
-      - name: Set Test Cluster Name
-        run: |
-          echo "TEST_CLUSTER_NAME=eks-integration-test-cluster-${{ matrix.test }}-$GITHUB_RUN_ID" >> $GITHUB_ENV
-      - name: Chekcout code
-        uses: actions/checkout@v2
-      - name: Dotenv Action
-        id: dotenv
-        uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
-      - name: Change splunk enterprise to release image on main branches
-        if: github.ref == 'refs/heads/main'
-        run: |
-          echo "SPLUNK_ENTERPRISE_IMAGE=${{ steps.dotenv.outputs.SPLUNK_ENTERPRISE_RELEASE_IMAGE }}" >> $GITHUB_ENV
-      - name: Install Kubectl
-        uses: Azure/setup-kubectl@v3
-        with:
-          version: ${{ steps.dotenv.outputs.KUBECTL_VERSION }}
-      - name: Install Python
-        uses: actions/setup-python@v2
-      - name: Install AWS CLI
-        run: |
-          curl "${{ steps.dotenv.outputs.AWSCLI_URL}}" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          sudo ./aws/install --update
-          aws --version
-      - name: Setup Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ steps.dotenv.outputs.GO_VERSION }}
-      - name: Install Ginkgo
-        run: |
-          make setup/ginkgo
-      - name: Install Helm
-        run: |
-          curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-          chmod 700 get_helm.sh
-          ./get_helm.sh
-          DESIRED_VERSION=v3.8.2 bash get_helm.sh
-      - name: Install EKS CTL
-        run: |
-          curl --silent --insecure --location "https://github.com/weaveworks/eksctl/releases/download/${{ steps.dotenv.outputs.EKSCTL_VERSION }}/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-          sudo mv /tmp/eksctl /usr/local/bin
-          eksctl version
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.5.0
-      - name: Install Operator SDK
-        run: |
-          sudo curl -L -o /usr/local/bin/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/${{ steps.dotenv.outputs.OPERATOR_SDK_VERSION }}/operator-sdk-${{ steps.dotenv.outputs.OPERATOR_SDK_VERSION }}-x86_64-linux-gnu
-          sudo chmod +x /usr/local/bin/operator-sdk
-      - name: Configure Docker Hub credentials
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN}}
-      - name: Set Splunk Operator image
-        run: |
-            echo "SPLUNK_OPERATOR_IMAGE=${{ env.SPLUNK_OPERATOR_IMAGE_NAME }}:$GITHUB_SHA" >> $GITHUB_ENV
-      - name: Pull Splunk Enterprise Image
-        run: docker pull ${{ env.SPLUNK_ENTERPRISE_IMAGE }}
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-      - name: Tag and Push Splunk Enterprise Image to ECR
-        run: |
-          docker tag ${{ env.SPLUNK_ENTERPRISE_IMAGE }} ${{ secrets.ECR_REPOSITORY }}/${{ env.SPLUNK_ENTERPRISE_IMAGE }}
-          docker push ${{ secrets.ECR_REPOSITORY }}/${{ env.SPLUNK_ENTERPRISE_IMAGE }}
-      - name: Create EKS cluster
-        run: |
-           export EKS_CLUSTER_K8_VERSION=${{ steps.dotenv.outputs.EKS_CLUSTER_K8_VERSION }}
-           make cluster-up
-      - name: install metric server
-        run: |
-          kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
-      - name: install k8s dashboard
-        run: |
-          kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.5/aio/deploy/recommended.yaml
-      - name: Setup Kustomize
-        run: |
-          sudo snap install kustomize
-          mkdir -p ./bin
-          cp /snap/bin/kustomize ./bin/kustomize
-      - name: Run smoke test
-        id: smoketest
-        run: |
-          make int-test
-      - name: Collect Test Logs
-        if: ${{ always() }}
-        run: |
-          mkdir -p /tmp/pod_logs
-          find ./test -name "*.log" -exec cp {} /tmp/pod_logs \;
-      - name: Archive Pod Logs
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4.4.0
-        with:
-          name: "splunk-pods-logs--artifacts-${{ matrix.test }}"
-          path: "/tmp/pod_logs/**"
-      - name: Cleanup Test Case artifacts
-        if: ${{ always() }}
-        run: |
-          make cleanup
-          make clean
-      - name: Cleanup up EKS cluster
-        if: ${{ always() }}
-        run: |
-          make cluster-down
-      #- name: Test Report
-      #  uses: dorny/test-reporter@v1
-      #  if: success() || failure()    # run this step even if previous step failed
-      #  with:
-      #    name: Integration Tests          # Name of the check run which will be created
-      #    path: inttest-*.xml         # Path to test results
-      #    reporter: jest-junit        # Format of test results
+  #   - name: Login to Amazon ECR
+  #     uses: aws-actions/amazon-ecr-login@v1
+  #   - name: Pull Splunk Operator Image Locally
+  #     run: |
+  #       docker pull ${{ env.IMAGE_NAME }}
+  #   - name: Verify Signed Splunk Operator image 
+  #     run: |
+  #       cosign verify --key env://COSIGN_PUBLIC_KEY  ${{ env.IMAGE_NAME }}
+  #     env:
+  #       COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
+  #   - name: Run Trivy vulnerability scanner
+  #     uses: aquasecurity/trivy-action@master
+  #     with:
+  #       image-ref: '${{ env.IMAGE_NAME }}'
+  #       format: sarif
+  #       #exit-code: 1
+  #       severity: 'CRITICAL'
+  #       ignore-unfixed: true
+  #       output: 'trivy-results.sarif'
+  #   - name: Upload Trivy scan results to GitHub Security tab
+  #     uses: github/codeql-action/upload-sarif@v3
+  #     with:
+  #       sarif_file: 'trivy-results.sarif'
+  # smoke-tests:
+  #   needs: vulnerability-scan
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test: [
+  #               basic,
+  #               appframeworksS1,
+  #               managerappframeworkc3,
+  #               managerappframeworkm4,
+  #               managersecret,
+  #               managermc,
+  #              ]
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     CLUSTER_NODES: 1
+  #     CLUSTER_WORKERS: 3
+  #     SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE }}
+  #     SPLUNK_ENTERPRISE_RELEASE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_RELEASE_IMAGE }}
+  #     SPLUNK_OPERATOR_IMAGE_NAME: splunk/splunk-operator
+  #     SPLUNK_OPERATOR_IMAGE_FILENAME: splunk-operator
+  #     TEST_FOCUS: "${{ matrix.test }}"
+  #     # This regex matches any string not containing smoke keyword
+  #     TEST_TO_SKIP: "^(?:[^s]+|s(?:$|[^m]|m(?:$|[^o]|o(?:$|[^k]|k(?:$|[^e])))))*$"
+  #     TEST_CLUSTER_PLATFORM: eks
+  #     EKS_VPC_PRIVATE_SUBNET_STRING: ${{ secrets.EKS_VPC_PRIVATE_SUBNET_STRING }}
+  #     EKS_VPC_PUBLIC_SUBNET_STRING: ${{ secrets.EKS_VPC_PUBLIC_SUBNET_STRING }}
+  #     TEST_BUCKET: ${{ secrets.TEST_BUCKET }}
+  #     TEST_INDEXES_S3_BUCKET: ${{ secrets.TEST_INDEXES_S3_BUCKET }}
+  #     ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+  #     PRIVATE_REGISTRY: ${{ secrets.ECR_REPOSITORY }}
+  #     S3_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+  #     ENTERPRISE_LICENSE_LOCATION: ${{ secrets.ENTERPRISE_LICENSE_LOCATION }}
+  #     EKS_SSH_PUBLIC_KEY: ${{ secrets.EKS_SSH_PUBLIC_KEY }}
+  #     CLUSTER_WIDE: "true"
+  #     DEPLOYMENT_TYPE: ""
+  #   steps:
+  #     - name: Set Test Cluster Name
+  #       run: |
+  #         echo "TEST_CLUSTER_NAME=eks-integration-test-cluster-${{ matrix.test }}-$GITHUB_RUN_ID" >> $GITHUB_ENV
+  #     - name: Chekcout code
+  #       uses: actions/checkout@v2
+  #     - name: Dotenv Action
+  #       id: dotenv
+  #       uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
+  #     - name: Change splunk enterprise to release image on main branches
+  #       if: github.ref == 'refs/heads/main'
+  #       run: |
+  #         echo "SPLUNK_ENTERPRISE_IMAGE=${{ steps.dotenv.outputs.SPLUNK_ENTERPRISE_RELEASE_IMAGE }}" >> $GITHUB_ENV
+  #     - name: Install Kubectl
+  #       uses: Azure/setup-kubectl@v3
+  #       with:
+  #         version: ${{ steps.dotenv.outputs.KUBECTL_VERSION }}
+  #     - name: Install Python
+  #       uses: actions/setup-python@v2
+  #     - name: Install AWS CLI
+  #       run: |
+  #         curl "${{ steps.dotenv.outputs.AWSCLI_URL}}" -o "awscliv2.zip"
+  #         unzip awscliv2.zip
+  #         sudo ./aws/install --update
+  #         aws --version
+  #     - name: Setup Go
+  #       uses: actions/setup-go@v2
+  #       with:
+  #         go-version: ${{ steps.dotenv.outputs.GO_VERSION }}
+  #     - name: Install Ginkgo
+  #       run: |
+  #         make setup/ginkgo
+  #     - name: Install Helm
+  #       run: |
+  #         curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+  #         chmod 700 get_helm.sh
+  #         ./get_helm.sh
+  #         DESIRED_VERSION=v3.8.2 bash get_helm.sh
+  #     - name: Install EKS CTL
+  #       run: |
+  #         curl --silent --insecure --location "https://github.com/weaveworks/eksctl/releases/download/${{ steps.dotenv.outputs.EKSCTL_VERSION }}/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+  #         sudo mv /tmp/eksctl /usr/local/bin
+  #         eksctl version
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v2.5.0
+  #     - name: Install Operator SDK
+  #       run: |
+  #         sudo curl -L -o /usr/local/bin/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/${{ steps.dotenv.outputs.OPERATOR_SDK_VERSION }}/operator-sdk-${{ steps.dotenv.outputs.OPERATOR_SDK_VERSION }}-x86_64-linux-gnu
+  #         sudo chmod +x /usr/local/bin/operator-sdk
+  #     - name: Configure Docker Hub credentials
+  #       uses: docker/login-action@v1
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         password: ${{ secrets.DOCKERHUB_TOKEN}}
+  #     - name: Set Splunk Operator image
+  #       run: |
+  #           echo "SPLUNK_OPERATOR_IMAGE=${{ env.SPLUNK_OPERATOR_IMAGE_NAME }}:$GITHUB_SHA" >> $GITHUB_ENV
+  #     - name: Pull Splunk Enterprise Image
+  #       run: docker pull ${{ env.SPLUNK_ENTERPRISE_IMAGE }}
+  #     - name: Configure AWS credentials
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+  #     - name: Login to Amazon ECR
+  #       id: login-ecr
+  #       uses: aws-actions/amazon-ecr-login@v1
+  #     - name: Tag and Push Splunk Enterprise Image to ECR
+  #       run: |
+  #         docker tag ${{ env.SPLUNK_ENTERPRISE_IMAGE }} ${{ secrets.ECR_REPOSITORY }}/${{ env.SPLUNK_ENTERPRISE_IMAGE }}
+  #         docker push ${{ secrets.ECR_REPOSITORY }}/${{ env.SPLUNK_ENTERPRISE_IMAGE }}
+  #     - name: Create EKS cluster
+  #       run: |
+  #          export EKS_CLUSTER_K8_VERSION=${{ steps.dotenv.outputs.EKS_CLUSTER_K8_VERSION }}
+  #          make cluster-up
+  #     - name: install metric server
+  #       run: |
+  #         kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+  #     - name: install k8s dashboard
+  #       run: |
+  #         kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.5/aio/deploy/recommended.yaml
+  #     - name: Setup Kustomize
+  #       run: |
+  #         sudo snap install kustomize
+  #         mkdir -p ./bin
+  #         cp /snap/bin/kustomize ./bin/kustomize
+  #     - name: Run smoke test
+  #       id: smoketest
+  #       run: |
+  #         make int-test
+  #     - name: Collect Test Logs
+  #       if: ${{ always() }}
+  #       run: |
+  #         mkdir -p /tmp/pod_logs
+  #         find ./test -name "*.log" -exec cp {} /tmp/pod_logs \;
+  #     - name: Archive Pod Logs
+  #       if: ${{ always() }}
+  #       uses: actions/upload-artifact@v4.4.0
+  #       with:
+  #         name: "splunk-pods-logs--artifacts-${{ matrix.test }}"
+  #         path: "/tmp/pod_logs/**"
+  #     - name: Cleanup Test Case artifacts
+  #       if: ${{ always() }}
+  #       run: |
+  #         make cleanup
+  #         make clean
+  #     - name: Cleanup up EKS cluster
+  #       if: ${{ always() }}
+  #       run: |
+  #         make cluster-down
+  #     #- name: Test Report
+  #     #  uses: dorny/test-reporter@v1
+  #     #  if: success() || failure()    # run this step even if previous step failed
+  #     #  with:
+  #     #    name: Integration Tests          # Name of the check run which will be created
+  #     #    path: inttest-*.xml         # Path to test results
+  #     #    reporter: jest-junit        # Format of test results

--- a/api/v4/clustermanager_types.go
+++ b/api/v4/clustermanager_types.go
@@ -123,7 +123,7 @@ func (cmstr *ClusterManager) NewEvent(eventType, reason, message string) corev1.
 			Namespace:    cmstr.ObjectMeta.Namespace,
 		},
 		InvolvedObject: corev1.ObjectReference{
-			Kind:       "Clustermanager",
+			Kind:       "ClusterManager",
 			Namespace:  cmstr.Namespace,
 			Name:       cmstr.Name,
 			UID:        cmstr.UID,

--- a/pkg/splunk/enterprise/searchheadcluster.go
+++ b/pkg/splunk/enterprise/searchheadcluster.go
@@ -57,6 +57,7 @@ func ApplySearchHeadCluster(ctx context.Context, client splcommon.ControllerClie
 	var err error
 	// Initialize phase
 	cr.Status.Phase = enterpriseApi.PhaseError
+	cr.Status.DeployerPhase = enterpriseApi.PhaseError
 
 	// Update the CR Status
 	defer updateCRStatus(ctx, client, cr, &err)

--- a/pkg/splunk/enterprise/searchheadcluster_test.go
+++ b/pkg/splunk/enterprise/searchheadcluster_test.go
@@ -765,6 +765,51 @@ func TestGetDeployerStatefulSet(t *testing.T) {
 	test(`{"kind":"StatefulSet","apiVersion":"apps/v1","metadata":{"name":"splunk-stack1-deployer","namespace":"test","creationTimestamp":null,"labels":{"app.kubernetes.io/component":"search-head","app.kubernetes.io/instance":"splunk-stack1-deployer","app.kubernetes.io/managed-by":"splunk-operator","app.kubernetes.io/name":"deployer","app.kubernetes.io/part-of":"splunk-stack1-search-head"},"ownerReferences":[{"apiVersion":"","kind":"","name":"stack1","uid":"","controller":true}]},"spec":{"replicas":1,"selector":{"matchLabels":{"app.kubernetes.io/component":"search-head","app.kubernetes.io/instance":"splunk-stack1-deployer","app.kubernetes.io/managed-by":"splunk-operator","app.kubernetes.io/name":"deployer","app.kubernetes.io/part-of":"splunk-stack1-search-head"}},"template":{"metadata":{"creationTimestamp":null,"labels":{"app.kubernetes.io/component":"search-head","app.kubernetes.io/instance":"splunk-stack1-deployer","app.kubernetes.io/managed-by":"splunk-operator","app.kubernetes.io/name":"deployer","app.kubernetes.io/part-of":"splunk-stack1-search-head"},"annotations":{"traffic.sidecar.istio.io/excludeOutboundPorts":"8089,8191,9997","traffic.sidecar.istio.io/includeInboundPorts":"8000"}},"spec":{"volumes":[{"name":"splunk-test-probe-configmap","configMap":{"name":"splunk-test-probe-configmap","defaultMode":365}},{"name":"mnt-splunk-secrets","secret":{"secretName":"splunk-stack1-deployer-secret-v1","defaultMode":420}}],"containers":[{"name":"splunk","image":"splunk/splunk","ports":[{"name":"http-splunkweb","containerPort":8000,"protocol":"TCP"},{"name":"https-splunkd","containerPort":8089,"protocol":"TCP"}],"env":[{"name":"SPLUNK_SEARCH_HEAD_URL","value":"splunk-stack1-search-head-0.splunk-stack1-search-head-headless.test.svc.cluster.local,splunk-stack1-search-head-1.splunk-stack1-search-head-headless.test.svc.cluster.local,splunk-stack1-search-head-2.splunk-stack1-search-head-headless.test.svc.cluster.local"},{"name":"SPLUNK_SEARCH_HEAD_CAPTAIN_URL","value":"splunk-stack1-search-head-0.splunk-stack1-search-head-headless.test.svc.cluster.local"},{"name":"SPLUNK_HOME","value":"/opt/splunk"},{"name":"SPLUNK_START_ARGS","value":"--accept-license"},{"name":"SPLUNK_DEFAULTS_URL","value":"/mnt/apps/apps.yml,/mnt/splunk-secrets/default.yml"},{"name":"SPLUNK_HOME_OWNERSHIP_ENFORCEMENT","value":"false"},{"name":"SPLUNK_ROLE","value":"splunk_deployer"},{"name":"SPLUNK_DECLARATIVE_ADMIN_PASSWORD","value":"true"},{"name":"SPLUNK_OPERATOR_K8_LIVENESS_DRIVER_FILE_PATH","value":"/tmp/splunk_operator_k8s/probes/k8_liveness_driver.sh"}],"resources":{"limits":{"cpu":"4","memory":"8Gi"},"requests":{"cpu":"100m","memory":"512Mi"}},"volumeMounts":[{"name":"pvc-etc","mountPath":"/opt/splunk/etc"},{"name":"pvc-var","mountPath":"/opt/splunk/var"},{"name":"splunk-test-probe-configmap","mountPath":"/mnt/probes"},{"name":"mnt-splunk-secrets","mountPath":"/mnt/splunk-secrets"}],"livenessProbe":{"exec":{"command":["/mnt/probes/livenessProbe.sh"]},"initialDelaySeconds":30,"timeoutSeconds":30,"periodSeconds":30,"failureThreshold":3},"readinessProbe":{"exec":{"command":["/mnt/probes/readinessProbe.sh"]},"initialDelaySeconds":10,"timeoutSeconds":5,"periodSeconds":5,"failureThreshold":3},"startupProbe":{"exec":{"command":["/mnt/probes/startupProbe.sh"]},"initialDelaySeconds":40,"timeoutSeconds":30,"periodSeconds":30,"failureThreshold":12},"imagePullPolicy":"IfNotPresent","securityContext":{"capabilities":{"add":["NET_BIND_SERVICE"],"drop":["ALL"]},"privileged":false,"runAsUser":41812,"runAsNonRoot":true,"allowPrivilegeEscalation":false,"seccompProfile":{"type":"RuntimeDefault"}}}],"serviceAccountName":"defaults","securityContext":{"runAsUser":41812,"runAsNonRoot":true,"fsGroup":41812,"fsGroupChangePolicy":"OnRootMismatch"},"affinity":{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"weight":100,"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/instance","operator":"In","values":["splunk-stack1-deployer"]}]},"topologyKey":"kubernetes.io/hostname"}}]}},"schedulerName":"default-scheduler"}},"volumeClaimTemplates":[{"metadata":{"name":"pvc-etc","namespace":"test","creationTimestamp":null,"labels":{"app.kubernetes.io/component":"search-head","app.kubernetes.io/instance":"splunk-stack1-deployer","app.kubernetes.io/managed-by":"splunk-operator","app.kubernetes.io/name":"deployer","app.kubernetes.io/part-of":"splunk-stack1-search-head"}},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"10Gi"}}},"status":{}},{"metadata":{"name":"pvc-var","namespace":"test","creationTimestamp":null,"labels":{"app.kubernetes.io/component":"search-head","app.kubernetes.io/instance":"splunk-stack1-deployer","app.kubernetes.io/managed-by":"splunk-operator","app.kubernetes.io/name":"deployer","app.kubernetes.io/part-of":"splunk-stack1-search-head"}},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"100Gi"}}},"status":{}}],"serviceName":"splunk-stack1-deployer-headless","podManagementPolicy":"Parallel","updateStrategy":{"type":"OnDelete"}},"status":{"replicas":0,"availableReplicas":0}}`)
 }
 
+func TestApplySearchHeadClusterValidationFailure(t *testing.T) {
+	ctx := context.TODO()
+	shc := &enterpriseApi.SearchHeadCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SearchHeadCluster",
+			APIVersion: "enterprise.splunk.com/v3",
+		},
+
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: enterpriseApi.SearchHeadClusterSpec{
+			CommonSplunkSpec: enterpriseApi.CommonSplunkSpec{
+				LivenessProbe: &enterpriseApi.Probe{
+					InitialDelaySeconds: -5, // Invalid value
+				},
+				Volumes: []corev1.Volume{},
+			},
+		},
+		Status: enterpriseApi.SearchHeadClusterStatus{},
+	}
+
+	c := spltest.NewMockClient()
+
+	err := c.Create(ctx, shc)
+	if err != nil {
+		t.Errorf("shc CR creation failed: %v", err)
+	}
+
+	result, err := ApplySearchHeadCluster(ctx, c, shc)
+	if err == nil {
+		t.Errorf("Expected error for negative InitialDelaySeconds, got nil")
+	}
+	if shc.Status.Phase != enterpriseApi.PhaseError {
+		t.Errorf("Expected PhaseError, got %v", shc.Status.Phase)
+	}
+	if shc.Status.DeployerPhase != enterpriseApi.PhaseError {
+		t.Errorf("Expected DeployerPhaseError, got %v", shc.Status.DeployerPhase)
+	}
+	if !result.Requeue {
+		t.Errorf("Expected result.Requeue to be true on error")
+	}
+}
+
 func TestAppFrameworkSearchHeadClusterShouldNotFail(t *testing.T) {
 	ctx := context.TODO()
 	cr := enterpriseApi.SearchHeadCluster{

--- a/pkg/splunk/enterprise/searchheadcluster_test.go
+++ b/pkg/splunk/enterprise/searchheadcluster_test.go
@@ -770,7 +770,7 @@ func TestApplySearchHeadClusterValidationFailure(t *testing.T) {
 	shc := &enterpriseApi.SearchHeadCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "SearchHeadCluster",
-			APIVersion: "enterprise.splunk.com/v3",
+			APIVersion: "enterprise.splunk.com/v4",
 		},
 
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -2240,7 +2240,7 @@ func updateCRStatus(ctx context.Context, client splcommon.ControllerClient, orig
 			// Status update successful
 			break
 		} else {
-			scopedLog.Error(err, "Status update failed")
+			scopedLog.Error(err, "Error trying to update the CR status")
 		}
 
 		time.Sleep(time.Duration(tryCnt) * 10 * time.Millisecond)

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -2239,6 +2239,8 @@ func updateCRStatus(ctx context.Context, client splcommon.ControllerClient, orig
 
 			// Status update successful
 			break
+		} else {
+			scopedLog.Error(err, "Status update failed")
 		}
 
 		time.Sleep(time.Duration(tryCnt) * 10 * time.Millisecond)


### PR DESCRIPTION
### Description

This PR fixes the handling of error scenarios for search head cluster and cluster manager CRs. SearchHeadCluster CRs were not showing error messages due to an invalid `DeployerPhase` value. ClusterManager CRs were not showing events due to an incorrect `Kind` value. Logs and unit tests were added to verify this issue is fixed and help debug in the future.

### Key Changes

* Corrected the `Kind` field value in `ClusterManager` events from `"Clustermanager"` to `"ClusterManager"` to ensure proper object references. (`api/v4/clustermanager_types.go`)
* Added a new `DeployerPhase` field initial value of `PhaseError` during the cluster's initialization. This is required for shc with validation errors to be retrieved by the operator. (`pkg/splunk/enterprise/searchheadcluster.go`)

### Testing and Verification

* Unit test added
* Deployed a ClusterManager and SearchHeadCluster CR with an invalid spec, and verified that errors show in the following outputs:
    * `kubectl get shc`
    * `kubectl describe shc`
    * `kubectl get clustermanager`
    * `kubectl describe clustermanager`

### Related Issues

* https://splunk.atlassian.net/browse/CSPL-3867

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [X] Relevant unit and integration tests are included.
- [X] Documentation has been updated accordingly.
- [X] All tests pass locally.
- [X] The PR description follows the project's guidelines.
