### PR TITLE
CSPL-4027: Allow custom labels on helm chart service and service account

### DIFF
--- a/helm-chart/splunk-operator/templates/app_download.yaml
+++ b/helm-chart/splunk-operator/templates/app_download.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: {{ $.Release.Name }}
   name:  {{ $volume.persistentVolumeClaim.claimName }}
+  namespace: {{ include "splunk-operator.namespace" . }}
 spec:
   accessModes:
   - ReadWriteOnce

--- a/helm-chart/splunk-operator/templates/app_download.yaml
+++ b/helm-chart/splunk-operator/templates/app_download.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: {{ $.Release.Name }}
   name:  {{ $volume.persistentVolumeClaim.claimName }}
-  namespace: {{ include "splunk-operator.namespace" . }}
+  namespace: {{ include "splunk-operator.namespace" $ }}
 spec:
   accessModes:
   - ReadWriteOnce

--- a/helm-chart/splunk-operator/templates/service.yaml
+++ b/helm-chart/splunk-operator/templates/service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "splunk-operator.operator.fullname" . }}-controller-manager-service
   labels:
 {{- include "splunk-operator.labels" . | nindent 4 }}
+{{- if .Values.splunkOperator.labels }}
+{{ toYaml .Values.splunkOperator.labels | nindent 4 }}
+{{- end }}
   annotations:
 {{ toYaml .Values.splunkOperator.annotations | nindent 4 }}
 spec:

--- a/helm-chart/splunk-operator/templates/serviceaccount.yaml
+++ b/helm-chart/splunk-operator/templates/serviceaccount.yaml
@@ -5,5 +5,8 @@ metadata:
   namespace: {{ include "splunk-operator.namespace" . }}
   labels:
 {{- include "splunk-operator.labels" . | nindent 4 }}
+{{- if .Values.splunkOperator.labels }}
+{{ toYaml .Values.splunkOperator.labels | nindent 4 }}
+{{- end }}
   annotations:
 {{ toYaml .Values.splunkOperator.annotations | nindent 4 }}


### PR DESCRIPTION
### Description

This PR allows users to set labels on the splunk operator controller manager service account and service created by helm deployments. Previously, these two entities would only use default labels created by the helm chart, but it will now include any labels added by the user through the `splunkOperator.labels` field, similar to how the deployment is already created.

### Key Changes

- Update helm chart templates to copy labels to service and service account for splunk operator

### Testing and Verification

Manual testing before and after changes using the following values.yaml file:
```
splunkOperator:
  labels:
    custom-label: raizel
  persistentVolumeClaim:
    storageClassName: "gp2"
  splunkGeneralTerms: "--accept-sgt-current-at-splunk-com"
```
- 3.0.0 release: `helm install splunk-operator splunk/splunk-operator -f values.yaml`
```
% kubectl describe service splunk-operator-controller-manager-service 
Name:                     splunk-operator-controller-manager-service
Namespace:                default
Labels:                   app.kubernetes.io/instance=splunk-operator
                          app.kubernetes.io/managed-by=Helm
                          app.kubernetes.io/name=splunk-operator
                          app.kubernetes.io/version=3.0.0
                          control-plane=controller-manager
                          helm.sh/chart=splunk-operator-3.0.0
Annotations:              meta.helm.sh/release-name: splunk-operator
                          meta.helm.sh/release-namespace: default
...
% kubectl describe serviceaccount splunk-operator-controller-manager 
Name:                splunk-operator-controller-manager
Namespace:           default
Labels:              app.kubernetes.io/instance=splunk-operator
                     app.kubernetes.io/managed-by=Helm
                     app.kubernetes.io/name=splunk-operator
                     app.kubernetes.io/version=3.0.0
                     control-plane=controller-manager
                     helm.sh/chart=splunk-operator-3.0.0
Annotations:         meta.helm.sh/release-name: splunk-operator
                     meta.helm.sh/release-namespace: default
...
% kubectl describe deployment splunk-operator-controller-manager 
Name:               splunk-operator-controller-manager
Namespace:          default
CreationTimestamp:  Fri, 03 Oct 2025 14:17:08 -0500
Labels:             app.kubernetes.io/instance=splunk-operator
                    app.kubernetes.io/managed-by=Helm
                    app.kubernetes.io/name=splunk-operator
                    app.kubernetes.io/version=3.0.0
                    control-plane=controller-manager
                    custom-label=raizel
                    helm.sh/chart=splunk-operator-3.0.0
Annotations:        deployment.kubernetes.io/revision: 1
                    meta.helm.sh/release-name: splunk-operator
                    meta.helm.sh/release-namespace: default
...
```

- Branch Release (see the custom label added to all entities): `helm install splunk-operator ./helm-chart/splunk-operator -f values.yaml`
```
% kubectl describe service splunk-operator-controller-manager-service 
Name:                     splunk-operator-controller-manager-service
Namespace:                default
Labels:                   app.kubernetes.io/instance=splunk-operator
                          app.kubernetes.io/managed-by=Helm
                          app.kubernetes.io/name=splunk-operator
                          app.kubernetes.io/version=3.0.0
                          control-plane=controller-manager
                          custom-label=raizel
                          helm.sh/chart=splunk-operator-3.0.0
Annotations:              meta.helm.sh/release-name: splunk-operator
                          meta.helm.sh/release-namespace: default
...
% kubectl describe serviceaccount splunk-operator-controller-manager 
Name:                splunk-operator-controller-manager
Namespace:           default
Labels:              app.kubernetes.io/instance=splunk-operator
                     app.kubernetes.io/managed-by=Helm
                     app.kubernetes.io/name=splunk-operator
                     app.kubernetes.io/version=3.0.0
                     control-plane=controller-manager
                     custom-label=raizel
                     helm.sh/chart=splunk-operator-3.0.0
Annotations:         meta.helm.sh/release-name: splunk-operator
                     meta.helm.sh/release-namespace: default
...
% kubectl describe serviceaccount splunk-operator-controller-manager 
Name:                splunk-operator-controller-manager
Namespace:           default
Labels:              app.kubernetes.io/instance=splunk-operator
                     app.kubernetes.io/managed-by=Helm
                     app.kubernetes.io/name=splunk-operator
                     app.kubernetes.io/version=3.0.0
                     control-plane=controller-manager
                     custom-label=raizel
                     helm.sh/chart=splunk-operator-3.0.0
Annotations:         meta.helm.sh/release-name: splunk-operator
                     meta.helm.sh/release-namespace: default
```

### Related Issues

- https://splunk.atlassian.net/browse/CSPL-4027

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [X] Relevant unit and integration tests are included.
- [X] Documentation has been updated accordingly.
- [X] All tests pass locally.
- [X] The PR description follows the project's guidelines.
