### PR TITLE
fix: fix long execution time unit tests

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -107,11 +107,11 @@ func main() {
 		// as certificates issued by a trusted Certificate Authority (CA). The primary risk is potentially allowing
 		// unauthorized access to sensitive metrics data. Consider replacing with CertDir, CertName, and KeyName
 		// to provide certificates, ensuring the server communicates using trusted and secure certificates.
-		TLSOpts: tlsOpts,
+		TLSOpts:        tlsOpts,
 		FilterProvider: filters.WithAuthenticationAndAuthorization,
 	}
 
-	// TODO: enable https for /metrics endpoint by default  
+	// TODO: enable https for /metrics endpoint by default
 	// if secureMetrics {
 	// 	// FilterProvider is used to protect the metrics endpoint with authn/authz.
 	// 	// These configurations ensure that only authorized users and service accounts

--- a/go.mod
+++ b/go.mod
@@ -12,13 +12,13 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.71
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.85
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.84.1
-	github.com/go-logr/logr v1.4.2
+	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/minio/minio-go/v7 v7.0.16
-	github.com/onsi/ginkgo/v2 v2.23.4
-	github.com/onsi/gomega v1.38.0
+	github.com/onsi/ginkgo/v2 v2.27.2
+	github.com/onsi/gomega v1.38.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1
 	github.com/stretchr/testify v1.9.0
@@ -39,6 +39,7 @@ require (
 	cloud.google.com/go/iam v1.1.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.11 // indirect
@@ -126,8 +127,10 @@ require (
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect
+	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect
@@ -143,7 +146,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240528184218-531527333157 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a // indirect
 	google.golang.org/grpc v1.65.0 // indirect
-	google.golang.org/protobuf v1.36.6 // indirect
+	google.golang.org/protobuf v1.36.7 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.4.1/go.mod h1:ap1dmS6vQK
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
@@ -118,6 +120,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
+github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=
@@ -247,8 +251,12 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.23.4 h1:ktYTpKJAVZnDT4VjxSbiBenUjmlL/5QkBEocaWXiQus=
 github.com/onsi/ginkgo/v2 v2.23.4/go.mod h1:Bt66ApGPBFzHyR+JO10Zbt0Gsp4uWxu5mIOTusL46e8=
+github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
+github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.0 h1:c/WX+w8SLAinvuKKQFh77WEucCnPk4j2OTUr7lt7BeY=
 github.com/onsi/gomega v1.38.0/go.mod h1:OcXcwId0b9QsE7Y49u+BTrL4IdKOBOKnD6VQNTJEB6o=
+github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
+github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -333,6 +341,8 @@ go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=
 go.uber.org/zap v1.26.0/go.mod h1:dtElttAiwGvoJ/vj4IwHBS/gXsEu/pZ50mUIRWuG0so=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -354,6 +364,8 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/mod v0.29.0 h1:HV8lRxZC4l2cr3Zq1LvtOsi/ThTgWnUk/y64QSs8GwA=
+golang.org/x/mod v0.29.0/go.mod h1:NyhrlYXJ2H4eJiRy/WDBO6HMqZQ6q9nk4JzS3NuCK+w=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -501,6 +513,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
 google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
+google.golang.org/protobuf v1.36.7 h1:IgrO7UwFQGJdRNXH/sQux4R1Dj1WAKcLElzeeRaXV2A=
+google.golang.org/protobuf v1.36.7/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/internal/controller/clustermanager_controller.go
+++ b/internal/controller/clustermanager_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	metrics "github.com/splunk/splunk-operator/pkg/splunk/client/metrics"
 	enterprise "github.com/splunk/splunk-operator/pkg/splunk/enterprise"
+	splutil "github.com/splunk/splunk-operator/pkg/splunk/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -103,7 +104,7 @@ func (r *ClusterManagerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	reqLogger.Info("start", "CR version", instance.GetResourceVersion())
 
-	result, err := ApplyClusterManager(ctx, r.Client, instance)
+	result, err := ApplyClusterManager(ctx, r.Client, instance, nil)
 	if result.Requeue && result.RequeueAfter != 0 {
 		reqLogger.Info("Requeued", "period(seconds)", int(result.RequeueAfter/time.Second))
 	}
@@ -112,8 +113,8 @@ func (r *ClusterManagerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 }
 
 // ApplyClusterManager adding to handle unit test case
-var ApplyClusterManager = func(ctx context.Context, client client.Client, instance *enterpriseApi.ClusterManager) (reconcile.Result, error) {
-	return enterprise.ApplyClusterManager(ctx, client, instance)
+var ApplyClusterManager = func(ctx context.Context, client client.Client, instance *enterpriseApi.ClusterManager, podExecClient splutil.PodExecClientImpl) (reconcile.Result, error) {
+	return enterprise.ApplyClusterManager(ctx, client, instance, podExecClient)
 }
 
 func (r *ClusterManagerReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/clustermanager_controller_test.go
+++ b/internal/controller/clustermanager_controller_test.go
@@ -3,9 +3,11 @@ package controller
 import (
 	"context"
 	"fmt"
+
 	"github.com/splunk/splunk-operator/internal/controller/testutils"
 
 	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
+	splutil "github.com/splunk/splunk-operator/pkg/splunk/util"
 
 	"time"
 
@@ -35,7 +37,7 @@ var _ = Describe("ClusterManager Controller", func() {
 
 		It("Get ClusterManager custom resource should failed", func() {
 			namespace := "ns-splunk-cm-1"
-			ApplyClusterManager = func(ctx context.Context, client client.Client, instance *enterpriseApi.ClusterManager) (reconcile.Result, error) {
+			ApplyClusterManager = func(ctx context.Context, client client.Client, instance *enterpriseApi.ClusterManager, podExecClient splutil.PodExecClientImpl) (reconcile.Result, error) {
 				return reconcile.Result{}, nil
 			}
 			nsSpecs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
@@ -51,7 +53,7 @@ var _ = Describe("ClusterManager Controller", func() {
 
 		It("Create ClusterManager custom resource with annotations should pause", func() {
 			namespace := "ns-splunk-cm-2"
-			ApplyClusterManager = func(ctx context.Context, client client.Client, instance *enterpriseApi.ClusterManager) (reconcile.Result, error) {
+			ApplyClusterManager = func(ctx context.Context, client client.Client, instance *enterpriseApi.ClusterManager, podExecClient splutil.PodExecClientImpl) (reconcile.Result, error) {
 				return reconcile.Result{}, nil
 			}
 			nsSpecs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
@@ -71,7 +73,7 @@ var _ = Describe("ClusterManager Controller", func() {
 	Context("ClusterManager Management", func() {
 		It("Create ClusterManager custom resource should succeeded", func() {
 			namespace := "ns-splunk-cm-3"
-			ApplyClusterManager = func(ctx context.Context, client client.Client, instance *enterpriseApi.ClusterManager) (reconcile.Result, error) {
+			ApplyClusterManager = func(ctx context.Context, client client.Client, instance *enterpriseApi.ClusterManager, podExecClient splutil.PodExecClientImpl) (reconcile.Result, error) {
 				return reconcile.Result{}, nil
 			}
 			nsSpecs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
@@ -84,7 +86,7 @@ var _ = Describe("ClusterManager Controller", func() {
 
 		It("Cover Unused methods", func() {
 			namespace := "ns-splunk-cm-4"
-			ApplyClusterManager = func(ctx context.Context, client client.Client, instance *enterpriseApi.ClusterManager) (reconcile.Result, error) {
+			ApplyClusterManager = func(ctx context.Context, client client.Client, instance *enterpriseApi.ClusterManager, podExecClient splutil.PodExecClientImpl) (reconcile.Result, error) {
 				return reconcile.Result{}, nil
 			}
 			nsSpecs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}

--- a/pkg/splunk/enterprise/clustermanager_test.go
+++ b/pkg/splunk/enterprise/clustermanager_test.go
@@ -137,7 +137,7 @@ func TestApplyClusterManager(t *testing.T) {
 	revised.Spec.Image = "splunk/test"
 	revised.SetGroupVersionKind(gvk)
 	reconcile := func(c *spltest.MockClient, cr interface{}) error {
-		_, err := ApplyClusterManager(ctx, c, cr.(*enterpriseApi.ClusterManager))
+		_, err := ApplyClusterManager(ctx, c, cr.(*enterpriseApi.ClusterManager), nil)
 		return err
 	}
 	spltest.ReconcileTesterWithoutRedundantCheck(t, "TestApplyClusterManager", &current, revised, createCalls, updateCalls, reconcile, true)
@@ -147,7 +147,7 @@ func TestApplyClusterManager(t *testing.T) {
 	revised.ObjectMeta.DeletionTimestamp = &currentTime
 	revised.ObjectMeta.Finalizers = []string{"enterprise.splunk.com/delete-pvc"}
 	deleteFunc := func(cr splcommon.MetaObject, c splcommon.ControllerClient) (bool, error) {
-		_, err := ApplyClusterManager(ctx, c, cr.(*enterpriseApi.ClusterManager))
+		_, err := ApplyClusterManager(ctx, c, cr.(*enterpriseApi.ClusterManager), nil)
 		return true, err
 	}
 	splunkDeletionTester(t, revised, deleteFunc)
@@ -159,7 +159,7 @@ func TestApplyClusterManager(t *testing.T) {
 	c := spltest.NewMockClient()
 	_ = errors.New(splcommon.Rerr)
 	current.Kind = "ClusterManager"
-	_, err := ApplyClusterManager(ctx, c, &current)
+	_, err := ApplyClusterManager(ctx, c, &current, nil)
 	if err == nil {
 		t.Errorf("Expected error")
 	}
@@ -226,7 +226,7 @@ func TestApplyClusterManager(t *testing.T) {
 	}
 
 	current.Kind = "ClusterManager"
-	_, err = ApplyClusterManager(ctx, c, &current)
+	_, err = ApplyClusterManager(ctx, c, &current, nil)
 	if err == nil {
 		t.Errorf("Expected error")
 	}
@@ -243,7 +243,7 @@ func TestApplyClusterManager(t *testing.T) {
 	current.Status.SmartStore.VolList[0].SecretRef = "s3-secret"
 	current.Status.ResourceRevMap["s3-secret"] = "v2"
 	current.Kind = "ClusterManager"
-	_, err = ApplyClusterManager(ctx, c, &current)
+	_, err = ApplyClusterManager(ctx, c, &current, nil)
 	if err == nil {
 		t.Errorf("Expected error")
 	}
@@ -258,7 +258,7 @@ func TestApplyClusterManager(t *testing.T) {
 	current.Spec.SmartStore.VolList[0].SecretRef = ""
 	current.Spec.SmartStore.Defaults.IndexAndGlobalCommonSpec.VolName = "msos_s2s3_vol"
 	current.Kind = "ClusterManager"
-	_, err = ApplyClusterManager(ctx, c, &current)
+	_, err = ApplyClusterManager(ctx, c, &current, nil)
 	if err != nil {
 		t.Errorf("Don't expected error here")
 	}
@@ -315,7 +315,7 @@ func TestApplyClusterManager(t *testing.T) {
 		},
 	}
 	current.Kind = "ClusterManager"
-	_, err = ApplyClusterManager(ctx, c, &current)
+	_, err = ApplyClusterManager(ctx, c, &current, nil)
 	if err == nil {
 		t.Errorf("Expected error")
 	}
@@ -333,7 +333,7 @@ func TestApplyClusterManager(t *testing.T) {
 	rerr := errors.New(splcommon.Rerr)
 	c.InduceErrorKind[splcommon.MockClientInduceErrorGet] = rerr
 	current.Kind = "ClusterManager"
-	_, err = ApplyClusterManager(ctx, c, &current)
+	_, err = ApplyClusterManager(ctx, c, &current, nil)
 	if err == nil {
 		t.Errorf("Expected error")
 	}
@@ -535,7 +535,7 @@ func TestClusterManagerSpecNotCreatedWithoutGeneralTerms(t *testing.T) {
 	c := spltest.NewMockClient()
 
 	// Attempt to apply the cluster manager spec
-	_, err := ApplyClusterManager(ctx, c, &cm)
+	_, err := ApplyClusterManager(ctx, c, &cm, nil)
 
 	// Assert that an error is returned
 	if err == nil {
@@ -663,7 +663,7 @@ func TestApplyClusterManagerWithSmartstore(t *testing.T) {
 
 	// Without S3 keys, ApplyClusterManager should fail
 	current.Kind = "ClusterManager"
-	_, err := ApplyClusterManager(ctx, client, &current)
+	_, err := ApplyClusterManager(ctx, client, &current, nil)
 	if err == nil {
 		t.Errorf("ApplyClusterManager should fail without S3 secrets configured")
 	}
@@ -693,7 +693,7 @@ func TestApplyClusterManagerWithSmartstore(t *testing.T) {
 	revised.Spec.Image = "splunk/test"
 	reconcile := func(c *spltest.MockClient, cr interface{}) error {
 		current.Kind = "ClusterManager"
-		_, err := ApplyClusterManager(context.Background(), c, cr.(*enterpriseApi.ClusterManager))
+		_, err := ApplyClusterManager(context.Background(), c, cr.(*enterpriseApi.ClusterManager), nil)
 		return err
 	}
 
@@ -721,12 +721,12 @@ func TestApplyClusterManagerWithSmartstore(t *testing.T) {
 
 	current.Status.BundlePushTracker.NeedToPushManagerApps = true
 	current.Kind = "ClusterManager"
-	if _, err = ApplyClusterManager(context.Background(), client, &current); err != nil {
+	if _, err = ApplyClusterManager(context.Background(), client, &current, nil); err != nil {
 		t.Errorf("ApplyClusterManager() should not have returned error")
 	}
 
 	current.Spec.CommonSplunkSpec.EtcVolumeStorageConfig.StorageCapacity = "-abcd"
-	if _, err := ApplyClusterManager(context.Background(), client, &current); err == nil {
+	if _, err := ApplyClusterManager(context.Background(), client, &current, nil); err == nil {
 		t.Errorf("ApplyClusterManager() should have returned error")
 	}
 
@@ -736,7 +736,7 @@ func TestApplyClusterManagerWithSmartstore(t *testing.T) {
 	ss.Spec.Replicas = &replicas
 	ss.Spec.Template.Spec.Containers[0].Image = "splunk/splunk"
 	client.AddObject(ss)
-	if result, err := ApplyClusterManager(context.Background(), client, &current); err == nil && !result.Requeue {
+	if result, err := ApplyClusterManager(context.Background(), client, &current, nil); err == nil && !result.Requeue {
 		t.Errorf("ApplyClusterManager() should have returned error or result.requeue should have been false")
 	}
 
@@ -746,7 +746,7 @@ func TestApplyClusterManagerWithSmartstore(t *testing.T) {
 	client.AddObjects(objects)
 	current.Spec.CommonSplunkSpec.Mock = false
 
-	if _, err := ApplyClusterManager(context.Background(), client, &current); err == nil {
+	if _, err := ApplyClusterManager(context.Background(), client, &current, nil); err == nil {
 		t.Errorf("ApplyClusterManager() should have returned error")
 	}
 }
@@ -774,7 +774,7 @@ func TestPerformCmBundlePush(t *testing.T) {
 
 	// When the secret object is not present, should return an error
 	current.Status.BundlePushTracker.NeedToPushManagerApps = true
-	err := PerformCmBundlePush(ctx, client, &current)
+	err := PerformCmBundlePush(ctx, client, &current, nil)
 	if err == nil {
 		t.Errorf("Should return error, when the secret object is not present")
 	}
@@ -806,28 +806,28 @@ func TestPerformCmBundlePush(t *testing.T) {
 
 	//Re-attempting to push the CM bundle in less than 5 seconds should return an error
 	current.Status.BundlePushTracker.LastCheckInterval = time.Now().Unix() - 1
-	err = PerformCmBundlePush(ctx, client, &current)
+	err = PerformCmBundlePush(ctx, client, &current, nil)
 	if err == nil {
 		t.Errorf("Bundle Push Should fail, if attempted to push within 5 seconds interval")
 	}
 
 	//Re-attempting to push the CM bundle after 5 seconds passed, should not return an error
 	current.Status.BundlePushTracker.LastCheckInterval = time.Now().Unix() - 10
-	err = PerformCmBundlePush(ctx, client, &current)
+	err = PerformCmBundlePush(ctx, client, &current, nil)
 	if err != nil && strings.HasPrefix(err.Error(), "Will re-attempt to push the bundle after the 5 seconds") {
 		t.Errorf("Bundle Push Should not fail if reattempted after 5 seconds interval passed. Error: %s", err.Error())
 	}
 
 	// When the CM Bundle push is not pending, should not return an error
 	current.Status.BundlePushTracker.NeedToPushManagerApps = false
-	err = PerformCmBundlePush(ctx, client, &current)
+	err = PerformCmBundlePush(ctx, client, &current, nil)
 	if err != nil {
 		t.Errorf("Should not return an error when the Bundle push is not required. Error: %s", err.Error())
 	}
 
 	// Negative testing
 	current.Status.BundlePushTracker.NeedToPushManagerApps = true
-	err = PerformCmBundlePush(ctx, client, &current)
+	err = PerformCmBundlePush(ctx, client, &current, nil)
 	if err != nil && strings.HasPrefix(err.Error(), "Will re-attempt to push the bundle after the 5 seconds") {
 		t.Errorf("Bundle Push Should not fail if reattempted after 5 seconds interval passed. Error: %s", err.Error())
 	}
@@ -958,7 +958,7 @@ func TestAppFrameworkApplyClusterManagerShouldNotFail(t *testing.T) {
 	}
 
 	cm.Kind = "ClusterManager"
-	_, err = ApplyClusterManager(context.Background(), client, &cm)
+	_, err = ApplyClusterManager(context.Background(), client, &cm, nil)
 	if err != nil {
 		t.Errorf("ApplyClusterManager should not have returned error here.")
 	}
@@ -1061,7 +1061,7 @@ func TestApplyClusterManagerDeletion(t *testing.T) {
 		t.Errorf("Unable to create download directory for apps :%s", splcommon.AppDownloadVolume)
 	}
 	cm.Kind = "ClusterManager"
-	_, err = ApplyClusterManager(ctx, c, &cm)
+	_, err = ApplyClusterManager(ctx, c, &cm, nil)
 	if err != nil {
 		t.Errorf("ApplyClusterManager should not have returned error here.")
 	}
@@ -1576,7 +1576,7 @@ func TestIsClusterManagerReadyForUpgrade(t *testing.T) {
 
 	cm.Kind = "ClusterManager"
 	client.Create(ctx, &cm)
-	_, err = ApplyClusterManager(ctx, client, &cm)
+	_, err = ApplyClusterManager(ctx, client, &cm, nil)
 	if err != nil {
 		t.Errorf("applyClusterManager should not have returned error; err=%v", err)
 	}
@@ -1715,7 +1715,7 @@ func TestChangeClusterManagerAnnotations(t *testing.T) {
 
 	cm.Kind = "ClusterManager"
 	client.Create(ctx, cm)
-	_, err = ApplyClusterManager(ctx, client, cm)
+	_, err = ApplyClusterManager(ctx, client, cm, nil)
 	if err != nil {
 		t.Errorf("applyClusterManager should not have returned error; err=%v", err)
 	}
@@ -1745,6 +1745,41 @@ func TestClusterManagerWitReadyState(t *testing.T) {
 	// create directory for app framework
 	newpath := filepath.Join("/tmp", "appframework")
 	_ = os.MkdirAll(newpath, os.ModePerm)
+
+	// Mock GetCMMultisiteEnvVarsCall to avoid 5-second HTTP timeout
+	// This function tries to connect to Splunk REST API which doesn't exist in unit tests
+	GetCMMultisiteEnvVarsCall = func(ctx context.Context, cr *enterpriseApi.ClusterManager, namespaceScopedSecret *corev1.Secret) ([]corev1.EnvVar, error) {
+		extraEnv := getClusterManagerExtraEnv(cr, &cr.Spec.CommonSplunkSpec)
+		return extraEnv, nil
+	}
+
+	savedPerformCmBundlePush := PerformCmBundlePush
+	PerformCmBundlePush = func(ctx context.Context, c splcommon.ControllerClient, cr *enterpriseApi.ClusterManager, podExecClient splutil.PodExecClientImpl) error {
+		// Just set the flag to false to simulate successful bundle push
+		cr.Status.BundlePushTracker.NeedToPushManagerApps = false
+		return nil
+	}
+	defer func() { PerformCmBundlePush = savedPerformCmBundlePush }()
+
+	// Mock GetPodExecClient to return a mock client that simulates pod operations locally
+	savedGetPodExecClient := splutil.GetPodExecClient
+	splutil.GetPodExecClient = func(client splcommon.ControllerClient, cr splcommon.MetaObject, targetPodName string) splutil.PodExecClientImpl {
+		mockClient := &spltest.MockPodExecClient{
+			Client:        client,
+			Cr:            cr,
+			TargetPodName: targetPodName,
+		}
+		// Add mock responses for common commands
+		ctx := context.TODO()
+		// Mock mkdir command (used by createDirOnSplunkPods)
+		mockClient.AddMockPodExecReturnContext(ctx, "", &spltest.MockPodExecReturnContext{
+			StdOut: "",
+			StdErr: "",
+			Err:    nil,
+		})
+		return mockClient
+	}
+	defer func() { splutil.GetPodExecClient = savedGetPodExecClient }()
 
 	// adding getapplist to fix test case
 	GetAppsList = func(ctx context.Context, remoteDataClientMgr RemoteDataClientManager) (splclient.RemoteDataListResponse, error) {
@@ -1870,7 +1905,7 @@ func TestClusterManagerWitReadyState(t *testing.T) {
 	// simulate create clustermanager instance before reconcilation
 	c.Create(ctx, clustermanager)
 
-	_, err := ApplyClusterManager(ctx, c, clustermanager)
+	_, err := ApplyClusterManager(ctx, c, clustermanager, nil)
 	if err != nil {
 		t.Errorf("Unexpected error while running reconciliation for clustermanager with app framework  %v", err)
 		debug.PrintStack()
@@ -1913,7 +1948,7 @@ func TestClusterManagerWitReadyState(t *testing.T) {
 
 	// call reconciliation
 	clustermanager.Kind = "ClusterManager"
-	_, err = ApplyClusterManager(ctx, c, clustermanager)
+	_, err = ApplyClusterManager(ctx, c, clustermanager, nil)
 	if err != nil {
 		t.Errorf("Unexpected error while running reconciliation for cluster manager with app framework  %v", err)
 		debug.PrintStack()
@@ -2032,7 +2067,7 @@ func TestClusterManagerWitReadyState(t *testing.T) {
 
 	// call reconciliation
 	clustermanager.Kind = "ClusterManager"
-	_, err = ApplyClusterManager(ctx, c, clustermanager)
+	_, err = ApplyClusterManager(ctx, c, clustermanager, nil)
 	if err != nil {
 		t.Errorf("Unexpected error while running reconciliation for cluster manager with app framework  %v", err)
 		debug.PrintStack()

--- a/pkg/splunk/enterprise/clustermaster.go
+++ b/pkg/splunk/enterprise/clustermaster.go
@@ -331,7 +331,8 @@ func CheckIfMastersmartstoreConfigMapUpdatedToPod(ctx context.Context, c splcomm
 }
 
 // PerformCmasterBundlePush initiates the bundle push from cluster manager
-func PerformCmasterBundlePush(ctx context.Context, c splcommon.ControllerClient, cr *enterpriseApiV3.ClusterMaster) error {
+// Defined as a variable to allow mocking in unit tests
+var PerformCmasterBundlePush = func(ctx context.Context, c splcommon.ControllerClient, cr *enterpriseApiV3.ClusterMaster) error {
 	if !cr.Status.BundlePushTracker.NeedToPushMasterApps {
 		return nil
 	}
@@ -428,7 +429,8 @@ func getClusterMasterList(ctx context.Context, c splcommon.ControllerClient, cr 
 }
 
 // VerifyCMasterisMultisite checks if its a multisite
-func VerifyCMasterisMultisite(ctx context.Context, cr *enterpriseApiV3.ClusterMaster, namespaceScopedSecret *corev1.Secret) ([]corev1.EnvVar, error) {
+// Defined as a variable to allow mocking in unit tests
+var VerifyCMasterisMultisite = func(ctx context.Context, cr *enterpriseApiV3.ClusterMaster, namespaceScopedSecret *corev1.Secret) ([]corev1.EnvVar, error) {
 	var err error
 	reqLogger := log.FromContext(ctx)
 	scopedLog := reqLogger.WithName("Verify if Multisite Indexer Cluster").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())

--- a/pkg/splunk/enterprise/configuration_test.go
+++ b/pkg/splunk/enterprise/configuration_test.go
@@ -254,7 +254,7 @@ func TestSmartstoreApplyClusterManagerFailsOnInvalidSmartStoreConfig(t *testing.
 
 	client := spltest.NewMockClient()
 
-	_, err := ApplyClusterManager(context.TODO(), client, &cr)
+	_, err := ApplyClusterManager(context.TODO(), client, &cr, nil)
 	if err == nil {
 		t.Errorf("ApplyClusterManager should fail on invalid smartstore config")
 	}

--- a/pkg/splunk/enterprise/licensemaster_test.go
+++ b/pkg/splunk/enterprise/licensemaster_test.go
@@ -844,19 +844,54 @@ func TestLicenseMasterWithReadyState(t *testing.T) {
 	mclient.AddHandler(wantRequest2, 200, string(response2), nil)
 
 	// mock the verify RF peer funciton
+	savedVerifyRFPeers := VerifyRFPeers
+	defer func() { VerifyRFPeers = savedVerifyRFPeers }()
 	VerifyRFPeers = func(ctx context.Context, mgr indexerClusterPodManager, client splcommon.ControllerClient) error {
 		return nil
 	}
+
+	// Mock VerifyCMasterisMultisite to avoid HTTP timeout when ApplyClusterMaster is called
+	savedVerifyCMasterisMultisite := VerifyCMasterisMultisite
+	defer func() { VerifyCMasterisMultisite = savedVerifyCMasterisMultisite }()
+	VerifyCMasterisMultisite = func(ctx context.Context, cr *enterpriseApiV3.ClusterMaster, namespaceScopedSecret *corev1.Secret) ([]corev1.EnvVar, error) {
+		extraEnv := getClusterMasterExtraEnv(cr, &cr.Spec.CommonSplunkSpec)
+		return extraEnv, nil
+	}
+
+	// Initialize GlobalResourceTracker to enable app framework
+	initGlobalResourceTracker()
 
 	// create directory for app framework
 	newpath := filepath.Join("/tmp", "appframework")
 	_ = os.MkdirAll(newpath, os.ModePerm)
 
 	// adding getapplist to fix test case
+	savedGetAppsList := GetAppsList
+	defer func() { GetAppsList = savedGetAppsList }()
 	GetAppsList = func(ctx context.Context, remoteDataClientMgr RemoteDataClientManager) (splclient.RemoteDataListResponse, error) {
 		RemoteDataListResponse := splclient.RemoteDataListResponse{}
 		return RemoteDataListResponse, nil
 	}
+
+	// Mock GetPodExecClient to return a mock client that simulates pod operations locally
+	savedGetPodExecClient := splutil.GetPodExecClient
+	splutil.GetPodExecClient = func(client splcommon.ControllerClient, cr splcommon.MetaObject, targetPodName string) splutil.PodExecClientImpl {
+		mockClient := &spltest.MockPodExecClient{
+			Client:        client,
+			Cr:            cr,
+			TargetPodName: targetPodName,
+		}
+		// Add mock responses for common commands
+		ctx := context.TODO()
+		// Mock mkdir command (used by createDirOnSplunkPods)
+		mockClient.AddMockPodExecReturnContext(ctx, "mkdir -p", &spltest.MockPodExecReturnContext{
+			StdOut: "",
+			StdErr: "",
+			Err:    nil,
+		})
+		return mockClient
+	}
+	defer func() { splutil.GetPodExecClient = savedGetPodExecClient }()
 
 	sch := pkgruntime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(sch))
@@ -914,6 +949,8 @@ func TestLicenseMasterWithReadyState(t *testing.T) {
 	}
 
 	// Mock the addTelApp function for unit tests
+	savedAddTelApp := addTelApp
+	defer func() { addTelApp = savedAddTelApp }()
 	addTelApp = func(ctx context.Context, podExecClient splutil.PodExecClientImpl, replicas int32, cr splcommon.MetaObject) error {
 		return nil
 	}

--- a/pkg/splunk/enterprise/monitoringconsole_test.go
+++ b/pkg/splunk/enterprise/monitoringconsole_test.go
@@ -1180,7 +1180,7 @@ func TestChangeMonitoringConsoleAnnotations(t *testing.T) {
 	cm.Spec.Image = "splunk/splunk:latest"
 	// Create the instances
 	client.Create(ctx, cm)
-	_, err := ApplyClusterManager(ctx, client, cm)
+	_, err := ApplyClusterManager(ctx, client, cm, nil)
 	if err != nil {
 		t.Errorf("applyClusterManager should not have returned error; err=%v", err)
 	}

--- a/pkg/splunk/enterprise/types.go
+++ b/pkg/splunk/enterprise/types.go
@@ -129,6 +129,10 @@ type PipelineWorker struct {
 
 	// indicates a fan out worker
 	fanOut bool
+
+	// Optional injected pod exec client for testing (avoids real network I/O)
+	// If nil, runPodCopyWorker will create a real client
+	podExecClient splutil.PodExecClientImpl
 }
 
 // PipelinePhase represents one phase in the overall installation pipeline

--- a/pkg/splunk/enterprise/upgrade_test.go
+++ b/pkg/splunk/enterprise/upgrade_test.go
@@ -214,7 +214,7 @@ func TestUpgradePathValidation(t *testing.T) {
 		t.Errorf("applyMonitoringConsole should not have returned error; err=%v", err)
 	}
 
-	_, err = ApplyClusterManager(ctx, client, &cm)
+	_, err = ApplyClusterManager(ctx, client, &cm, nil)
 	// license manager statefulset is not created
 	if err != nil && !k8serrors.IsNotFound(err) {
 		t.Errorf("applyClusterManager should not have returned error; err=%v", err)
@@ -268,7 +268,7 @@ func TestUpgradePathValidation(t *testing.T) {
 		t.Errorf("lm is not in ready state")
 	}
 
-	_, err = ApplyClusterManager(ctx, client, &cm)
+	_, err = ApplyClusterManager(ctx, client, &cm, nil)
 	// lm statefulset should have been created by now, this should pass
 	if err != nil {
 		t.Errorf("applyClusterManager should not have returned error; err=%v", err)
@@ -279,7 +279,7 @@ func TestUpgradePathValidation(t *testing.T) {
 	updateStatefulSetsInTest(t, ctx, client, 1, fmt.Sprintf("splunk-%s-cluster-manager", cm.Name), cm.Namespace)
 	cm.Status.TelAppInstalled = true
 	// cluster manager is found  and creat
-	_, err = ApplyClusterManager(ctx, client, &cm)
+	_, err = ApplyClusterManager(ctx, client, &cm, nil)
 	// lm statefulset should have been created by now, this should pass
 	if err != nil {
 		t.Errorf("applyClusterManager should not have returned error; err=%v", err)
@@ -532,7 +532,7 @@ func TestUpgradePathValidation(t *testing.T) {
 	}
 
 	cm.Status.TelAppInstalled = true
-	_, err = ApplyClusterManager(ctx, client, &cm)
+	_, err = ApplyClusterManager(ctx, client, &cm, nil)
 	if err != nil {
 		t.Errorf("applyClusterManager after update should not have returned error; err=%v", err)
 	}
@@ -585,13 +585,13 @@ func TestUpgradePathValidation(t *testing.T) {
 	}
 
 	cm.Status.TelAppInstalled = true
-	_, err = ApplyClusterManager(ctx, client, &cm)
+	_, err = ApplyClusterManager(ctx, client, &cm, nil)
 	if err != nil {
 		t.Errorf("applyClusterManager after update should not have returned error; err=%v", err)
 	}
 
 	cm.Status.TelAppInstalled = true
-	_, err = ApplyClusterManager(ctx, client, &cm)
+	_, err = ApplyClusterManager(ctx, client, &cm, nil)
 	if err != nil {
 		t.Errorf("applyClusterManager after update should not have returned error; err=%v", err)
 	}

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -2503,7 +2503,7 @@ func loadFixture(t *testing.T, filename string) string {
 	if err != nil {
 		t.Fatalf("Failed to load fixture %s: %v", filename, err)
 	}
-	
+
 	// Compact the JSON to match the output from json.Marshal
 	var compactJSON bytes.Buffer
 	if err := json.Compact(&compactJSON, data); err != nil {

--- a/pkg/splunk/enterprise/util_test.go
+++ b/pkg/splunk/enterprise/util_test.go
@@ -3261,7 +3261,7 @@ func TestGetCurrentImage(t *testing.T) {
 		WithStatusSubresource(&enterpriseApi.SearchHeadCluster{})
 	client := builder.Build()
 	client.Create(ctx, &current)
-	_, err := ApplyClusterManager(ctx, client, &current)
+	_, err := ApplyClusterManager(ctx, client, &current, nil)
 	if err != nil {
 		t.Errorf("applyClusterManager should not have returned error; err=%v", err)
 	}

--- a/pkg/splunk/util/secrets.go
+++ b/pkg/splunk/util/secrets.go
@@ -34,7 +34,7 @@ import (
 )
 
 // GetSpecificSecretTokenFromPod retrieves a specific secret token's value from a Pod
-func GetSpecificSecretTokenFromPod(ctx context.Context, c splcommon.ControllerClient, PodName string, namespace string, secretToken string) (string, error) {
+func getSpecificSecretTokenFromPodImpl(ctx context.Context, c splcommon.ControllerClient, PodName string, namespace string, secretToken string) (string, error) {
 	// Get Pod data
 	secret, err := GetSecretFromPod(ctx, c, PodName, namespace)
 	if err != nil {
@@ -56,6 +56,9 @@ func GetSpecificSecretTokenFromPod(ctx context.Context, c splcommon.ControllerCl
 
 	return string(secret.Data[secretToken]), nil
 }
+
+// GetSpecificSecretTokenFromPod is a var function to allow mocking in tests
+var GetSpecificSecretTokenFromPod = getSpecificSecretTokenFromPodImpl
 
 // GetSecretFromPod retrieves secret data from a pod
 func GetSecretFromPod(ctx context.Context, c splcommon.ControllerClient, PodName string, namespace string) (*corev1.Secret, error) {

--- a/pkg/splunk/util/util.go
+++ b/pkg/splunk/util/util.go
@@ -228,8 +228,8 @@ type PodExecClient struct {
 	targetPodName string
 }
 
-// GetPodExecClient returns the client object used to execute pod exec commands
-func GetPodExecClient(client splcommon.ControllerClient, cr splcommon.MetaObject, targetPodName string) *PodExecClient {
+// getPodExecClientImpl is the actual implementation that creates a real PodExecClient
+func getPodExecClientImpl(client splcommon.ControllerClient, cr splcommon.MetaObject, targetPodName string) PodExecClientImpl {
 	return &PodExecClient{
 		client:        client,
 		cr:            cr,
@@ -237,6 +237,10 @@ func GetPodExecClient(client splcommon.ControllerClient, cr splcommon.MetaObject
 		targetPodName: targetPodName,
 	}
 }
+
+// GetPodExecClient is a var that can be mocked in tests to return a mock PodExecClient
+// By default it returns a real PodExecClient
+var GetPodExecClient = getPodExecClientImpl
 
 // suppressHarmlessErrorMessages suppresses harmless error messages
 func suppressHarmlessErrorMessages(values ...*string) {

--- a/pkg/splunk/util/util_test.go
+++ b/pkg/splunk/util/util_test.go
@@ -214,6 +214,18 @@ func TestDeepCopy(t *testing.T) {
 
 func TestPodExecCommand(t *testing.T) {
 	ctx := context.TODO()
+
+	// Mock podExecGetConfig to return a config with localhost as server
+	// This prevents the test from trying to connect to a real Kubernetes cluster
+	// and timing out. Instead, it will fail fast with connection refused.
+	savedPodExecGetConfig := podExecGetConfig
+	defer func() { podExecGetConfig = savedPodExecGetConfig }()
+	podExecGetConfig = func() (*rest.Config, error) {
+		return &rest.Config{
+			Host: "http://127.0.0.1:1", // Use invalid port for fast failure
+		}, nil
+	}
+
 	// Create pod
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/secret/manager_secret_m4_test.go
+++ b/test/secret/manager_secret_m4_test.go
@@ -17,8 +17,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 
 	enterpriseApi "github.com/splunk/splunk-operator/api/v4"

--- a/test/secret/manager_secret_s1_test.go
+++ b/test/secret/manager_secret_s1_test.go
@@ -19,8 +19,8 @@ import (
 
 	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 
-	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"

--- a/test/secret/secret_c3_test.go
+++ b/test/secret/secret_c3_test.go
@@ -19,8 +19,8 @@ import (
 
 	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 
-	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 
 	"github.com/splunk/splunk-operator/test/testenv"

--- a/test/secret/secret_m4_test.go
+++ b/test/secret/secret_m4_test.go
@@ -19,8 +19,8 @@ import (
 
 	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 
-	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 
 	"github.com/splunk/splunk-operator/test/testenv"

--- a/test/secret/secret_s1_test.go
+++ b/test/secret/secret_s1_test.go
@@ -19,8 +19,8 @@ import (
 
 	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 
-	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"

--- a/test/smartstore/manager_smartstore_test.go
+++ b/test/smartstore/manager_smartstore_test.go
@@ -7,8 +7,8 @@ import (
 
 	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 
-	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 
 	"github.com/splunk/splunk-operator/test/testenv"

--- a/test/smartstore/smartstore_test.go
+++ b/test/smartstore/smartstore_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 
 	enterpriseApiV3 "github.com/splunk/splunk-operator/api/v3"

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -17,8 +17,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 
 	"github.com/splunk/splunk-operator/test/testenv"


### PR DESCRIPTION
# Fix Unit Tests Using Real Network I/O

## Description

Unit tests were taking 30+ minutes to run because they were making real network calls - HTTP requests to Splunk REST APIs that don't exist in the test environment (5-second timeouts each) and Kubernetes pod exec commands trying to connect to real clusters (30-second timeouts). This PR fixes that by mocking out the network I/O functions.

The goal of this PR is only to shorten the execution time of the existing tests to speed up the development process.

## Key Changes

TL;DR: we mock out the network I/O functions!

### Production Code

- **pkg/splunk/enterprise/clustermaster.go**
  - Converted `PerformCmasterBundlePush` and `VerifyCMasterisMultisite` from regular functions to var functions so they can be mocked in tests

### Test Code

- **pkg/splunk/enterprise/clustermaster_test.go**
  - Added mocks for `VerifyCMasterisMultisite`, `GetPodExecClient`, and `PerformCmasterBundlePush`
  - Added `initGlobalResourceTracker()` call for app framework tests

- **pkg/splunk/enterprise/clustermanager_test.go**
  - Added mocks for `GetCMMultisiteEnvVarsCall`, `PerformCmBundlePush`, and `GetPodExecClient`

- **pkg/splunk/enterprise/standalone_test.go**
  - Added mocks for `GetAppsList` and `GetPodExecClient`
  - Added app download directory setup with cleanup

- **pkg/splunk/enterprise/indexercluster_test.go**
  - Added mocks for `VerifyRFPeers`, `GetSpecificSecretTokenFromPod`, `newIndexerClusterPodManager`, `GetAppsList`, and `GetPodExecClient`

- **pkg/splunk/enterprise/licensemanager_test.go**
  - Added mocks for `VerifyRFPeers`, `addTelApp`, `GetAppsList`, and `GetPodExecClient`

- **pkg/splunk/enterprise/licensemaster_test.go**
  - Added mocks for `VerifyCMasterisMultisite`, `VerifyRFPeers`, `addTelApp`, `GetAppsList`, and `GetPodExecClient`

- **pkg/splunk/enterprise/afwscheduler_test.go**
  - Added timing variable overrides to speed up worker loops
  - Added `GetPodExecClient` mock

- **pkg/splunk/util/util_test.go**
  - Added `podExecGetConfig` mock to return fast-failing config instead of real K8s config

## Testing and Verification

Ran the full test suite before and after:

| Test | Before | After |
|------|--------|-------|
| TestPodExecCommand | 150s | 0.01s |
| TestStandaloneWithReadyState | 77s | 2.6s |
| TestLicenseManagerWithReadyState | 78s | 4s |
| TestLicenseMasterWithReadyState | 86s | 2.14s |
| TestIndexerClusterWithReadyState | 78s | 3.5s |
| TestClusterMasterWitReadyState | 92s | 1.4s |
| TestApplyClusterMasterWithSmartstore | 90s | 0.00s |
| TestClusterManagerWitReadyState | 75s | 0.01s |
| TestInstallWorkerHandler | 150s | 6s |
| TestRunPodCopyWorker | 150s | 0.00s |
| TestPodCopyWorkerHandler | 751s | 0.05s |

**BEFORE**:

```text
coverage: 97.7% of statements
composite coverage: 86.0% of statements

Ginkgo ran 6 suites in 36m48.729625s
Test Suite Passed
```

**AFTER**:

```text
coverage: 97.3% of statements
composite coverage: 86.1% of statements

Ginkgo ran 6 suites in 4m50.211326625s
Test Suite Passed
```

No new tests added.

this PR fixes existing tests by only mocking network I/O.

Coverage impact: None. 

All mocked functions have their own dedicated unit tests (e.g., `TestPerformCmasterBundlePush`, `TestVerifyRFPeers`, `TestGetAppsList*`). The integration tests mock these functions because their purpose is to test the reconciliation flow, not the individual network functions.

## Future works
At the momemt, we are using the "var function" pattern - converting regular functions to package-level variables that can be swapped out in tests. 

While this gets the job done, IMO, it's not idea, and not a good practice:

- Global state can cause test pollution if we forget to restore the original function
- Every test needs boilerplate save/defer/restore code (because of the above reason)
- Functions like `VerifyCMasterisMultisite` that create internal dependencies (e.g., `splclient.NewSplunkClient`) can't be fully tested because the hardcoded dependencies aren't mockable
- Parallel test execution becomes risky

A better long-term approach would be **Dependency Injection** - passing dependencies as function parameters or struct fields. For example, instead of `VerifyCMasterisMultisite` hardcoding `splclient.NewSplunkClient`, it could accept a `NewSplunkClientFunc` parameter. 

This makes the code more testable, removes global state, and makes dependencies explicit. But that's a bigger refactor for another day.


## Related Issues
https://github.com/splunk/splunk-operator/issues/1636

## PR Checklist

- [x] Code changes adhere to the project's coding standards.
- [x] Relevant unit and integration tests are included.
- [x] Documentation has been updated accordingly.
- [x] All tests pass locally.
- [x] The PR description follows the project's guidelines.


