### PR TITLE
Add link to required value for Splunk General Terms

### DIFF
--- a/docs/CustomResources.md
+++ b/docs/CustomResources.md
@@ -355,7 +355,7 @@ The MC pod is referenced by using the `monitoringConsoleRef` parameter. There is
 
 ## Examples of Guaranteed and Burstable QoS
 
-You can change the CPU and memory resources, and assign different Quality of Services (QoS) classes to your pods using the [Kubernetes Quality of Service section](README.md#using-kubernetes-quality-of-service-classes). Here are some examples:
+You can change the CPU and memory resources, and assign different Quality of Services (QoS) classes to your pods. Here are some examples:
   
 ### A Guaranteed QoS Class example:
 Set equal ```requests``` and ```limits``` values for CPU and memory to establish a QoS class of Guaranteed. 

--- a/docs/Helm.md
+++ b/docs/Helm.md
@@ -107,10 +107,8 @@ release "splunk-operator-test" uninstalled
 
 ## Splunk Enterprise deployments
 
-The Splunk Enterprise chart allows you to install and configure Splunk Enterprise custom resources. The ```splunk/splunk-enterprise``` chart has the ```splunk/splunk-operator``` chart as a dependency by default. To satisfy the dependencies please use the following command:
-```
-helm dependency build splunk/splunk-enterprise
-```
+The Splunk Enterprise chart allows you to install and configure Splunk Enterprise custom resources. The ```splunk/splunk-enterprise``` chart has the ```splunk/splunk-operator``` chart as a dependency by default.
+
 If the operator is already installed then you will need to disable the dependency:
 ```
 helm install --set splunk-operator.enabled=false <RELEASE_NAME> splunk/splunk-enterprise -n <RELEASE_NAMESPACE>

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ This repository is used to build the Splunk
 for Kubernetes (SOK). If you are just looking for documentation on how to
 deploy and use the latest release, please visit the published
 [Splunk Operator documentation site](https://splunk.github.io/splunk-operator/)
-or review the in-repo [Getting Started Documentation](GettingStarted.md).
+or review the in-repo [Getting Started Documentation](GettingStarted.html).
 
 ## Splunk General Terms Acceptance
 
@@ -35,7 +35,7 @@ By default, the SPLUNK_GENERAL_TERMS environment variable will be set to an empt
 make deploy IMG=docker.io/splunk/splunk-operator:<tag name> WATCH_NAMESPACE="namespace1" RELATED_IMAGE_SPLUNK_ENTERPRISE="splunk/splunk:edge" SPLUNK_GENERAL_TERMS="--accept-sgt-current-at-splunk-com"
 ```
 
-For more information about this change, see the [Splunk General Terms Migration Documentation](SplunkGeneralTermsMigration.md).
+For more information about this change, see the [Splunk General Terms Migration Documentation](SplunkGeneralTermsMigration.html).
 
 ## Prerequisites
 
@@ -107,7 +107,7 @@ In addition to the source code, this repository includes:
 * `tools`: Build scripts, templates, etc. used to build the container image
 * `config`: Kubernetes YAML templates used to install the Splunk Operator
 * `docs`: Getting Started Guide and other documentation in Markdown format
-* `test`: Integration test framework built using Ginko. See [docs](test/README.md) for more info.
+* `test`: Integration test framework built using Ginkgo. See [docs](https://github.com/splunk/splunk-operator/blob/main/test/README.md) for more info.
 
 ## Building the operator
 
@@ -158,7 +158,7 @@ make run
 This will use your current Kubernetes context from `~/.kube/config` to manage
 resources in your current namespace.
 
-Please see the [Getting Started Documentation](GettingStarted.md) for more
+Please see the [Getting Started Documentation](GettingStarted.html) for more
 information, including instructions on how to install the operator in your
 cluster.
 

--- a/docs/SplunkGeneralTermsMigration.md
+++ b/docs/SplunkGeneralTermsMigration.md
@@ -16,7 +16,7 @@ All users deploying Splunk Enterprise 10.x or later image versions instances mus
 
 Starting with the 3.0.0 release, there is now a mandatory acknowledgment mechanism for the Splunk General Terms (SGT) within the Splunk Operator for Kubernetes. **This is a breaking change, and user action is required.** This involves creating a new `SPLUNK_GENERAL_TERMS` environment variable in the splunk operator deployment, which gets passed to every CRD.
 
-To learn more about the required value for this variable, please see the [README](../README.md) or Splunk Enterprise 10.x image’s README.
+To learn more about the required value for this variable, please see the [README](index.html#splunk-general-terms-acceptance) or Splunk Enterprise 10.x image’s README.
 
 ## How does this affect existing deployments?
 
@@ -25,11 +25,11 @@ Existing deployments of the Splunk Operator for Kubernetes will not be affected 
 ## How to plan for a migration?
 
 When you are ready to upgrade from version 1.x.x or 2.x.x to 3.0.0 or later, there are a few options you have to set the `SPLUNK_GENERAL_TERMS` to the proper value. By default, the SPLUNK_GENERAL_TERMS environment variable will be set to an empty string.
-1. Pass the `SPLUNK_GENERAL_TERMS` parameter with the required value to the `make deploy` command
+1. Pass the `SPLUNK_GENERAL_TERMS` parameter with the [required value](index.html#splunk-general-terms-acceptance) to the `make deploy` command.
 ```
-make deploy IMG=docker.io/splunk/splunk-operator:<tag name> SPLUNK_GENERAL_TERMS="[required value]"
+make deploy IMG=docker.io/splunk/splunk-operator:<tag name> SPLUNK_GENERAL_TERMS="<required value>"
 ```
-2. Update the value in the Splunk Operator installation file from the release on GitHub
+2. Update the value in the Splunk Operator installation file from the [release](https://github.com/splunk/splunk-operator/releases/latest) on GitHub with the [required value](index.html#splunk-general-terms-acceptance).
 ```yaml
 ...
         env:
@@ -40,7 +40,7 @@ make deploy IMG=docker.io/splunk/splunk-operator:<tag name> SPLUNK_GENERAL_TERMS
         - name: OPERATOR_NAME
           value: splunk-operator
         - name: SPLUNK_GENERAL_TERMS
-          value: "[required value]"
+          value: "<required value>"
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -48,11 +48,11 @@ make deploy IMG=docker.io/splunk/splunk-operator:<tag name> SPLUNK_GENERAL_TERMS
               fieldPath: metadata.name
 ...
 ```
-3. Set the value in a `helm install` command
+3. Set the [required value](index.html#splunk-general-terms-acceptance) in a `helm install` command.
 ```
-helm install -f new_values.yaml --set splunkOperator.splunkGeneralTerms="[required value]" <RELEASE_NAME> splunk/splunk-operator -n <RELEASE_NAMESPACE>
+helm install -f new_values.yaml --set splunkOperator.splunkGeneralTerms="<required value>" <RELEASE_NAME> splunk/splunk-operator -n <RELEASE_NAMESPACE>
 ```
-4. Edit the splunk-operator-controller-manager deployment after it is deployed
+4. Edit the splunk-operator-controller-manager deployment after it is deployed to include the [required value](index.html#splunk-general-terms-acceptance).
 ```
 kubectl edit deployment splunk-operator-controller-manager -n splunk-operator
 ```


### PR DESCRIPTION
### Description

This PR updates the documentation with suggestions from users to make it more obvious where to find the required value for the Splunk General Terms acceptance. Users must read the legal language in the README before accepting the SGT, so it is only included in one file, but referenced in other places.

### Key Changes

- Remove unused commands and README sections
- Update README links to work with Jekyll
- Add hyperlinks to required value for SGT migration

### Testing and Verification

`make docs-preview` locally and navigated through the documents.

### Related Issues

N/A

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [X] Documentation has been updated accordingly.
- [ ] All tests pass locally.
- [X] The PR description follows the project's guidelines.
