### PR TITLE
Prerelease workflow: helm charts and makefile updates

### DIFF
--- a/.github/workflows/pre-release-workflow.yml
+++ b/.github/workflows/pre-release-workflow.yml
@@ -96,6 +96,15 @@ jobs:
         exclude: "ChangeLog.md"
         include: "helm-chart/splunk-enterprise/**.yaml"
 
+    - name: Update Operator Version in Makefile
+      if: github.event.inputs.old_operator_version != github.event.inputs.new_operator_version
+      uses: jacobtomlinson/gha-find-replace@v3
+      with:
+        find: "${{ github.event.inputs.old_operator_version }}"
+        replace: "${{ github.event.inputs.new_operator_version }}"
+        exclude: "ChangeLog.md"
+        include: "Makefile"
+
     - name: Update Operator Image name in DOCS
       if: github.event.inputs.old_operator_version != github.event.inputs.new_operator_version
       uses: jacobtomlinson/gha-find-replace@v3

--- a/.github/workflows/pre-release-workflow.yml
+++ b/.github/workflows/pre-release-workflow.yml
@@ -114,15 +114,6 @@ jobs:
         exclude: "ChangeLog.md"
         include: "**.md"
 
-    - name: Update Splunk Operator VERSION in DOCS
-      if: github.event.inputs.old_operator_version != github.event.inputs.new_operator_version
-      uses: jacobtomlinson/gha-find-replace@v3
-      with:
-        find: "${{ github.event.inputs.old_operator_version }} or later"
-        replace: "${{ github.event.inputs.new_operator_version }} or later"
-        exclude: "ChangeLog.md"
-        include: "**.md"
-
     - name: Update Splunk Operator upgrade string in DOCS
       if: github.event.inputs.old_operator_version != github.event.inputs.new_operator_version
       uses: jacobtomlinson/gha-find-replace@v3
@@ -172,15 +163,6 @@ jobs:
         replace: "${{ github.event.inputs.new_enterprise_version }}"
         include: "**values.yaml"
 
-    - name: Update Splunk Enterprise image in DOCS
-      if: github.event.inputs.old_enterprise_version != github.event.inputs.new_enterprise_version
-      uses: jacobtomlinson/gha-find-replace@v3
-      with:
-        find: "${{ github.event.inputs.old_enterprise_version }} or later"
-        replace: "${{ github.event.inputs.new_enterprise_version }} or later"
-        exclude: "ChangeLog.md"
-        include: "**.md"
-
     - name: Install Operator SDK
       run: |
         export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
@@ -193,6 +175,10 @@ jobs:
     - name: Run Bundle Creation for the release
       run: |
         make bundle IMAGE_TAG_BASE=docker.io/splunk/splunk-operator VERSION=${{ github.event.inputs.release_version }} IMG=docker.io/splunk/splunk-operator:${{ github.event.inputs.release_version }} SPLUNK_ENTERPRISE_IMAGE=docker.io/splunk/splunk:${{ github.event.inputs.new_enterprise_version }}
+
+    - name: Remove old helm chart dependencies
+      run: |
+        rm -rf helm-chart/splunk-enterprise/charts/splunk-operator-*
 
     - name: Run helm chart package creation
       run: |


### PR DESCRIPTION
### Description

In the 3.0.0 release, we made a change to remove old splunk operator helm charts from the splunk enterprise dependencies to avoid incompatible versions. This PR removes the old dependencies as part of the pre-release workflow.

Also, this PR updates the Makefile with the new operator version. This will remove the need for a separate PR, such as https://github.com/splunk/splunk-operator/pull/1566.

### Key Changes

- Update Makefile version during prerelease workflow
- Remove old helm chart from splunk-enterprise dependencies

### Testing and Verification

N/A

### Related Issues

N/A

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [X] Relevant unit and integration tests are included.
- [X] Documentation has been updated accordingly.
- [X] All tests pass locally.
- [X] The PR description follows the project's guidelines.
