### PR TITLE
support AWS S3 region parsing for 4-part regions

### DIFF
--- a/pkg/splunk/client/awss3client.go
+++ b/pkg/splunk/client/awss3client.go
@@ -62,7 +62,7 @@ type AWSS3Client struct {
 	Downloader         SplunkAWSDownloadClient
 }
 
-var regionRegex = ".*.s3[-,.]([a-z]+-[a-z]+(?:-[a-z]+)?-[0-9]+)\\..*amazonaws.com"
+var regionRegex = ".*.s3[-,.]([a-z]+-[a-z]+(?:-[a-z]+)?-[0-9]+)\\..*amazonaws\\.com"
 
 // GetRegion extracts the region from the endpoint field
 func GetRegion(ctx context.Context, endpoint string, region *string) error {

--- a/pkg/splunk/client/awss3client_test.go
+++ b/pkg/splunk/client/awss3client_test.go
@@ -137,6 +137,11 @@ func TestGetRegion(t *testing.T) {
 			endpoint:    "https://storage.googleapis.com",
 			expectError: true,
 		},
+		{
+			name:        "Invalid endpoint - malformed domain",
+			endpoint:    "https://s3.us-west-2.amazonawsXcom",
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Description

Fixes AWS S3 region parsing to support 4-part regions like `us-gov-west-1`, `us-iso-east-1`, and `us-isob-east-1`. The previous regex only matched 3-part regions (e.g., `us-west-2`), causing App Framework to fail when using GovCloud or ISO endpoints.

### Key Changes

- **`pkg/splunk/client/awss3client.go`**: Updated `regionRegex` from `([a-z]+-[a-z]+-[0-9]+)` to `([a-z]+-[a-z]+(?:-[a-z]+)?-[0-9]+)` to make the third region component optional
- **`pkg/splunk/client/awss3client_test.go`**: Added `TestGetRegion()` with 10 test cases covering standard (3-part), GovCloud (4-part), and ISO regions, plus error scenarios

### Testing and Verification

- Added comprehensive unit tests validating region extraction for:
  - Standard regions: `us-west-2`, `eu-west-1`
  - GovCloud regions: `us-gov-west-1`, `us-gov-east-1`
  - ISO regions: `us-iso-east-1`, `us-isob-east-1`
  - Bucket prefix variations and invalid endpoints

### Related Issues

https://github.com/splunk/splunk-operator/issues/1567

### PR Checklist

- [x] Code changes adhere to the project's coding standards.
- [x] Relevant unit and integration tests are included.
- [x] Documentation has been updated accordingly.
- [x] All tests pass locally.
- [x] The PR description follows the project's guidelines.
