### PR TITLE
CSPL-3707: Update documentation around minimum number of indexer cluster peers

### DIFF
--- a/docs/CustomResources.md
+++ b/docs/CustomResources.md
@@ -193,7 +193,7 @@ the `Standalone` resource provides the following `Spec` configuration parameters
 
 | Key        | Type    | Description                                       |
 | ---------- | ------- | ------------------------------------------------- |
-| replicas   | integer | The number of standalone replicas (defaults to 1) |
+| replicas   | integer | The number of standalone replicas (miminum of 1, which is the default) |
 
 
 ## SearchHeadCluster Resource Spec Parameters
@@ -263,7 +263,7 @@ the `IndexerCluster` resource provides the following `Spec` configuration parame
 
 | Key        | Type    | Description                                           |
 | ---------- | ------- | ----------------------------------------------------- |
-| replicas   | integer | The number of indexer cluster members (defaults to 1) |
+| replicas   | integer | The number of indexer cluster members (minimum of 3, which is the default) |
 
 
 ## MonitoringConsole Resource Spec Parameters

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -117,7 +117,7 @@ EOF
 ```
 This will automatically configure a cluster, with a predetermined number of index cluster peers generated automatically based upon the replication_factor (RF) set. This example includes the `monitoringConsoleRef` parameter used to define a monitoring console pod. 
 
-NOTE: If you try to specify the number of `replicas` on an IndexerCluster CR less than the RF (as set on ClusterManager,) the Splunk Operator will always scale the number of peers to either the `replication_factor` for single site indexer clusters, or to the `origin` count in `site_replication_factor` for multi-site indexer clusters.
+NOTE: If you try to specify the number of `replicas` on an IndexerCluster CR less than the RF (as set on ClusterManager,) the Splunk Operator will always scale the number of peers to either the `replication_factor` for single site indexer clusters, or to the `origin` count in `site_replication_factor` for multi-site indexer clusters. The minimum number of indexer cluster peers is 3.
 
 After starting the cluster manager, indexer cluster peers, and monitoring console pods using the examples above, use the `kubectl get pods` command to verify your environment:
 ```


### PR DESCRIPTION
### Description

This PR updates the documentation around minimum number of replicas of standalone and indexer peers. Search head cluster minimums are already documented.

### Key Changes

- Update CustomResources.md to include the correct minimum replicas for indexer cluster.
- Update Examples.md with information about minimum replicas.

### Testing and Verification

N/A

### Related Issues

- https://splunk.atlassian.net/browse/CSPL-3707
- https://github.com/splunk/splunk-operator/issues/1131

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [X] Documentation has been updated accordingly.
- [ ] All tests pass locally.
- [X] The PR description follows the project's guidelines.
