### PR TITLE
CSPL-4132: Update ubi-minimal image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 # Setup defaults for build arguments
 ARG PLATFORMS=linux/amd64,linux/arm64
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-# This sha relates to ubi minimal version 8.10-1756195339, which is tagged as 8.10 and latest as of Sep 3, 2025
 ARG BASE_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal
 ARG BASE_IMAGE_VERSION=8.10-1761032271
 

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ docker-push: ## Push docker image with the manager.
 # Defaults:
 #   Build Platform: linux/amd64,linux/arm64
 #   Build Base OS: registry.access.redhat.com/ubi8/ubi-minimal
-#   Build Base OS Version: 8.10-1756195339
+#   Build Base OS Version: 8.10-1761032271
 # Pass only what is required, the rest will be defaulted
 # Setup defaults for build arguments
 PLATFORMS ?= linux/amd64,linux/arm64


### PR DESCRIPTION
### Description

This PR updates the ubi8 minimal image to mitigate security vulnerabilities in included packages.

1. libssh 0.9.6-14.el8: A flaw was found in libssh's handling of key exchange (KEX) processes when a client repeatedly sends incorrect KEX guesses. The library fails to free memory during these rekey operations, which can gradually exhaust system memory. This issue can lead to crashes on the client side, particularly when using libgcrypt, which impacts application stability and availability.
2. gnutls 3.6.16-8.el8_10.3: A NULL pointer dereference flaw was found in the GnuTLS software in _gnutls_figure_common_ciphersuite().
3. libssh-config 0.9.6-14.el8: A flaw was found in libssh's handling of key exchange (KEX) processes when a client repeatedly sends incorrect KEX guesses. The library fails to free memory during these rekey operations, which can gradually exhaust system memory. This issue can lead to crashes on the client side, particularly when using libgcrypt, which impacts application stability and availability.

### Key Changes

- Update the ubi8 minimal version

### Testing and Verification

N/A

### Related Issues

- https://splunk.atlassian.net/browse/VULN-38980
- https://splunk.atlassian.net/browse/VULN-39654
- https://splunk.atlassian.net/browse/VULN-38981

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [X] Relevant unit and integration tests are included.
- [X] Documentation has been updated accordingly.
- [X] All tests pass locally.
- [X] The PR description follows the project's guidelines.
