### PR TITLE
CSPL-4006: Replication port issue fix

### DIFF
--- a/pkg/splunk/util/secrets.go
+++ b/pkg/splunk/util/secrets.go
@@ -365,6 +365,7 @@ splunk:
     pass4SymmKey: "%s"
     idxc:
         secret: "%s"
+		replication_port: 9887
     shc:
         secret: "%s"
 `,


### PR DESCRIPTION
### Description

The issue seemed to be that when customers use DefaultsURL or ConfigMap-based defaults, they rely entirely on those sources for replication port config, and if there's any timing issue, parsing problem, or configuration error in the user-provided defaults, the replication port won't be set, causing pod startup failures. This is due to the ordering of how we are [checking for our default configuration](https://github.com/splunk/splunk-operator/blob/1b0ee2307e6a20574f3b5ca3bcdf6878c9bf0ebc/pkg/splunk/enterprise/configuration.go#L913-L923) 

The replication_port config was missing from operator-managed default.yml. This would cause IndexerCluster pods to fail with "need to specify replication port". 

This seemed to be a quite simple way to address this issue, and since 9887 is the designated default Splunk replication port, seemed to make sense to include as a part of the default config. Open to discussion on potential better solutions to this, however.

### Key Changes

This proposed change is as minimal as I could think to do. Port 9887 is the designated default Splunk replication_port, so this seemed to be a reasonable add to the default.yaml that we create.

### Testing and Verification

Was able to replicate issue locally and verified this fix can work.

### Related Issues

- Jira issue: https://splunk.atlassian.net/browse/CSPL-4006
- Team discussion: https://splunk.slack.com/archives/C07DE987ALF/p1757664970912129

### PR Checklist

- [x] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [x] All tests pass locally.
- [x] The PR description follows the project's guidelines.
