### PR TITLE
CSPL-3973: Monitoring console removes peers after restart bugfix

### DIFF
--- a/pkg/splunk/enterprise/monitoringconsole.go
+++ b/pkg/splunk/enterprise/monitoringconsole.go
@@ -320,7 +320,7 @@ func AddURLsConfigMap(revised *corev1.ConfigMap, crName string, newURLs []corev1
 			//2. if length of both same then just reconcile
 			if len(crURLs) == len(url.Value) {
 				//reconcile
-				break
+				continue
 			} else if len(crURLs) < len(url.Value) { //3. incoming URLs are more than current scaling up
 				//scaling UP
 				for _, newEntry := range newInsURLs {

--- a/pkg/splunk/enterprise/monitoringconsole_test.go
+++ b/pkg/splunk/enterprise/monitoringconsole_test.go
@@ -352,6 +352,125 @@ func TestApplyMonitoringConsoleEnvConfigMap(t *testing.T) {
 
 }
 
+func TestAddURLsConfigMapMultipleEnvVars(t *testing.T) {
+	// Scenario: Multiple URL types need to be added/updated
+	// The first URL already exists and matches, but subsequent URLs need processing
+
+	t.Run("All URLs processed when first matches", func(t *testing.T) {
+		configMap := &corev1.ConfigMap{
+			Data: map[string]string{
+				"SPLUNK_CLUSTER_MANAGER_URL": "splunk-cm-cluster-manager-service",
+				"SPLUNK_INDEXER_URL":         "splunk-idx-indexer-0,splunk-idx-indexer-1",
+			},
+		}
+
+		newURLs := []corev1.EnvVar{
+			{Name: "SPLUNK_CLUSTER_MANAGER_URL", Value: "splunk-cm-cluster-manager-service"},                      // matches
+			{Name: "SPLUNK_INDEXER_URL", Value: "splunk-idx-indexer-0,splunk-idx-indexer-1,splunk-idx-indexer-2"}, // scale up
+			{Name: "SPLUNK_SEARCH_HEAD_URL", Value: "splunk-sh-search-head-0,splunk-sh-search-head-1"},            // new
+		}
+
+		AddURLsConfigMap(configMap, "test-cr", newURLs)
+
+		if configMap.Data["SPLUNK_CLUSTER_MANAGER_URL"] != "splunk-cm-cluster-manager-service" {
+			t.Errorf("SPLUNK_CLUSTER_MANAGER_URL was modified, expected unchanged")
+		}
+
+		expectedIndexerURL := "splunk-idx-indexer-0,splunk-idx-indexer-1,splunk-idx-indexer-2"
+		if configMap.Data["SPLUNK_INDEXER_URL"] != expectedIndexerURL {
+			t.Errorf("SPLUNK_INDEXER_URL not updated correctly. Got: %s, Want: %s",
+				configMap.Data["SPLUNK_INDEXER_URL"], expectedIndexerURL)
+		}
+
+		expectedSearchHeadURL := "splunk-sh-search-head-0,splunk-sh-search-head-1"
+		if configMap.Data["SPLUNK_SEARCH_HEAD_URL"] != expectedSearchHeadURL {
+			t.Errorf("SPLUNK_SEARCH_HEAD_URL not added. Got: %s, Want: %s",
+				configMap.Data["SPLUNK_SEARCH_HEAD_URL"], expectedSearchHeadURL)
+		}
+	})
+
+	t.Run("Multiple matching URLs all preserved", func(t *testing.T) {
+		configMap := &corev1.ConfigMap{
+			Data: map[string]string{
+				"SPLUNK_CLUSTER_MANAGER_URL": "splunk-cm-cluster-manager-service",
+				"SPLUNK_INDEXER_URL":         "splunk-idx-indexer-0,splunk-idx-indexer-1",
+				"SPLUNK_SEARCH_HEAD_URL":     "splunk-sh-search-head-0",
+				"SPLUNK_LICENSE_MANAGER_URL": "splunk-lm-license-manager-service",
+			},
+		}
+
+		newURLs := []corev1.EnvVar{
+			{Name: "SPLUNK_CLUSTER_MANAGER_URL", Value: "splunk-cm-cluster-manager-service"},
+			{Name: "SPLUNK_INDEXER_URL", Value: "splunk-idx-indexer-0,splunk-idx-indexer-1"},
+			{Name: "SPLUNK_SEARCH_HEAD_URL", Value: "splunk-sh-search-head-0"},
+			{Name: "SPLUNK_LICENSE_MANAGER_URL", Value: "splunk-lm-license-manager-service"},
+		}
+
+		AddURLsConfigMap(configMap, "test-cr", newURLs)
+
+		for _, url := range newURLs {
+			if val, ok := configMap.Data[url.Name]; !ok {
+				t.Errorf("URL %s was removed from ConfigMap (bug manifestation)", url.Name)
+			} else if val != url.Value {
+				t.Errorf("URL %s was modified. Got: %s, Want: %s", url.Name, val, url.Value)
+			}
+		}
+	})
+
+	t.Run("First URL matches, second is new, third scales up", func(t *testing.T) {
+		configMap := &corev1.ConfigMap{
+			Data: map[string]string{
+				"SPLUNK_CLUSTER_MANAGER_URL": "splunk-cm-cluster-manager-service",
+				"SPLUNK_INDEXER_URL":         "splunk-idx-indexer-0",
+			},
+		}
+
+		newURLs := []corev1.EnvVar{
+			{Name: "SPLUNK_CLUSTER_MANAGER_URL", Value: "splunk-cm-cluster-manager-service"}, // matches
+			{Name: "SPLUNK_LICENSE_MANAGER_URL", Value: "splunk-lm-license-manager-service"}, // new
+			{Name: "SPLUNK_INDEXER_URL", Value: "splunk-idx-indexer-0,splunk-idx-indexer-1"}, // scale up
+		}
+
+		AddURLsConfigMap(configMap, "test-cr", newURLs)
+
+		if _, ok := configMap.Data["SPLUNK_CLUSTER_MANAGER_URL"]; !ok {
+			t.Errorf("SPLUNK_CLUSTER_MANAGER_URL was removed")
+		}
+
+		if _, ok := configMap.Data["SPLUNK_LICENSE_MANAGER_URL"]; !ok {
+			t.Errorf("SPLUNK_LICENSE_MANAGER_URL was not added (bug: loop exited early)")
+		}
+
+		expectedIndexerURL := "splunk-idx-indexer-0,splunk-idx-indexer-1"
+		if configMap.Data["SPLUNK_INDEXER_URL"] != expectedIndexerURL {
+			t.Errorf("SPLUNK_INDEXER_URL not scaled up. Got: %s, Want: %s",
+				configMap.Data["SPLUNK_INDEXER_URL"], expectedIndexerURL)
+		}
+	})
+
+	t.Run("Empty ConfigMap with multiple URLs", func(t *testing.T) {
+		configMap := &corev1.ConfigMap{
+			Data: map[string]string{},
+		}
+
+		newURLs := []corev1.EnvVar{
+			{Name: "SPLUNK_CLUSTER_MANAGER_URL", Value: "splunk-cm-cluster-manager-service"},
+			{Name: "SPLUNK_INDEXER_URL", Value: "splunk-idx-indexer-0,splunk-idx-indexer-1"},
+			{Name: "SPLUNK_SEARCH_HEAD_URL", Value: "splunk-sh-search-head-0"},
+		}
+
+		AddURLsConfigMap(configMap, "test-cr", newURLs)
+
+		for _, url := range newURLs {
+			if val, ok := configMap.Data[url.Name]; !ok {
+				t.Errorf("URL %s was not added to empty ConfigMap", url.Name)
+			} else if val != url.Value {
+				t.Errorf("URL %s has wrong value. Got: %s, Want: %s", url.Name, val, url.Value)
+			}
+		}
+	})
+}
+
 func TestGetMonitoringConsoleStatefulSet(t *testing.T) {
 	os.Setenv("SPLUNK_GENERAL_TERMS", "--accept-sgt-current-at-splunk-com")
 


### PR DESCRIPTION
### Description

Peers are removed from the monitoring console when the monitoring console pod is restarted. After another restart, some peers are added back but others are removed, creating an inconsistent state where the monitoring console doesn't have a complete view of all peers.


### Key Changes

- `continue` skips to the next iteration of the outer loop (`for _, url := range newURLs`)
- This ensures all environment variables in the `newURLs` array are processed
- Each URL type is evaluated independently
- No peers are accidentally removed due to premature loop termination
### Testing and Verification

_How did you test these changes? What automated tests are added?_

### Related Issues

_Jira tickets, GitHub issues, Support tickets..._

### PR Checklist

- [ ] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [ ] All tests pass locally.
- [ ] The PR description follows the project's guidelines.
