### PR TITLE
CSPL-4238: Upgrade golang.org/x/crypto from 0.39.0 to 0.43.0

### DIFF
--- a/.github/workflows/build-test-push-workflow.yml
+++ b/.github/workflows/build-test-push-workflow.yml
@@ -5,7 +5,6 @@ on:
     branches:
     - main
     - develop
-    - CSPL_4238_xcrypto
 jobs:
   check-formating:
     runs-on: ubuntu-latest

--- a/.github/workflows/int-test-workflow.yml
+++ b/.github/workflows/int-test-workflow.yml
@@ -5,7 +5,6 @@ on:
       - develop
       - main
       - feature**
-      - CSPL_4238_xcrypto
 jobs:
   build-operator-image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Upgrade golang.org/x/crypto from 0.39.0 to 0.43.0 to fix a security vulnerability.

CVE | CVE-2025-47913
Severity | SEC_HIGH
Dependency | golang.org/x/crypto

### Key Changes

- Update golang.org/x/crypto version in go.mod and go.sum

### Testing and Verification

- Smoke and integration tests all pass: https://github.com/splunk/splunk-operator/actions/runs/19470156757

### Related Issues

- https://splunk.atlassian.net/browse/CSPL-4238
- https://splunk.atlassian.net/browse/VULN-53388

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [X] Relevant unit and integration tests are included.
- [X] Documentation has been updated accordingly.
- [X] All tests pass locally.
- [X] The PR description follows the project's guidelines.
