### PR TITLE
CSPL-4026: Update app framework documentation to deploy apps with multiple scopes

### DIFF
--- a/docs/AppFramework.md
+++ b/docs/AppFramework.md
@@ -39,7 +39,7 @@
 
 ## About App Framework
 
-The Splunk Operator provides support for Splunk app and add-on deployment using the App Framework. The App Framework specification supports configuration management using the Splunk Enterprise cluster and standalone [custom resources](https://splunk.github.io/splunk-operator/CustomResources.html) (CR).
+The Splunk Operator provides support for Splunk app and add-on deployment using the App Framework. The App Framework specification supports configuration management using the Splunk Enterprise [custom resources](https://splunk.github.io/splunk-operator/CustomResources.html) (CR) for both clustered and standalone deployments.
 
 Splunk apps and add-ons deployed or installed outside of the App Framework are not managed, and are unsupported.
 
@@ -56,7 +56,7 @@ The App Framework maintains a checksum for each app or add-on archive file in th
    * Azure blob storage
    * GCP Cloud Storage
 2) The App framework requires read-only access to the path used to host the apps. DO NOT give any other access to the operator to maintain the integrity of data in S3 bucket , Azure blob container or GCP bucket.
-3) Splunk apps and add-ons should be stored in a .tgz or .spl archive format.
+3) Splunk apps and add-ons should be stored in a .tgz, .tar.gz, or .spl archive format.
 4) Connections to the remote object storage endpoint need to be secured using a minimum version of TLS 1.2.
 5) A persistent storage volume and path for the Operator Pod. See [Add a persistent storage volume to the Operator pod](#add-a-persistent-storage-volume-to-the-operator-pod).
 


### PR DESCRIPTION
### Description

This pull request adds comprehensive documentation for installing Splunk apps using the App Framework for both local and cluster scopes on Indexer Clusters and Search Head Clusters. It also expands the CRD support table to clarify install locations for each scope and resource type. The changes provide step-by-step instructions and example configurations for S3, Azure Blob, and GCP storage backends.

### Key Changes

* Added a detailed guide for installing apps for both local and cluster scopes on Indexer Cluster, including credential setup, remote storage configuration, and example `ClusterManager.yaml` manifests for S3, Azure Blob, and GCP buckets.
* Added a parallel guide for installing apps for both local and cluster scopes on Search Head Cluster, with credential setup and example `SearchHeadCluster.yaml` manifests for S3, Azure Blob, and GCP buckets.
* Expanded the CRD support table to include columns for local and cluster scope install locations, clarifying where apps are installed for each resource type and scope.

### Testing and Verification

* Manual testing of deploying an app on indexers and search heads with both local and cluster scopes.

### Related Issues

* https://splunk.atlassian.net/browse/CSPL-4026
* https://github.com/splunk/splunk-operator/issues/1471

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [X] Relevant unit and integration tests are included.
- [X] Documentation has been updated accordingly.
- [X] All tests pass locally.
- [X] The PR description follows the project's guidelines.
