### PR TITLE
Update ubi8 minimal version for security updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ ARG PLATFORMS=linux/amd64,linux/arm64
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-# This sha relates to ubi minimal version 8.10-1755105495, which is tagged as 8.10 and latest as of Aug 17, 2025
+# This sha relates to ubi minimal version 8.10-1756195339, which is tagged as 8.10 and latest as of Sep 3, 2025
 ARG BASE_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal
-ARG BASE_IMAGE_VERSION=8.10-1755105495
+ARG BASE_IMAGE_VERSION=8.10-1756195339
 
 # Build the manager binary
 FROM golang:1.24.2 AS builder

--- a/Makefile
+++ b/Makefile
@@ -158,12 +158,12 @@ docker-push: ## Push docker image with the manager.
 # Defaults:
 #   Build Platform: linux/amd64,linux/arm64
 #   Build Base OS: registry.access.redhat.com/ubi8/ubi-minimal
-#   Build Base OS Version: 8.10-1755105495
+#   Build Base OS Version: 8.10-1756195339
 # Pass only what is required, the rest will be defaulted
 # Setup defaults for build arguments
 PLATFORMS ?= linux/amd64,linux/arm64
 BASE_IMAGE ?= registry.access.redhat.com/ubi8/ubi-minimal
-BASE_IMAGE_VERSION ?= 8.10-1755105495
+BASE_IMAGE_VERSION ?= 8.10-1756195339
 
 docker-buildx:
 	@if [ -z "${IMG}" ]; then \


### PR DESCRIPTION
### Description

This PR updates the ubi8 minimal image to mitigate security vulnerabilities in included packages.


Tool | Trivy
--- | ---
CVE | CVE-2025-5917,CVE-2025-25724,CVE-2025-1632,CVE-2018-1000879,CVE-2024-57970,CVE-2020-21674,CVE-2025-5915,CVE-2025-5918,CVE-2025-5916,CVE-2025-5914,CVE-2018-1000880
Severity | SEC_HIGH
Dependency | libarchive
Package Path | rpm/redhat/libarchive
Previous Version | 3.3.3-5.el8
Fixed Version | 3.3.3-6.el8_10
Details | A vulnerability has been identified in the libarchive library. This flaw involves an 'off-by-one' miscalculation when handling prefixes and suffixes for file names. This can lead to a 1-byte write overflow. While seemingly small, such an overflow can corrupt adjacent memory, leading to unpredictable program behavior, crashes, or in specific circumstances, could be leveraged as a building block for more sophisticated exploitation.

### Key Changes

- Update the ubi8 minimal version

### Testing and Verification

N/A

### Related Issues

- https://splunk.atlassian.net/browse/VULN-27787

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [X] Relevant unit and integration tests are included.
- [X] Documentation has been updated accordingly.
- [X] All tests pass locally.
- [X] The PR description follows the project's guidelines.
