### PR TITLE
CSPL-4281 Fix MC crash loop during scale-down

### DIFF
--- a/pkg/splunk/enterprise/clustermanager.go
+++ b/pkg/splunk/enterprise/clustermanager.go
@@ -209,6 +209,14 @@ func ApplyClusterManager(ctx context.Context, client splcommon.ControllerClient,
 	}
 	cr.Status.Phase = phase
 
+	//Update MC configmap
+	if cr.Spec.MonitoringConsoleRef.Name != "" {
+		_, err = ApplyMonitoringConsoleEnvConfigMap(ctx, client, cr.GetNamespace(), cr.GetName(), cr.Spec.MonitoringConsoleRef.Name, extraEnv, true)
+		if err != nil {
+			return result, err
+		}
+	}
+
 	// no need to requeue if everything is ready
 	if cr.Status.Phase == enterpriseApi.PhaseReady {
 		//upgrade fron automated MC to MC CRD
@@ -216,13 +224,6 @@ func ApplyClusterManager(ctx context.Context, client splcommon.ControllerClient,
 		err = splctrl.DeleteReferencesToAutomatedMCIfExists(ctx, client, cr, namespacedName)
 		if err != nil {
 			scopedLog.Error(err, "Error in deleting automated monitoring console resource")
-		}
-		//Update MC configmap
-		if cr.Spec.MonitoringConsoleRef.Name != "" {
-			_, err = ApplyMonitoringConsoleEnvConfigMap(ctx, client, cr.GetNamespace(), cr.GetName(), cr.Spec.MonitoringConsoleRef.Name, extraEnv, true)
-			if err != nil {
-				return result, err
-			}
 		}
 
 		// Create podExecClient

--- a/pkg/splunk/enterprise/licensemanager.go
+++ b/pkg/splunk/enterprise/licensemanager.go
@@ -148,6 +148,13 @@ func ApplyLicenseManager(ctx context.Context, client splcommon.ControllerClient,
 	}
 	cr.Status.Phase = phase
 
+	if cr.Spec.MonitoringConsoleRef.Name != "" {
+		_, err = ApplyMonitoringConsoleEnvConfigMap(ctx, client, cr.GetNamespace(), cr.GetName(), cr.Spec.MonitoringConsoleRef.Name, getLicenseManagerURL(cr, &cr.Spec.CommonSplunkSpec), true)
+		if err != nil {
+			return result, err
+		}
+	}
+
 	// no need to requeue if everything is ready
 	if cr.Status.Phase == enterpriseApi.PhaseReady {
 		//upgrade fron automated MC to MC CRD
@@ -155,12 +162,6 @@ func ApplyLicenseManager(ctx context.Context, client splcommon.ControllerClient,
 		err = splctrl.DeleteReferencesToAutomatedMCIfExists(ctx, client, cr, namespacedName)
 		if err != nil {
 			scopedLog.Error(err, "Error in deleting automated monitoring console resource")
-		}
-		if cr.Spec.MonitoringConsoleRef.Name != "" {
-			_, err = ApplyMonitoringConsoleEnvConfigMap(ctx, client, cr.GetNamespace(), cr.GetName(), cr.Spec.MonitoringConsoleRef.Name, getLicenseManagerURL(cr, &cr.Spec.CommonSplunkSpec), true)
-			if err != nil {
-				return result, err
-			}
 		}
 
 		// Add a splunk operator telemetry app

--- a/pkg/splunk/enterprise/licensemaster.go
+++ b/pkg/splunk/enterprise/licensemaster.go
@@ -148,6 +148,13 @@ func ApplyLicenseMaster(ctx context.Context, client splcommon.ControllerClient, 
 	}
 	cr.Status.Phase = phase
 
+	if cr.Spec.MonitoringConsoleRef.Name != "" {
+		_, err = ApplyMonitoringConsoleEnvConfigMap(ctx, client, cr.GetNamespace(), cr.GetName(), cr.Spec.MonitoringConsoleRef.Name, getLicenseMasterURL(cr, &cr.Spec.CommonSplunkSpec), true)
+		if err != nil {
+			return result, err
+		}
+	}
+
 	// no need to requeue if everything is ready
 	if cr.Status.Phase == enterpriseApi.PhaseReady {
 		//upgrade fron automated MC to MC CRD
@@ -155,12 +162,6 @@ func ApplyLicenseMaster(ctx context.Context, client splcommon.ControllerClient, 
 		err = splctrl.DeleteReferencesToAutomatedMCIfExists(ctx, client, cr, namespacedName)
 		if err != nil {
 			scopedLog.Error(err, "Error in deleting automated monitoring console resource")
-		}
-		if cr.Spec.MonitoringConsoleRef.Name != "" {
-			_, err = ApplyMonitoringConsoleEnvConfigMap(ctx, client, cr.GetNamespace(), cr.GetName(), cr.Spec.MonitoringConsoleRef.Name, getLicenseMasterURL(cr, &cr.Spec.CommonSplunkSpec), true)
-			if err != nil {
-				return result, err
-			}
 		}
 
 		// Add a splunk operator telemetry app

--- a/pkg/splunk/enterprise/searchheadcluster.go
+++ b/pkg/splunk/enterprise/searchheadcluster.go
@@ -211,6 +211,13 @@ func ApplySearchHeadCluster(ctx context.Context, client splcommon.ControllerClie
 		finalResult = handleAppFrameworkActivity(ctx, client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig)
 	}
 
+	if cr.Spec.MonitoringConsoleRef.Name != "" {
+		_, err = ApplyMonitoringConsoleEnvConfigMap(ctx, client, cr.GetNamespace(), cr.GetName(), cr.Spec.MonitoringConsoleRef.Name, getSearchHeadEnv(cr), true)
+		if err != nil {
+			return result, err
+		}
+	}
+
 	// no need to requeue if everything is ready
 	if cr.Status.Phase == enterpriseApi.PhaseReady {
 		//upgrade fron automated MC to MC CRD
@@ -218,12 +225,6 @@ func ApplySearchHeadCluster(ctx context.Context, client splcommon.ControllerClie
 		err = splctrl.DeleteReferencesToAutomatedMCIfExists(ctx, client, cr, namespacedName)
 		if err != nil {
 			scopedLog.Error(err, "Error in deleting automated monitoring console resource")
-		}
-		if cr.Spec.MonitoringConsoleRef.Name != "" {
-			_, err = ApplyMonitoringConsoleEnvConfigMap(ctx, client, cr.GetNamespace(), cr.GetName(), cr.Spec.MonitoringConsoleRef.Name, getSearchHeadEnv(cr), true)
-			if err != nil {
-				return result, err
-			}
 		}
 
 		// Reset secrets related status structs


### PR DESCRIPTION
### Description
Fixes MC crash loop during scale-down. MC ConfigMap update was gated by `phase == PhaseReady` check, causing peer config to not update when resources scaled down. MC kept trying to connect to deleted pods, resulting in continuous restarts.
### Key Changes
Moved ApplyMonitoringConsoleEnvConfigMap() outside phase check in:

- `standalone.go`
- `clustermanager.go` / `clustermaster.go`
- `searchheadcluster.go`
- `licensemanager.go` / `licensemaster.go`

ConfigMap now updates immediately after StatefulSet changes, keeping peer list synchronized.
### Testing and Verification
Automated: Existing managermc1 test validates MC ConfigMap and Ready state
### Related Issues
JIRA: CSPL-4281 - MC crashes on Standalone scale-down
### PR Checklist
- [x] Code changes adhere to coding standards
- [x] Tests included and pass locally
- [ ] Documentation updated
- [x] PR description follows guidelines