### PR TITLE
Amadeus patches: Advanced Statefulset scaling + Support for updating VolumeClaimTemplates

### DIFF
--- a/api/v4/common_types.go
+++ b/api/v4/common_types.go
@@ -112,6 +112,14 @@ type Spec struct {
 
 	// TopologySpreadConstraint https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
 	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
+
+	// FSGroupChangePolicy defines the policy for changing ownership and permission of the volume
+	// before being exposed inside the Pod. Valid values are "Always" and "OnRootMismatch".
+	// Default is "OnRootMismatch" for improved performance.
+	// Can be overridden by the operator.splunk.com/fs-group-change-policy annotation.
+	// +kubebuilder:validation:Enum=Always;OnRootMismatch
+	// +optional
+	FSGroupChangePolicy *corev1.PodFSGroupChangePolicy `json:"fsGroupChangePolicy,omitempty"`
 }
 
 // Phase is used to represent the current phase of a custom resource

--- a/pkg/splunk/common/statefulset_util.go
+++ b/pkg/splunk/common/statefulset_util.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2018-2022 Splunk Inc. All rights reserved.
+
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// MergeStatefulSetMetaUpdates compares and merges StatefulSet ObjectMeta (labels and annotations).
+// This does NOT trigger pod restarts since it only touches StatefulSet-level metadata.
+// Returns true if there were any changes.
+func MergeStatefulSetMetaUpdates(ctx context.Context, current, revised *metav1.ObjectMeta, name string) bool {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("MergeStatefulSetMetaUpdates").WithValues("name", name)
+	result := false
+
+	// Check Annotations - normalize nil to empty map for comparison
+	currentAnnotations := current.Annotations
+	if currentAnnotations == nil {
+		currentAnnotations = map[string]string{}
+	}
+	revisedAnnotations := revised.Annotations
+	if revisedAnnotations == nil {
+		revisedAnnotations = map[string]string{}
+	}
+	if !reflect.DeepEqual(currentAnnotations, revisedAnnotations) {
+		scopedLog.Info("StatefulSet Annotations differ",
+			"current", current.Annotations,
+			"revised", revised.Annotations)
+		current.Annotations = revised.Annotations
+		result = true
+	}
+
+	// Check Labels - normalize nil to empty map for comparison
+	currentLabels := current.Labels
+	if currentLabels == nil {
+		currentLabels = map[string]string{}
+	}
+	revisedLabels := revised.Labels
+	if revisedLabels == nil {
+		revisedLabels = map[string]string{}
+	}
+	if !reflect.DeepEqual(currentLabels, revisedLabels) {
+		scopedLog.Info("StatefulSet Labels differ",
+			"current", current.Labels,
+			"revised", revised.Labels)
+		current.Labels = revised.Labels
+		result = true
+	}
+
+	return result
+}

--- a/pkg/splunk/common/statefulset_util_test.go
+++ b/pkg/splunk/common/statefulset_util_test.go
@@ -1,0 +1,390 @@
+// Copyright (c) 2018-2022 Splunk Inc. All rights reserved.
+
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Helper function to create a base StatefulSet for testing
+func newTestStatefulSet(name, namespace string) *appsv1.StatefulSet {
+	var replicas int32 = 1
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      make(map[string]string),
+			Annotations: make(map[string]string),
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": name},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      make(map[string]string),
+					Annotations: make(map[string]string),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "splunk",
+							Image: "splunk/splunk:8.2.0",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("2"),
+									corev1.ResourceMemory: resource.MustParse("2Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestMergeStatefulSetMetaUpdates(t *testing.T) {
+	tests := []struct {
+		name                string
+		current             func() *metav1.ObjectMeta
+		revised             func() *metav1.ObjectMeta
+		expectedReturn      bool
+		expectedLabels      map[string]string
+		expectedAnnotations map[string]string
+	}{
+		{
+			name: "No changes - same labels and annotations",
+			current: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "splunk", "team": "x"},
+					Annotations: map[string]string{"note": "value"},
+				}
+			},
+			revised: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "splunk", "team": "x"},
+					Annotations: map[string]string{"note": "value"},
+				}
+			},
+			expectedReturn:      false,
+			expectedLabels:      map[string]string{"app": "splunk", "team": "x"},
+			expectedAnnotations: map[string]string{"note": "value"},
+		},
+		{
+			name: "Label added",
+			current: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "splunk"},
+					Annotations: map[string]string{},
+				}
+			},
+			revised: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "splunk", "team": "x"},
+					Annotations: map[string]string{},
+				}
+			},
+			expectedReturn:      true,
+			expectedLabels:      map[string]string{"app": "splunk", "team": "x"},
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name: "Label changed",
+			current: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "splunk", "team": "x"},
+					Annotations: map[string]string{},
+				}
+			},
+			revised: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "splunk", "team": "y"},
+					Annotations: map[string]string{},
+				}
+			},
+			expectedReturn:      true,
+			expectedLabels:      map[string]string{"app": "splunk", "team": "y"},
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name: "Label removed",
+			current: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "splunk", "team": "x", "env": "prod"},
+					Annotations: map[string]string{},
+				}
+			},
+			revised: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "splunk", "team": "x"},
+					Annotations: map[string]string{},
+				}
+			},
+			expectedReturn:      true,
+			expectedLabels:      map[string]string{"app": "splunk", "team": "x"},
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name: "Annotation added",
+			current: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "splunk"},
+					Annotations: map[string]string{},
+				}
+			},
+			revised: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "splunk"},
+					Annotations: map[string]string{"foo": "bar"},
+				}
+			},
+			expectedReturn:      true,
+			expectedLabels:      map[string]string{"app": "splunk"},
+			expectedAnnotations: map[string]string{"foo": "bar"},
+		},
+		{
+			name: "Annotation changed",
+			current: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "splunk"},
+					Annotations: map[string]string{"foo": "bar"},
+				}
+			},
+			revised: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "splunk"},
+					Annotations: map[string]string{"foo": "baz"},
+				}
+			},
+			expectedReturn:      true,
+			expectedLabels:      map[string]string{"app": "splunk"},
+			expectedAnnotations: map[string]string{"foo": "baz"},
+		},
+		{
+			name: "Both labels and annotations changed",
+			current: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "splunk", "team": "x"},
+					Annotations: map[string]string{"foo": "bar"},
+				}
+			},
+			revised: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "splunk", "team": "y"},
+					Annotations: map[string]string{"foo": "baz", "new": "annotation"},
+				}
+			},
+			expectedReturn:      true,
+			expectedLabels:      map[string]string{"app": "splunk", "team": "y"},
+			expectedAnnotations: map[string]string{"foo": "baz", "new": "annotation"},
+		},
+		{
+			name: "Nil labels in current - handles gracefully",
+			current: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      nil,
+					Annotations: map[string]string{},
+				}
+			},
+			revised: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"team": "x"},
+					Annotations: map[string]string{},
+				}
+			},
+			expectedReturn:      true,
+			expectedLabels:      map[string]string{"team": "x"},
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name: "Nil annotations in current - handles gracefully",
+			current: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "splunk"},
+					Annotations: nil,
+				}
+			},
+			revised: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "splunk"},
+					Annotations: map[string]string{"foo": "bar"},
+				}
+			},
+			expectedReturn:      true,
+			expectedLabels:      map[string]string{"app": "splunk"},
+			expectedAnnotations: map[string]string{"foo": "bar"},
+		},
+		{
+			name: "Nil labels in revised - handles gracefully",
+			current: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"team": "x"},
+					Annotations: map[string]string{},
+				}
+			},
+			revised: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      nil,
+					Annotations: map[string]string{},
+				}
+			},
+			expectedReturn:      true,
+			expectedLabels:      nil,
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name: "Both nil in current and revised - no change",
+			current: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      nil,
+					Annotations: nil,
+				}
+			},
+			revised: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      nil,
+					Annotations: nil,
+				}
+			},
+			expectedReturn:      false,
+			expectedLabels:      nil,
+			expectedAnnotations: nil,
+		},
+		{
+			name: "Empty maps vs nil - now considered equal (avoids false positive changes)",
+			current: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				}
+			},
+			revised: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      nil,
+					Annotations: nil,
+				}
+			},
+			expectedReturn:      false,               // nil and empty map are semantically equivalent
+			expectedLabels:      map[string]string{}, // current not modified when no real change
+			expectedAnnotations: map[string]string{}, // current not modified when no real change
+		},
+		{
+			name: "Multiple annotations added and removed",
+			current: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "splunk"},
+					Annotations: map[string]string{"old1": "val1", "old2": "val2"},
+				}
+			},
+			revised: func() *metav1.ObjectMeta {
+				return &metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "default",
+					Labels:      map[string]string{"app": "splunk"},
+					Annotations: map[string]string{"new1": "val1", "new2": "val2"},
+				}
+			},
+			expectedReturn:      true,
+			expectedLabels:      map[string]string{"app": "splunk"},
+			expectedAnnotations: map[string]string{"new1": "val1", "new2": "val2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			current := tt.current()
+			revised := tt.revised()
+
+			result := MergeStatefulSetMetaUpdates(ctx, current, revised, "test-sts")
+
+			if result != tt.expectedReturn {
+				t.Errorf("MergeStatefulSetMetaUpdates() returned %v, want %v", result, tt.expectedReturn)
+			}
+
+			if !reflect.DeepEqual(current.Labels, tt.expectedLabels) {
+				t.Errorf("After merge, Labels = %v, want %v", current.Labels, tt.expectedLabels)
+			}
+
+			if !reflect.DeepEqual(current.Annotations, tt.expectedAnnotations) {
+				t.Errorf("After merge, Annotations = %v, want %v", current.Annotations, tt.expectedAnnotations)
+			}
+		})
+	}
+}

--- a/pkg/splunk/common/types.go
+++ b/pkg/splunk/common/types.go
@@ -57,3 +57,13 @@ type StatefulSetPodManager interface {
 	// FinishUpgrade finishes rolling upgrade process; it returns an error if upgrade process can't be finished
 	FinishUpgrade(context.Context, int32) error
 }
+
+// K8EventPublisher is an interface for publishing Kubernetes events
+// This interface allows decoupling the event publishing logic from specific implementations
+type K8EventPublisher interface {
+	// Normal publishes a normal event to Kubernetes
+	Normal(ctx context.Context, reason, message string)
+
+	// Warning publishes a warning event to Kubernetes
+	Warning(ctx context.Context, reason, message string)
+}

--- a/pkg/splunk/common/util.go
+++ b/pkg/splunk/common/util.go
@@ -17,6 +17,7 @@ package common
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -29,6 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func init() {
@@ -47,23 +49,685 @@ func AsOwner(cr MetaObject, isController bool) metav1.OwnerReference {
 	}
 }
 
-// AppendParentMeta appends parent's metadata to a child
+// Prefix constants for selective metadata propagation.
+// These prefixes allow users to specify metadata that should only appear on specific resource types.
+//
+// Usage:
+//   - pod-only.prometheus.io/scrape: "true"  → appears as prometheus.io/scrape: "true" on pods only
+//   - sts-only.amadeus.com/priority: "high"  → appears as amadeus.com/priority: "high" on StatefulSet only
+const (
+	// podOnlyPrefix is stripped during Pod Template propagation.
+	// Example: "pod-only.prometheus.io/scrape" → "prometheus.io/scrape"
+	podOnlyPrefix = "pod-only."
+
+	// stsOnlyPrefix is stripped during StatefulSet propagation.
+	// Example: "sts-only.amadeus.com/priority" → "amadeus.com/priority"
+	stsOnlyPrefix = "sts-only."
+)
+
+// podTemplateExcludedPrefixes defines prefixes excluded from Pod Template metadata propagation.
+// Labels/annotations with these prefixes will NOT be copied from the CR to Pod Template.
+//
+// The exclusion rules are:
+//   - kubectl.kubernetes.io/*: kubectl-managed metadata (e.g., last-applied-configuration)
+//   - operator.splunk.com/*: Operator-internal metadata not meant for pods
+//   - sts-only.*: StatefulSet-only labels that should not propagate to pods
+//
+// Note: pod-only.* keys are NOT excluded - they are transformed (prefix stripped)
+// during propagation, allowing users to specify pod-specific metadata on the CR.
+var podTemplateExcludedPrefixes = []string{
+	"kubectl.kubernetes.io/",
+	"operator.splunk.com/",
+	stsOnlyPrefix, // StatefulSet-only labels don't go to pods
+}
+
+// statefulSetExcludedPrefixes defines prefixes excluded from StatefulSet ObjectMeta propagation.
+// Labels/annotations with these prefixes will NOT be copied from the CR to StatefulSet metadata.
+//
+// The exclusion rules are:
+//   - kubectl.kubernetes.io/*: kubectl-managed metadata (e.g., last-applied-configuration)
+//   - operator.splunk.com/*: Operator-internal metadata not meant for StatefulSet
+//   - pod-only.*: Pod-only labels that should not propagate to StatefulSet
+//
+// Note: sts-only.* keys are NOT excluded - they are transformed (prefix stripped)
+// during propagation, allowing users to specify StatefulSet-specific metadata on the CR.
+var statefulSetExcludedPrefixes = []string{
+	"kubectl.kubernetes.io/",
+	"operator.splunk.com/",
+	podOnlyPrefix, // Pod-only labels don't go to StatefulSet
+}
+
+// Tracking Annotations for Metadata Sync
+//
+// These annotation keys store JSON arrays of keys that were propagated from the CR (Custom Resource)
+// to child resources (StatefulSet, Pod Template). They enable "sync" semantics rather than
+// "append-only" semantics:
+//
+// SYNC BEHAVIOR (new):
+//   - Keys added to CR are propagated to child resources
+//   - Keys updated on CR are updated on child resources
+//   - Keys REMOVED from CR are REMOVED from child resources (if previously managed)
+//
+// APPEND-ONLY BEHAVIOR (old - used by AppendParentMeta):
+//   - Keys added to CR are propagated to child resources
+//   - Keys updated on CR may NOT update child resources (no-clobber)
+//   - Keys removed from CR are NOT removed from child resources
+//
+// By tracking which keys were propagated, the operator can distinguish between:
+//   - CR-managed keys: Can be safely removed when removed from CR
+//   - External keys: Applied by users/tools, must be preserved
+//
+// The annotations store sorted JSON arrays for deterministic comparison, e.g.:
+//
+//	["team","environment","cost-center"]
+const (
+	// ManagedCRLabelKeysAnnotation tracks which label keys were propagated from CR metadata.
+	// Value is a JSON array of label key strings, e.g., ["team","environment"].
+	// Used by SyncParentMetaToStatefulSet to identify keys that can be removed.
+	ManagedCRLabelKeysAnnotation = "operator.splunk.com/managed-cr-label-keys"
+
+	// ManagedCRAnnotationKeysAnnotation tracks which annotation keys were propagated from CR metadata.
+	// Value is a JSON array of annotation key strings.
+	// Used by SyncParentMetaToStatefulSet to identify keys that can be removed.
+	ManagedCRAnnotationKeysAnnotation = "operator.splunk.com/managed-cr-annotation-keys"
+)
+
+// GetManagedLabelKeys returns the list of label keys that were previously propagated from CR.
+// It parses the JSON array stored in the ManagedCRLabelKeysAnnotation.
+// Returns an empty slice if the annotation is missing, empty, or contains invalid JSON.
+func GetManagedLabelKeys(annotations map[string]string) []string {
+	if annotations == nil {
+		return []string{}
+	}
+	value, exists := annotations[ManagedCRLabelKeysAnnotation]
+	if !exists || value == "" {
+		return []string{}
+	}
+	var keys []string
+	if err := json.Unmarshal([]byte(value), &keys); err != nil {
+		return []string{}
+	}
+	return keys
+}
+
+// GetManagedAnnotationKeys returns the list of annotation keys that were previously propagated from CR.
+// It parses the JSON array stored in the ManagedCRAnnotationKeysAnnotation.
+// Returns an empty slice if the annotation is missing, empty, or contains invalid JSON.
+func GetManagedAnnotationKeys(annotations map[string]string) []string {
+	if annotations == nil {
+		return []string{}
+	}
+	value, exists := annotations[ManagedCRAnnotationKeysAnnotation]
+	if !exists || value == "" {
+		return []string{}
+	}
+	var keys []string
+	if err := json.Unmarshal([]byte(value), &keys); err != nil {
+		return []string{}
+	}
+	return keys
+}
+
+// SetManagedLabelKeys stores the list of label keys that were propagated from CR.
+// It serializes the keys as a sorted JSON array and stores it in ManagedCRLabelKeysAnnotation.
+// If keys is nil or empty, the annotation is removed.
+// The annotations map must not be nil.
+func SetManagedLabelKeys(annotations map[string]string, keys []string) {
+	if annotations == nil {
+		return
+	}
+	if len(keys) == 0 {
+		delete(annotations, ManagedCRLabelKeysAnnotation)
+		return
+	}
+	// Sort keys for deterministic output
+	sortedKeys := make([]string, len(keys))
+	copy(sortedKeys, keys)
+	sort.Strings(sortedKeys)
+	// Serialize to JSON
+	data, err := json.Marshal(sortedKeys)
+	if err != nil {
+		return
+	}
+	annotations[ManagedCRLabelKeysAnnotation] = string(data)
+}
+
+// SetManagedAnnotationKeys stores the list of annotation keys that were propagated from CR.
+// It serializes the keys as a sorted JSON array and stores it in ManagedCRAnnotationKeysAnnotation.
+// If keys is nil or empty, the annotation is removed.
+// The annotations map must not be nil.
+func SetManagedAnnotationKeys(annotations map[string]string, keys []string) {
+	if annotations == nil {
+		return
+	}
+	if len(keys) == 0 {
+		delete(annotations, ManagedCRAnnotationKeysAnnotation)
+		return
+	}
+	// Sort keys for deterministic output
+	sortedKeys := make([]string, len(keys))
+	copy(sortedKeys, keys)
+	sort.Strings(sortedKeys)
+	// Serialize to JSON
+	data, err := json.Marshal(sortedKeys)
+	if err != nil {
+		return
+	}
+	annotations[ManagedCRAnnotationKeysAnnotation] = string(data)
+}
+
+// hasExcludedPrefix checks if key starts with any excluded prefix
+func hasExcludedPrefix(key string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsManagedKey returns true if a key is "managed" (can be propagated from CR).
+// A key is managed if it does NOT have any of the excluded prefixes.
+//
+// Managed keys are user-defined labels/annotations that should be synced to child resources.
+// Examples of managed keys:
+//   - "team" (plain user label)
+//   - "environment" (plain user label)
+//   - "pod.operator.splunk.com/custom" (transformed during propagation)
+//
+// Examples of non-managed keys:
+//   - "kubectl.kubernetes.io/last-applied-configuration" (kubectl internal)
+//   - "operator.splunk.com/finalizer" (operator internal)
+func IsManagedKey(key string, excludedPrefixes []string) bool {
+	return !hasExcludedPrefix(key, excludedPrefixes)
+}
+
+// IsProtectedKey returns true if a key must be preserved and not removed during sync.
+//
+// A key is protected if it:
+//   - Is part of the selector labels (used for pod selection by StatefulSet)
+//   - Has an excluded prefix (operator-managed or system labels)
+//
+// Protected keys are NEVER removed during sync, even if they were previously managed.
+// This prevents breaking StatefulSet pod selection which relies on immutable selectors.
+//
+// Note: In practice, selector labels shouldn't appear in managed key lists because
+// they are set by the operator, not propagated from CR metadata. This is a safety check.
+func IsProtectedKey(key string, selectorLabels map[string]string, excludedPrefixes []string) bool {
+	// Key is protected if it's in selector labels
+	if _, exists := selectorLabels[key]; exists {
+		return true
+	}
+	// Key is protected if it has an excluded prefix
+	return hasExcludedPrefix(key, excludedPrefixes)
+}
+
+// stripTargetPrefix removes the target prefix from a key if present.
+// Returns the transformed key and true if transformation occurred,
+// or the original key and false if no transformation was needed.
+//
+// This enables users to apply metadata selectively to specific resource types
+// using a simple prefix-stripping pattern:
+//
+// Example transformations:
+//   - "pod-only.prometheus.io/scrape" → "prometheus.io/scrape" (for Pod Template)
+//   - "pod-only.istio.io/inject" → "istio.io/inject" (for Pod Template)
+//   - "sts-only.amadeus.com/priority" → "amadeus.com/priority" (for StatefulSet)
+//
+// Use case: A user wants a label only on pods, not on the StatefulSet:
+//
+//	apiVersion: enterprise.splunk.com/v4
+//	kind: Standalone
+//	metadata:
+//	  labels:
+//	    pod-only.prometheus.io/scrape: "true"  # Only appears on pods as prometheus.io/scrape
+func stripTargetPrefix(key, prefix string) (string, bool) {
+	if strings.HasPrefix(key, prefix) {
+		return key[len(prefix):], true
+	}
+	return key, false
+}
+
+// AppendParentMeta appends parent's metadata to a child (typically Pod Template).
+// This function uses APPEND-ONLY semantics - it only adds keys that don't exist on the child.
+//
+// Behavior:
+//   - Excludes labels/annotations with excluded prefixes (kubectl.kubernetes.io/*, operator.splunk.com/*, sts-only.*)
+//   - Transforms pod-only.* keys by stripping the prefix (e.g., pod-only.prometheus.io/scrape → prometheus.io/scrape)
+//   - Does NOT overwrite existing keys on child (no-clobber)
+//   - Does NOT remove keys from child that are removed from parent
+//
+// Conflict Resolution:
+//   - If both pod-only.XXXX/YYYY and explicit XXXX/YYYY exist on parent, the prefixed key wins (more specific)
+//
+// For full sync semantics (including key removal), use SyncParentMetaToPodTemplate instead.
+//
+// Deprecated: Use SyncParentMetaToPodTemplate for new code that needs sync semantics.
+// This function is retained for backward compatibility and for cases where
+// append-only behavior is explicitly desired.
 func AppendParentMeta(child, parent metav1.Object) {
-	// append labels from parent
+	// append labels from parent (excluding StatefulSet-only prefixes, transforming pod prefix)
 	for k, v := range parent.GetLabels() {
-		// prevent clobber of labels added by operator
-		if _, ok := child.GetLabels()[k]; !ok {
-			child.GetLabels()[k] = v
+		finalKey := k
+		wasTransformed := false
+
+		// Transform pod-only.* by stripping the prefix
+		// Example: pod-only.prometheus.io/scrape → prometheus.io/scrape
+		if newKey, transformed := stripTargetPrefix(k, podOnlyPrefix); transformed {
+			finalKey = newKey
+			wasTransformed = true
+			// Conflict resolution: prefixed key wins over explicit key (more specific)
+			// Don't skip - we'll set the value below, overwriting any explicit key
+		}
+
+		// Skip if child already has this key (no clobber) - but allow transformed keys to win
+		if _, ok := child.GetLabels()[finalKey]; ok && !wasTransformed {
+			continue
+		}
+
+		// For transformed keys, we intentionally propagate them
+		// For non-transformed keys, apply standard exclusion logic
+		if !wasTransformed && hasExcludedPrefix(k, podTemplateExcludedPrefixes) {
+			continue
+		}
+
+		child.GetLabels()[finalKey] = v
+	}
+
+	// append annotations from parent (excluding StatefulSet-only prefixes, transforming pod prefix)
+	for k, v := range parent.GetAnnotations() {
+		finalKey := k
+		wasTransformed := false
+
+		// Transform pod-only.* by stripping the prefix
+		// Example: pod-only.prometheus.io/scrape → prometheus.io/scrape
+		if newKey, transformed := stripTargetPrefix(k, podOnlyPrefix); transformed {
+			finalKey = newKey
+			wasTransformed = true
+			// Conflict resolution: prefixed key wins over explicit key (more specific)
+			// Don't skip - we'll set the value below, overwriting any explicit key
+		}
+
+		// Skip if child already has this key (no clobber) - but allow transformed keys to win
+		if _, ok := child.GetAnnotations()[finalKey]; ok && !wasTransformed {
+			continue
+		}
+
+		// For transformed keys, we intentionally propagate them
+		// For non-transformed keys, apply standard exclusion logic
+		if !wasTransformed && hasExcludedPrefix(k, podTemplateExcludedPrefixes) {
+			continue
+		}
+
+		child.GetAnnotations()[finalKey] = v
+	}
+}
+
+// ComputeDesiredPodTemplateKeys calculates the labels and annotations from parent (CR)
+// that are eligible for propagation to Pod Template.
+// It applies prefix filtering (excludes kubectl.kubernetes.io/*, operator.splunk.com/*, sts-only.*)
+// and prefix transformation (pod-only.* → prefix stripped, e.g., pod-only.prometheus.io/scrape → prometheus.io/scrape).
+//
+// Conflict Resolution:
+//   - If both pod-only.XXXX/YYYY and explicit XXXX/YYYY exist on parent, the prefixed key wins (more specific)
+//
+// Returns maps of desired labels and annotations with transformed keys.
+func ComputeDesiredPodTemplateKeys(parent metav1.Object) (labels map[string]string, annotations map[string]string) {
+	labels = make(map[string]string)
+	annotations = make(map[string]string)
+
+	// Process labels - first pass: collect all non-prefixed keys
+	for k, v := range parent.GetLabels() {
+		// Skip keys with excluded prefixes
+		if hasExcludedPrefix(k, podTemplateExcludedPrefixes) {
+			continue
+		}
+		// Skip pod-only.* keys in first pass (handled in second pass)
+		if strings.HasPrefix(k, podOnlyPrefix) {
+			continue
+		}
+		labels[k] = v
+	}
+
+	// Process labels - second pass: add transformed pod-only.* keys (prefixed keys win as more specific)
+	for k, v := range parent.GetLabels() {
+		if newKey, transformed := stripTargetPrefix(k, podOnlyPrefix); transformed {
+			// Conflict resolution: prefixed key wins over explicit key (more specific)
+			labels[newKey] = v
 		}
 	}
 
-	// append annotations from parent
+	// Process annotations - first pass: collect all non-prefixed keys
 	for k, v := range parent.GetAnnotations() {
-		// ignore Annotations set by kubectl
-		// AND prevent clobber of annotations added by operator
-		if _, ok := child.GetAnnotations()[k]; !ok && !strings.HasPrefix(k, "kubectl.kubernetes.io/") {
-			child.GetAnnotations()[k] = v
+		// Skip keys with excluded prefixes
+		if hasExcludedPrefix(k, podTemplateExcludedPrefixes) {
+			continue
 		}
+		// Skip pod-only.* keys in first pass (handled in second pass)
+		if strings.HasPrefix(k, podOnlyPrefix) {
+			continue
+		}
+		annotations[k] = v
+	}
+
+	// Process annotations - second pass: add transformed pod-only.* keys (prefixed keys win as more specific)
+	for k, v := range parent.GetAnnotations() {
+		if newKey, transformed := stripTargetPrefix(k, podOnlyPrefix); transformed {
+			// Conflict resolution: prefixed key wins over explicit key (more specific)
+			annotations[newKey] = v
+		}
+	}
+
+	return labels, annotations
+}
+
+// SyncParentMeta synchronizes parent (CR) metadata to child (Pod Template) with full sync semantics.
+// Unlike AppendParentMeta which only adds, this function also removes keys that were previously
+// managed but no longer exist on the parent.
+//
+// Parameters:
+//   - ctx: Context for logging
+//   - child: The child object (Pod Template) whose metadata will be updated
+//   - parent: The parent object (CR) that is the source of truth for metadata
+//   - protectedLabels: Labels that must not be overwritten by parent metadata (typically selector labels).
+//     These are labels set by the operator that must match the StatefulSet's immutable selector.
+//     If a parent label key exists in protectedLabels, it will be skipped during propagation.
+//   - previousManagedLabels: Keys that were previously propagated from CR (for removal detection)
+//   - previousManagedAnnotations: Keys that were previously propagated from CR (for removal detection)
+//
+// Returns:
+//   - newManagedLabels: Keys that are now managed (currently propagated from CR)
+//   - newManagedAnnotations: Keys that are now managed (currently propagated from CR)
+func SyncParentMetaToPodTemplate(ctx context.Context, child, parent metav1.Object, protectedLabels map[string]string, previousManagedLabels, previousManagedAnnotations []string) (newManagedLabels, newManagedAnnotations []string) {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("SyncParentMetaToPodTemplate")
+
+	// Compute desired keys from parent
+	desiredLabels, desiredAnnotations := ComputeDesiredPodTemplateKeys(parent)
+
+	// Initialize child maps if nil
+	if child.GetLabels() == nil {
+		child.SetLabels(make(map[string]string))
+	}
+	if child.GetAnnotations() == nil {
+		child.SetAnnotations(make(map[string]string))
+	}
+
+	childLabels := child.GetLabels()
+	childAnnotations := child.GetAnnotations()
+
+	// Create sets for efficient lookup
+	previousLabelSet := make(map[string]bool)
+	for _, k := range previousManagedLabels {
+		previousLabelSet[k] = true
+	}
+	previousAnnotationSet := make(map[string]bool)
+	for _, k := range previousManagedAnnotations {
+		previousAnnotationSet[k] = true
+	}
+
+	// Track changes for logging
+	labelsAdded, labelsUpdated, labelsRemoved := 0, 0, 0
+	annotationsAdded, annotationsUpdated, annotationsRemoved := 0, 0, 0
+
+	// Sync labels: add/update desired keys, but skip protected labels
+	for k, v := range desiredLabels {
+		// Skip protected labels - these must not be overwritten by CR metadata
+		// Protected labels are typically selector labels set by the operator
+		if _, isProtected := protectedLabels[k]; isProtected {
+			continue
+		}
+		if existing, exists := childLabels[k]; exists {
+			if existing != v {
+				labelsUpdated++
+			}
+		} else {
+			labelsAdded++
+		}
+		childLabels[k] = v
+	}
+
+	// Sync labels: remove previously managed keys that are no longer desired
+	// Skip protected labels - they must never be removed even if they were in previousManagedLabels
+	for _, k := range previousManagedLabels {
+		if _, isProtected := protectedLabels[k]; isProtected {
+			continue
+		}
+		if _, stillDesired := desiredLabels[k]; !stillDesired {
+			delete(childLabels, k)
+			labelsRemoved++
+		}
+	}
+
+	// Sync annotations: add/update desired keys
+	for k, v := range desiredAnnotations {
+		if existing, exists := childAnnotations[k]; exists {
+			if existing != v {
+				annotationsUpdated++
+			}
+		} else {
+			annotationsAdded++
+		}
+		childAnnotations[k] = v
+	}
+
+	// Sync annotations: remove previously managed keys that are no longer desired
+	for _, k := range previousManagedAnnotations {
+		if _, stillDesired := desiredAnnotations[k]; !stillDesired {
+			delete(childAnnotations, k)
+			annotationsRemoved++
+		}
+	}
+
+	// Build list of currently managed keys (excluding protected labels)
+	newManagedLabels = make([]string, 0, len(desiredLabels))
+	for k := range desiredLabels {
+		// Don't track protected labels as "managed" since we didn't propagate them
+		if _, isProtected := protectedLabels[k]; isProtected {
+			continue
+		}
+		newManagedLabels = append(newManagedLabels, k)
+	}
+	sort.Strings(newManagedLabels)
+
+	newManagedAnnotations = make([]string, 0, len(desiredAnnotations))
+	for k := range desiredAnnotations {
+		newManagedAnnotations = append(newManagedAnnotations, k)
+	}
+	sort.Strings(newManagedAnnotations)
+
+	// Log summary of changes (Info for removals, Debug for adds/updates)
+	if labelsRemoved > 0 || annotationsRemoved > 0 {
+		scopedLog.Info("Pod template metadata sync removed keys",
+			"labelsRemoved", labelsRemoved,
+			"annotationsRemoved", annotationsRemoved)
+	}
+	if labelsAdded > 0 || labelsUpdated > 0 || annotationsAdded > 0 || annotationsUpdated > 0 {
+		scopedLog.V(1).Info("Pod template metadata sync added/updated keys",
+			"labelsAdded", labelsAdded,
+			"labelsUpdated", labelsUpdated,
+			"annotationsAdded", annotationsAdded,
+			"annotationsUpdated", annotationsUpdated)
+	}
+
+	return newManagedLabels, newManagedAnnotations
+}
+
+// ComputeDesiredStatefulSetKeys calculates the labels and annotations from parent (CR)
+// that are eligible for propagation to StatefulSet ObjectMeta.
+// It applies prefix filtering (excludes kubectl.kubernetes.io/*, operator.splunk.com/*, pod-only.*)
+// and prefix transformation (sts-only.* → prefix stripped, e.g., sts-only.amadeus.com/priority → amadeus.com/priority).
+//
+// Conflict Resolution:
+//   - If both sts-only.XXXX/YYYY and explicit XXXX/YYYY exist on parent, the prefixed key wins (more specific)
+//
+// Returns maps of desired labels and annotations with transformed keys.
+func ComputeDesiredStatefulSetKeys(parent metav1.Object) (labels map[string]string, annotations map[string]string) {
+	labels = make(map[string]string)
+	annotations = make(map[string]string)
+
+	// Process labels - first pass: collect all non-prefixed keys
+	for k, v := range parent.GetLabels() {
+		// Skip keys with excluded prefixes
+		if hasExcludedPrefix(k, statefulSetExcludedPrefixes) {
+			continue
+		}
+		// Skip sts-only.* keys in first pass (handled in second pass)
+		if strings.HasPrefix(k, stsOnlyPrefix) {
+			continue
+		}
+		labels[k] = v
+	}
+
+	// Process labels - second pass: add transformed sts-only.* keys (prefixed keys win as more specific)
+	for k, v := range parent.GetLabels() {
+		if newKey, transformed := stripTargetPrefix(k, stsOnlyPrefix); transformed {
+			// Conflict resolution: prefixed key wins over explicit key (more specific)
+			labels[newKey] = v
+		}
+	}
+
+	// Process annotations - first pass: collect all non-prefixed keys
+	for k, v := range parent.GetAnnotations() {
+		// Skip keys with excluded prefixes
+		if hasExcludedPrefix(k, statefulSetExcludedPrefixes) {
+			continue
+		}
+		// Skip sts-only.* keys in first pass (handled in second pass)
+		if strings.HasPrefix(k, stsOnlyPrefix) {
+			continue
+		}
+		annotations[k] = v
+	}
+
+	// Process annotations - second pass: add transformed sts-only.* keys (prefixed keys win as more specific)
+	for k, v := range parent.GetAnnotations() {
+		if newKey, transformed := stripTargetPrefix(k, stsOnlyPrefix); transformed {
+			// Conflict resolution: prefixed key wins over explicit key (more specific)
+			annotations[newKey] = v
+		}
+	}
+
+	return labels, annotations
+}
+
+// SyncParentMetaToStatefulSet synchronizes parent (CR) metadata to StatefulSet ObjectMeta with full sync semantics.
+// Unlike AppendParentMetaToStatefulSet which only adds, this function also removes keys that were previously
+// managed but no longer exist on the parent.
+//
+// Parameters:
+//   - ctx: Context for logging
+//   - child: The StatefulSet whose metadata will be updated
+//   - parent: The parent object (CR) that is the source of truth for metadata
+//   - selectorLabels: Labels used for pod selection that must never be removed
+//
+// This function:
+//   - Reads previous managed keys from child's annotations (using GetManagedLabelKeys/GetManagedAnnotationKeys)
+//   - Computes desired keys from parent using ComputeDesiredStatefulSetKeys
+//   - Adds/updates desired keys
+//   - Removes keys that are in previousManaged but not in desired (respecting protected keys)
+//   - Updates managed key tracking annotations (using SetManagedLabelKeys/SetManagedAnnotationKeys)
+func SyncParentMetaToStatefulSet(ctx context.Context, child, parent metav1.Object, selectorLabels map[string]string) {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("SyncParentMetaToStatefulSet").WithValues(
+		"namespace", child.GetNamespace(),
+		"name", child.GetName())
+
+	// Initialize child maps if nil
+	if child.GetLabels() == nil {
+		child.SetLabels(make(map[string]string))
+	}
+	if child.GetAnnotations() == nil {
+		child.SetAnnotations(make(map[string]string))
+	}
+
+	childLabels := child.GetLabels()
+	childAnnotations := child.GetAnnotations()
+
+	// Read previous managed keys from child's annotations
+	previousManagedLabels := GetManagedLabelKeys(childAnnotations)
+	previousManagedAnnotations := GetManagedAnnotationKeys(childAnnotations)
+
+	// Compute desired keys from parent
+	desiredLabels, desiredAnnotations := ComputeDesiredStatefulSetKeys(parent)
+
+	// Track changes for logging
+	labelsAdded, labelsUpdated, labelsRemoved := 0, 0, 0
+	annotationsAdded, annotationsUpdated, annotationsRemoved := 0, 0, 0
+
+	// Sync labels: add/update desired keys
+	for k, v := range desiredLabels {
+		if existing, exists := childLabels[k]; exists {
+			if existing != v {
+				labelsUpdated++
+			}
+		} else {
+			labelsAdded++
+		}
+		childLabels[k] = v
+	}
+
+	// Sync labels: remove previously managed keys that are no longer desired
+	// Only protect selector labels - managed keys are removable even with excluded prefixes
+	// because they were put there by us from CR metadata (possibly transformed)
+	for _, k := range previousManagedLabels {
+		if _, stillDesired := desiredLabels[k]; !stillDesired {
+			// Only protect selector labels - they must never be removed
+			if _, isSelectorLabel := selectorLabels[k]; !isSelectorLabel {
+				delete(childLabels, k)
+				labelsRemoved++
+			}
+		}
+	}
+
+	// Sync annotations: add/update desired keys
+	for k, v := range desiredAnnotations {
+		if existing, exists := childAnnotations[k]; exists {
+			if existing != v {
+				annotationsUpdated++
+			}
+		} else {
+			annotationsAdded++
+		}
+		childAnnotations[k] = v
+	}
+
+	// Sync annotations: remove previously managed keys that are no longer desired
+	// Annotations don't have selector label concerns, so all managed keys are removable
+	for _, k := range previousManagedAnnotations {
+		if _, stillDesired := desiredAnnotations[k]; !stillDesired {
+			delete(childAnnotations, k)
+			annotationsRemoved++
+		}
+	}
+
+	// Build list of currently managed keys
+	newManagedLabels := make([]string, 0, len(desiredLabels))
+	for k := range desiredLabels {
+		newManagedLabels = append(newManagedLabels, k)
+	}
+
+	newManagedAnnotations := make([]string, 0, len(desiredAnnotations))
+	for k := range desiredAnnotations {
+		newManagedAnnotations = append(newManagedAnnotations, k)
+	}
+
+	// Update managed key tracking annotations
+	SetManagedLabelKeys(childAnnotations, newManagedLabels)
+	SetManagedAnnotationKeys(childAnnotations, newManagedAnnotations)
+
+	// Log summary of changes (Info for removals, Debug for adds/updates)
+	if labelsRemoved > 0 || annotationsRemoved > 0 {
+		scopedLog.Info("StatefulSet metadata sync removed keys",
+			"labelsRemoved", labelsRemoved,
+			"annotationsRemoved", annotationsRemoved)
+	}
+	if labelsAdded > 0 || labelsUpdated > 0 || annotationsAdded > 0 || annotationsUpdated > 0 {
+		scopedLog.V(1).Info("StatefulSet metadata sync added/updated keys",
+			"labelsAdded", labelsAdded,
+			"labelsUpdated", labelsUpdated,
+			"annotationsAdded", annotationsAdded,
+			"annotationsUpdated", annotationsUpdated)
 	}
 }
 

--- a/pkg/splunk/enterprise/afwscheduler_test.go
+++ b/pkg/splunk/enterprise/afwscheduler_test.go
@@ -110,7 +110,7 @@ func TestCreateAndAddPipelineWorker(t *testing.T) {
 	}
 
 	client := spltest.NewMockClient()
-	_, err := splctrl.ApplyStatefulSet(ctx, client, sts)
+	_, err := splctrl.ApplyStatefulSet(ctx, client, sts, nil)
 	if err != nil {
 		t.Errorf("unable to apply statefulset")
 	}
@@ -688,7 +688,7 @@ func TestPhaseManagersTermination(t *testing.T) {
 		},
 	}
 
-	_, err := splctrl.ApplyStatefulSet(ctx, c, sts)
+	_, err := splctrl.ApplyStatefulSet(ctx, c, sts, nil)
 	if err != nil {
 		t.Errorf("unable to apply statefulset")
 	}
@@ -784,7 +784,7 @@ func TestPhaseManagersMsgChannels(t *testing.T) {
 	client.AddObject(pod)
 
 	// Create the statefulset
-	_, err := splctrl.ApplyStatefulSet(ctx, client, sts)
+	_, err := splctrl.ApplyStatefulSet(ctx, client, sts, nil)
 	if err != nil {
 		t.Errorf("unable to apply statefulset")
 	}
@@ -1313,7 +1313,7 @@ func TestAfwGetReleventStatefulsetByKind(t *testing.T) {
 		},
 	}
 
-	_, err := splctrl.ApplyStatefulSet(ctx, c, &current)
+	_, err := splctrl.ApplyStatefulSet(ctx, c, &current, nil)
 	if err != nil {
 		return
 	}
@@ -1330,7 +1330,7 @@ func TestAfwGetReleventStatefulsetByKind(t *testing.T) {
 		},
 	}
 
-	_, _ = splctrl.ApplyStatefulSet(ctx, c, &current)
+	_, _ = splctrl.ApplyStatefulSet(ctx, c, &current, nil)
 	if afwGetReleventStatefulsetByKind(ctx, &cr, c) == nil {
 		t.Errorf("Unable to get the sts for SHC deployer")
 	}
@@ -1344,7 +1344,7 @@ func TestAfwGetReleventStatefulsetByKind(t *testing.T) {
 		},
 	}
 
-	_, _ = splctrl.ApplyStatefulSet(ctx, c, &current)
+	_, _ = splctrl.ApplyStatefulSet(ctx, c, &current, nil)
 	if afwGetReleventStatefulsetByKind(ctx, &cr, c) == nil {
 		t.Errorf("Unable to get the sts for SHC deployer")
 	}
@@ -1358,7 +1358,7 @@ func TestAfwGetReleventStatefulsetByKind(t *testing.T) {
 		},
 	}
 
-	_, _ = splctrl.ApplyStatefulSet(ctx, c, &current)
+	_, _ = splctrl.ApplyStatefulSet(ctx, c, &current, nil)
 	if afwGetReleventStatefulsetByKind(ctx, &cr, c) == nil {
 		t.Errorf("Unable to get the sts for SHC deployer")
 	}
@@ -3656,7 +3656,7 @@ func TestNeedToRunClusterScopedPlaybook(t *testing.T) {
 	}
 
 	client := spltest.NewMockClient()
-	_, err := splctrl.ApplyStatefulSet(ctx, client, sts)
+	_, err := splctrl.ApplyStatefulSet(ctx, client, sts, nil)
 	if err != nil {
 		t.Errorf("unable to apply statefulset")
 	}
@@ -3943,7 +3943,7 @@ func TestInstallWorkerHandler(t *testing.T) {
 		},
 	}
 
-	_, err := splctrl.ApplyStatefulSet(ctx, client, sts)
+	_, err := splctrl.ApplyStatefulSet(ctx, client, sts, nil)
 	if err != nil {
 		t.Errorf("unable to apply statefulset")
 	}
@@ -4133,7 +4133,7 @@ func TestAfwSchedulerEntry(t *testing.T) {
 	}
 
 	client := spltest.NewMockClient()
-	_, err := splctrl.ApplyStatefulSet(ctx, client, sts)
+	_, err := splctrl.ApplyStatefulSet(ctx, client, sts, nil)
 	if err != nil {
 		t.Errorf("unable to apply statefulset")
 	}

--- a/pkg/splunk/enterprise/configuration.go
+++ b/pkg/splunk/enterprise/configuration.go
@@ -98,6 +98,43 @@ func getSplunkLabels(instanceIdentifier string, instanceType InstanceType, partO
 	return labels
 }
 
+// getFSGroupChangePolicy returns the fsGroupChangePolicy to use based on precedence:
+// 1. Annotation value (if valid)
+// 2. Spec field value (if set)
+// 3. Default value (OnRootMismatch)
+// Invalid annotation values are logged as warnings and ignored.
+func getFSGroupChangePolicy(ctx context.Context, annotations map[string]string, specPolicy *corev1.PodFSGroupChangePolicy) *corev1.PodFSGroupChangePolicy {
+	reqLogger := log.FromContext(ctx)
+
+	// Check annotation first (highest precedence)
+	if annotations != nil {
+		if annotationValue, exists := annotations[splctrl.FSGroupChangePolicyAnnotation]; exists {
+			switch annotationValue {
+			case string(corev1.FSGroupChangeAlways):
+				policy := corev1.FSGroupChangeAlways
+				return &policy
+			case string(corev1.FSGroupChangeOnRootMismatch):
+				policy := corev1.FSGroupChangeOnRootMismatch
+				return &policy
+			default:
+				reqLogger.Info("Invalid fsGroupChangePolicy annotation value, falling back to spec or default",
+					"annotation", splctrl.FSGroupChangePolicyAnnotation,
+					"value", annotationValue,
+					"validValues", []string{"Always", "OnRootMismatch"})
+			}
+		}
+	}
+
+	// Check spec field (second precedence)
+	if specPolicy != nil {
+		return specPolicy
+	}
+
+	// Return default (lowest precedence)
+	defaultPolicy := corev1.FSGroupChangeOnRootMismatch
+	return &defaultPolicy
+}
+
 // getSplunkVolumeClaims returns a standard collection of Kubernetes volume claims.
 func getSplunkVolumeClaims(cr splcommon.MetaObject, spec *enterpriseApi.CommonSplunkSpec, labels map[string]string, volumeType string, adminManagedPV bool) (corev1.PersistentVolumeClaim, error) {
 	var storageCapacity resource.Quantity
@@ -903,12 +940,12 @@ func updateSplunkPodTemplateWithConfig(ctx context.Context, client splcommon.Con
 	runAsUser := int64(41812)
 	fsGroup := int64(41812)
 	runAsNonRoot := true
-	fsGroupChangePolicy := corev1.FSGroupChangeOnRootMismatch
+	fsGroupChangePolicy := getFSGroupChangePolicy(ctx, cr.GetAnnotations(), spec.FSGroupChangePolicy)
 	podTemplateSpec.Spec.SecurityContext = &corev1.PodSecurityContext{
 		RunAsUser:           &runAsUser,
 		FSGroup:             &fsGroup,
 		RunAsNonRoot:        &runAsNonRoot,
-		FSGroupChangePolicy: &fsGroupChangePolicy,
+		FSGroupChangePolicy: fsGroupChangePolicy,
 	}
 
 	livenessProbe := getLivenessProbe(ctx, cr, instanceType, spec)

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -36,7 +36,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	rclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -820,6 +819,10 @@ func (mgr *indexerClusterPodManager) Update(ctx context.Context, c splcommon.Con
 }
 
 // PrepareScaleDown for indexerClusterPodManager prepares indexer pod to be removed via scale down event; it returns true when ready
+// This method queries the Cluster Manager directly for fresh peer state to avoid race conditions
+// where the peer status shows "GracefulShutdown" but is_searchable is still true (peer still in committed generation).
+// Splunk CM will reject removal of peers that are still searchable with:
+// "Peer cannot be removed. It is currently in the latest committed generation."
 func (mgr *indexerClusterPodManager) PrepareScaleDown(ctx context.Context, n int32) (bool, error) {
 	// first, decommission indexer peer with enforceCounts=true; this will rebalance buckets across other peers
 	complete, err := mgr.decommission(ctx, n, true)
@@ -830,9 +833,37 @@ func (mgr *indexerClusterPodManager) PrepareScaleDown(ctx context.Context, n int
 		return false, nil
 	}
 
-	// next, remove the peer
+	peerName := GetSplunkStatefulsetPodName(SplunkIndexer, mgr.cr.GetName(), n)
+
+	// Query CM directly for fresh peer state (CR status may be stale)
+	peers, err := GetClusterManagerPeersCall(ctx, mgr)
+	if err != nil {
+		return false, fmt.Errorf("failed to query Cluster Manager for peer %s: %w", peerName, err)
+	}
+
+	peerInfo, found := peers[peerName]
+	if !found {
+		mgr.log.Info("Peer not found in Cluster Manager, treating as already removed", "peerName", peerName)
+		return true, nil
+	}
+
+	// Wait for is_searchable=false before removal (peer must leave committed generation first)
+	if peerInfo.Searchable {
+		mgr.log.Info("Peer still in committed generation, waiting",
+			"peerName", peerName, "peerID", peerInfo.ID, "status", peerInfo.Status)
+		return false, nil
+	}
+
+	mgr.log.Info("Removing peer from Cluster Manager",
+		"peerName", peerName, "peerID", peerInfo.ID, "status", peerInfo.Status)
+
 	c := mgr.getClusterManagerClient(ctx)
-	return true, c.RemoveIndexerClusterPeer(mgr.cr.Status.Peers[n].ID)
+	err = c.RemoveIndexerClusterPeer(peerInfo.ID)
+	if err != nil {
+		return false, fmt.Errorf("failed to remove peer %s (ID: %s) from Cluster Manager: %w", peerName, peerInfo.ID, err)
+	}
+
+	return true, nil
 }
 
 // PrepareRecycle for indexerClusterPodManager prepares indexer pod to be recycled for updates; it returns true when ready
@@ -853,8 +884,20 @@ func (mgr *indexerClusterPodManager) FinishRecycle(ctx context.Context, n int32)
 }
 
 // decommission for indexerClusterPodManager decommissions an indexer pod; it returns true when ready
+// NOTE: This method returns true for out-of-bounds cases because there's no peer state to track or decommission.
+// This differs from PrepareScaleDown which must actively remove the peer from CM and uses a fallback query mechanism.
 func (mgr *indexerClusterPodManager) decommission(ctx context.Context, n int32, enforceCounts bool) (bool, error) {
 	peerName := GetSplunkStatefulsetPodName(SplunkIndexer, mgr.cr.GetName(), n)
+
+	// Bounds check to prevent panic when accessing Status.Peers array
+	numPeers := int32(len(mgr.cr.Status.Peers))
+	if n >= numPeers {
+		// If peer index is out of bounds, there's no status entry to track decommission state.
+		// Return true to indicate decommission is complete - nothing to decommission.
+		mgr.log.Info("Peer index out of bounds in Status.Peers - treating as decommission complete",
+			"peerIndex", n, "peerName", peerName, "peersLength", numPeers)
+		return true, nil
+	}
 
 	switch mgr.cr.Status.Peers[n].Status {
 	case "Up":
@@ -888,12 +931,51 @@ func (mgr *indexerClusterPodManager) decommission(ctx context.Context, n int32, 
 		return true, nil
 
 	case "": // this can happen after the peer has been removed from the indexer cluster
-		mgr.log.Info("Peer has empty ID", "peerName", peerName)
-		return false, nil
+		mgr.log.Info("Peer has empty status - treating as decommission complete", "peerName", peerName)
+		return true, nil
 	}
 
 	// unhandled status
 	return false, fmt.Errorf("Status=%s", mgr.cr.Status.Peers[n].Status)
+}
+
+// cleanupPeerFromClusterManager removes a peer directly from the Cluster Manager by querying for the peer by name.
+// This is a fallback mechanism used when the CR status is stale or out of sync (e.g., after manual pod deletion).
+// It queries the Cluster Manager for all peers, finds the peer matching the given name, and removes it.
+// Returns nil if the peer is successfully removed or if the peer is not found (already removed).
+// Returns an error if the Cluster Manager query fails or if peer removal fails.
+func (mgr *indexerClusterPodManager) cleanupPeerFromClusterManager(ctx context.Context, peerName string) error {
+	mgr.log.Info("Attempting direct cleanup from Cluster Manager using peer name fallback",
+		"peerName", peerName, "reason", "CR status is stale or out of sync")
+
+	// Get all peers from the Cluster Manager
+	peers, err := GetClusterManagerPeersCall(ctx, mgr)
+	if err != nil {
+		return fmt.Errorf("failed to get peers from Cluster Manager: %w", err)
+	}
+
+	// Look for the peer by name (peers map uses peer name as key, but we also check Label field)
+	peerInfo, found := peers[peerName]
+	if !found {
+		// Peer not found in CM - this is OK, it may have already been removed
+		mgr.log.Info("Peer not found in Cluster Manager, likely already removed",
+			"peerName", peerName)
+		return nil
+	}
+
+	// Found the peer, now remove it using its ID
+	mgr.log.Info("Found peer in Cluster Manager, removing it",
+		"peerName", peerName, "peerID", peerInfo.ID, "peerStatus", peerInfo.Status)
+
+	c := mgr.getClusterManagerClient(ctx)
+	err = c.RemoveIndexerClusterPeer(peerInfo.ID)
+	if err != nil {
+		return fmt.Errorf("failed to remove peer %s (ID: %s) from Cluster Manager: %w", peerName, peerInfo.ID, err)
+	}
+
+	mgr.log.Info("Successfully removed peer from Cluster Manager",
+		"peerName", peerName, "peerID", peerInfo.ID)
+	return nil
 }
 
 // getClient for indexerClusterPodManager returns a SplunkClient for the member n
@@ -1082,7 +1164,7 @@ func validateIndexerClusterSpec(ctx context.Context, c splcommon.ControllerClien
 }
 
 // helper function to get the list of IndexerCluster types in the current namespace
-func getIndexerClusterList(ctx context.Context, c splcommon.ControllerClient, cr splcommon.MetaObject, listOpts []client.ListOption) (enterpriseApi.IndexerClusterList, error) {
+func getIndexerClusterList(ctx context.Context, c splcommon.ControllerClient, cr splcommon.MetaObject, listOpts []rclient.ListOption) (enterpriseApi.IndexerClusterList, error) {
 	reqLogger := log.FromContext(ctx)
 	scopedLog := reqLogger.WithName("getIndexerClusterList").WithValues("name", cr.GetName(), "namespace", cr.GetNamespace())
 

--- a/pkg/splunk/enterprise/indexercluster_test.go
+++ b/pkg/splunk/enterprise/indexercluster_test.go
@@ -859,17 +859,65 @@ func TestIndexerClusterPodManager(t *testing.T) {
 	indexerClusterPodManagerUpdateTester(t, method, mockHandlers, 1, enterpriseApi.PhaseUpdating, statefulSet, wantCalls, nil, statefulSet, pod)
 
 	// test scale down => pod not found
+	// Reset mockHandlers to original peer list (not "Down" status from previous test)
+	mockHandlers[1].Body = splcommon.TestIndexerClusterPodManagerPeer
+	// cleanupPeerFromClusterManager makes another GET peers call to verify peer doesn't exist
+	// The peer (splunk-stack1-indexer-1) doesn't exist in the response, so no POST remove_peers call
+	mockHandlers = append(mockHandlers, spltest.MockHTTPHandler{
+		Method: "GET",
+		URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/peers?count=0&output_mode=json",
+		Status: 200,
+		Err:    nil,
+		Body:   splcommon.TestIndexerClusterPodManagerPeer,
+	})
 	pod.ObjectMeta.Name = "splunk-stack1-2"
 	replicas = 2
+	statefulSet.Spec.Replicas = &replicas // Ensure Spec matches Status
 	statefulSet.Status.Replicas = 2
 	statefulSet.Status.ReadyReplicas = 2
 	statefulSet.Status.UpdatedReplicas = 2
-	wantCalls = map[string][]spltest.MockFuncCall{"Get": {funcCalls[0], funcCalls[1], funcCalls[1], funcCalls[4], funcCalls[4], funcCalls[0]}, "Create": {funcCalls[1]}}
+
+	// Get calls include:
+	// - StatefulSet (initial)
+	// - Secrets for namespace-scoped secret
+	// - Cluster manager pod (multiple times for status updates)
+	// - StatefulSet re-fetch
+	// - CM pod (for GetClusterManagerPeersCall in PrepareScaleDown - peer not found, no RemoveIndexerClusterPeer call)
+	// - PVC Gets (for scale-down cleanup)
+	podNotFoundCalls := []spltest.MockFuncCall{
+		{MetaName: "*v1.StatefulSet-test-splunk-stack1"},
+		{MetaName: "*v1.Secret-test-splunk-test-secret"},
+		{MetaName: "*v1.Secret-test-splunk-test-secret"},
+		{MetaName: "*v1.Pod-test-splunk-manager1-cluster-manager-0"},
+		{MetaName: "*v1.Pod-test-splunk-manager1-cluster-manager-0"},
+		{MetaName: "*v1.StatefulSet-test-splunk-stack1"},             // Re-fetch StatefulSet
+		{MetaName: "*v1.Pod-test-splunk-manager1-cluster-manager-0"}, // GetClusterManagerPeersCall in PrepareScaleDown (peer not found, returns early)
+		{MetaName: "*v1.PersistentVolumeClaim-test-pvc-etc-splunk-stack1-1"},
+		{MetaName: "*v1.PersistentVolumeClaim-test-pvc-var-splunk-stack1-1"},
+	}
+	wantCalls = map[string][]spltest.MockFuncCall{
+		"Get":    podNotFoundCalls,
+		"Create": {funcCalls[1]},
+		"Update": {funcCalls[0]}, // StatefulSet update to scale down
+	}
 	method = "indexerClusterPodManager.Update(Pod Not Found)"
 	indexerClusterPodManagerUpdateTester(t, method, mockHandlers, 1, enterpriseApi.PhaseScalingDown, statefulSet, wantCalls, nil, statefulSet, pod)
 
 	// test scale down => decommission pod
+	// Reset mockHandlers to avoid handler[2] overwriting handler[1] in the map (they have same URL)
+	mockHandlers = mockHandlers[:2]
+	replicas = 2 // Ensure Spec.Replicas matches Status.Replicas
+	statefulSet.Spec.Replicas = &replicas
 	mockHandlers[1].Body = loadFixture(t, "configmap_indexer_smartstore.json")
+	// Add duplicate peers handler for GetClusterManagerPeersCall in PrepareScaleDown (checks is_searchable)
+	mockHandlers = append(mockHandlers, spltest.MockHTTPHandler{
+		Method: "GET",
+		URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/peers?count=0&output_mode=json",
+		Status: 200,
+		Err:    nil,
+		Body:   loadFixture(t, "configmap_indexer_smartstore.json"),
+	})
+	// Add mock handler for remove_peers POST call
 	mockHandlers = append(mockHandlers, spltest.MockHTTPHandler{
 		Method: "POST",
 		URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/control/control/remove_peers?peers=D39B1729-E2C5-4273-B9B2-534DA7C2F866",
@@ -887,10 +935,11 @@ func TestIndexerClusterPodManager(t *testing.T) {
 		{MetaName: "*v1.Secret-test-splunk-test-secret"},
 		{MetaName: "*v1.Pod-test-splunk-manager1-cluster-manager-0"},
 		{MetaName: "*v1.Pod-test-splunk-manager1-cluster-manager-0"},
-		{MetaName: "*v1.StatefulSet-test-splunk-stack1"},
-		{MetaName: "*v1.Pod-test-splunk-manager1-cluster-manager-0"},
-		{MetaName: "*v1.PersistentVolumeClaim-test-pvc-etc-splunk-stack1-1"},
-		{MetaName: "*v1.PersistentVolumeClaim-test-pvc-var-splunk-stack1-1"},
+		{MetaName: "*v1.StatefulSet-test-splunk-stack1"},                     // Re-fetch StatefulSet in UpdateStatefulSetPods
+		{MetaName: "*v1.Pod-test-splunk-manager1-cluster-manager-0"},         // getClusterManagerClient in PrepareScaleDown
+		{MetaName: "*v1.Pod-test-splunk-manager1-cluster-manager-0"},         // getClusterManagerClient for RemoveIndexerClusterPeer
+		{MetaName: "*v1.PersistentVolumeClaim-test-pvc-etc-splunk-stack1-1"}, // PVC check (returns NotFound)
+		{MetaName: "*v1.PersistentVolumeClaim-test-pvc-var-splunk-stack1-1"}, // PVC check (returns NotFound)
 	}
 	wantCalls = map[string][]spltest.MockFuncCall{"Get": decommisionFuncCalls, "Create": {funcCalls[1]}, "Delete": pvcCalls, "Update": {funcCalls[0]}}
 	//wantCalls["Get"] = append(wantCalls["Get"], pvcCalls...)
@@ -900,6 +949,9 @@ func TestIndexerClusterPodManager(t *testing.T) {
 	}
 	method = "indexerClusterPodManager.Update(Decommission)"
 	pod.ObjectMeta.Name = "splunk-stack1-0"
+	// Note: We don't create pod-1 here because the test is for the case where the pod
+	// has already been decommissioned and removed, so the pod existence check should fail
+	// and the code should skip PrepareScaleDown and go straight to scaling down.
 	indexerClusterPodManagerUpdateTester(t, method, mockHandlers, 1, enterpriseApi.PhaseScalingDown, statefulSet, wantCalls, nil, statefulSet, pod, pvcList[0], pvcList[1])
 }
 
@@ -2000,6 +2052,716 @@ func TestIndexerClusterWithReadyState(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error while running reconciliation for indexer cluster with app framework  %v", err)
 		debug.PrintStack()
+	}
+}
+
+// TestPrepareScaleDownOutOfBounds tests PrepareScaleDown when peer index is out of bounds
+func TestPrepareScaleDownOutOfBounds(t *testing.T) {
+	os.Setenv("SPLUNK_GENERAL_TERMS", "--accept-sgt-current-at-splunk-com")
+	ctx := context.TODO()
+
+	// Create indexer cluster pod manager with empty peer status (out of bounds scenario)
+	mockHandlers := []spltest.MockHTTPHandler{
+		{
+			Method: "GET",
+			URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/info?count=0&output_mode=json",
+			Status: 200,
+			Err:    nil,
+			Body:   splcommon.TestIndexerClusterPodManagerInfo,
+		},
+		{
+			Method: "GET",
+			URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/peers?count=0&output_mode=json",
+			Status: 200,
+			Err:    nil,
+			Body:   `{"entry": []}`, // Empty peers list
+		},
+	}
+
+	mockSplunkClient := &spltest.MockHTTPClient{}
+	mockSplunkClient.AddHandlers(mockHandlers...)
+	mgr := getIndexerClusterPodManager("TestPrepareScaleDownOutOfBounds", mockHandlers, mockSplunkClient, 3)
+
+	// Initialize status with updateStatus to set up the mgr state
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-stack1",
+			Namespace: "test",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: func() *int32 { r := int32(3); return &r }(),
+		},
+	}
+
+	c := spltest.NewMockClient()
+	mgr.c = c
+	err := mgr.updateStatus(ctx, statefulSet)
+	if err != nil {
+		t.Errorf("updateStatus failed: %v", err)
+	}
+
+	// Test PrepareScaleDown with index 2 when Status.Peers is empty (out of bounds)
+	ready, err := mgr.PrepareScaleDown(ctx, 2)
+	if err != nil {
+		t.Errorf("PrepareScaleDown should handle out of bounds gracefully, got error: %v", err)
+	}
+	if !ready {
+		t.Errorf("PrepareScaleDown should return true (ready) for out of bounds index")
+	}
+}
+
+// TestPrepareScaleDownEmptyPeerID tests PrepareScaleDown when peer ID is empty
+func TestPrepareScaleDownEmptyPeerID(t *testing.T) {
+	os.Setenv("SPLUNK_GENERAL_TERMS", "--accept-sgt-current-at-splunk-com")
+	ctx := context.TODO()
+
+	// Create peer response with valid ID first for the initial updateStatus call
+	// Note: 'name' field becomes the ID, 'label' field is the hostname used as map key
+	peerWithValidID := `{"entry":[{"name":"VALID-PEER-GUID-123","content":{"label":"splunk-stack1-indexer-0","status":"Up"}}]}`
+
+	mockHandlers := []spltest.MockHTTPHandler{
+		{
+			Method: "GET",
+			URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/info?count=0&output_mode=json",
+			Status: 200,
+			Err:    nil,
+			Body:   splcommon.TestIndexerClusterPodManagerInfo,
+		},
+		{
+			Method: "GET",
+			URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/peers?count=0&output_mode=json",
+			Status: 200,
+			Err:    nil,
+			Body:   peerWithValidID,
+		},
+	}
+
+	mockSplunkClient := &spltest.MockHTTPClient{}
+	mockSplunkClient.AddHandlers(mockHandlers...)
+	mgr := getIndexerClusterPodManager("TestPrepareScaleDownEmptyPeerID", mockHandlers, mockSplunkClient, 1)
+
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-stack1",
+			Namespace: "test",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: func() *int32 { r := int32(1); return &r }(),
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:        1,
+			ReadyReplicas:   1,
+			UpdatedReplicas: 1,
+		},
+	}
+
+	c := spltest.NewMockClient()
+	mgr.c = c
+	err := mgr.updateStatus(ctx, statefulSet)
+	if err != nil {
+		t.Errorf("updateStatus failed: %v", err)
+	}
+
+	// Verify we have a peer now
+	if len(mgr.cr.Status.Peers) == 0 {
+		t.Fatalf("Expected at least one peer in status after updateStatus")
+	}
+
+	// Manually set peer ID to empty to simulate the edge case
+	mgr.cr.Status.Peers[0].ID = ""
+
+	// Test PrepareScaleDown with empty peer ID - should trigger fallback path
+	// We're not testing the actual removal here, just that it handles empty ID gracefully
+	// by attempting the fallback (which will fail in this test setup, but that's OK)
+	_, err = mgr.PrepareScaleDown(ctx, 0)
+	// The fallback will attempt to query CM, but we haven't mocked that second GET request
+	// So we expect an error here, but the important thing is it didn't panic
+	// and it attempted the fallback path
+	if err == nil {
+		t.Logf("PrepareScaleDown completed (likely found no peer to remove)")
+	} else {
+		t.Logf("PrepareScaleDown attempted fallback cleanup (expected in this test setup): %v", err)
+	}
+	// The test passes as long as we didn't panic on empty ID
+}
+
+// TestCleanupPeerFromClusterManagerPeerExists tests cleanupPeerFromClusterManager when peer exists
+func TestCleanupPeerFromClusterManagerPeerExists(t *testing.T) {
+	os.Setenv("SPLUNK_GENERAL_TERMS", "--accept-sgt-current-at-splunk-com")
+	ctx := context.TODO()
+
+	peerName := "splunk-stack1-indexer-2"
+	peerID := "TEST-PEER-GUID-123"
+
+	// Mock response with the peer we're looking for
+	// Note: 'name' becomes the ID after parsing, 'label' is used as map key
+	peersResponse := fmt.Sprintf(`{
+		"entry": [
+			{
+				"name": "%s",
+				"content": {
+					"label": "%s",
+					"status": "Up"
+				}
+			}
+		]
+	}`, peerID, peerName)
+
+	mockHandlers := []spltest.MockHTTPHandler{
+		{
+			Method: "GET",
+			URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/info?count=0&output_mode=json",
+			Status: 200,
+			Err:    nil,
+			Body:   splcommon.TestIndexerClusterPodManagerInfo,
+		},
+		{
+			Method: "GET",
+			URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/peers?count=0&output_mode=json",
+			Status: 200,
+			Err:    nil,
+			Body:   peersResponse,
+		},
+		{
+			Method: "POST",
+			URL:    fmt.Sprintf("https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/control/control/remove_peers?peers=%s", peerID),
+			Status: 200,
+			Err:    nil,
+			Body:   `{}`,
+		},
+	}
+
+	mockSplunkClient := &spltest.MockHTTPClient{}
+	mockSplunkClient.AddHandlers(mockHandlers...)
+	mgr := getIndexerClusterPodManager("TestCleanupPeerFromClusterManagerPeerExists", mockHandlers, mockSplunkClient, 1)
+
+	c := spltest.NewMockClient()
+	mgr.c = c
+
+	// Call cleanupPeerFromClusterManager - should find and remove the peer
+	err := mgr.cleanupPeerFromClusterManager(ctx, peerName)
+	if err != nil {
+		t.Errorf("cleanupPeerFromClusterManager should succeed when peer exists, got error: %v", err)
+	}
+}
+
+// TestCleanupPeerFromClusterManagerPeerNotFound tests cleanupPeerFromClusterManager when peer doesn't exist
+func TestCleanupPeerFromClusterManagerPeerNotFound(t *testing.T) {
+	os.Setenv("SPLUNK_GENERAL_TERMS", "--accept-sgt-current-at-splunk-com")
+	ctx := context.TODO()
+
+	peerName := "splunk-stack1-indexer-2"
+
+	// Mock response with no matching peer (peer already removed)
+	// Using different label so the peer we're looking for won't be found
+	peersResponse := `{
+		"entry": [
+			{
+				"name": "DIFFERENT-PEER-GUID",
+				"content": {
+					"label": "splunk-stack1-indexer-0",
+					"status": "Up"
+				}
+			}
+		]
+	}`
+
+	mockHandlers := []spltest.MockHTTPHandler{
+		{
+			Method: "GET",
+			URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/info?count=0&output_mode=json",
+			Status: 200,
+			Err:    nil,
+			Body:   splcommon.TestIndexerClusterPodManagerInfo,
+		},
+		{
+			Method: "GET",
+			URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/peers?count=0&output_mode=json",
+			Status: 200,
+			Err:    nil,
+			Body:   peersResponse,
+		},
+	}
+
+	mockSplunkClient := &spltest.MockHTTPClient{}
+	mockSplunkClient.AddHandlers(mockHandlers...)
+	mgr := getIndexerClusterPodManager("TestCleanupPeerFromClusterManagerPeerNotFound", mockHandlers, mockSplunkClient, 1)
+
+	c := spltest.NewMockClient()
+	mgr.c = c
+
+	// Call cleanupPeerFromClusterManager - should return nil (success) when peer not found
+	err := mgr.cleanupPeerFromClusterManager(ctx, peerName)
+	if err != nil {
+		t.Errorf("cleanupPeerFromClusterManager should succeed when peer not found (already removed), got error: %v", err)
+	}
+}
+
+// TestCleanupPeerFromClusterManagerQueryFails tests cleanupPeerFromClusterManager when CM query fails
+func TestCleanupPeerFromClusterManagerQueryFails(t *testing.T) {
+	os.Setenv("SPLUNK_GENERAL_TERMS", "--accept-sgt-current-at-splunk-com")
+	ctx := context.TODO()
+
+	// Reset GetClusterManagerPeersCall to use the real implementation (not a mock from other tests)
+	// This ensures the test uses the HTTP handlers we set up below
+	originalGetClusterManagerPeersCall := GetClusterManagerPeersCall
+	defer func() {
+		GetClusterManagerPeersCall = originalGetClusterManagerPeersCall
+	}()
+	GetClusterManagerPeersCall = func(ctx context.Context, mgr *indexerClusterPodManager) (map[string]splclient.ClusterManagerPeerInfo, error) {
+		c := mgr.getClusterManagerClient(ctx)
+		return c.GetClusterManagerPeers()
+	}
+
+	peerName := "splunk-stack1-indexer-2"
+
+	mockHandlers := []spltest.MockHTTPHandler{
+		{
+			Method: "GET",
+			URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/info?count=0&output_mode=json",
+			Status: 200,
+			Err:    nil,
+			Body:   splcommon.TestIndexerClusterPodManagerInfo,
+		},
+		{
+			Method: "GET",
+			URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/peers?count=0&output_mode=json",
+			Status: 500,
+			Err:    fmt.Errorf("cluster manager unavailable"),
+			Body:   ``,
+		},
+	}
+
+	mockSplunkClient := &spltest.MockHTTPClient{}
+	mockSplunkClient.AddHandlers(mockHandlers...)
+	mgr := getIndexerClusterPodManager("TestCleanupPeerFromClusterManagerQueryFails", mockHandlers, mockSplunkClient, 1)
+
+	c := spltest.NewMockClient()
+	mgr.c = c
+
+	// Call cleanupPeerFromClusterManager - should return error when CM query fails
+	err := mgr.cleanupPeerFromClusterManager(ctx, peerName)
+	if err == nil {
+		t.Errorf("cleanupPeerFromClusterManager should return error when CM query fails")
+	}
+}
+
+// TestDecommissionOutOfBounds tests decommission with out-of-bounds peer index
+func TestDecommissionOutOfBounds(t *testing.T) {
+	os.Setenv("SPLUNK_GENERAL_TERMS", "--accept-sgt-current-at-splunk-com")
+	ctx := context.TODO()
+
+	mockHandlers := []spltest.MockHTTPHandler{
+		{
+			Method: "GET",
+			URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/info?count=0&output_mode=json",
+			Status: 200,
+			Err:    nil,
+			Body:   splcommon.TestIndexerClusterPodManagerInfo,
+		},
+		{
+			Method: "GET",
+			URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/peers?count=0&output_mode=json",
+			Status: 200,
+			Err:    nil,
+			Body:   `{"entry": []}`, // Empty peers list
+		},
+	}
+
+	mockSplunkClient := &spltest.MockHTTPClient{}
+	mockSplunkClient.AddHandlers(mockHandlers...)
+	mgr := getIndexerClusterPodManager("TestDecommissionOutOfBounds", mockHandlers, mockSplunkClient, 3)
+
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-stack1",
+			Namespace: "test",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: func() *int32 { r := int32(3); return &r }(),
+		},
+	}
+
+	c := spltest.NewMockClient()
+	mgr.c = c
+	err := mgr.updateStatus(ctx, statefulSet)
+	if err != nil {
+		t.Errorf("updateStatus failed: %v", err)
+	}
+
+	// Test decommission with index 2 when Status.Peers is empty (out of bounds)
+	ready, err := mgr.decommission(ctx, 2, false)
+	if err != nil {
+		t.Errorf("decommission should handle out of bounds gracefully, got error: %v", err)
+	}
+	if !ready {
+		t.Errorf("decommission should return true for out of bounds index (nothing to decommission)")
+	}
+}
+
+// TestNoZombiePeersAfterScaleDown verifies no zombie peers remain after various scale-down scenarios
+func TestNoZombiePeersAfterScaleDown(t *testing.T) {
+	os.Setenv("SPLUNK_GENERAL_TERMS", "--accept-sgt-current-at-splunk-com")
+	ctx := context.TODO()
+
+	testCases := []struct {
+		name         string
+		initialPeers string
+		peerIndex    int32
+		description  string
+	}{
+		{
+			name: "Normal scale-down with valid peer",
+			initialPeers: `{
+				"entry": [
+					{
+						"name": "peer-123",
+						"content": {
+							"label": "splunk-stack1-indexer-2",
+							"status": "Up"
+						}
+					}
+				]
+			}`,
+			peerIndex:   0,
+			description: "Peer exists with valid ID and should be removed",
+		},
+		{
+			name: "Scale-down with empty peer ID",
+			initialPeers: `{
+				"entry": [
+					{
+						"name": "peer-empty-id",
+						"content": {
+							"label": "splunk-stack1-indexer-2",
+							"status": "Up"
+						}
+					}
+				]
+			}`,
+			peerIndex:   0,
+			description: "Peer with empty ID should use fallback cleanup",
+		},
+		{
+			name:         "Scale-down with out-of-bounds index",
+			initialPeers: `{"entry": []}`,
+			peerIndex:    2,
+			description:  "Out of bounds index should be handled gracefully",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockHandlers := []spltest.MockHTTPHandler{
+				{
+					Method: "GET",
+					URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/info?count=0&output_mode=json",
+					Status: 200,
+					Err:    nil,
+					Body:   splcommon.TestIndexerClusterPodManagerInfo,
+				},
+				{
+					Method: "GET",
+					URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/peers?count=0&output_mode=json",
+					Status: 200,
+					Err:    nil,
+					Body:   tc.initialPeers,
+				},
+			}
+
+			// Add cleanup handlers if peer exists
+			if tc.peerIndex == 0 && tc.initialPeers != `{"entry": []}` {
+				// Add handlers for cleanup
+				mockHandlers = append(mockHandlers, spltest.MockHTTPHandler{
+					Method: "GET",
+					URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/peers?count=0&output_mode=json",
+					Status: 200,
+					Err:    nil,
+					Body:   tc.initialPeers,
+				})
+				mockHandlers = append(mockHandlers, spltest.MockHTTPHandler{
+					Method: "POST",
+					URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/control/control/remove_peers?peers=peer-123",
+					Status: 200,
+					Err:    nil,
+					Body:   `{}`,
+				})
+			}
+
+			mockSplunkClient := &spltest.MockHTTPClient{}
+			mockSplunkClient.AddHandlers(mockHandlers...)
+			mgr := getIndexerClusterPodManager(tc.name, mockHandlers, mockSplunkClient, 3)
+
+			statefulSet := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "splunk-stack1",
+					Namespace: "test",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: func() *int32 { r := int32(3); return &r }(),
+				},
+			}
+
+			c := spltest.NewMockClient()
+			mgr.c = c
+			err := mgr.updateStatus(ctx, statefulSet)
+			if err != nil {
+				t.Errorf("updateStatus failed: %v", err)
+			}
+
+			// Execute PrepareScaleDown
+			ready, err := mgr.PrepareScaleDown(ctx, tc.peerIndex)
+			if err != nil {
+				t.Errorf("%s: PrepareScaleDown failed: %v", tc.description, err)
+			}
+			if !ready {
+				t.Errorf("%s: PrepareScaleDown should be ready", tc.description)
+			}
+
+			// Success means no zombie peers should remain
+			t.Logf("%s: Successfully handled - no zombie peers", tc.description)
+		})
+	}
+}
+
+// TestPrepareScaleDownWaitsForSearchableTrue tests that PrepareScaleDown returns (false, nil)
+// when peer is in GracefulShutdown but is_searchable is still true (peer still in committed generation)
+func TestPrepareScaleDownWaitsForSearchableTrue(t *testing.T) {
+	os.Setenv("SPLUNK_GENERAL_TERMS", "--accept-sgt-current-at-splunk-com")
+	ctx := context.TODO()
+
+	peerName := "splunk-stack1-indexer-0"
+	peerID := "TEST-PEER-GUID-456"
+
+	// Save original and restore after test
+	originalGetClusterManagerPeersCall := GetClusterManagerPeersCall
+	defer func() {
+		GetClusterManagerPeersCall = originalGetClusterManagerPeersCall
+	}()
+
+	// Mock GetClusterManagerPeersCall to return peer with Searchable=true (still in committed generation)
+	GetClusterManagerPeersCall = func(ctx context.Context, mgr *indexerClusterPodManager) (map[string]splclient.ClusterManagerPeerInfo, error) {
+		return map[string]splclient.ClusterManagerPeerInfo{
+			peerName: {
+				ID:         peerID,
+				Label:      peerName,
+				Status:     "GracefulShutdown",
+				Searchable: true, // Still in committed generation - should wait
+			},
+		}, nil
+	}
+
+	mockHandlers := []spltest.MockHTTPHandler{
+		{
+			Method: "GET",
+			URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/info?count=0&output_mode=json",
+			Status: 200,
+			Err:    nil,
+			Body:   splcommon.TestIndexerClusterPodManagerInfo,
+		},
+	}
+
+	mockSplunkClient := &spltest.MockHTTPClient{}
+	mockSplunkClient.AddHandlers(mockHandlers...)
+	mgr := getIndexerClusterPodManager("TestPrepareScaleDownWaitsForSearchableTrue", mockHandlers, mockSplunkClient, 1)
+
+	// Set up CR status with peer in GracefulShutdown
+	mgr.cr.Status.Peers = []enterpriseApi.IndexerClusterMemberStatus{
+		{
+			ID:         peerID,
+			Name:       peerName,
+			Status:     "GracefulShutdown",
+			Searchable: true,
+		},
+	}
+
+	c := spltest.NewMockClient()
+	mgr.c = c
+
+	// Call PrepareScaleDown - should return (false, nil) because is_searchable is true
+	ready, err := mgr.PrepareScaleDown(ctx, 0)
+	if err != nil {
+		t.Errorf("PrepareScaleDown should not return error when waiting for is_searchable, got: %v", err)
+	}
+	if ready {
+		t.Errorf("PrepareScaleDown should return ready=false when peer is still searchable")
+	}
+}
+
+// TestPrepareScaleDownProceedsWhenNotSearchable tests that PrepareScaleDown calls RemoveIndexerClusterPeer
+// when peer is no longer searchable (is_searchable=false)
+func TestPrepareScaleDownProceedsWhenNotSearchable(t *testing.T) {
+	os.Setenv("SPLUNK_GENERAL_TERMS", "--accept-sgt-current-at-splunk-com")
+	ctx := context.TODO()
+
+	peerName := "splunk-stack1-indexer-0"
+	peerID := "TEST-PEER-GUID-789"
+
+	// Save original and restore after test
+	originalGetClusterManagerPeersCall := GetClusterManagerPeersCall
+	defer func() {
+		GetClusterManagerPeersCall = originalGetClusterManagerPeersCall
+	}()
+
+	// Mock GetClusterManagerPeersCall to return peer with Searchable=false (ready for removal)
+	GetClusterManagerPeersCall = func(ctx context.Context, mgr *indexerClusterPodManager) (map[string]splclient.ClusterManagerPeerInfo, error) {
+		return map[string]splclient.ClusterManagerPeerInfo{
+			peerName: {
+				ID:         peerID,
+				Label:      peerName,
+				Status:     "GracefulShutdown",
+				Searchable: false, // Not searchable - ready for removal
+			},
+		}, nil
+	}
+
+	mockHandlers := []spltest.MockHTTPHandler{
+		{
+			Method: "GET",
+			URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/info?count=0&output_mode=json",
+			Status: 200,
+			Err:    nil,
+			Body:   splcommon.TestIndexerClusterPodManagerInfo,
+		},
+		{
+			Method: "POST",
+			URL:    fmt.Sprintf("https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/control/control/remove_peers?peers=%s", peerID),
+			Status: 200,
+			Err:    nil,
+			Body:   `{}`,
+		},
+	}
+
+	mockSplunkClient := &spltest.MockHTTPClient{}
+	mockSplunkClient.AddHandlers(mockHandlers...)
+	mgr := getIndexerClusterPodManager("TestPrepareScaleDownProceedsWhenNotSearchable", mockHandlers, mockSplunkClient, 1)
+
+	// Set up CR status with peer in GracefulShutdown
+	mgr.cr.Status.Peers = []enterpriseApi.IndexerClusterMemberStatus{
+		{
+			ID:         peerID,
+			Name:       peerName,
+			Status:     "GracefulShutdown",
+			Searchable: false,
+		},
+	}
+
+	c := spltest.NewMockClient()
+	mgr.c = c
+
+	// Call PrepareScaleDown - should succeed and remove the peer
+	ready, err := mgr.PrepareScaleDown(ctx, 0)
+	if err != nil {
+		t.Errorf("PrepareScaleDown should succeed when peer is not searchable, got error: %v", err)
+	}
+	if !ready {
+		t.Errorf("PrepareScaleDown should return ready=true when peer is removed successfully")
+	}
+}
+
+// TestPrepareScaleDownPeerAlreadyRemovedFromCM tests that PrepareScaleDown returns (true, nil)
+// when peer is not found in Cluster Manager (already removed)
+func TestPrepareScaleDownPeerAlreadyRemovedFromCM(t *testing.T) {
+	os.Setenv("SPLUNK_GENERAL_TERMS", "--accept-sgt-current-at-splunk-com")
+	ctx := context.TODO()
+
+	peerName := "splunk-stack1-indexer-0"
+
+	// Save original and restore after test
+	originalGetClusterManagerPeersCall := GetClusterManagerPeersCall
+	defer func() {
+		GetClusterManagerPeersCall = originalGetClusterManagerPeersCall
+	}()
+
+	// Mock GetClusterManagerPeersCall to return empty map (peer not found)
+	GetClusterManagerPeersCall = func(ctx context.Context, mgr *indexerClusterPodManager) (map[string]splclient.ClusterManagerPeerInfo, error) {
+		return map[string]splclient.ClusterManagerPeerInfo{}, nil // Empty - peer already removed
+	}
+
+	mockHandlers := []spltest.MockHTTPHandler{
+		{
+			Method: "GET",
+			URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/info?count=0&output_mode=json",
+			Status: 200,
+			Err:    nil,
+			Body:   splcommon.TestIndexerClusterPodManagerInfo,
+		},
+	}
+
+	mockSplunkClient := &spltest.MockHTTPClient{}
+	mockSplunkClient.AddHandlers(mockHandlers...)
+	mgr := getIndexerClusterPodManager("TestPrepareScaleDownPeerAlreadyRemovedFromCM", mockHandlers, mockSplunkClient, 1)
+
+	// Set up CR status (may be stale)
+	mgr.cr.Status.Peers = []enterpriseApi.IndexerClusterMemberStatus{
+		{
+			ID:         "OLD-PEER-GUID",
+			Name:       peerName,
+			Status:     "GracefulShutdown",
+			Searchable: false,
+		},
+	}
+
+	c := spltest.NewMockClient()
+	mgr.c = c
+
+	// Call PrepareScaleDown - should return (true, nil) because peer is already gone
+	ready, err := mgr.PrepareScaleDown(ctx, 0)
+	if err != nil {
+		t.Errorf("PrepareScaleDown should succeed when peer is not found in CM, got error: %v", err)
+	}
+	if !ready {
+		t.Errorf("PrepareScaleDown should return ready=true when peer is already removed from CM")
+	}
+}
+
+// TestPrepareScaleDownCMQueryFails tests that PrepareScaleDown returns error when CM query fails
+func TestPrepareScaleDownCMQueryFails(t *testing.T) {
+	os.Setenv("SPLUNK_GENERAL_TERMS", "--accept-sgt-current-at-splunk-com")
+	ctx := context.TODO()
+
+	// Save original and restore after test
+	originalGetClusterManagerPeersCall := GetClusterManagerPeersCall
+	defer func() {
+		GetClusterManagerPeersCall = originalGetClusterManagerPeersCall
+	}()
+
+	// Mock GetClusterManagerPeersCall to return error
+	GetClusterManagerPeersCall = func(ctx context.Context, mgr *indexerClusterPodManager) (map[string]splclient.ClusterManagerPeerInfo, error) {
+		return nil, fmt.Errorf("cluster manager unavailable")
+	}
+
+	mockHandlers := []spltest.MockHTTPHandler{
+		{
+			Method: "GET",
+			URL:    "https://splunk-manager1-cluster-manager-service.test.svc.cluster.local:8089/services/cluster/manager/info?count=0&output_mode=json",
+			Status: 200,
+			Err:    nil,
+			Body:   splcommon.TestIndexerClusterPodManagerInfo,
+		},
+	}
+
+	mockSplunkClient := &spltest.MockHTTPClient{}
+	mockSplunkClient.AddHandlers(mockHandlers...)
+	mgr := getIndexerClusterPodManager("TestPrepareScaleDownCMQueryFails", mockHandlers, mockSplunkClient, 1)
+
+	// Set up CR status
+	mgr.cr.Status.Peers = []enterpriseApi.IndexerClusterMemberStatus{
+		{
+			ID:         "PEER-GUID",
+			Name:       "splunk-stack1-indexer-0",
+			Status:     "GracefulShutdown",
+			Searchable: true,
+		},
+	}
+
+	c := spltest.NewMockClient()
+	mgr.c = c
+
+	// Call PrepareScaleDown - should return error when CM query fails
+	_, err := mgr.PrepareScaleDown(ctx, 0)
+	if err == nil {
+		t.Errorf("PrepareScaleDown should return error when CM query fails")
 	}
 }
 

--- a/pkg/splunk/enterprise/testdata/fixtures/statefulset_stack1_cluster_manager_with_service_account_2.json
+++ b/pkg/splunk/enterprise/testdata/fixtures/statefulset_stack1_cluster_manager_with_service_account_2.json
@@ -13,6 +13,9 @@
       "app.kubernetes.io/part-of": "splunk-stack1-indexer",
       "app.kubernetes.io/test-extra-label": "test-extra-label-value"
     },
+    "annotations": {
+      "operator.splunk.com/managed-cr-label-keys": "[\"app.kubernetes.io/test-extra-label\"]"
+    },
     "ownerReferences": [
       {
         "apiVersion": "",

--- a/pkg/splunk/enterprise/testdata/fixtures/statefulset_stack1_cluster_master_with_service_account_2.json
+++ b/pkg/splunk/enterprise/testdata/fixtures/statefulset_stack1_cluster_master_with_service_account_2.json
@@ -13,6 +13,9 @@
       "app.kubernetes.io/part-of": "splunk-stack1-indexer",
       "app.kubernetes.io/test-extra-label": "test-extra-label-value"
     },
+    "annotations": {
+      "operator.splunk.com/managed-cr-label-keys": "[\"app.kubernetes.io/test-extra-label\"]"
+    },
     "ownerReferences": [
       {
         "apiVersion": "",

--- a/pkg/splunk/enterprise/testdata/fixtures/statefulset_stack1_indexer_with_service_account_2.json
+++ b/pkg/splunk/enterprise/testdata/fixtures/statefulset_stack1_indexer_with_service_account_2.json
@@ -13,6 +13,9 @@
       "app.kubernetes.io/part-of": "splunk-manager1-indexer",
       "app.kubernetes.io/test-extra-label": "test-extra-label-value"
     },
+    "annotations": {
+      "operator.splunk.com/managed-cr-label-keys": "[\"app.kubernetes.io/test-extra-label\"]"
+    },
     "ownerReferences": [
       {
         "apiVersion": "",

--- a/pkg/splunk/enterprise/testdata/fixtures/statefulset_stack1_license_manager_with_service_account_2.json
+++ b/pkg/splunk/enterprise/testdata/fixtures/statefulset_stack1_license_manager_with_service_account_2.json
@@ -13,6 +13,9 @@
       "app.kubernetes.io/part-of": "splunk-stack1-license-manager",
       "app.kubernetes.io/test-extra-label": "test-extra-label-value"
     },
+    "annotations": {
+      "operator.splunk.com/managed-cr-label-keys": "[\"app.kubernetes.io/test-extra-label\"]"
+    },
     "ownerReferences": [
       {
         "apiVersion": "",

--- a/pkg/splunk/enterprise/testdata/fixtures/statefulset_stack1_license_master_with_service_account_2.json
+++ b/pkg/splunk/enterprise/testdata/fixtures/statefulset_stack1_license_master_with_service_account_2.json
@@ -13,6 +13,9 @@
       "app.kubernetes.io/part-of": "splunk-stack1-license-master",
       "app.kubernetes.io/test-extra-label": "test-extra-label-value"
     },
+    "annotations": {
+      "operator.splunk.com/managed-cr-label-keys": "[\"app.kubernetes.io/test-extra-label\"]"
+    },
     "ownerReferences": [
       {
         "apiVersion": "",

--- a/pkg/splunk/enterprise/testdata/fixtures/statefulset_stack1_monitoring_console_with_service_account_1.json
+++ b/pkg/splunk/enterprise/testdata/fixtures/statefulset_stack1_monitoring_console_with_service_account_1.json
@@ -13,6 +13,9 @@
       "app.kubernetes.io/part-of": "splunk-stack1-monitoring-console",
       "app.kubernetes.io/test-extra-label": "test-extra-label-value"
     },
+    "annotations": {
+      "operator.splunk.com/managed-cr-label-keys": "[\"app.kubernetes.io/test-extra-label\"]"
+    },
     "ownerReferences": [
       {
         "apiVersion": "",

--- a/pkg/splunk/enterprise/testdata/fixtures/statefulset_stack1_search_head_with_service_account_2.json
+++ b/pkg/splunk/enterprise/testdata/fixtures/statefulset_stack1_search_head_with_service_account_2.json
@@ -13,6 +13,9 @@
       "app.kubernetes.io/part-of": "splunk-stack1-search-head",
       "app.kubernetes.io/test-extra-label": "test-extra-label-value"
     },
+    "annotations": {
+      "operator.splunk.com/managed-cr-label-keys": "[\"app.kubernetes.io/test-extra-label\"]"
+    },
     "ownerReferences": [
       {
         "apiVersion": "",

--- a/pkg/splunk/enterprise/testdata/fixtures/statefulset_stack1_standalone_with_service_account_2.json
+++ b/pkg/splunk/enterprise/testdata/fixtures/statefulset_stack1_standalone_with_service_account_2.json
@@ -13,6 +13,9 @@
       "app.kubernetes.io/part-of": "splunk-stack1-standalone",
       "app.kubernetes.io/test-extra-label": "test-extra-label-value"
     },
+    "annotations": {
+      "operator.splunk.com/managed-cr-label-keys": "[\"app.kubernetes.io/test-extra-label\"]"
+    },
     "ownerReferences": [
       {
         "apiVersion": "",

--- a/pkg/splunk/enterprise/util_test.go
+++ b/pkg/splunk/enterprise/util_test.go
@@ -2314,7 +2314,7 @@ func TestMigrateAfwStatus(t *testing.T) {
 	}
 
 	client := spltest.NewMockClient()
-	_, err := splctrl.ApplyStatefulSet(ctx, client, sts)
+	_, err := splctrl.ApplyStatefulSet(ctx, client, sts, nil)
 	if err != nil {
 		t.Errorf("unable to apply statefulset")
 	}
@@ -2512,7 +2512,7 @@ func TestCheckAndMigrateAppDeployStatus(t *testing.T) {
 		},
 	}
 
-	_, err = splctrl.ApplyStatefulSet(ctx, client, sts)
+	_, err = splctrl.ApplyStatefulSet(ctx, client, sts, nil)
 	if err != nil {
 		t.Errorf("unable to apply statefulset")
 	}

--- a/pkg/splunk/splkcontroller/statefulset.go
+++ b/pkg/splunk/splkcontroller/statefulset.go
@@ -17,8 +17,11 @@ package splkcontroller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"math"
 	"reflect"
+	"strconv"
 	"time"
 
 	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
@@ -48,14 +51,600 @@ const (
 	// This annotation is automatically managed by the operator and should not be set manually.
 	// Expected format: RFC3339 timestamp (e.g., "2006-01-02T15:04:05Z07:00")
 	ScaleUpWaitStartedAnnotation = "operator.splunk.com/scale-up-wait-started"
+
+	// PreserveTotalCPUAnnotation is the annotation key to enable CPU-preserving scaling.
+	// When set on a StatefulSet, this annotation enables the operator to automatically
+	// adjust replicas to maintain the same total CPU allocation when CPU requests per pod change.
+	// Example: If set to "true" and pods scale from 4x2CPU to 8x1CPU, total CPU (8) is preserved.
+	// This is useful for license-based or cost-optimized deployments where total resource
+	// allocation should remain constant regardless of individual pod sizing.
+	PreserveTotalCPUAnnotation = "operator.splunk.com/preserve-total-cpu"
+
+	// Directional values for PreserveTotalCPUAnnotation
+	// PreserveTotalCPUDown enables CPU-preserving scaling only when replicas decrease
+	// (i.e., when CPU per pod increases)
+	PreserveTotalCPUDown = "down"
+
+	// PreserveTotalCPUUp enables CPU-preserving scaling only when replicas increase
+	// (i.e., when CPU per pod decreases). NOTE: Scale-up is not yet supported.
+	PreserveTotalCPUUp = "up"
+
+	// PreserveTotalCPUBoth enables CPU-preserving scaling for both directions
+	PreserveTotalCPUBoth = "both"
+
+	// PreserveTotalCPUTrue is an alias for "both", providing backward compatibility
+	PreserveTotalCPUTrue = "true"
+
+	// ParallelPodUpdatesAnnotation is the annotation key to specify the number of pods that can be updated in parallel.
+	// When set on a StatefulSet, this annotation controls how many pods can be deleted/recycled simultaneously
+	// during rolling updates. This can significantly speed up large cluster updates.
+	//
+	// The annotation accepts either:
+	//   - A floating-point value <= 1.0: Interpreted as a percentage of total replicas
+	//     Example: "0.25" means 25% of pods can be updated in parallel
+	//   - A value > 1.0: Interpreted as an absolute number of pods
+	//     Example: "3" allows up to 3 pods to be updated at once
+	//
+	// If the annotation is missing or invalid, the default value of 1 is used (sequential updates).
+	// Valid range: 1 to total number of replicas. Values outside this range are clamped.
+	ParallelPodUpdatesAnnotation = "operator.splunk.com/parallel-pod-updates"
+
+	// CPUAwareTransitionStateAnnotation stores the complete state of a CPU-aware transition as JSON.
+	// This annotation is automatically managed by the operator and should not be set manually.
+	// The JSON structure includes original/target replicas, CPU per pod, and timestamps.
+	CPUAwareTransitionStateAnnotation = "operator.splunk.com/cpu-aware-transition-state"
+
+	// DefaultParallelPodUpdates is the default number of pods to update in parallel when the annotation is not set.
+	DefaultParallelPodUpdates = 1
 )
+
+// CPUAwareTransitionState represents the complete state of a CPU-aware scaling transition.
+// This struct is serialized to JSON and stored in the CPUAwareTransitionStateAnnotation.
+type CPUAwareTransitionState struct {
+	// OriginalReplicas is the number of replicas before the transition started
+	OriginalReplicas int32 `json:"originalReplicas"`
+	// TargetReplicas is the number of replicas after the transition completes
+	TargetReplicas int32 `json:"targetReplicas"`
+	// OriginalCPUMillis is the CPU request per pod (in millicores) before the transition
+	OriginalCPUMillis int64 `json:"originalCPUMillis"`
+	// TargetCPUMillis is the CPU request per pod (in millicores) after the transition
+	TargetCPUMillis int64 `json:"targetCPUMillis"`
+	// StartedAt is the timestamp when the transition started (RFC3339 format)
+	StartedAt string `json:"startedAt"`
+	// FinishedAt is the timestamp when the transition completed (RFC3339 format, empty if in progress)
+	FinishedAt string `json:"finishedAt,omitempty"`
+}
+
+// UnifiedTransitionStateAnnotation stores the state of all concurrent transitions as JSON.
+const UnifiedTransitionStateAnnotation = "operator.splunk.com/unified-transition-state"
+
+// UnifiedTransitionStallTimeoutAnnotation allows users to configure the maximum time
+// a unified transition can run before being considered stalled.
+// Format: duration string (e.g., "30m", "1h")
+// Default: 30 minutes
+const UnifiedTransitionStallTimeoutAnnotation = "operator.splunk.com/unified-transition-stall-timeout"
+
+// DefaultUnifiedTransitionStallTimeout is the default timeout for detecting stalled transitions.
+const DefaultUnifiedTransitionStallTimeout = 30 * time.Minute
+
+// MaxPodRecycleFailures is the maximum number of times a pod can fail recycling
+// before being marked as permanently failed and skipped.
+const MaxPodRecycleFailures = 3
+
+// ScalingCPUMetrics tracks CPU allocation across old and new spec pods during transitions
+type ScalingCPUMetrics struct {
+	TotalReadyCPU     int64 // Total CPU of all ready pods
+	NewSpecReadyPods  int32 // Number of ready pods with new spec
+	NewSpecReadyCPU   int64 // Total CPU of ready pods with new spec
+	OldSpecReadyPods  int32 // Number of ready pods with old spec
+	OldSpecReadyCPU   int64 // Total CPU of ready pods with old spec
+	OriginalTotalCPU  int64 // Original total CPU before transition
+	TargetTotalCPU    int64 // Target total CPU after transition
+	TargetCPUPerPod   int64 // CPU per pod in target spec
+	OriginalCPUPerPod int64 // CPU per pod in original spec
+}
+
+// isPreserveTotalCPUEnabled checks if the CPU-preserving scaling annotation is enabled on the StatefulSet.
+func isPreserveTotalCPUEnabled(statefulSet *appsv1.StatefulSet) bool {
+	if statefulSet.Annotations == nil {
+		return false
+	}
+	value, exists := statefulSet.Annotations[PreserveTotalCPUAnnotation]
+	if !exists {
+		return false
+	}
+	// Accept "true", "both", "down", or "up" as valid enabled values
+	switch value {
+	case PreserveTotalCPUTrue, PreserveTotalCPUBoth, PreserveTotalCPUDown, PreserveTotalCPUUp:
+		return true
+	default:
+		return false
+	}
+}
+
+// getReplicaScalingDirection determines the direction of replica scaling based on CPU changes.
+// Returns "down" if newCPU > originalCPU (replicas will decrease to maintain total CPU).
+// Returns "up" if newCPU < originalCPU (replicas would increase to maintain total CPU).
+// Returns "" if CPU values are equal (no scaling needed).
+func getReplicaScalingDirection(originalCPU, newCPU int64) string {
+	if newCPU > originalCPU {
+		return PreserveTotalCPUDown
+	}
+	if newCPU < originalCPU {
+		return PreserveTotalCPUUp
+	}
+	return ""
+}
+
+// isCPUScalingAllowed checks if CPU-preserving scaling is allowed for the given direction.
+// The annotation value can be:
+// - "true" or "both": Allow scaling in both directions
+// - "down": Allow only when replicas decrease (CPU per pod increases)
+// - "up": Allow only when replicas increase (CPU per pod decreases)
+// - Any other value or missing: Disabled (returns false)
+func isCPUScalingAllowed(statefulSet *appsv1.StatefulSet, direction string) bool {
+	if statefulSet.Annotations == nil {
+		return false
+	}
+	value, exists := statefulSet.Annotations[PreserveTotalCPUAnnotation]
+	if !exists {
+		return false
+	}
+
+	// Normalize and check
+	switch value {
+	case PreserveTotalCPUTrue, PreserveTotalCPUBoth:
+		return true
+	case PreserveTotalCPUDown:
+		return direction == PreserveTotalCPUDown
+	case PreserveTotalCPUUp:
+		return direction == PreserveTotalCPUUp
+	default:
+		return false
+	}
+}
+
+// SyncCRReplicasFromCPUAwareTransition checks if CPU-aware scaling completed and the CR
+// needs to be updated. Returns the target replicas if CR update is needed.
+// This function does NOT remove the annotation - caller must do that after updating CR.
+//
+// It enforces that FinishedAt must be set before returning needsSync=true.
+// This prevents the CR from being updated before the transition is actually complete,
+// which could cause the annotation to be cleared prematurely.
+//
+// Returns:
+// - (targetReplicas, true) if CR.Spec.Replicas should be updated to targetReplicas
+// - (0, false) if no update needed (annotation absent, FinishedAt not set, or CR already matches)
+func SyncCRReplicasFromCPUAwareTransition(statefulSet *appsv1.StatefulSet, crReplicas int32) (int32, bool) {
+	if statefulSet.Annotations == nil {
+		return 0, false
+	}
+
+	stateJSON, exists := statefulSet.Annotations[CPUAwareTransitionStateAnnotation]
+	if !exists {
+		return 0, false
+	}
+
+	var state CPUAwareTransitionState
+	if err := json.Unmarshal([]byte(stateJSON), &state); err != nil {
+		return 0, false
+	}
+
+	// CRITICAL: Require FinishedAt to be set before signaling CR update.
+	// This ensures the transition is truly complete and prevents clearing
+	// the annotation prematurely.
+	if state.FinishedAt == "" {
+		return 0, false
+	}
+
+	// Only signal update if:
+	// 1. FinishedAt is set (transition is complete)
+	// 2. StatefulSet has reached target
+	// 3. CR doesn't match target yet
+	if *statefulSet.Spec.Replicas == state.TargetReplicas && crReplicas != state.TargetReplicas {
+		return state.TargetReplicas, true
+	}
+
+	return 0, false
+}
+
+// ClearCPUAwareTransitionAnnotation removes the CPUAwareTransitionStateAnnotation from the StatefulSet.
+// Call this after successfully updating the CR's replicas.
+func ClearCPUAwareTransitionAnnotation(ctx context.Context, c splcommon.ControllerClient,
+	statefulSet *appsv1.StatefulSet) error {
+
+	if statefulSet.Annotations == nil {
+		return nil
+	}
+	if _, exists := statefulSet.Annotations[CPUAwareTransitionStateAnnotation]; !exists {
+		return nil
+	}
+
+	delete(statefulSet.Annotations, CPUAwareTransitionStateAnnotation)
+	return splutil.UpdateResource(ctx, c, statefulSet)
+}
+
+// getUnifiedTransitionState parses the UnifiedTransitionStateAnnotation and returns the state.
+// If the new annotation is not present, it checks for the old CPUAwareTransitionStateAnnotation
+// and migrates it to the new format for backward compatibility.
+// Returns nil if no transition state is found.
+// Returns true if the StatefulSet has a transition annotation AND the transition is finished.
+func IsCPUPreservingScalingFinished(statefulSet *appsv1.StatefulSet) bool {
+	if statefulSet.Annotations == nil {
+		return false
+	}
+
+	stateJSON, exists := statefulSet.Annotations[CPUAwareTransitionStateAnnotation]
+	if !exists {
+		return false
+	}
+
+	var state CPUAwareTransitionState
+	if err := json.Unmarshal([]byte(stateJSON), &state); err != nil {
+		return false
+	}
+
+	// Transition is finished when FinishedAt timestamp is set
+	return state.FinishedAt != ""
+}
+
+// checkCPUTransitionCompletion checks if: replicas == targetReplicas AND all pods [0..targetReplicas-1] have target CPU (new spec).
+// Returns true if the transition is complete and ready to persist FinishedAt.
+func checkCPUTransitionCompletion(
+	ctx context.Context,
+	c splcommon.ControllerClient,
+	statefulSet *appsv1.StatefulSet,
+	targetReplicas int32,
+	targetCPUMillis int64,
+) bool {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("checkCPUTransitionCompletion").WithValues(
+		"name", statefulSet.GetObjectMeta().GetName(),
+		"namespace", statefulSet.GetObjectMeta().GetNamespace())
+
+	replicas := *statefulSet.Spec.Replicas
+	if replicas != targetReplicas {
+		scopedLog.Info("Replicas not at target", "current", replicas, "target", targetReplicas)
+		return false
+	}
+
+	// Check all pods [0, targetReplicas-1] have new spec
+	for n := int32(0); n < targetReplicas; n++ {
+		podName := fmt.Sprintf("%s-%d", statefulSet.GetName(), n)
+		podNamespacedName := types.NamespacedName{Namespace: statefulSet.GetNamespace(), Name: podName}
+		var pod corev1.Pod
+		if err := c.Get(ctx, podNamespacedName, &pod); err != nil {
+			// Pod doesn't exist yet - not complete
+			scopedLog.Info("Pod not found, transition not complete", "podName", podName)
+			return false
+		}
+		if !hasNewSpec(&pod, targetCPUMillis) {
+			scopedLog.Info("Pod does not have new spec", "podName", podName,
+				"currentCPU", extractCPUFromPod(&pod), "targetCPU", targetCPUMillis)
+			return false
+		}
+	}
+
+	scopedLog.Info("All pods have new spec, transition complete",
+		"targetReplicas", targetReplicas, "targetCPUMillis", targetCPUMillis)
+	return true
+}
+
+// persistCPUTransitionFinished sets FinishedAt timestamp,
+// marshal state, write CPUAwareTransitionStateAnnotation, and update the StatefulSet.
+// Used by both handleCPUPreservingScaleUp and handleCPUPreservingScaleDown.
+// Returns error if persistence fails.
+func persistCPUTransitionFinished(
+	ctx context.Context,
+	c splcommon.ControllerClient,
+	statefulSet *appsv1.StatefulSet,
+	state *CPUAwareTransitionState,
+) error {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("persistCPUTransitionFinished").WithValues(
+		"name", statefulSet.GetObjectMeta().GetName(),
+		"namespace", statefulSet.GetObjectMeta().GetNamespace())
+
+	// Set FinishedAt timestamp
+	state.FinishedAt = time.Now().Format(time.RFC3339)
+
+	// Marshal and persist
+	updatedStateJSON, marshalErr := json.Marshal(state)
+	if marshalErr != nil {
+		scopedLog.Error(marshalErr, "Failed to marshal completed transition state")
+		return marshalErr
+	}
+
+	statefulSet.Annotations[CPUAwareTransitionStateAnnotation] = string(updatedStateJSON)
+	if updateErr := splutil.UpdateResource(ctx, c, statefulSet); updateErr != nil {
+		scopedLog.Error(updateErr, "Failed to persist FinishedAt timestamp")
+		return updateErr
+	}
+
+	scopedLog.Info("Transition completion persisted", "finishedAt", state.FinishedAt)
+	return nil
+}
+
+// getCPURequest extracts the CPU request from a pod template spec.
+// Returns the CPU millicores (e.g., "2" CPU = 2000 millicores) or 0 if not found.
+func getCPURequest(podSpec *corev1.PodSpec) int64 {
+	if podSpec == nil || len(podSpec.Containers) == 0 {
+		return 0
+	}
+	// Use the first container's CPU request as the reference
+	cpuRequest := podSpec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	return cpuRequest.MilliValue()
+}
+
+// calculateAdjustedReplicas calculates the new replica count to maintain total CPU when per-pod CPU changes.
+// Formula: newReplicas = (currentReplicas * currentCPUPerPod) / newCPUPerPod
+// Returns the adjusted replica count, rounded up to ensure we don't under-provision.
+func calculateAdjustedReplicas(currentReplicas int32, currentCPUPerPod, newCPUPerPod int64) int32 {
+	if newCPUPerPod == 0 {
+		return currentReplicas // Avoid division by zero
+	}
+	totalCPU := currentReplicas * int32(currentCPUPerPod)
+	adjustedReplicas := (totalCPU + int32(newCPUPerPod) - 1) / int32(newCPUPerPod) // Ceiling division
+	if adjustedReplicas < 1 {
+		return 1 // Ensure at least 1 replica
+	}
+	return adjustedReplicas
+}
+
+// getParallelPodUpdates extracts and validates the parallel pod updates setting from StatefulSet annotations.
+// Returns the number of pods that can be updated in parallel during rolling updates.
+//
+// The annotation accepts either:
+//   - A floating-point value < 1.0: Interpreted as a percentage of total replicas
+//     Example: "0.25" means 25% of pods can be updated in parallel
+//   - A value >= 1.0: Interpreted as an absolute number of pods
+//     Example: "3" or "3.0" allows up to 3 pods to be updated at once
+//
+// If the annotation is missing, invalid, or out of range, returns DefaultParallelPodUpdates (1).
+// The returned value is clamped between 1 and the total number of replicas.
+func getParallelPodUpdates(statefulSet *appsv1.StatefulSet) int32 {
+	if statefulSet.Annotations == nil {
+		return DefaultParallelPodUpdates
+	}
+
+	value, exists := statefulSet.Annotations[ParallelPodUpdatesAnnotation]
+	if !exists || value == "" {
+		return DefaultParallelPodUpdates
+	}
+
+	// Parse the annotation value as float64
+	floatValue, err := strconv.ParseFloat(value, 64)
+	if err != nil || floatValue <= 0 {
+		return DefaultParallelPodUpdates
+	}
+
+	var parallelUpdates int32
+	totalReplicas := int32(1)
+	if statefulSet.Spec.Replicas != nil {
+		totalReplicas = *statefulSet.Spec.Replicas
+	}
+
+	if floatValue < 1.0 {
+		// Percentage mode: value is a fraction of total replicas
+		// e.g., 0.25 means 25% of replicas
+		calculated := float64(totalReplicas) * floatValue
+		parallelUpdates = int32(math.Ceil(calculated))
+	} else {
+		// Absolute mode: value is the exact number of pods
+		// e.g., 1.0, 2.5, 3 all treated as absolute values
+		parallelUpdates = int32(math.Round(floatValue))
+	}
+
+	// Clamp to reasonable bounds: at least 1, at most total replicas
+	if parallelUpdates < 1 {
+		return 1
+	}
+	if parallelUpdates > totalReplicas {
+		return totalReplicas
+	}
+
+	return parallelUpdates
+}
+
+// isPodReady checks if a pod is in Ready condition
+func isPodReady(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// extractCPUFromPod extracts CPU millicores from a running pod
+func extractCPUFromPod(pod *corev1.Pod) int64 {
+	if len(pod.Spec.Containers) == 0 {
+		return 0
+	}
+	// Use first container's CPU request
+	cpuRequest := pod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	return cpuRequest.MilliValue()
+}
+
+// hasNewSpec checks if a pod has the new spec (compares CPU)
+func hasNewSpec(pod *corev1.Pod, targetCPU int64) bool {
+	podCPU := extractCPUFromPod(pod)
+	return podCPU == targetCPU
+}
+
+// computeReadyCPUMetricsForScaleDown calculates CPU metrics for scale-down transitions.
+// Pod population: READY pods only.
+// It uses stored original/target CPU values from CPUAwareTransitionState.
+func computeReadyCPUMetricsForScaleDown(
+	ctx context.Context,
+	c splcommon.ControllerClient,
+	statefulSet *appsv1.StatefulSet,
+	state CPUAwareTransitionState,
+) (ScalingCPUMetrics, error) {
+	scopedLog := log.FromContext(ctx)
+	logger := scopedLog.WithName("computeReadyCPUMetricsForScaleDown").WithValues(
+		"name", statefulSet.GetObjectMeta().GetName(),
+		"namespace", statefulSet.GetObjectMeta().GetNamespace())
+
+	metrics := ScalingCPUMetrics{
+		OriginalCPUPerPod: state.OriginalCPUMillis,
+		TargetCPUPerPod:   state.TargetCPUMillis,
+		OriginalTotalCPU:  int64(state.OriginalReplicas) * state.OriginalCPUMillis,
+		TargetTotalCPU:    int64(state.TargetReplicas) * state.TargetCPUMillis,
+	}
+
+	// List all pods for this StatefulSet to get live CPU allocation
+	selector, err := metav1.LabelSelectorAsSelector(statefulSet.Spec.Selector)
+	if err != nil {
+		return metrics, err
+	}
+
+	podList := &corev1.PodList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(statefulSet.GetNamespace()),
+		client.MatchingLabelsSelector{Selector: selector},
+	}
+
+	err = c.List(ctx, podList, listOpts...)
+	if err != nil {
+		return metrics, err
+	}
+
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+
+		if !isPodReady(pod) {
+			continue
+		}
+
+		podCPU := extractCPUFromPod(pod)
+		metrics.TotalReadyCPU += podCPU
+
+		// Check if pod has new spec
+		if hasNewSpec(pod, state.TargetCPUMillis) {
+			metrics.NewSpecReadyPods++
+			metrics.NewSpecReadyCPU += podCPU
+		} else {
+			metrics.OldSpecReadyPods++
+			metrics.OldSpecReadyCPU += podCPU
+		}
+	}
+
+	logger.Info("Computed CPU metrics for scale-down",
+		"totalReadyCPU", metrics.TotalReadyCPU,
+		"newSpecPods", metrics.NewSpecReadyPods,
+		"newSpecCPU", metrics.NewSpecReadyCPU,
+		"oldSpecPods", metrics.OldSpecReadyPods,
+		"oldSpecCPU", metrics.OldSpecReadyCPU,
+		"originalCPUPerPod", metrics.OriginalCPUPerPod,
+		"targetCPUPerPod", metrics.TargetCPUPerPod,
+		"originalTotalCPU", metrics.OriginalTotalCPU,
+		"targetTotalCPU", metrics.TargetTotalCPU)
+
+	return metrics, nil
+}
+
+// ScaleUpCPUMetrics tracks CPU allocation during scale-up transitions
+// Unlike ScalingCPUMetrics which uses ready pods only, this includes all non-terminated pods
+type ScaleUpCPUMetrics struct {
+	TotalPodCPU      int64 // Total CPU of all non-terminated pods
+	OldSpecPodCount  int32 // Number of non-terminated pods with old spec
+	NewSpecPodCount  int32 // Number of non-terminated pods with new spec
+	OldSpecReadyPods int32 // Number of READY pods with old spec (eligible for recycling)
+}
+
+// computeCPUCeiling calculates the CPU ceiling for scale-up transitions.
+// The ceiling is the original total CPU plus a buffer based on parallelUpdates.
+// This ensures we can make progress by adding new pods while staying within a reasonable CPU bound.
+func computeCPUCeiling(state CPUAwareTransitionState, parallelUpdates int32) int64 {
+	originalTotalCPU := int64(state.OriginalReplicas) * state.OriginalCPUMillis
+	// Buffer allows adding up to parallelUpdates new pods without exceeding ceiling
+	bufferCPU := int64(parallelUpdates) * state.TargetCPUMillis
+	return originalTotalCPU + bufferCPU
+}
+
+// computeNonTerminatedCPUMetricsForScaleUp calculates CPU metrics for scale-up transitions.
+// Pod population: all non-terminated pods.
+// Unlike computeReadyCPUMetricsForScaleDown (READY pods only),
+// this function counts ALL non-terminated pods because during scale-up
+// we need to know the total CPU requests being made to the cluster.
+func computeNonTerminatedCPUMetricsForScaleUp(
+	ctx context.Context,
+	c splcommon.ControllerClient,
+	statefulSet *appsv1.StatefulSet,
+	state CPUAwareTransitionState,
+) (ScaleUpCPUMetrics, error) {
+	scopedLog := log.FromContext(ctx)
+	logger := scopedLog.WithName("computeNonTerminatedCPUMetricsForScaleUp").WithValues(
+		"name", statefulSet.GetObjectMeta().GetName(),
+		"namespace", statefulSet.GetObjectMeta().GetNamespace())
+
+	metrics := ScaleUpCPUMetrics{}
+
+	// List all pods for this StatefulSet
+	selector, err := metav1.LabelSelectorAsSelector(statefulSet.Spec.Selector)
+	if err != nil {
+		return metrics, err
+	}
+
+	podList := &corev1.PodList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(statefulSet.GetNamespace()),
+		client.MatchingLabelsSelector{Selector: selector},
+	}
+
+	err = c.List(ctx, podList, listOpts...)
+	if err != nil {
+		return metrics, err
+	}
+
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+
+		// Skip terminated pods (Succeeded or Failed phase)
+		if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+			continue
+		}
+
+		podCPU := extractCPUFromPod(pod)
+		metrics.TotalPodCPU += podCPU
+
+		// Check if pod has new spec (target CPU)
+		if hasNewSpec(pod, state.TargetCPUMillis) {
+			metrics.NewSpecPodCount++
+		} else {
+			metrics.OldSpecPodCount++
+			// Track ready old-spec pods separately (eligible for recycling)
+			if isPodReady(pod) {
+				metrics.OldSpecReadyPods++
+			}
+		}
+	}
+
+	logger.Info("Computed CPU metrics for scale-up",
+		"totalPodCPU", metrics.TotalPodCPU,
+		"oldSpecPodCount", metrics.OldSpecPodCount,
+		"newSpecPodCount", metrics.NewSpecPodCount,
+		"oldSpecReadyPods", metrics.OldSpecReadyPods,
+		"targetCPU", state.TargetCPUMillis,
+		"originalCPU", state.OriginalCPUMillis)
+
+	return metrics, nil
+}
 
 // DefaultStatefulSetPodManager is a simple StatefulSetPodManager that does nothing
 type DefaultStatefulSetPodManager struct{}
 
-// Update for DefaultStatefulSetPodManager handles all updates for a statefulset of standard pods
+// Update for DefaultStatefulSetPodManager handles all updates for a statefulset of standard pods.
 func (mgr *DefaultStatefulSetPodManager) Update(ctx context.Context, client splcommon.ControllerClient, statefulSet *appsv1.StatefulSet, desiredReplicas int32) (enterpriseApi.Phase, error) {
-	phase, err := ApplyStatefulSet(ctx, client, statefulSet)
+	// Get eventPublisher from context
+	var eventPublisher splcommon.K8EventPublisher
+	if ep := ctx.Value(splcommon.EventPublisherKey); ep != nil {
+		eventPublisher = ep.(splcommon.K8EventPublisher)
+	}
+
+	phase, err := ApplyStatefulSet(ctx, client, statefulSet, eventPublisher)
+
 	if err == nil && phase == enterpriseApi.PhaseReady {
 		phase, err = UpdateStatefulSetPods(ctx, client, statefulSet, mgr, desiredReplicas)
 	}
@@ -82,7 +671,17 @@ func (mgr *DefaultStatefulSetPodManager) FinishUpgrade(ctx context.Context, n in
 }
 
 // ApplyStatefulSet creates or updates a Kubernetes StatefulSet
-func ApplyStatefulSet(ctx context.Context, c splcommon.ControllerClient, revised *appsv1.StatefulSet) (enterpriseApi.Phase, error) {
+// It intelligently handles different types of changes:
+// - VolumeClaimTemplate changes: Delete + Recreate with orphan cascade (preserves pods and PVCs)
+// - Label/Annotation changes: In-place update
+// - Pod template changes: In-place update
+// - No changes: No operation
+func ApplyStatefulSet(ctx context.Context, c splcommon.ControllerClient, revised *appsv1.StatefulSet, eventPublisher splcommon.K8EventPublisher) (enterpriseApi.Phase, error) {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("ApplyStatefulSet").WithValues(
+		"name", revised.GetObjectMeta().GetName(),
+		"namespace", revised.GetObjectMeta().GetNamespace())
+
 	namespacedName := types.NamespacedName{Namespace: revised.GetNamespace(), Name: revised.GetName()}
 	var current appsv1.StatefulSet
 
@@ -105,16 +704,201 @@ func ApplyStatefulSet(ctx context.Context, c splcommon.ControllerClient, revised
 
 	// found an existing StatefulSet
 
+	// Save original CPU value before MergePodUpdates modifies current
+	originalCPU := getCPURequest(&current.Spec.Template.Spec)
+	originalReplicas := *current.Spec.Replicas
+
 	// check for changes in Pod template
 	hasUpdates := MergePodUpdates(ctx, &current.Spec.Template, &revised.Spec.Template, current.GetObjectMeta().GetName())
 
 	// check for changes in StatefulSet-level metadata (labels and annotations)
 	hasUpdates = hasUpdates || splcommon.MergeStatefulSetMetaUpdates(ctx, &current.ObjectMeta, &revised.ObjectMeta, current.GetName())
 
+	// Compare VolumeClaimTemplates to detect changes
+	vctResult := CompareVolumeClaimTemplates(&current, revised)
+
+	if vctResult.RequiresRecreate {
+		// VCT changes require StatefulSet recreation (delete and recreate)
+		scopedLog.Info("VolumeClaimTemplate changes require StatefulSet recreation",
+			"reason", vctResult.RecreateReason)
+		if eventPublisher != nil {
+			eventPublisher.Warning(ctx, "VCTRecreateRequired", fmt.Sprintf("StatefulSet will be recreated: %s", vctResult.RecreateReason))
+		}
+
+		// Delete the existing StatefulSet with orphan propagation (keeps pods and PVCs)
+		err = splutil.DeleteResource(ctx, c, &current, client.PropagationPolicy(metav1.DeletePropagationOrphan))
+		if err != nil {
+			scopedLog.Error(err, "Failed to delete StatefulSet for VCT update")
+			return enterpriseApi.PhaseError, err
+		}
+
+		scopedLog.Info("Deleted StatefulSet for VCT recreation, will recreate on next reconcile")
+		if eventPublisher != nil {
+			eventPublisher.Normal(ctx, "VCTRecreateInProgress", "StatefulSet deleted for VCT update, will recreate on next reconcile")
+		}
+
+		// Return to trigger reconcile which will recreate the StatefulSet
+		return enterpriseApi.PhasePending, nil
+	}
+
+	// Handle storage expansions if any
+	if len(vctResult.StorageExpansions) > 0 {
+		scopedLog.Info("Storage expansions detected, attempting PVC expansion",
+			"expansions", len(vctResult.StorageExpansions))
+
+		err = ExpandPVCStorage(ctx, c, &current, vctResult.StorageExpansions, eventPublisher)
+		if err != nil {
+			scopedLog.Error(err, "Failed to expand PVC storage")
+			// Don't fail the reconcile, log the error and continue
+			// The storage expansion might fail due to storage class not supporting expansion
+		}
+	}
+
 	*revised = current // caller expects that object passed represents latest state
 
-	// only update if there are material differences, as determined by comparison function
+	// Detect if we need a unified transition for VCT migration and/or CPU changes
+	// This replaces the legacy CPU-aware transition when VCT migration is also needed
+	newCPU := getCPURequest(&revised.Spec.Template.Spec)
+	needsCPUTransition := isPreserveTotalCPUEnabled(revised) && originalCPU != newCPU
+	needsVCTMigration := vctResult.RequiresPVCMigration
+
+	// Check if unified transition is already in progress
+	existingUnifiedState, _ := getUnifiedTransitionState(revised)
+
+	// If the existing unified state is a completed transition (migrated from old annotation),
+	// treat it as if there's no active transition so we can start a new one
+	if existingUnifiedState != nil && existingUnifiedState.FinishedAt != "" {
+		scopedLog.Info("Ignoring completed unified state for new transition detection",
+			"finishedAt", existingUnifiedState.FinishedAt)
+		existingUnifiedState = nil
+	}
+
+	// Initialize unified transition when VCT migration is needed (with or without CPU change)
+	// This uses the new unified transition system instead of legacy CPU-aware transition
+	if needsVCTMigration && existingUnifiedState == nil {
+		scopedLog.Info("Initializing unified transition for VCT migration",
+			"needsCPUTransition", needsCPUTransition,
+			"needsVCTMigration", needsVCTMigration)
+
+		// Build unified state
+		state := initUnifiedTransitionState(nil, nil)
+
+		if needsCPUTransition {
+			adjustedReplicas := calculateAdjustedReplicas(originalReplicas, originalCPU, newCPU)
+			state.CPUChange = &CPUTransition{
+				OriginalCPUMillis: originalCPU,
+				TargetCPUMillis:   newCPU,
+				OriginalReplicas:  originalReplicas,
+				TargetReplicas:    adjustedReplicas,
+			}
+		}
+
+		// Build VCT migration state
+		expectedSC := make(map[string]string)
+		expectedModes := make(map[string][]corev1.PersistentVolumeAccessMode)
+
+		for _, change := range vctResult.PVCMigrationChanges {
+			if change.NewStorageClass != "" {
+				expectedSC[change.TemplateName] = change.NewStorageClass
+			}
+			if len(change.NewAccessModes) > 0 {
+				expectedModes[change.TemplateName] = change.NewAccessModes
+			}
+		}
+
+		state.VCTMigration = &VCTMigrationTransition{
+			ExpectedStorageClasses: expectedSC,
+			ExpectedAccessModes:    expectedModes,
+		}
+
+		// Persist state to annotation
+		if err := persistUnifiedTransitionState(ctx, c, revised, state); err != nil {
+			scopedLog.Error(err, "Failed to persist unified transition state")
+			return enterpriseApi.PhaseError, err
+		}
+
+		if eventPublisher != nil {
+			msg := "Started unified transition for VCT migration"
+			if needsCPUTransition {
+				msg += " with CPU-aware scaling"
+			}
+			eventPublisher.Normal(ctx, "UnifiedTransitionStarted", msg)
+		}
+
+		hasUpdates = true
+	}
+
+	// Apply CPU-aware scaling adjustments AFTER copying current to revised
+	// Note: MergePodUpdates already merged the new template into current, so current now has the NEW CPU value
+	// We compare the original CPU (before merge) with the new CPU (after merge) to detect changes
+	// SKIP if unified transition was initialized above (it handles CPU changes too)
+	if isPreserveTotalCPUEnabled(revised) && existingUnifiedState == nil && !needsVCTMigration {
+		direction := getReplicaScalingDirection(originalCPU, newCPU)
+
+		if direction != "" && isCPUScalingAllowed(revised, direction) {
+			adjustedReplicas := calculateAdjustedReplicas(originalReplicas, originalCPU, newCPU)
+
+			if adjustedReplicas != originalReplicas {
+				scopedLog.Info("CPU-aware scaling detected. Will handle gradually with CPU constraints",
+					"direction", direction,
+					"originalCPU", originalCPU,
+					"originalReplicas", originalReplicas,
+					"currentTotalCPU", originalReplicas*int32(originalCPU),
+					"newCPU", newCPU,
+					"targetReplicas", adjustedReplicas,
+					"targetTotalCPU", adjustedReplicas*int32(newCPU),
+				)
+
+				// Keep current replicas, will be adjusted gradually
+				// Store complete transition state as JSON annotation
+				if revised.Annotations == nil {
+					revised.Annotations = make(map[string]string)
+				}
+
+				// Clear any completed transition annotation before creating new one
+				if existingStateJSON, exists := revised.Annotations[CPUAwareTransitionStateAnnotation]; exists {
+					var existingState CPUAwareTransitionState
+					if parseErr := json.Unmarshal([]byte(existingStateJSON), &existingState); parseErr == nil {
+						if existingState.FinishedAt != "" {
+							scopedLog.Info("Clearing completed transition annotation",
+								"previousFinishedAt", existingState.FinishedAt)
+
+							delete(revised.Annotations, CPUAwareTransitionStateAnnotation)
+
+							if clearErr := splutil.UpdateResource(ctx, c, revised); clearErr != nil {
+								scopedLog.Error(clearErr, "Failed to clear completed transition annotation")
+								return enterpriseApi.PhaseError, clearErr
+							}
+
+							// Re-fetch after clearing to ensure we have latest resource version
+							if getErr := c.Get(ctx, namespacedName, revised); getErr != nil {
+								scopedLog.Error(getErr, "Failed to re-fetch StatefulSet after clearing annotation")
+								return enterpriseApi.PhaseError, getErr
+							}
+						}
+					}
+				}
+
+				transitionState := CPUAwareTransitionState{
+					OriginalReplicas:  originalReplicas,
+					TargetReplicas:    adjustedReplicas,
+					OriginalCPUMillis: originalCPU,
+					TargetCPUMillis:   newCPU,
+					StartedAt:         time.Now().Format(time.RFC3339),
+				}
+				stateJSON, jsonErr := json.Marshal(transitionState)
+				if jsonErr != nil {
+					scopedLog.Error(jsonErr, "Failed to marshal CPU-aware transition state")
+					return enterpriseApi.PhaseError, jsonErr
+				}
+				revised.Annotations[CPUAwareTransitionStateAnnotation] = string(stateJSON)
+				hasUpdates = true
+			}
+		}
+	}
+
 	if hasUpdates {
+		// only update if there are material differences, as determined by comparison function
 		// this updates the desired state template, but doesn't actually modify any pods
 		// because we use an "OnUpdate" strategy https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
 		// note also that this ignores Replicas, which is handled below by UpdateStatefulSetPods
@@ -185,8 +969,14 @@ func handleScaleDown(ctx context.Context, c splcommon.ControllerClient, stateful
 
 	// delete PVCs used by the pod so that a future scale up will have clean state
 	for _, vol := range statefulSet.Spec.VolumeClaimTemplates {
+		// VolumeClaimTemplate's namespace is typically empty (inherits from StatefulSet),
+		// so we need to fall back to the StatefulSet's namespace when building PVC names
+		pvcNamespace := vol.ObjectMeta.Namespace
+		if pvcNamespace == "" {
+			pvcNamespace = statefulSet.GetNamespace()
+		}
 		namespacedName := types.NamespacedName{
-			Namespace: statefulSet.GetNamespace(),
+			Namespace: pvcNamespace,
 			Name:      fmt.Sprintf("%s-%s", vol.ObjectMeta.Name, podName),
 		}
 		var pvc corev1.PersistentVolumeClaim
@@ -237,6 +1027,8 @@ func handleScaleUp(ctx context.Context, c splcommon.ControllerClient, statefulSe
 	scopedLog := reqLogger.WithName("handleScaleUp").WithValues(
 		"name", statefulSet.GetObjectMeta().GetName(),
 		"desiredReplicas", desiredReplicas,
+		"replicas", replicas,
+		"readyReplicas", readyReplicas,
 		"namespace", statefulSet.GetObjectMeta().GetNamespace())
 
 	if readyReplicas >= desiredReplicas {
@@ -307,9 +1099,7 @@ func handleScaleUp(ctx context.Context, c splcommon.ControllerClient, statefulSe
 				// Still within timeout window, continue waiting
 				scopedLog.Info("Waiting for pods to become ready before scaling up",
 					"timeout", timeout,
-					"elapsed", elapsed,
-					"readyReplicas", readyReplicas,
-					"replicas", replicas)
+					"elapsed", elapsed)
 				if readyReplicas > 0 {
 					return enterpriseApi.PhaseScalingUp, nil
 				}
@@ -318,7 +1108,7 @@ func handleScaleUp(ctx context.Context, c splcommon.ControllerClient, statefulSe
 		}
 	}
 	// All current pods are ready (or timeout exceeded), proceed with scale up
-	scopedLog.Info("Scaling replicas up", "replicas", desiredReplicas)
+	scopedLog.Info("Scaling replicas up")
 	*statefulSet.Spec.Replicas = desiredReplicas
 	err := splutil.UpdateResource(ctx, c, statefulSet)
 	if err != nil {
@@ -331,6 +1121,518 @@ func handleScaleUp(ctx context.Context, c splcommon.ControllerClient, statefulSe
 		return enterpriseApi.PhaseScalingUp, err
 	}
 	return enterpriseApi.PhaseScalingUp, nil
+}
+
+// handleCPUPreservingScaleUp manages the gradual scale-up transition when CPU-preserving scaling is enabled.
+// This function implements a ceiling-based algorithm to prevent CPU request spikes during scale-up.
+//
+// Algorithm (4 steps):
+//  1. CHECK COMPLETION - If replicas == targetReplicas AND all pods [0, targetReplicas-1] have new spec
+//  2. COMPUTE METRICS - Get totalPodCPU (all non-terminated pods), cpuCeiling
+//  3. ADD NEW PODS - If under ceiling and below target replicas, add pods
+//  4. RECYCLE OLD PODS - If ceiling prevents adding and old-spec pods exist, recycle to free capacity
+//
+// The CPU ceiling is: originalTotalCPU + (parallelUpdates × targetCPUPerPod)
+// This ensures we never exceed the original total CPU by more than a small buffer.
+//
+// Returns: (phase, handled, error)
+// - (phase, true, nil) if CPU-preserving scale-up is being handled (caller should return phase)
+// - (PhaseReady, false, nil) if CPU-preserving scale-up is not applicable (caller should continue)
+// - (PhaseError, true, error) if an error occurred
+func handleCPUPreservingScaleUp(
+	ctx context.Context,
+	c splcommon.ControllerClient,
+	statefulSet *appsv1.StatefulSet,
+	mgr splcommon.StatefulSetPodManager,
+	state CPUAwareTransitionState,
+) (enterpriseApi.Phase, bool, error) {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("handleCPUPreservingScaleUp").WithValues(
+		"name", statefulSet.GetObjectMeta().GetName(),
+		"namespace", statefulSet.GetObjectMeta().GetNamespace())
+
+	replicas := *statefulSet.Spec.Replicas
+	targetReplicas := state.TargetReplicas
+	parallelUpdates := getParallelPodUpdates(statefulSet)
+
+	// Clamp parallelUpdates to at least 1 (safety)
+	if parallelUpdates < 1 {
+		parallelUpdates = 1
+	}
+
+	cpuCeiling := computeCPUCeiling(state, parallelUpdates)
+
+	scopedLog.Info("CPU-aware scale-up active",
+		"currentReplicas", replicas,
+		"targetReplicas", targetReplicas,
+		"originalCPUMillis", state.OriginalCPUMillis,
+		"targetCPUMillis", state.TargetCPUMillis,
+		"cpuCeiling", cpuCeiling,
+		"parallelUpdates", parallelUpdates)
+
+	// Step 1: CHECK COMPLETION
+	// If replicas == targetReplicas AND all pods [0, targetReplicas-1] have new spec
+	if replicas == targetReplicas && checkCPUTransitionCompletion(ctx, c, statefulSet, targetReplicas, state.TargetCPUMillis) {
+		scopedLog.Info("CPU-aware scale-up complete, all pods have new spec",
+			"finalReplicas", targetReplicas,
+			"action", "caller should update CR replicas and remove annotation")
+
+		if err := persistCPUTransitionFinished(ctx, c, statefulSet, &state); err != nil {
+			return enterpriseApi.PhaseError, true, err
+		}
+
+		scopedLog.Info("Scale-up transition completion persisted", "finishedAt", state.FinishedAt)
+		return enterpriseApi.PhaseReady, true, nil
+	}
+
+	// Step 2: COMPUTE LIVE CPU METRICS
+	// Use all non-terminated pods (not just ready) to track total CPU requests
+	metrics, metricsErr := computeNonTerminatedCPUMetricsForScaleUp(ctx, c, statefulSet, state)
+	if metricsErr != nil {
+		scopedLog.Error(metricsErr, "Unable to compute CPU metrics for scale-up")
+		return enterpriseApi.PhaseError, true, metricsErr
+	}
+
+	scopedLog.Info("Scale-up CPU metrics computed",
+		"totalPodCPU", metrics.TotalPodCPU,
+		"cpuCeiling", cpuCeiling,
+		"oldSpecPodCount", metrics.OldSpecPodCount,
+		"newSpecPodCount", metrics.NewSpecPodCount,
+		"oldSpecReadyPods", metrics.OldSpecReadyPods)
+
+	// Step 3: ADD NEW PODS (if below target and under ceiling)
+	if replicas < targetReplicas {
+		availableRoom := cpuCeiling - metrics.TotalPodCPU
+		targetCPUPerPod := state.TargetCPUMillis
+
+		scopedLog.Info("Checking if we can add new pods",
+			"availableRoom", availableRoom,
+			"targetCPUPerPod", targetCPUPerPod,
+			"currentReplicas", replicas,
+			"targetReplicas", targetReplicas)
+
+		if availableRoom >= targetCPUPerPod {
+			// Calculate how many pods we can add
+			podsCanAdd := availableRoom / targetCPUPerPod
+			podsNeeded := int64(targetReplicas - replicas)
+			if podsCanAdd > podsNeeded {
+				podsCanAdd = podsNeeded
+			}
+			if podsCanAdd > int64(parallelUpdates) {
+				podsCanAdd = int64(parallelUpdates)
+			}
+
+			if podsCanAdd > 0 {
+				newReplicas := replicas + int32(podsCanAdd)
+				scopedLog.Info("Adding new pods (under CPU ceiling)",
+					"podsToAdd", podsCanAdd,
+					"newReplicas", newReplicas,
+					"availableRoom", availableRoom,
+					"cpuCeiling", cpuCeiling,
+					"totalPodCPU", metrics.TotalPodCPU)
+
+				*statefulSet.Spec.Replicas = newReplicas
+				updateErr := splutil.UpdateResource(ctx, c, statefulSet)
+				if updateErr != nil {
+					scopedLog.Error(updateErr, "Unable to update StatefulSet replicas for scale-up")
+					return enterpriseApi.PhaseError, true, updateErr
+				}
+				return enterpriseApi.PhaseScalingUp, true, nil
+			}
+		}
+
+		// Step 4: RECYCLE OLD-SPEC PODS to free capacity
+		// We can only add more pods if we recycle old-spec pods (which have higher CPU)
+		if metrics.OldSpecReadyPods > 0 {
+			scopedLog.Info("CPU ceiling reached, need to recycle old-spec pods to free capacity",
+				"availableRoom", availableRoom,
+				"targetCPUPerPod", targetCPUPerPod,
+				"oldSpecReadyPods", metrics.OldSpecReadyPods)
+
+			// Find old-spec READY pods and recycle up to parallelUpdates
+			recycledCount := int32(0)
+			for n := int32(0); n < replicas && recycledCount < parallelUpdates; n++ {
+				podName := fmt.Sprintf("%s-%d", statefulSet.GetName(), n)
+				podNamespacedName := types.NamespacedName{Namespace: statefulSet.GetNamespace(), Name: podName}
+				var pod corev1.Pod
+				podErr := c.Get(ctx, podNamespacedName, &pod)
+				if podErr != nil {
+					// Pod doesn't exist - skip
+					continue
+				}
+
+				// Skip pods that are not ready (being recreated) or already have new spec
+				if !isPodReady(&pod) || hasNewSpec(&pod, state.TargetCPUMillis) {
+					continue
+				}
+
+				// Found an old-spec READY pod - recycle it
+				scopedLog.Info("Recycling old-spec pod to free CPU capacity",
+					"podName", podName,
+					"podIndex", n,
+					"oldCPU", extractCPUFromPod(&pod),
+					"targetCPU", state.TargetCPUMillis)
+
+				// Prepare for recycle
+				ready, prepErr := mgr.PrepareRecycle(ctx, n)
+				if prepErr != nil {
+					scopedLog.Info("Unable to prepare pod for recycling, skipping for now",
+						"podName", podName,
+						"error", prepErr.Error())
+					continue
+				}
+
+				recycledCount++
+				if !ready {
+					scopedLog.Info("Pod preparation in progress", "podName", podName)
+					continue
+				}
+
+				// Delete the pod to trigger recreation with new spec
+				preconditions := client.Preconditions{UID: &pod.ObjectMeta.UID, ResourceVersion: &pod.ObjectMeta.ResourceVersion}
+				delErr := c.Delete(ctx, &pod, preconditions)
+				if delErr != nil {
+					scopedLog.Error(delErr, "Unable to delete Pod for recycling", "podName", podName)
+					return enterpriseApi.PhaseError, true, delErr
+				}
+
+				scopedLog.Info("Recycled pod for CPU-aware scale-up",
+					"podName", podName,
+					"recycledThisCycle", recycledCount,
+					"parallelUpdates", parallelUpdates)
+			}
+
+			if recycledCount > 0 {
+				return enterpriseApi.PhaseUpdating, true, nil
+			}
+		}
+	}
+
+	// No action possible this cycle - waiting for pods to be recreated or scheduling
+	scopedLog.Info("Waiting for scale-up progress (pods being created/recycled)")
+	return enterpriseApi.PhaseUpdating, true, nil
+}
+
+// handleCPUPreservingScaleDown manages the gradual scale-down transition when CPU-preserving scaling is enabled.
+// This function implements an interleaved recycle-and-balance algorithm that eliminates deadlock scenarios.
+//
+// Algorithm (4 steps):
+//  1. CHECK COMPLETION - If replicas == targetReplicas AND all pods [0, targetReplicas-1] have new spec
+//  2. COMPUTE METRICS - Get totalReadyCPU, originalTotalCPU, currentReplicas
+//  3. BALANCE - If surplusCPU >= oldCPUPerPod, reduce replicas (return PhaseScalingDown)
+//  4. RECYCLE - Recycle old-spec READY pods in [0, targetReplicas-1] up to parallelUpdates at a time
+//
+// Returns: (phase, handled, error)
+// - (phase, true, nil) if CPU-preserving scale-down is being handled (caller should return phase)
+// - (PhaseReady, false, nil) should never occur (caller already determined this is scale-down)
+// - (PhaseError, true, error) if an error occurred
+func handleCPUPreservingScaleDown(
+	ctx context.Context,
+	c splcommon.ControllerClient,
+	statefulSet *appsv1.StatefulSet,
+	mgr splcommon.StatefulSetPodManager,
+	state CPUAwareTransitionState,
+) (enterpriseApi.Phase, bool, error) {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("handleCPUPreservingScaleDown").WithValues(
+		"name", statefulSet.GetObjectMeta().GetName(),
+		"namespace", statefulSet.GetObjectMeta().GetNamespace())
+
+	replicas := *statefulSet.Spec.Replicas
+	readyReplicas := statefulSet.Status.ReadyReplicas
+	targetReplicas := state.TargetReplicas
+
+	scopedLog.Info("CPU-aware scale-down active",
+		"currentReplicas", replicas,
+		"targetReplicas", targetReplicas,
+		"readyReplicas", readyReplicas,
+		"originalCPUMillis", state.OriginalCPUMillis,
+		"targetCPUMillis", state.TargetCPUMillis)
+
+	// Step 1: CHECK COMPLETION using shared helper
+	// If replicas == targetReplicas AND all pods [0, targetReplicas-1] have new spec
+	if replicas == targetReplicas && checkCPUTransitionCompletion(ctx, c, statefulSet, targetReplicas, state.TargetCPUMillis) {
+		scopedLog.Info("CPU-aware transition complete, all kept pods have new spec",
+			"finalReplicas", targetReplicas,
+			"action", "caller should update CR replicas and remove annotation")
+
+		// Use shared helper to persist FinishedAt
+		if err := persistCPUTransitionFinished(ctx, c, statefulSet, &state); err != nil {
+			return enterpriseApi.PhaseError, true, err
+		}
+
+		scopedLog.Info("Transition completion persisted", "finishedAt", state.FinishedAt)
+		return enterpriseApi.PhaseReady, true, nil
+	}
+
+	// Step 2: COMPUTE LIVE CPU METRICS
+	// We use stored values from state for original/target CPU per pod,
+	// but need to query live pods to get current ready CPU allocation
+	metrics, metricsErr := computeReadyCPUMetricsForScaleDown(ctx, c, statefulSet, state)
+	if metricsErr != nil {
+		scopedLog.Error(metricsErr, "Unable to compute CPU metrics")
+		return enterpriseApi.PhaseError, true, metricsErr
+	}
+
+	scopedLog.Info("CPU metrics computed",
+		"totalReadyCPU", metrics.TotalReadyCPU,
+		"originalTotalCPU", metrics.OriginalTotalCPU,
+		"oldCPUPerPod", metrics.OriginalCPUPerPod,
+		"newSpecPods", metrics.NewSpecReadyPods,
+		"oldSpecPods", metrics.OldSpecReadyPods)
+
+	// Step 3: BALANCE (if possible) - reduce replicas when new-spec pods provide surplus CPU
+	// This happens BEFORE recycling to efficiently reduce replica count as soon as possible
+	// surplusCPU measures the extra CPU capacity provided by new-spec pods compared to what they replaced
+	surplusCPU := metrics.NewSpecReadyCPU - (int64(metrics.NewSpecReadyPods) * metrics.OriginalCPUPerPod)
+	originalCPUPerPod := metrics.OriginalCPUPerPod
+
+	if originalCPUPerPod > 0 && surplusCPU >= originalCPUPerPod && replicas > targetReplicas {
+		// Calculate how many old pods can be safely deleted based on the surplus
+		podsSafeToDelete := surplusCPU / originalCPUPerPod
+
+		// Calculate the target replica count based on safe deletions from the original count
+		calculatedTargetReplicas := state.OriginalReplicas - int32(podsSafeToDelete)
+
+		// Never go below the final target replicas
+		if calculatedTargetReplicas < targetReplicas {
+			calculatedTargetReplicas = targetReplicas
+		}
+
+		if replicas > calculatedTargetReplicas {
+			scopedLog.Info("Balancing CPU: reducing replicas based on new-spec surplus",
+				"surplusCPU", surplusCPU,
+				"originalCPUPerPod", originalCPUPerPod,
+				"newSpecReadyPods", metrics.NewSpecReadyPods,
+				"newSpecReadyCPU", metrics.NewSpecReadyCPU,
+				"originalReplicas", state.OriginalReplicas,
+				"podsSafeToDelete", podsSafeToDelete,
+				"currentReplicas", replicas,
+				"calculatedTargetReplicas", calculatedTargetReplicas)
+			statefulSet.Spec.Replicas = &calculatedTargetReplicas
+			updateErr := splutil.UpdateResource(ctx, c, statefulSet)
+			if updateErr != nil {
+				scopedLog.Error(updateErr, "Unable to update StatefulSet replicas for balancing")
+				return enterpriseApi.PhaseError, true, updateErr
+			}
+			return enterpriseApi.PhaseScalingDown, true, nil
+		}
+	}
+
+	// Step 4: RECYCLE OLD-SPEC KEPT PODS
+	// Find old-spec pods in [0, targetReplicas-1] and recycle up to parallelUpdates at a time
+	// Note: We don't wait for ALL pods to be ready first - that would block parallel recycling.
+	// Instead, we skip pods that are not ready (they're being recreated from previous recycle).
+
+	// Calculate CPU floor to enforce parallel update limit
+	// Note: All old pods have the same CPU spec, so use OriginalCPUPerPod directly
+	parallelUpdates := getParallelPodUpdates(statefulSet)
+	minCPUFloor := metrics.OriginalTotalCPU - (int64(parallelUpdates) * metrics.OriginalCPUPerPod)
+
+	scopedLog.Info("CPU floor calculated for parallel update enforcement",
+		"minCPUFloor", minCPUFloor,
+		"originalCPUPerPod", metrics.OriginalCPUPerPod,
+		"parallelUpdates", parallelUpdates)
+
+	// Track same-cycle recycle count
+	recycledCount := int32(0)
+	// Track running CPU total as pods are deleted within this cycle
+	totalReadyCPU := metrics.TotalReadyCPU
+
+	for n := int32(0); n < targetReplicas; n++ {
+		podName := fmt.Sprintf("%s-%d", statefulSet.GetName(), n)
+		podNamespacedName := types.NamespacedName{Namespace: statefulSet.GetNamespace(), Name: podName}
+		var pod corev1.Pod
+		podErr := c.Get(ctx, podNamespacedName, &pod)
+		if podErr != nil {
+			// Pod doesn't exist yet - being recreated from previous recycle
+			continue
+		}
+
+		// Skip pods that are not ready (being recreated) || already has new spec
+		if !isPodReady(&pod) || hasNewSpec(&pod, state.TargetCPUMillis) {
+			continue
+		}
+
+		// Found an old-spec READY pod that will be kept
+
+		// SECONDARY CHECK: Enforce same-cycle limit (defense-in-depth)
+		if recycledCount >= parallelUpdates {
+			scopedLog.Info("Reached same-cycle recycle limit",
+				"recycledCount", recycledCount,
+				"parallelUpdates", parallelUpdates)
+			break
+		}
+
+		// PRIMARY CHECK: Verify CPU floor won't be violated
+		podCPU := extractCPUFromPod(&pod)
+		afterRecycleCPU := totalReadyCPU - podCPU
+		if afterRecycleCPU < minCPUFloor {
+			// deficit represents how much CPU we would be short of the minimum floor
+			deficit := minCPUFloor - afterRecycleCPU
+			scopedLog.Info("Cannot recycle pod - would violate CPU floor",
+				"podName", podName,
+				"podCPU", podCPU,
+				"runningTotalCPU", totalReadyCPU,
+				"afterRecycleCPU", afterRecycleCPU,
+				"minCPUFloor", minCPUFloor,
+				"deficit", deficit)
+			continue
+		}
+
+		scopedLog.Info("Pod eligible for recycling", "podName", podName)
+
+		// All checks passed - proceed with PrepareRecycle
+		ready, prepErr := mgr.PrepareRecycle(ctx, n)
+		if prepErr != nil {
+			// Don't stop the entire transition - log and skip this pod
+			// It may be restarting for unrelated reasons (liveness probe, etc.)
+			// We'll check it again in the next reconciliation cycle
+			scopedLog.Info("Unable to prepare pod for recycling, skipping for now",
+				"podName", podName,
+				"error", prepErr.Error(),
+				"action", "will retry in next reconciliation")
+			continue
+		}
+
+		// we need to count this pod as recycled even if not ready yet
+		// because PrepareRecycle may have initiated decommissioning which takes time and will be done in background
+		recycledCount++
+		if !ready {
+			// Pod is being prepared for recycling (e.g., decommissioning) - count as pending
+			// and continue to check other pods for parallel recycling
+			scopedLog.Info("Pod preparation in progress, checking next pod", "podName", podName)
+			continue
+		}
+
+		// Delete the pod to trigger recreation with new spec
+		scopedLog.Info("Recycling pod for CPU-aware transition",
+			"podName", podName,
+			"podIndex", n,
+			"oldCPU", extractCPUFromPod(&pod),
+			"targetCPU", metrics.TargetCPUPerPod,
+			"recycledThisCycle", recycledCount+1,
+			"parallelUpdates", parallelUpdates)
+		preconditions := client.Preconditions{UID: &pod.ObjectMeta.UID, ResourceVersion: &pod.ObjectMeta.ResourceVersion}
+		delErr := c.Delete(ctx, &pod, preconditions)
+		if delErr != nil {
+			scopedLog.Error(delErr, "Unable to delete Pod for recycling", "podName", podName)
+			return enterpriseApi.PhaseError, true, delErr
+		}
+
+		// Update running total after successful deletion
+		// This ensures subsequent CPU floor checks in this cycle reflect the reduced capacity
+		totalReadyCPU -= podCPU
+
+		// Check if we've reached the parallel update limit
+		if recycledCount >= parallelUpdates {
+			scopedLog.Info("Reached parallel update limit for recycling",
+				"recycledCount", recycledCount,
+				"parallelUpdates", parallelUpdates,
+				"totalReadyCPU", totalReadyCPU,
+			)
+			break
+		}
+	}
+
+	if recycledCount > 0 {
+		return enterpriseApi.PhaseUpdating, true, nil
+	}
+
+	// No pods to recycle and no balancing possible
+	// This can happen when waiting for recycled pods to come back up
+	scopedLog.Info("No old-spec pods found to recycle, continuing")
+	return enterpriseApi.PhaseUpdating, true, nil
+}
+
+// handleCPUPreservingTransition is the main dispatcher for CPU-aware scaling transitions.
+// It validates the transition state and delegates to the appropriate handler:
+//   - handleCPUPreservingScaleUp: for scale-up (targetReplicas > currentReplicas)
+//   - handleCPUPreservingScaleDown: for scale-down (targetReplicas < currentReplicas)
+//
+// When replicas == targetReplicas, the dispatcher runs the shared completion probe and
+// persists FinishedAt if complete, ensuring both scale-up and scale-down have consistent
+// completion handling.
+//
+// Returns: (phase, handled, error)
+// - (phase, true, nil) if CPU-preserving transition is being handled (caller should return phase)
+// - (PhaseReady, false, nil) if CPU-preserving transition is not applicable (caller should continue)
+// - (PhaseError, true, error) if an error occurred
+func handleCPUPreservingTransition(
+	ctx context.Context,
+	c splcommon.ControllerClient,
+	statefulSet *appsv1.StatefulSet,
+	mgr splcommon.StatefulSetPodManager,
+	replicas int32,
+) (enterpriseApi.Phase, bool, error) {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("handleCPUPreservingTransition").WithValues(
+		"name", statefulSet.GetObjectMeta().GetName(),
+		"namespace", statefulSet.GetObjectMeta().GetNamespace())
+
+	// Check if CPU-preserving scaling is enabled
+	if !isPreserveTotalCPUEnabled(statefulSet) {
+		return enterpriseApi.PhaseReady, false, nil
+	}
+
+	// Check for transition state annotation
+	transitionStateJSON := ""
+	if statefulSet.Annotations != nil {
+		transitionStateJSON = statefulSet.Annotations[CPUAwareTransitionStateAnnotation]
+	}
+	if transitionStateJSON == "" {
+		return enterpriseApi.PhaseReady, false, nil
+	}
+
+	// Parse the transition state from JSON
+	var transitionState CPUAwareTransitionState
+	if parseErr := json.Unmarshal([]byte(transitionStateJSON), &transitionState); parseErr != nil {
+		scopedLog.Error(parseErr, "Failed to parse CPU-aware transition state")
+		return enterpriseApi.PhaseError, true, parseErr
+	}
+
+	// Short-circuit: if transition already completed (FinishedAt is set), skip all steps
+	if transitionState.FinishedAt != "" {
+		scopedLog.Info("CPU-aware transition already complete, skipping steps",
+			"finishedAt", transitionState.FinishedAt,
+			"targetReplicas", transitionState.TargetReplicas)
+		return enterpriseApi.PhaseReady, true, nil
+	}
+
+	targetReplicas := transitionState.TargetReplicas
+
+	// EXPLICIT COMPLETION CHECK: When replicas == targetReplicas, run shared completion probe.
+	// This handles the edge case where we're at target replicas but need to check/persist completion.
+	if replicas == targetReplicas {
+		if checkCPUTransitionCompletion(ctx, c, statefulSet, targetReplicas, transitionState.TargetCPUMillis) {
+			scopedLog.Info("CPU-aware transition complete at target replicas, persisting FinishedAt",
+				"targetReplicas", targetReplicas)
+			if err := persistCPUTransitionFinished(ctx, c, statefulSet, &transitionState); err != nil {
+				return enterpriseApi.PhaseError, true, err
+			}
+			return enterpriseApi.PhaseReady, true, nil
+		}
+		// At target replicas but not all pods have new spec yet - need to continue recycling
+		scopedLog.Info("At target replicas but completion check failed, continuing transition",
+			"targetReplicas", targetReplicas)
+	}
+
+	if targetReplicas > replicas {
+		// Scale-up case: dispatch to scale-up handler
+		// This handles the gradual scale-up with CPU ceiling enforcement
+		scopedLog.Info("Dispatching to CPU-aware scale-up handler",
+			"currentReplicas", replicas,
+			"targetReplicas", targetReplicas)
+		return handleCPUPreservingScaleUp(ctx, c, statefulSet, mgr, transitionState)
+	}
+
+	// Scale-down case (targetReplicas <= replicas): dispatch to scale-down handler
+	// This handles the gradual scale-down with CPU floor enforcement
+	// Note: This also handles the replicas == targetReplicas case when completion check failed above
+	scopedLog.Info("Dispatching to CPU-aware scale-down handler",
+		"currentReplicas", replicas,
+		"targetReplicas", targetReplicas)
+	return handleCPUPreservingScaleDown(ctx, c, statefulSet, mgr, transitionState)
 }
 
 // UpdateStatefulSetPods manages scaling and config updates for StatefulSets.
@@ -357,6 +1659,23 @@ func UpdateStatefulSetPods(ctx context.Context, c splcommon.ControllerClient, st
 	if err != nil {
 		scopedLog.Error(err, "Unable to re-fetch StatefulSet for latest status")
 		return enterpriseApi.PhaseError, err
+	}
+
+	// Get eventPublisher from context (if available)
+	var eventPublisher splcommon.K8EventPublisher
+	if ep := ctx.Value(splcommon.EventPublisherKey); ep != nil {
+		eventPublisher = ep.(splcommon.K8EventPublisher)
+	}
+
+	// Handle unified transition (combines CPU-aware scaling + VCT migration)
+	// This takes priority over the legacy handleCPUPreservingTransition
+	if phase, handled, err := handleUnifiedTransition(ctx, c, statefulSet, mgr, eventPublisher); handled {
+		return phase, err
+	}
+
+	// Handle CPU-preserving transition if enabled (legacy path for backward compatibility)
+	if phase, handled, err := handleCPUPreservingTransition(ctx, c, statefulSet, mgr, replicas); handled {
+		return phase, err
 	}
 
 	// check for scaling down - prioritize scale-down operations
@@ -395,59 +1714,9 @@ func UpdateStatefulSetPods(ctx context.Context, c splcommon.ControllerClient, st
 	}
 
 	// check existing pods for desired updates
-	for n := readyReplicas - 1; n >= 0; n-- {
-		// get Pod
-		podName := fmt.Sprintf("%s-%d", statefulSet.GetName(), n)
-		namespacedName := types.NamespacedName{Namespace: statefulSet.GetNamespace(), Name: podName}
-		var pod corev1.Pod
-		err := c.Get(ctx, namespacedName, &pod)
-		if err != nil {
-			scopedLog.Error(err, "Unable to find Pod", "podName", podName)
-			return enterpriseApi.PhaseError, err
-		}
-		if pod.Status.Phase != corev1.PodRunning || len(pod.Status.ContainerStatuses) == 0 || !pod.Status.ContainerStatuses[0].Ready {
-			scopedLog.Error(err, "Waiting for Pod to become ready", "podName", podName)
-			return enterpriseApi.PhaseUpdating, err
-		}
-
-		// terminate pod if it has pending updates; k8s will start a new one with revised template
-		if statefulSet.Status.UpdateRevision != "" && statefulSet.Status.UpdateRevision != pod.GetLabels()["controller-revision-hash"] {
-			// pod needs to be updated; first, prepare it to be recycled
-			ready, err := mgr.PrepareRecycle(ctx, n)
-			if err != nil {
-				scopedLog.Error(err, "Unable to prepare Pod for recycling", "podName", podName)
-				return enterpriseApi.PhaseError, err
-			}
-			if !ready {
-				// wait until pod quarantine has completed before deleting it
-				return enterpriseApi.PhaseUpdating, nil
-			}
-
-			// deleting pod will cause StatefulSet controller to create a new one with latest template
-			scopedLog.Info("Recycling Pod for updates", "podName", podName,
-				"statefulSetRevision", statefulSet.Status.UpdateRevision,
-				"podRevision", pod.GetLabels()["controller-revision-hash"])
-			preconditions := client.Preconditions{UID: &pod.ObjectMeta.UID, ResourceVersion: &pod.ObjectMeta.ResourceVersion}
-			err = c.Delete(ctx, &pod, preconditions)
-			if err != nil {
-				scopedLog.Error(err, "Unable to delete Pod", "podName", podName)
-				return enterpriseApi.PhaseError, err
-			}
-
-			// only delete one at a time
-			return enterpriseApi.PhaseUpdating, nil
-		}
-
-		// check if pod was previously prepared for recycling; if so, complete
-		complete, err := mgr.FinishRecycle(ctx, n)
-		if err != nil {
-			scopedLog.Error(err, "Unable to complete recycling of pod", "podName", podName)
-			return enterpriseApi.PhaseError, err
-		}
-		if !complete {
-			// return and wait until next reconcile to let things settle down
-			return enterpriseApi.PhaseUpdating, nil
-		}
+	phase, err := CheckStatefulSetPodsForUpdates(ctx, c, statefulSet, mgr, readyReplicas)
+	if phase != enterpriseApi.PhaseReady || err != nil {
+		return phase, err
 	}
 
 	// Remove unwanted owner references
@@ -468,6 +1737,102 @@ func UpdateStatefulSetPods(ctx context.Context, c splcommon.ControllerClient, st
 	}
 
 	scopedLog.Info("Statefulset - Phase Ready")
+
+	return enterpriseApi.PhaseReady, nil
+}
+
+// CheckStatefulSetPodsForUpdates checks existing pods for desired updates and handles recycling if needed.
+// This function iterates through all pods in reverse order (highest index first) and:
+// - Verifies each pod exists and is ready
+// - Compares pod revision with StatefulSet UpdateRevision
+// - Initiates controlled pod recycling (PrepareRecycle -> Delete -> FinishRecycle)
+// - Supports parallel pod updates via annotation (default: 1 pod at a time)
+// Returns PhaseUpdating while updates are in progress, PhaseReady when all pods are current.
+func CheckStatefulSetPodsForUpdates(ctx context.Context,
+	c splcommon.ControllerClient, statefulSet *appsv1.StatefulSet,
+	mgr splcommon.StatefulSetPodManager, readyReplicas int32,
+) (enterpriseApi.Phase, error) {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("CheckStatefulSetPodsForUpdates").WithValues("name", statefulSet.GetName(), "namespace", statefulSet.GetNamespace())
+
+	// Get the maximum number of pods to update in parallel
+	maxParallelUpdates := getParallelPodUpdates(statefulSet)
+	podsDeletedThisCycle := int32(0)
+
+	scopedLog.Info("Checking pods for updates", "maxParallelUpdates", maxParallelUpdates)
+
+	for n := readyReplicas - 1; n >= 0; n-- {
+		// get Pod
+		podName := fmt.Sprintf("%s-%d", statefulSet.GetName(), n)
+		namespacedName := types.NamespacedName{Namespace: statefulSet.GetNamespace(), Name: podName}
+		var pod corev1.Pod
+		err := c.Get(ctx, namespacedName, &pod)
+		if err != nil {
+			scopedLog.Error(err, "Unable to find Pod", "podName", podName)
+			return enterpriseApi.PhaseError, err
+		}
+		if pod.Status.Phase != corev1.PodRunning || len(pod.Status.ContainerStatuses) == 0 || !pod.Status.ContainerStatuses[0].Ready {
+			scopedLog.Info("Waiting for Pod to become ready", "podName", podName)
+			return enterpriseApi.PhaseUpdating, nil
+		}
+
+		// terminate pod if it has pending updates; k8s will start a new one with revised template
+		if statefulSet.Status.UpdateRevision != "" && statefulSet.Status.UpdateRevision != pod.GetLabels()["controller-revision-hash"] {
+			// pod needs to be updated; first, prepare it to be recycled
+			ready, err := mgr.PrepareRecycle(ctx, n)
+			if err != nil {
+				scopedLog.Error(err, "Unable to prepare Pod for recycling", "podName", podName)
+				return enterpriseApi.PhaseError, err
+			}
+			if !ready {
+				// wait until pod quarantine has completed before deleting it
+				return enterpriseApi.PhaseUpdating, nil
+			}
+
+			// deleting pod will cause StatefulSet controller to create a new one with revised template
+			scopedLog.Info("Recycling Pod for updates", "podName", podName,
+				"statefulSetRevision", statefulSet.Status.UpdateRevision,
+				"podRevision", pod.GetLabels()["controller-revision-hash"])
+			preconditions := client.Preconditions{UID: &pod.ObjectMeta.UID, ResourceVersion: &pod.ObjectMeta.ResourceVersion}
+			err = c.Delete(ctx, &pod, preconditions)
+			if err != nil {
+				scopedLog.Error(err, "Unable to delete Pod", "podName", podName)
+				return enterpriseApi.PhaseError, err
+			}
+
+			// Track number of pods deleted in this cycle
+			podsDeletedThisCycle++
+
+			// Check if we've reached the parallel update limit
+			if podsDeletedThisCycle >= maxParallelUpdates {
+				scopedLog.Info("Reached parallel update limit, waiting for next reconcile",
+					"podsDeleted", podsDeletedThisCycle,
+					"maxParallel", maxParallelUpdates)
+				return enterpriseApi.PhaseUpdating, nil
+			}
+
+			// Continue to next pod for parallel updates
+			continue
+		}
+
+		// check if pod was previously prepared for recycling; if so, complete
+		complete, err := mgr.FinishRecycle(ctx, n)
+		if err != nil {
+			scopedLog.Error(err, "Unable to complete recycling of pod", "podName", podName)
+			return enterpriseApi.PhaseError, err
+		}
+		if !complete {
+			// return and wait until next reconcile to let things settle down
+			return enterpriseApi.PhaseUpdating, nil
+		}
+	}
+
+	// If we deleted any pods this cycle, return PhaseUpdating to wait for them to be recreated
+	if podsDeletedThisCycle > 0 {
+		scopedLog.Info("Pods deleted this cycle, waiting for recreation",
+			"podsDeleted", podsDeletedThisCycle)
+		return enterpriseApi.PhaseUpdating, nil
+	}
 
 	return enterpriseApi.PhaseReady, nil
 }
@@ -742,4 +2107,535 @@ func IsStatefulSetScalingUpOrDown(ctx context.Context, client splcommon.Controll
 	}
 
 	return enterpriseApi.StatefulSetNotScaling, nil
+}
+
+// isPodFullyUpdated checks if a pod has ALL required updates applied.
+// Returns true only if:
+// - CPU spec matches target (if CPUChange is active)
+// - All PVC storage classes match target (if VCTMigration is active)
+// - All PVC access modes match target (if VCTMigration specifies access modes)
+
+// canRecyclePodWithinCPUFloor checks if recycling a pod would violate the CPU floor constraint.
+// The CPU floor ensures that total ready CPU never drops below the minimum required to maintain
+// capacity during transitions.
+//
+// Returns true if:
+// - state.CPUChange is nil (no CPU transition active, no floor constraint)
+// - Recycling the pod would not drop total ready CPU below the floor
+//
+// Returns false if recycling would violate the CPU floor constraint.
+
+// recyclePodForUnifiedTransition handles pod recycling for combined CPU + VCT transitions.
+// Key insight: When recycling a pod, delete both the pod AND its PVCs if VCT migration is active.
+// The StatefulSet controller will recreate the pod with new spec AND new PVCs.
+//
+// Error handling:
+// - Pod deletion failures are logged and returned as errors (caller tracks failures)
+// - PVC deletion failures due to finalizers are logged as warnings and do not block pod deletion
+// - Stuck PVCs (deletion pending > 30 minutes) trigger warning events
+
+// handleUnifiedTransition manages combined CPU-aware scaling and VCT migration transitions.
+// This is the main entry point for unified transitions, replacing separate handlers.
+//
+// Key design principles:
+// 1. Recycle each pod ONCE for ALL pending changes (CPU + VCT)
+// 2. Handle replica scaling first (CPU ceiling/floor logic)
+// 3. Then recycle pods that need updates
+// 4. Respect parallelUpdates limit
+// 5. Enforce CPU floor during transitions
+// 6. Track failed pods and skip permanently failed ones after MaxPodRecycleFailures
+// 7. Detect stalled transitions and publish warning events
+//
+// Returns: (phase, handled, error)
+// - (phase, true, nil) if transition is being handled (caller should return phase)
+// - (PhaseReady, false, nil) if no transition needed (caller should continue)
+// - (PhaseError, true, error) if an error occurred
+func handleUnifiedTransition(
+	ctx context.Context,
+	c splcommon.ControllerClient,
+	statefulSet *appsv1.StatefulSet,
+	mgr splcommon.StatefulSetPodManager,
+	eventPublisher splcommon.K8EventPublisher,
+) (enterpriseApi.Phase, bool, error) {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("handleUnifiedTransition").WithValues(
+		"name", statefulSet.GetName(),
+		"namespace", statefulSet.GetNamespace())
+
+	// Check for unified transition state annotation
+	// IMPORTANT: Only handle transitions that were explicitly stored in the new format
+	// OR have VCT migration. CPU-only transitions from the old format should be handled
+	// by the legacy handleCPUPreservingTransition for backward compatibility.
+	if statefulSet.Annotations == nil {
+		return enterpriseApi.PhaseReady, false, nil
+	}
+
+	// Only process if the new unified annotation exists (not migrated from old format)
+	stateJSON, hasNewAnnotation := statefulSet.Annotations[UnifiedTransitionStateAnnotation]
+	if !hasNewAnnotation || stateJSON == "" {
+		// No new format annotation - let legacy handler take care of it
+		return enterpriseApi.PhaseReady, false, nil
+	}
+
+	state, err := getUnifiedTransitionState(statefulSet)
+	if err != nil {
+		scopedLog.Error(err, "Failed to get unified transition state")
+		return enterpriseApi.PhaseError, true, err
+	}
+
+	if state == nil {
+		// No transition in progress
+		return enterpriseApi.PhaseReady, false, nil
+	}
+
+	// Already complete?
+	if state.FinishedAt != "" {
+		scopedLog.Info("Unified transition already complete, clearing state")
+		if err := clearUnifiedTransitionState(ctx, c, statefulSet); err != nil {
+			return enterpriseApi.PhaseError, true, err
+		}
+		return enterpriseApi.PhaseReady, true, nil
+	}
+
+	// ============================================================
+	// CHECK FOR STALLED TRANSITION
+	// ============================================================
+	stallTimeout := getUnifiedTransitionStallTimeout(statefulSet)
+	if isTransitionStalled(state, stallTimeout) {
+		scopedLog.Info("Warning: Unified transition appears stalled",
+			"startedAt", state.StartedAt,
+			"stallTimeout", stallTimeout,
+			"failedPods", len(state.FailedPods))
+		if eventPublisher != nil {
+			failedPodCount := 0
+			if state.FailedPods != nil {
+				failedPodCount = len(state.FailedPods)
+			}
+			eventPublisher.Warning(ctx, "UnifiedTransitionStalled",
+				fmt.Sprintf("Unified transition has been running since %s (over %v). Failed pods: %d. Consider investigating or manually intervening.",
+					state.StartedAt, stallTimeout, failedPodCount))
+		}
+		// Continue processing but log warnings - don't block entirely
+	}
+
+	parallelUpdates := getParallelPodUpdates(statefulSet)
+
+	replicas := int32(1)
+	if statefulSet.Spec.Replicas != nil {
+		replicas = *statefulSet.Spec.Replicas
+	}
+
+	targetReplicas := replicas
+	if state.CPUChange != nil {
+		targetReplicas = state.CPUChange.TargetReplicas
+	}
+
+	scopedLog.Info("Processing unified transition",
+		"currentReplicas", replicas,
+		"targetReplicas", targetReplicas,
+		"parallelUpdates", parallelUpdates,
+		"hasCPUChange", state.CPUChange != nil,
+		"hasVCTMigration", state.VCTMigration != nil,
+		"failedPods", len(state.FailedPods))
+
+	// ============================================================
+	// STEP 1: Handle replica scaling first (if CPU change requires it)
+	// ============================================================
+	if state.CPUChange != nil {
+		if targetReplicas > replicas {
+			// Scale-up case: use CPU ceiling logic
+			phase, err := handleUnifiedScaleUp(ctx, c, statefulSet, mgr, state, parallelUpdates, eventPublisher)
+			if phase != enterpriseApi.PhaseReady {
+				return phase, true, err
+			}
+		} else if targetReplicas < replicas {
+			// Scale-down case: use CPU floor logic + delete PVCs
+			phase, err := handleUnifiedScaleDown(ctx, c, statefulSet, mgr, state, parallelUpdates, eventPublisher)
+			if phase != enterpriseApi.PhaseReady {
+				return phase, true, err
+			}
+		}
+	}
+
+	// ============================================================
+	// STEP 2: Recycle pods that need updates (CPU or VCT or both)
+	// ============================================================
+	recycledCount := int32(0)
+	allPodsUpdated := true
+	podsBeingRecycled := int32(0)
+	stateModified := false // Track if state needs to be persisted
+
+	for n := int32(0); n < targetReplicas && recycledCount < parallelUpdates; n++ {
+		podName := fmt.Sprintf("%s-%d", statefulSet.GetName(), n)
+		pod := &corev1.Pod{}
+		podNamespacedName := types.NamespacedName{
+			Namespace: statefulSet.GetNamespace(),
+			Name:      podName,
+		}
+
+		// Skip permanently failed pods (continue with others)
+		if isPodPermanentlyFailed(state, podName) {
+			scopedLog.Info("Skipping permanently failed pod",
+				"podName", podName,
+				"failCount", state.FailedPods[podName].FailCount,
+				"lastError", state.FailedPods[podName].LastError)
+			continue
+		}
+
+		if err := c.Get(ctx, podNamespacedName, pod); err != nil {
+			if k8serrors.IsNotFound(err) {
+				// Pod being recreated by StatefulSet controller
+				scopedLog.Info("Pod not found (being recreated)", "podName", podName)
+				allPodsUpdated = false
+				podsBeingRecycled++
+				continue
+			}
+			return enterpriseApi.PhaseError, true, err
+		}
+
+		// Skip pods that aren't ready (being recycled)
+		if !isPodReady(pod) {
+			scopedLog.Info("Pod not ready (being recycled)", "podName", podName)
+			allPodsUpdated = false
+			podsBeingRecycled++
+			continue
+		}
+
+		// Check if this pod is fully updated
+		updated, err := isPodFullyUpdated(ctx, c, pod, statefulSet, state)
+		if err != nil {
+			return enterpriseApi.PhaseError, true, err
+		}
+
+		if updated {
+			// This pod is done
+			scopedLog.V(1).Info("Pod fully updated", "podName", podName)
+			continue
+		}
+
+		allPodsUpdated = false
+
+		// Enforce CPU floor if CPU transition is active
+		if state.CPUChange != nil {
+			if !canRecyclePodWithinCPUFloor(ctx, c, statefulSet, pod, state, parallelUpdates) {
+				scopedLog.Info("Cannot recycle pod - would violate CPU floor", "podName", podName)
+				continue
+			}
+		}
+
+		// Recycle this pod (handles both CPU and VCT)
+		err = recyclePodForUnifiedTransition(ctx, c, statefulSet, mgr, pod, n, state, eventPublisher)
+		if err != nil {
+			scopedLog.Error(err, "Failed to recycle pod", "podName", podName)
+
+			// Track the failure in state
+			permanentlyFailed := recordPodFailure(state, podName, err.Error())
+			stateModified = true
+
+			if permanentlyFailed {
+				scopedLog.Info("Pod marked as permanently failed after max retries",
+					"podName", podName,
+					"maxRetries", MaxPodRecycleFailures)
+				if eventPublisher != nil {
+					eventPublisher.Warning(ctx, "PodRecycleFailed",
+						fmt.Sprintf("Pod %s has failed recycling %d times and will be skipped: %v",
+							podName, MaxPodRecycleFailures, err))
+				}
+			}
+
+			// Continue with other pods
+			continue
+		}
+
+		recycledCount++
+	}
+
+	// Persist state if we recorded any failures
+	if stateModified {
+		if err := persistUnifiedTransitionState(ctx, c, statefulSet, state); err != nil {
+			scopedLog.Error(err, "Failed to persist updated transition state with failure info")
+			// Don't fail the entire operation, continue
+		}
+	}
+
+	// ============================================================
+	// STEP 3: Check completion
+	// ============================================================
+	// Count permanently failed pods - if all non-failed pods are updated, consider complete
+	permanentlyFailedCount := 0
+	if state.FailedPods != nil {
+		for _, failInfo := range state.FailedPods {
+			if failInfo.FailCount >= MaxPodRecycleFailures {
+				permanentlyFailedCount++
+			}
+		}
+	}
+
+	if allPodsUpdated && replicas == targetReplicas && podsBeingRecycled == 0 {
+		scopedLog.Info("Unified transition complete",
+			"permanentlyFailedPods", permanentlyFailedCount)
+		state.FinishedAt = time.Now().Format(time.RFC3339)
+		if err := persistUnifiedTransitionState(ctx, c, statefulSet, state); err != nil {
+			return enterpriseApi.PhaseError, true, err
+		}
+
+		if eventPublisher != nil {
+			msg := "Unified transition complete"
+			if state.CPUChange != nil {
+				msg += fmt.Sprintf(" - CPU: %dm->%dm, Replicas: %d->%d",
+					state.CPUChange.OriginalCPUMillis, state.CPUChange.TargetCPUMillis,
+					state.CPUChange.OriginalReplicas, state.CPUChange.TargetReplicas)
+			}
+			if state.VCTMigration != nil {
+				msg += fmt.Sprintf(" - VCT: %d storage classes migrated",
+					len(state.VCTMigration.ExpectedStorageClasses))
+			}
+			if permanentlyFailedCount > 0 {
+				msg += fmt.Sprintf(" - WARNING: %d pods failed and were skipped", permanentlyFailedCount)
+			}
+			eventPublisher.Normal(ctx, "UnifiedTransitionComplete", msg)
+		}
+
+		return enterpriseApi.PhaseReady, true, nil
+	}
+
+	scopedLog.Info("Unified transition in progress",
+		"recycledThisCycle", recycledCount,
+		"podsBeingRecycled", podsBeingRecycled,
+		"parallelUpdates", parallelUpdates,
+		"permanentlyFailedPods", permanentlyFailedCount)
+
+	return enterpriseApi.PhaseUpdating, true, nil
+}
+
+// handleUnifiedScaleUp handles scale-up during CPU-aware transitions with optional VCT migration.
+// Uses CPU ceiling logic: add replicas while staying under the ceiling.
+func handleUnifiedScaleUp(
+	ctx context.Context,
+	c splcommon.ControllerClient,
+	statefulSet *appsv1.StatefulSet,
+	mgr splcommon.StatefulSetPodManager,
+	state *UnifiedTransitionState,
+	parallelUpdates int32,
+	eventPublisher splcommon.K8EventPublisher,
+) (enterpriseApi.Phase, error) {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("handleUnifiedScaleUp").WithValues(
+		"name", statefulSet.GetName(),
+		"namespace", statefulSet.GetNamespace())
+
+	replicas := int32(1)
+	if statefulSet.Spec.Replicas != nil {
+		replicas = *statefulSet.Spec.Replicas
+	}
+
+	targetReplicas := state.CPUChange.TargetReplicas
+
+	if replicas >= targetReplicas {
+		// Scale-up complete
+		return enterpriseApi.PhaseReady, nil
+	}
+
+	// Compute CPU ceiling: originalTotalCPU + buffer
+	cpuCeiling := computeCPUCeiling(CPUAwareTransitionState{
+		OriginalCPUMillis: state.CPUChange.OriginalCPUMillis,
+		TargetCPUMillis:   state.CPUChange.TargetCPUMillis,
+		OriginalReplicas:  state.CPUChange.OriginalReplicas,
+		TargetReplicas:    state.CPUChange.TargetReplicas,
+	}, parallelUpdates)
+
+	// Compute current CPU from non-terminated pods
+	cpuState := CPUAwareTransitionState{
+		OriginalCPUMillis: state.CPUChange.OriginalCPUMillis,
+		TargetCPUMillis:   state.CPUChange.TargetCPUMillis,
+		OriginalReplicas:  state.CPUChange.OriginalReplicas,
+		TargetReplicas:    state.CPUChange.TargetReplicas,
+	}
+	metrics, err := computeNonTerminatedCPUMetricsForScaleUp(ctx, c, statefulSet, cpuState)
+	if err != nil {
+		scopedLog.Error(err, "Failed to compute CPU metrics for scale-up")
+		return enterpriseApi.PhaseError, err
+	}
+
+	// Calculate available room for new pods
+	availableRoom := cpuCeiling - metrics.TotalPodCPU
+	targetCPUPerPod := state.CPUChange.TargetCPUMillis
+
+	scopedLog.Info("Scale-up CPU metrics",
+		"currentReplicas", replicas,
+		"targetReplicas", targetReplicas,
+		"cpuCeiling", cpuCeiling,
+		"totalPodCPU", metrics.TotalPodCPU,
+		"availableRoom", availableRoom,
+		"targetCPUPerPod", targetCPUPerPod)
+
+	if availableRoom >= targetCPUPerPod {
+		// Calculate how many pods we can add
+		podsCanAdd := availableRoom / targetCPUPerPod
+		podsNeeded := int64(targetReplicas - replicas)
+		if podsCanAdd > podsNeeded {
+			podsCanAdd = podsNeeded
+		}
+		if podsCanAdd > int64(parallelUpdates) {
+			podsCanAdd = int64(parallelUpdates)
+		}
+
+		if podsCanAdd > 0 {
+			newReplicas := replicas + int32(podsCanAdd)
+			scopedLog.Info("Adding new pods (under CPU ceiling)",
+				"podsToAdd", podsCanAdd,
+				"newReplicas", newReplicas)
+
+			*statefulSet.Spec.Replicas = newReplicas
+			if err := splutil.UpdateResource(ctx, c, statefulSet); err != nil {
+				scopedLog.Error(err, "Failed to update replicas for scale-up")
+				return enterpriseApi.PhaseError, err
+			}
+
+			if eventPublisher != nil {
+				eventPublisher.Normal(ctx, "ScalingUp",
+					fmt.Sprintf("Scaling up from %d to %d replicas (target: %d) for unified transition",
+						replicas, newReplicas, targetReplicas))
+			}
+
+			return enterpriseApi.PhaseScalingUp, nil
+		}
+	}
+
+	// Cannot add more pods yet (need to recycle old-spec pods first)
+	scopedLog.Info("Waiting to add more pods (recycling old-spec pods to free capacity)",
+		"availableRoom", availableRoom,
+		"targetCPUPerPod", targetCPUPerPod)
+
+	return enterpriseApi.PhaseUpdating, nil
+}
+
+// handleUnifiedScaleDown handles scale-down during CPU-aware transitions with optional VCT migration.
+// Uses CPU floor logic: ensure target pods have new spec before reducing replicas.
+// Key: When deleting pods for scale-down, also delete their PVCs if VCT migration is active.
+func handleUnifiedScaleDown(
+	ctx context.Context,
+	c splcommon.ControllerClient,
+	statefulSet *appsv1.StatefulSet,
+	mgr splcommon.StatefulSetPodManager,
+	state *UnifiedTransitionState,
+	parallelUpdates int32,
+	eventPublisher splcommon.K8EventPublisher,
+) (enterpriseApi.Phase, error) {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("handleUnifiedScaleDown").WithValues(
+		"name", statefulSet.GetName(),
+		"namespace", statefulSet.GetNamespace())
+
+	replicas := int32(1)
+	if statefulSet.Spec.Replicas != nil {
+		replicas = *statefulSet.Spec.Replicas
+	}
+
+	targetReplicas := state.CPUChange.TargetReplicas
+
+	if replicas <= targetReplicas {
+		// Scale-down complete
+		return enterpriseApi.PhaseReady, nil
+	}
+
+	// First, ensure all remaining pods have new spec before we remove replicas
+	// This maintains CPU floor during transition
+	for n := int32(0); n < targetReplicas; n++ {
+		podName := fmt.Sprintf("%s-%d", statefulSet.GetName(), n)
+		pod := &corev1.Pod{}
+		podNamespacedName := types.NamespacedName{
+			Namespace: statefulSet.GetNamespace(),
+			Name:      podName,
+		}
+
+		if err := c.Get(ctx, podNamespacedName, pod); err != nil {
+			if k8serrors.IsNotFound(err) {
+				// Pod being created
+				scopedLog.Info("Pod being created, waiting", "podName", podName)
+				return enterpriseApi.PhaseUpdating, nil
+			}
+			return enterpriseApi.PhaseError, err
+		}
+
+		if !isPodReady(pod) {
+			// Pod not ready yet
+			scopedLog.Info("Pod not ready, waiting", "podName", podName)
+			return enterpriseApi.PhaseUpdating, nil
+		}
+
+		updated, err := isPodFullyUpdated(ctx, c, pod, statefulSet, state)
+		if err != nil {
+			return enterpriseApi.PhaseError, err
+		}
+
+		if !updated {
+			// Need to wait for all target pods to be updated first
+			scopedLog.Info("Waiting for pod to be updated before scale-down", "podName", podName)
+			return enterpriseApi.PhaseUpdating, nil
+		}
+	}
+
+	// All target pods have new spec - safe to reduce replicas
+	// Calculate how many replicas to remove
+	replicasToRemove := replicas - targetReplicas
+	if replicasToRemove > parallelUpdates {
+		replicasToRemove = parallelUpdates
+	}
+
+	// Delete PVCs for pods that will be removed (if VCT migration is active)
+	if state.VCTMigration != nil {
+		for n := replicas - replicasToRemove; n < replicas; n++ {
+			podName := fmt.Sprintf("%s-%d", statefulSet.GetName(), n)
+
+			// Delete PVCs for this pod
+			for vctName := range state.VCTMigration.ExpectedStorageClasses {
+				pvcName := fmt.Sprintf("%s-%s", vctName, podName)
+				pvc := &corev1.PersistentVolumeClaim{}
+				pvcNamespacedName := types.NamespacedName{
+					Namespace: statefulSet.GetNamespace(),
+					Name:      pvcName,
+				}
+
+				if err := c.Get(ctx, pvcNamespacedName, pvc); err != nil {
+					if k8serrors.IsNotFound(err) {
+						continue
+					}
+					return enterpriseApi.PhaseError, err
+				}
+
+				scopedLog.Info("Deleting PVC for scale-down", "pvcName", pvcName)
+				if err := c.Delete(ctx, pvc); err != nil && !k8serrors.IsNotFound(err) {
+					return enterpriseApi.PhaseError, err
+				}
+
+				if eventPublisher != nil {
+					eventPublisher.Normal(ctx, "PVCDeleted",
+						fmt.Sprintf("Deleted PVC %s during scale-down", pvcName))
+				}
+			}
+		}
+	}
+
+	newReplicas := replicas - replicasToRemove
+
+	scopedLog.Info("Scaling down for unified transition",
+		"currentReplicas", replicas,
+		"newReplicas", newReplicas,
+		"targetReplicas", targetReplicas)
+
+	// Update StatefulSet replicas
+	*statefulSet.Spec.Replicas = newReplicas
+	if err := splutil.UpdateResource(ctx, c, statefulSet); err != nil {
+		scopedLog.Error(err, "Failed to update replicas for scale-down")
+		return enterpriseApi.PhaseError, err
+	}
+
+	if eventPublisher != nil {
+		eventPublisher.Normal(ctx, "ScalingDown",
+			fmt.Sprintf("Scaling down from %d to %d replicas (target: %d) for unified transition",
+				replicas, newReplicas, targetReplicas))
+	}
+
+	return enterpriseApi.PhaseScalingDown, nil
 }

--- a/pkg/splunk/splkcontroller/statefulset.go
+++ b/pkg/splunk/splkcontroller/statefulset.go
@@ -94,6 +94,11 @@ const (
 	// The JSON structure includes original/target replicas, CPU per pod, and timestamps.
 	CPUAwareTransitionStateAnnotation = "operator.splunk.com/cpu-aware-transition-state"
 
+	// FSGroupChangePolicyAnnotation is the annotation key for overriding the fsGroupChangePolicy
+	// on the pod security context. Valid values are "Always" or "OnRootMismatch".
+	// When set, this annotation takes precedence over the spec.fsGroupChangePolicy field.
+	FSGroupChangePolicyAnnotation = "operator.splunk.com/fs-group-change-policy"
+
 	// DefaultParallelPodUpdates is the default number of pods to update in parallel when the annotation is not set.
 	DefaultParallelPodUpdates = 1
 )

--- a/pkg/splunk/splkcontroller/statefulset.go
+++ b/pkg/splunk/splkcontroller/statefulset.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 
@@ -31,6 +32,22 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	// ScaleUpReadyWaitTimeoutAnnotation is the user-facing annotation that allows users to configure
+	// the timeout for waiting for pods to become ready during scale-up operations.
+	// This annotation can be set on the CR and will propagate to the StatefulSet.
+	// Expected format: duration string (e.g., "10m", "5m30s", "0s")
+	// Default behavior (if not set): wait indefinitely for pods to become ready
+	// Setting to "0s" will skip waiting and proceed immediately with scale-up
+	ScaleUpReadyWaitTimeoutAnnotation = "operator.splunk.com/scale-up-ready-wait-timeout"
+
+	// ScaleUpWaitStartedAnnotation is an internal annotation used by the operator to track
+	// when the waiting period for pod readiness started during scale-up operations.
+	// This annotation is automatically managed by the operator and should not be set manually.
+	// Expected format: RFC3339 timestamp (e.g., "2006-01-02T15:04:05Z07:00")
+	ScaleUpWaitStartedAnnotation = "operator.splunk.com/scale-up-wait-started"
 )
 
 // DefaultStatefulSetPodManager is a simple StatefulSetPodManager that does nothing
@@ -115,12 +132,221 @@ func ApplyStatefulSet(ctx context.Context, c splcommon.ControllerClient, revised
 	return enterpriseApi.PhaseReady, nil
 }
 
-// UpdateStatefulSetPods manages scaling and config updates for StatefulSets
+// handleScaleDown manages the scale-down operation for a StatefulSet by safely removing pods.
+//
+// The function handles scale-down through a careful sequence of steps:
+//  1. Identifies the highest-numbered pod to remove (following StatefulSet ordering conventions)
+//  2. Calls mgr.PrepareScaleDown to initiate cleanup, regardless of pod state
+//     (The pod manager implementation decides what cleanup is needed based on actual pod state)
+//  3. Waits for PrepareScaleDown to complete before proceeding with pod termination
+//  4. Updates the StatefulSet replica count to terminate the pod
+//  5. Deletes associated PVCs to ensure clean state for potential future scale-ups
+//
+// This approach is designed to ensure proper cleanup in all scenarios, including edge cases (but do happen in practice) where:
+// - Pods are deleted manually outside of the operator
+// - Pods are in unexpected or transitional states
+// - The Cluster Manager still has references to peers that no longer exist
+//
+// This function returns PhaseScalingDown when operation is in progress, PhaseError on failure,
+// and throws error if there is any error encountered during the scale-down process
+func handleScaleDown(ctx context.Context, c splcommon.ControllerClient, statefulSet *appsv1.StatefulSet, mgr splcommon.StatefulSetPodManager, replicas int32, desiredReplicas int32) (enterpriseApi.Phase, error) {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("handleScaleDown").WithValues(
+		"name", statefulSet.GetObjectMeta().GetName(),
+		"desiredReplicas", desiredReplicas,
+		"namespace", statefulSet.GetObjectMeta().GetNamespace())
+
+	// prepare pod for removal via scale down (highest-numbered pod per StatefulSet convention)
+	n := replicas - 1
+	podName := fmt.Sprintf("%s-%d", statefulSet.GetName(), n)
+
+	// always call PrepareScaleDown to ensure proper cleanup regardless of pod state.
+	// This handles edge cases where pods are deleted manually or in unexpected states,
+	// preventing zombie peers in the Cluster Manager. The pod manager implementation
+	// will decide if actual cleanup is needed based on the pod's current state.
+	ready, err := mgr.PrepareScaleDown(ctx, n)
+	if err != nil {
+		scopedLog.Error(err, "Unable to prepare Pod for scale down", "podName", podName)
+		return enterpriseApi.PhaseError, err
+	}
+	if !ready {
+		// wait until pod preparation has completed before deleting it
+		return enterpriseApi.PhaseScalingDown, nil
+	}
+
+	// scale down statefulset to terminate pod
+	scopedLog.Info("Scaling replicas down", "replicas", n)
+	*statefulSet.Spec.Replicas = n
+	err = splutil.UpdateResource(ctx, c, statefulSet)
+	if err != nil {
+		scopedLog.Error(err, "Scale down update failed for StatefulSet")
+		return enterpriseApi.PhaseError, err
+	}
+
+	// delete PVCs used by the pod so that a future scale up will have clean state
+	for _, vol := range statefulSet.Spec.VolumeClaimTemplates {
+		namespacedName := types.NamespacedName{
+			Namespace: statefulSet.GetNamespace(),
+			Name:      fmt.Sprintf("%s-%s", vol.ObjectMeta.Name, podName),
+		}
+		var pvc corev1.PersistentVolumeClaim
+		err := c.Get(ctx, namespacedName, &pvc)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				// PVC doesn't exist, nothing to delete
+				scopedLog.Info("PVC not found, skipping deletion", "pvcName", namespacedName.Name)
+				continue
+			}
+			scopedLog.Error(err, "Unable to find PVC for deletion", "pvcName", namespacedName.Name)
+			return enterpriseApi.PhaseError, err
+		}
+		scopedLog.Info("Deleting PVC", "pvcName", pvc.ObjectMeta.Name)
+		err = c.Delete(ctx, &pvc)
+		if err != nil {
+			scopedLog.Error(err, "Unable to delete PVC", "pvcName", pvc.ObjectMeta.Name)
+			return enterpriseApi.PhaseError, err
+		}
+	}
+
+	return enterpriseApi.PhaseScalingDown, nil
+}
+
+// handleScaleUp manages the scale-up operation for a StatefulSet
+//
+// This function also implements a configurable timeout mechanism that allows users to control
+// how long the operator waits for existing pods to become ready before scaling up.
+// The timeout can be configured via the ScaleUpReadyWaitTimeoutAnnotation on the CR/StatefulSet.
+//
+// Behavior:
+//   - Early return if no scale-up is needed (readyReplicas >= desiredReplicas)
+//   - Waits for all current pods to be ready before scaling up (if readyReplicas < replicas)
+//     Respects configurable timeout using getScaleUpReadyWaitTimeout()
+//   - Tracks wait start time using setScaleUpWaitStarted() to enable timeout calculation
+//   - Setting timeout to 0 bypasses the wait entirely and proceeds immediately
+//   - Proceeds with scale-up after timeout expires even if not all pods are ready
+//   - Clears wait timestamp after successful scale-up via clearScaleUpWaitStarted()
+//
+// The timeout mechanism prevents indefinite waiting when pods fail to become ready,
+// allowing the operator to make forward progress while maintaining the principle of
+// waiting for stability during normal operations.
+//
+// This function returns PhasePending when waiting for initial pods, PhaseScalingUp when actively scaling,
+// and throws error if there is any error encountered during the scale-up process
+func handleScaleUp(ctx context.Context, c splcommon.ControllerClient, statefulSet *appsv1.StatefulSet, replicas int32, readyReplicas int32, desiredReplicas int32) (enterpriseApi.Phase, error) {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("handleScaleUp").WithValues(
+		"name", statefulSet.GetObjectMeta().GetName(),
+		"desiredReplicas", desiredReplicas,
+		"namespace", statefulSet.GetObjectMeta().GetNamespace())
+
+	if readyReplicas >= desiredReplicas {
+		// No scale-up needed
+		return enterpriseApi.PhaseReady, nil
+	}
+
+	// Before scaling up, wait for all current pods to be ready
+	if readyReplicas < replicas {
+		// Get the configured timeout for waiting
+		timeout := getScaleUpReadyWaitTimeout(statefulSet)
+
+		// If timeout is negative, wait forever (no timeout bypass)
+		if timeout < 0 {
+			// Check if we have a wait start time (used to log once per scale-up)
+			_, hasStartTime := getScaleUpWaitStarted(statefulSet)
+
+			if !hasStartTime {
+				// First time waiting, record the start time and log informative message
+				scopedLog.Info("Waiting for all pods to become ready before scaling up (no timeout configured). Set annotation 'operator.splunk.com/scale-up-ready-wait-timeout' to proceed with scale-up after a specified duration.")
+				err := setScaleUpWaitStarted(ctx, c, statefulSet)
+				if err != nil {
+					scopedLog.Error(err, "Failed to set scale-up wait start time")
+					return enterpriseApi.PhaseError, err
+				}
+			}
+			// Continue waiting indefinitely
+			if readyReplicas > 0 {
+				return enterpriseApi.PhaseScalingUp, nil
+			}
+			return enterpriseApi.PhasePending, nil
+		}
+
+		// If timeout is 0, bypass the wait and proceed immediately with scale-up
+		if timeout == 0 {
+			scopedLog.Info("Timeout set to 0, bypassing wait for pods to be ready")
+			// Jump to scale-up logic below
+		} else {
+			// Check if we have a wait start time
+			startTime, hasStartTime := getScaleUpWaitStarted(statefulSet)
+
+			if !hasStartTime {
+				// First time waiting, record the start time
+				scopedLog.Info("Starting to wait for pods to become ready before scaling up")
+				err := setScaleUpWaitStarted(ctx, c, statefulSet)
+				if err != nil {
+					scopedLog.Error(err, "Failed to set scale-up wait start time")
+					return enterpriseApi.PhaseError, err
+				}
+				// Return to continue waiting in next reconcile
+				if readyReplicas > 0 {
+					return enterpriseApi.PhaseScalingUp, nil
+				}
+				return enterpriseApi.PhasePending, nil
+			}
+
+			// We have a start time, check if timeout has been exceeded
+			elapsed := time.Since(startTime)
+			if elapsed > timeout {
+				// Timeout exceeded, proceed with scale-up despite not all pods being ready
+				notReadyCount := replicas - readyReplicas
+				scopedLog.Info("Proceeding with scale-up after timeout",
+					"timeout", timeout,
+					"elapsed", elapsed,
+					"notReadyCount", notReadyCount)
+				// Jump to scale-up logic below
+			} else {
+				// Still within timeout window, continue waiting
+				scopedLog.Info("Waiting for pods to become ready before scaling up",
+					"timeout", timeout,
+					"elapsed", elapsed,
+					"readyReplicas", readyReplicas,
+					"replicas", replicas)
+				if readyReplicas > 0 {
+					return enterpriseApi.PhaseScalingUp, nil
+				}
+				return enterpriseApi.PhasePending, nil
+			}
+		}
+	}
+	// All current pods are ready (or timeout exceeded), proceed with scale up
+	scopedLog.Info("Scaling replicas up", "replicas", desiredReplicas)
+	*statefulSet.Spec.Replicas = desiredReplicas
+	err := splutil.UpdateResource(ctx, c, statefulSet)
+	if err != nil {
+		return enterpriseApi.PhaseScalingUp, err
+	}
+	// Clear the scale-up wait timestamp after successful scale-up
+	// Return error to trigger requeue and prevent stale annotations
+	if err := clearScaleUpWaitStarted(ctx, c, statefulSet); err != nil {
+		scopedLog.Error(err, "Failed to clear scale-up wait timestamp")
+		return enterpriseApi.PhaseScalingUp, err
+	}
+	return enterpriseApi.PhaseScalingUp, nil
+}
+
+// UpdateStatefulSetPods manages scaling and config updates for StatefulSets.
+// The function implements careful ordering of operations:
+// 1. Prioritize scale-down operations (removes pods even if not all are ready)
+// 2. Wait for current pods to be ready before scaling up (ensures stability), or bypass wait if timeout exceeded
+// 3. Handle pod updates for revision changes after scaling is complete
+// This ordering ensures stable operations and prevents cascading issues during scaling.
 func UpdateStatefulSetPods(ctx context.Context, c splcommon.ControllerClient, statefulSet *appsv1.StatefulSet, mgr splcommon.StatefulSetPodManager, desiredReplicas int32) (enterpriseApi.Phase, error) {
 	reqLogger := log.FromContext(ctx)
 	scopedLog := reqLogger.WithName("UpdateStatefulSetPods").WithValues(
 		"name", statefulSet.GetObjectMeta().GetName(),
 		"namespace", statefulSet.GetObjectMeta().GetNamespace())
+
+	replicas := *statefulSet.Spec.Replicas
+	readyReplicas := statefulSet.Status.ReadyReplicas
 
 	// Re-fetch the StatefulSet to ensure we have the latest status, especially UpdateRevision.
 	// This addresses a race condition where the StatefulSet controller may not have updated
@@ -133,9 +359,19 @@ func UpdateStatefulSetPods(ctx context.Context, c splcommon.ControllerClient, st
 		return enterpriseApi.PhaseError, err
 	}
 
-	// wait for all replicas ready
-	replicas := *statefulSet.Spec.Replicas
-	readyReplicas := statefulSet.Status.ReadyReplicas
+	// check for scaling down - prioritize scale-down operations
+	// Check StatefulSet spec replicas (not readyReplicas) to handle cases where replicas > desiredReplicas but readyReplicas < desiredReplicas
+	if replicas > desiredReplicas {
+		return handleScaleDown(ctx, c, statefulSet, mgr, replicas, desiredReplicas)
+	}
+
+	// check for scaling up
+	if readyReplicas < desiredReplicas {
+		return handleScaleUp(ctx, c, statefulSet, replicas, readyReplicas, desiredReplicas)
+	}
+
+	// readyReplicas == desiredReplicas
+	// wait for all replicas to be ready
 	if readyReplicas < replicas {
 		scopedLog.Info("Waiting for pods to become ready")
 		if readyReplicas > 0 {
@@ -148,64 +384,15 @@ func UpdateStatefulSetPods(ctx context.Context, c splcommon.ControllerClient, st
 	}
 
 	// readyReplicas == replicas
-
-	// check for scaling up
-	if readyReplicas < desiredReplicas {
-		// scale up StatefulSet to match desiredReplicas
-		scopedLog.Info("Scaling replicas up", "replicas", desiredReplicas)
-		*statefulSet.Spec.Replicas = desiredReplicas
-		return enterpriseApi.PhaseScalingUp, splutil.UpdateResource(ctx, c, statefulSet)
-	}
-
-	// check for scaling down
-	if readyReplicas > desiredReplicas {
-		// prepare pod for removal via scale down
-		n := readyReplicas - 1
-		podName := fmt.Sprintf("%s-%d", statefulSet.GetName(), n)
-		ready, err := mgr.PrepareScaleDown(ctx, n)
-		if err != nil {
-			scopedLog.Error(err, "Unable to decommission Pod", "podName", podName)
-			return enterpriseApi.PhaseError, err
-		}
-		if !ready {
-			// wait until pod quarantine has completed before deleting it
-			return enterpriseApi.PhaseScalingDown, nil
-		}
-
-		// scale down statefulset to terminate pod
-		scopedLog.Info("Scaling replicas down", "replicas", n)
-		*statefulSet.Spec.Replicas = n
-		err = splutil.UpdateResource(ctx, c, statefulSet)
-		if err != nil {
-			scopedLog.Error(err, "Scale down update failed for StatefulSet")
-			return enterpriseApi.PhaseError, err
-		}
-
-		// delete PVCs used by the pod so that a future scale up will have clean state
-		for _, vol := range statefulSet.Spec.VolumeClaimTemplates {
-			namespacedName := types.NamespacedName{
-				Namespace: vol.ObjectMeta.Namespace,
-				Name:      fmt.Sprintf("%s-%s", vol.ObjectMeta.Name, podName),
-			}
-			var pvc corev1.PersistentVolumeClaim
-			err := c.Get(ctx, namespacedName, &pvc)
-			if err != nil {
-				scopedLog.Error(err, "Unable to find PVC for deletion", "pvcName", pvc.ObjectMeta.Name)
-				return enterpriseApi.PhaseError, err
-			}
-			scopedLog.Info("Deleting PVC", "pvcName", pvc.ObjectMeta.Name)
-			err = c.Delete(ctx, &pvc)
-			if err != nil {
-				scopedLog.Error(err, "Unable to delete PVC", "pvcName", pvc.ObjectMeta.Name)
-				return enterpriseApi.PhaseError, err
-			}
-		}
-
-		return enterpriseApi.PhaseScalingDown, nil
-	}
-
-	// ready and no StatefulSet scaling is required
 	// readyReplicas == desiredReplicas
+	// ready and no StatefulSet scaling is required
+
+	// Clear the scale-up wait timestamp now that all pods are ready and scaling is complete
+	// Return error to trigger requeue and prevent stale annotations
+	if err := clearScaleUpWaitStarted(ctx, c, statefulSet); err != nil {
+		scopedLog.Error(err, "Failed to clear scale-up wait timestamp")
+		return enterpriseApi.PhaseReady, err
+	}
 
 	// check existing pods for desired updates
 	for n := readyReplicas - 1; n >= 0; n-- {
@@ -241,7 +428,7 @@ func UpdateStatefulSetPods(ctx context.Context, c splcommon.ControllerClient, st
 				"statefulSetRevision", statefulSet.Status.UpdateRevision,
 				"podRevision", pod.GetLabels()["controller-revision-hash"])
 			preconditions := client.Preconditions{UID: &pod.ObjectMeta.UID, ResourceVersion: &pod.ObjectMeta.ResourceVersion}
-			err = c.Delete(context.Background(), &pod, preconditions)
+			err = c.Delete(ctx, &pod, preconditions)
 			if err != nil {
 				scopedLog.Error(err, "Unable to delete Pod", "podName", podName)
 				return enterpriseApi.PhaseError, err
@@ -283,6 +470,155 @@ func UpdateStatefulSetPods(ctx context.Context, c splcommon.ControllerClient, st
 	scopedLog.Info("Statefulset - Phase Ready")
 
 	return enterpriseApi.PhaseReady, nil
+}
+
+// getScaleUpReadyWaitTimeout parses the ScaleUpReadyWaitTimeoutAnnotation from the StatefulSet
+// and returns the configured timeout duration.
+//
+// Return values:
+//   - If the annotation is missing, invalid format, or negative: returns 0 (immediate bypass, no wait)
+//   - Otherwise: returns the parsed duration as-is (any valid Go duration is accepted)
+//   - Use "-1" or any negative value to wait forever
+//
+// For CRs, users should use the `sts-only.operator.splunk.com/scale-up-ready-wait-timeout`
+// annotation to prevent propagation to pod templates. The unprefixed key
+// `operator.splunk.com/scale-up-ready-wait-timeout` is for direct StatefulSet annotation.
+func getScaleUpReadyWaitTimeout(statefulSet *appsv1.StatefulSet) time.Duration {
+	// defaultTimeout of 0 means "never wait" - scale up immediately without waiting
+	// for existing pods to be ready. Use negative values (e.g., "-1") to wait forever.
+	const defaultTimeout = time.Duration(0)
+
+	if statefulSet.Annotations == nil {
+		return defaultTimeout
+	}
+
+	timeoutStr, exists := statefulSet.Annotations[ScaleUpReadyWaitTimeoutAnnotation]
+	if !exists {
+		return defaultTimeout
+	}
+
+	// Parse the duration string
+	timeout, err := time.ParseDuration(timeoutStr)
+	if err != nil {
+		// Invalid format, return default (no wait)
+		return defaultTimeout
+	}
+
+	// Negative values mean "wait forever" - return as-is
+	if timeout < 0 {
+		return timeout
+	}
+
+	// Zero means immediate bypass, any positive duration is accepted as-is
+	return timeout
+}
+
+// getScaleUpWaitStarted retrieves and parses the ScaleUpWaitStartedAnnotation timestamp
+// from the StatefulSet. Returns the parsed time and true if found and valid, otherwise
+// returns zero time and false.
+func getScaleUpWaitStarted(statefulSet *appsv1.StatefulSet) (time.Time, bool) {
+	if statefulSet.Annotations == nil {
+		return time.Time{}, false
+	}
+
+	timestampStr, exists := statefulSet.Annotations[ScaleUpWaitStartedAnnotation]
+	if !exists {
+		return time.Time{}, false
+	}
+
+	// Parse RFC3339 timestamp
+	timestamp, err := time.Parse(time.RFC3339, timestampStr)
+	if err != nil {
+		// Invalid format
+		return time.Time{}, false
+	}
+
+	return timestamp, true
+}
+
+// setScaleUpWaitStarted sets the ScaleUpWaitStartedAnnotation to the current time on the StatefulSet.
+// This marks the beginning of the wait period for pod readiness during scale-up operations.
+// After updating, it re-fetches the StatefulSet to prevent stale data issues in subsequent operations.
+func setScaleUpWaitStarted(ctx context.Context, c splcommon.ControllerClient, statefulSet *appsv1.StatefulSet) error {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("setScaleUpWaitStarted").WithValues(
+		"name", statefulSet.GetObjectMeta().GetName(),
+		"namespace", statefulSet.GetObjectMeta().GetNamespace())
+
+	// Initialize annotations map if nil
+	if statefulSet.Annotations == nil {
+		statefulSet.Annotations = make(map[string]string)
+	}
+
+	// Set the current time in RFC3339 format
+	currentTime := time.Now().Format(time.RFC3339)
+	statefulSet.Annotations[ScaleUpWaitStartedAnnotation] = currentTime
+
+	scopedLog.Info("Setting scale-up wait started timestamp", "timestamp", currentTime)
+
+	// Update the StatefulSet
+	err := splutil.UpdateResource(ctx, c, statefulSet)
+	if err != nil {
+		scopedLog.Error(err, "Failed to update StatefulSet with wait started annotation")
+		return err
+	}
+
+	// Re-fetch the StatefulSet to ensure we have the latest version from etcd.
+	// This prevents race conditions where subsequent operations might work with stale data,
+	// particularly important when the annotation is checked immediately after being set.
+	namespacedName := types.NamespacedName{Namespace: statefulSet.GetNamespace(), Name: statefulSet.GetName()}
+	err = c.Get(ctx, namespacedName, statefulSet)
+	if err != nil {
+		scopedLog.Error(err, "Failed to re-fetch StatefulSet after setting wait started annotation")
+		return err
+	}
+
+	return nil
+}
+
+// clearScaleUpWaitStarted removes the ScaleUpWaitStartedAnnotation from the StatefulSet.
+// This is called when the wait period is complete or when scale-up operations finish.
+// After updating, it re-fetches the StatefulSet to prevent stale data issues in subsequent operations.
+func clearScaleUpWaitStarted(ctx context.Context, c splcommon.ControllerClient, statefulSet *appsv1.StatefulSet) error {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("clearScaleUpWaitStarted").WithValues(
+		"name", statefulSet.GetObjectMeta().GetName(),
+		"namespace", statefulSet.GetObjectMeta().GetNamespace())
+
+	// Check if annotations exist and the annotation is present
+	if statefulSet.Annotations == nil {
+		// Nothing to clear
+		return nil
+	}
+
+	if _, exists := statefulSet.Annotations[ScaleUpWaitStartedAnnotation]; !exists {
+		// Annotation doesn't exist, nothing to do
+		return nil
+	}
+
+	scopedLog.Info("Clearing scale-up wait started timestamp")
+
+	// Remove the annotation
+	delete(statefulSet.Annotations, ScaleUpWaitStartedAnnotation)
+
+	// Update the StatefulSet
+	err := splutil.UpdateResource(ctx, c, statefulSet)
+	if err != nil {
+		scopedLog.Error(err, "Failed to update StatefulSet to clear wait started annotation")
+		return err
+	}
+
+	// Re-fetch the StatefulSet to ensure we have the latest version from etcd.
+	// This prevents race conditions where subsequent operations might work with stale data,
+	// particularly important in reconciliation loops where the StatefulSet state is checked frequently.
+	namespacedName := types.NamespacedName{Namespace: statefulSet.GetNamespace(), Name: statefulSet.GetName()}
+	err = c.Get(ctx, namespacedName, statefulSet)
+	if err != nil {
+		scopedLog.Error(err, "Failed to re-fetch StatefulSet after clearing wait started annotation")
+		return err
+	}
+
+	return nil
 }
 
 // SetStatefulSetOwnerRef sets owner references for statefulset

--- a/pkg/splunk/splkcontroller/statefulset.go
+++ b/pkg/splunk/splkcontroller/statefulset.go
@@ -90,6 +90,10 @@ func ApplyStatefulSet(ctx context.Context, c splcommon.ControllerClient, revised
 
 	// check for changes in Pod template
 	hasUpdates := MergePodUpdates(ctx, &current.Spec.Template, &revised.Spec.Template, current.GetObjectMeta().GetName())
+
+	// check for changes in StatefulSet-level metadata (labels and annotations)
+	hasUpdates = hasUpdates || splcommon.MergeStatefulSetMetaUpdates(ctx, &current.ObjectMeta, &revised.ObjectMeta, current.GetName())
+
 	*revised = current // caller expects that object passed represents latest state
 
 	// only update if there are material differences, as determined by comparison function

--- a/pkg/splunk/splkcontroller/statefulset_cpu_scaledown_test.go
+++ b/pkg/splunk/splkcontroller/statefulset_cpu_scaledown_test.go
@@ -1,0 +1,2113 @@
+// Copyright (c) 2018-2022 Splunk Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splkcontroller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
+	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
+	spltest "github.com/splunk/splunk-operator/pkg/splunk/test"
+)
+
+// createTestTransitionStateJSON creates a JSON string for CPUAwareTransitionState annotation
+// used in tests. This helper simplifies creating test annotations with the new JSON format.
+func createTestTransitionStateJSON(originalReplicas, targetReplicas int32, originalCPUMillis, targetCPUMillis int64) string {
+	return createTestTransitionStateJSONWithFinished(originalReplicas, targetReplicas, originalCPUMillis, targetCPUMillis, "")
+}
+
+// createTestTransitionStateJSONWithFinished creates a JSON string with optional FinishedAt timestamp
+func createTestTransitionStateJSONWithFinished(originalReplicas, targetReplicas int32, originalCPUMillis, targetCPUMillis int64, finishedAt string) string {
+	state := CPUAwareTransitionState{
+		OriginalReplicas:  originalReplicas,
+		TargetReplicas:    targetReplicas,
+		OriginalCPUMillis: originalCPUMillis,
+		TargetCPUMillis:   targetCPUMillis,
+		StartedAt:         "2026-01-10T10:00:00Z",
+		FinishedAt:        finishedAt,
+	}
+	data, _ := json.Marshal(state)
+	return string(data)
+}
+
+// Helper function to create test pods with specific CPU
+func createCPUTestPod(name, namespace, cpu string, ready bool, revision string) *corev1.Pod {
+	cpuQuantity := resource.MustParse(cpu)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"controller-revision-hash": revision,
+				"app":                      "splunk",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "splunk",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: cpuQuantity,
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Ready: ready},
+			},
+		},
+	}
+	if ready {
+		pod.Status.Conditions = []corev1.PodCondition{
+			{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+		}
+	}
+	return pod
+}
+
+func TestUpdateStatefulSetPods_CPUAwareDefersToPodRecycling(t *testing.T) {
+	// This test verifies that CPU-aware scaling recycles kept pods when there's no excess CPU.
+	// When there IS excess CPU, balancing (reducing replicas) happens first.
+	// This test sets up a scenario with NO excess CPU to verify recycling behavior.
+	//
+	// Scenario: 6 pods × 2CPU -> 3 pods × 4CPU
+	// All pods still have old spec (2 CPU each), no recycling has happened yet
+	// TotalReadyCPU = 6 × 2 = 12 CPU
+	// OriginalTotalCPU = 6 × 2 = 12 CPU
+	// excessCPU = 0 -> No balancing possible, must recycle first
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 6
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation:        "true",
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(6, 3, 2000, 4000),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "splunk"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas:  6,
+			UpdateRevision: "v2", // New revision
+		},
+	}
+
+	// All 6 pods still have old spec (2 CPU each) - no recycling has happened yet
+	// TotalReadyCPU = 6 × 2 = 12 CPU
+	// OriginalTotalCPU = 6 × 2 = 12 CPU
+	// excessCPU = 0 -> No balancing possible, must recycle pods 0, 1, 2 (kept pods)
+	podList := &corev1.PodList{}
+
+	// All pods have old spec (2 CPU each)
+	for i := 0; i < 6; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("splunk-indexer-%d", i), "test", "2", true, "v1")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+	c.ListObj = podList
+
+	c.AddObject(sts)
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	// Execute
+	phase, err := UpdateStatefulSetPods(ctx, c, sts, mgr, 3)
+
+	// Verify - with no excess CPU, recycling must happen first
+	// Pod 0 is the lowest index kept pod with old spec, so it gets recycled
+	if err != nil {
+		t.Errorf("UpdateStatefulSetPods() error = %v", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("Expected PhaseUpdating (recycling), got %v", phase)
+	}
+
+	// Verify pod0 was deleted (recycled) - lowest index kept pod with old spec
+	namespacedName := types.NamespacedName{Namespace: "test", Name: "splunk-indexer-0"}
+	var pod corev1.Pod
+	err = c.Get(ctx, namespacedName, &pod)
+	if err == nil {
+		t.Errorf("Expected pod0 to be deleted for recycling, but it still exists")
+	}
+
+	// Verify pod5 (highest index, will be deleted during scale-down) was NOT recycled
+	// It will be deleted when we reduce StatefulSet replicas later
+	namespacedName = types.NamespacedName{Namespace: "test", Name: "splunk-indexer-5"}
+	err = c.Get(ctx, namespacedName, &pod)
+	if err != nil {
+		t.Errorf("Expected pod5 to still exist (not recycled, will be deleted when replicas reduced)")
+	}
+
+	// Verify replicas not yet reduced (no excess CPU for balancing)
+	if *sts.Spec.Replicas != 6 {
+		t.Errorf("Expected replicas to remain 6, got %d", *sts.Spec.Replicas)
+	}
+}
+
+func TestUpdateStatefulSetPods_CPUAwareReducesReplicasAfterRecycling(t *testing.T) {
+	// This test verifies the interleaved balance behavior:
+	// After ONE pod is recycled and gains excess CPU, balancing happens immediately.
+	// This is more efficient than waiting for all kept pods to be recycled.
+	//
+	// Scenario: 5×2CPU -> 3×4CPU
+	// Pods 0,1,2 (kept): Pod 0 recycled (has new spec), pods 1,2 still old spec
+	// TotalReadyCPU = 1×4 + 4×2 = 12, OriginalTotalCPU = 5×2 = 10, excess = 2
+	// Balance immediately: 5->4 (don't wait for pods 1,2 to recycle)
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 5
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation:        "true",
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(5, 3, 2000, 4000),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "splunk"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas:  5,
+			UpdateRevision: "v2",
+		},
+	}
+
+	// Pod 0: NEW spec (4 CPU) - recycled and ready
+	// Pods 1-4: OLD spec (2 CPU) - not yet recycled
+	// This is the realistic interleaved state after pod-0 recycled
+	podList := &corev1.PodList{}
+	pod0 := createCPUTestPod("splunk-indexer-0", "test", "4", true, "v2")
+	c.AddObject(pod0)
+	podList.Items = append(podList.Items, *pod0)
+
+	for i := 1; i < 5; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("splunk-indexer-%d", i), "test", "2", true, "v1")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+	c.ListObj = podList
+
+	c.AddObject(sts)
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	// Execute
+	phase, err := UpdateStatefulSetPods(ctx, c, sts, mgr, 3)
+
+	// Verify - should reduce replicas by 1 (interleaved balancing)
+	if err != nil {
+		t.Errorf("UpdateStatefulSetPods() error = %v", err)
+	}
+	if phase != enterpriseApi.PhaseScalingDown {
+		t.Errorf("Expected PhaseScalingDown (interleaved balance), got %v", phase)
+	}
+
+	// Verify replicas reduced by 1 (from 5->4), not all the way to target (3)
+	// This demonstrates the interleaved approach: balance as soon as possible
+	if *sts.Spec.Replicas != 4 {
+		t.Errorf("Expected replicas reduced to 4 (interleaved), got %d", *sts.Spec.Replicas)
+	}
+
+	// This demonstrates the key benefit of Balance-First:
+	// As soon as ONE pod is recycled (not all), we can start reducing replicas.
+	// With 15-min pod readiness, this saves significant time:
+	// - Balance-First: Start reducing after 15 min (when pod-0 ready)
+	// - Recycle-First: Start reducing after 45 min (when all 3 kept pods ready)
+}
+
+func TestUpdateStatefulSetPods_CPUAwareBalancingDeletions(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Scenario: 10×8CPU -> 4×20CPU, test parallel recycling with parallelUpdates=3
+	// All pods still have old spec (8 CPU each) - no recycling has happened yet
+	// TotalReadyCPU = 10 × 8 = 80 CPU
+	// OriginalTotalCPU = 10 × 8 = 80 CPU
+	// excessCPU = 0 -> No balancing possible, must recycle first
+	var replicas int32 = 10
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation:        "true",
+				ParallelPodUpdatesAnnotation:      "3",
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(10, 4, 8000, 20000),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "splunk"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("20"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: 10,
+		},
+	}
+
+	// All 10 pods have old spec (8 CPU each) - no recycling has happened yet
+	// Kept pods [0, 3]: all need recycling
+	// minCPUFloor = 80000 - (3 × 8000) = 56000m
+	// After recycling 3 pods: 80000 - 24000 = 56000m >= 56000m ✅
+	podList := &corev1.PodList{}
+	for i := 0; i < 10; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("splunk-indexer-%d", i), "test", "8", true, "v1")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+	c.ListObj = podList
+
+	c.AddObject(sts)
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	// Execute - with no excess CPU, recycling happens first
+	// Should recycle up to 3 pods (parallelUpdates=3) within CPU floor
+	phase, err := UpdateStatefulSetPods(ctx, c, sts, mgr, 4)
+
+	// Verify
+	if err != nil {
+		t.Errorf("UpdateStatefulSetPods() error = %v", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("Expected PhaseUpdating, got %v", phase)
+	}
+
+	// Verify pods 0, 1, 2 were recycled (lowest index kept pods with old spec)
+	deletedCount := 0
+	for i := 0; i < 3; i++ {
+		namespacedName := types.NamespacedName{Namespace: "test", Name: fmt.Sprintf("splunk-indexer-%d", i)}
+		var pod corev1.Pod
+		err := c.Get(ctx, namespacedName, &pod)
+		if err != nil {
+			deletedCount++
+		}
+	}
+	if deletedCount != 3 {
+		t.Errorf("Expected 3 pods recycled (parallelUpdates=3), got %d", deletedCount)
+	}
+
+	// Verify pod-9 (highest index, outside kept range) was NOT recycled
+	namespacedName := types.NamespacedName{Namespace: "test", Name: "splunk-indexer-9"}
+	var pod corev1.Pod
+	err = c.Get(ctx, namespacedName, &pod)
+	if err != nil {
+		t.Errorf("Expected pod-9 to still exist (not in kept range)")
+	}
+}
+
+func TestUpdateStatefulSetPods_CPUBoundsEnforcement(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Create StatefulSet
+	var replicas int32 = 6
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation:        "true",
+				ParallelPodUpdatesAnnotation:      "10", // Very high to test bounds
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(6, 3, 2000, 4000),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "splunk"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: 6,
+		},
+	}
+
+	// Create 1 new-spec pod (4 CPU)
+	podList := &corev1.PodList{}
+	pod := createCPUTestPod("splunk-indexer-0", "test", "4", true, "v2")
+	c.AddObject(pod)
+	podList.Items = append(podList.Items, *pod)
+
+	// Create 5 old-spec pods (2 CPU each) - total 10 CPU
+	// Original total: 6 * 2 = 12 CPU
+	// Current total: 1*4 + 5*2 = 14 CPU
+	for i := 1; i < 6; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("splunk-indexer-%d", i), "test", "2", true, "v1")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+	c.ListObj = podList
+
+	c.AddObject(sts)
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	// Execute - with excess CPU, the algorithm will first try to balance (reduce replicas)
+	// Total ready CPU = 1*4 + 5*2 = 14 CPU (14000m)
+	// Original total = 6 × 2000 = 12000m
+	// Excess = 14000 - 12000 = 2000m
+	// Since excess (2000m) >= oldCPUPerPod (2000m), it can delete 1 excess pod
+	phase, err := UpdateStatefulSetPods(ctx, c, sts, mgr, 3)
+
+	// Verify - Step 3 (Balance) triggers before Step 4 (Recycle)
+	if err != nil {
+		t.Errorf("UpdateStatefulSetPods() error = %v", err)
+	}
+	// The algorithm follows: BALANCE before RECYCLE
+	// With excess CPU, it will reduce replicas first (PhaseScalingDown)
+	if phase != enterpriseApi.PhaseScalingDown {
+		t.Errorf("Expected PhaseScalingDown (balance step), got %v", phase)
+	}
+}
+
+func TestUpdateStatefulSetPods_CPUAwareScaleDownComplete(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Create StatefulSet at target replicas (scale-down already complete, just need to verify all pods have new spec)
+	var replicas int32 = 3
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation:        "true",
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(5, 3, 2000, 4000),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "splunk"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: 3,
+		},
+	}
+
+	// All pods (0-2) are new-spec pods with 4 CPU each
+	podList := &corev1.PodList{}
+	for i := 0; i < 3; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("splunk-indexer-%d", i), "test", "4", true, "v2")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+	c.ListObj = podList
+
+	c.AddObject(sts)
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	// Execute - should finalize scale-down
+	phase, err := UpdateStatefulSetPods(ctx, c, sts, mgr, 3)
+
+	// Verify - should update replicas to target
+	if err != nil {
+		t.Errorf("UpdateStatefulSetPods() error = %v", err)
+	}
+
+	if phase != enterpriseApi.PhaseReady {
+		t.Errorf("Expected PhaseReady when transition completes, got %v", phase)
+	}
+
+	// Verify FinishedAt is set in the annotation
+	var updatedSts appsv1.StatefulSet
+	if getErr := c.Get(ctx, types.NamespacedName{Name: "splunk-indexer", Namespace: "test"}, &updatedSts); getErr != nil {
+		t.Fatalf("Failed to get updated StatefulSet: %v", getErr)
+	}
+
+	if updatedSts.Annotations == nil {
+		t.Fatal("Expected annotations to exist after completion")
+	}
+
+	stateJSON, exists := updatedSts.Annotations[CPUAwareTransitionStateAnnotation]
+	if !exists {
+		t.Fatal("Expected transition annotation to exist (cleared later by CR update)")
+	}
+
+	var finalState CPUAwareTransitionState
+	if unmarshalErr := json.Unmarshal([]byte(stateJSON), &finalState); unmarshalErr != nil {
+		t.Fatalf("Failed to unmarshal final state: %v", unmarshalErr)
+	}
+
+	if finalState.FinishedAt == "" {
+		t.Error("Expected FinishedAt to be set when transition completes")
+	}
+
+	// Verify IsCPUPreservingScalingFinished returns true
+	if !IsCPUPreservingScalingFinished(&updatedSts) {
+		t.Error("Expected IsCPUPreservingScalingFinished to return true")
+	}
+}
+
+// TestInterleavedRecycle_6x2_to_3x4 tests the canonical scenario from PRD Section 7
+// Scenario: 6 pods × 2CPU -> 3 pods × 4CPU (total 12 CPU preserved)
+// This verifies the interleaved algorithm correctly balances after each recycle.
+func TestInterleavedRecycle_6x2_to_3x4(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Initial state: 6 pods with 2CPU each, target is 3 pods with 4CPU
+	var replicas int32 = 6
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation:        "true",
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(6, 3, 2000, 4000),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "splunk"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4000m"), // Target: 4 CPU
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: 6,
+		},
+	}
+
+	// Reconcile 1: All 6 pods have old spec (2 CPU)
+	// Expected: totalReadyCPU=12, originalTotalCPU=12, excessCPU=0
+	// Action: No balance possible, recycle pod-0
+	podList := &corev1.PodList{}
+	for i := 0; i < 6; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("splunk-indexer-%d", i), "test", "2000m", true, "v1")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+	c.ListObj = podList
+	c.AddObject(sts)
+
+	mgr := &DefaultStatefulSetPodManager{}
+	phase, err := UpdateStatefulSetPods(ctx, c, sts, mgr, 3)
+
+	if err != nil {
+		t.Errorf("Reconcile 1: unexpected error = %v", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("Reconcile 1: expected PhaseUpdating (recycling pod-0), got %v", phase)
+	}
+
+	// Verify pod-0 was deleted for recycling
+	namespacedName := types.NamespacedName{Namespace: "test", Name: "splunk-indexer-0"}
+	var pod corev1.Pod
+	err = c.Get(ctx, namespacedName, &pod)
+	if err == nil {
+		t.Errorf("Reconcile 1: expected pod-0 to be deleted for recycling")
+	}
+}
+
+// TestInterleavedRecycle_BalanceAfterRecycle tests that balancing occurs when there's excess CPU
+func TestInterleavedRecycle_BalanceAfterRecycle(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// State after pod-0 recycled: 1×4CPU + 5×2CPU
+	// totalReadyCPU = 4 + 10 = 14, originalTotalCPU = 12, excessCPU = 2
+	// excessCPU (2) >= oldCPUPerPod (2), so can delete 1 pod
+	var replicas int32 = 6
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation:        "true",
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(6, 3, 2000, 4000),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "splunk"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4000m"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: 6,
+		},
+	}
+
+	// Create pods: pod-0 has new spec (4 CPU), pods 1-5 have old spec (2 CPU)
+	podList := &corev1.PodList{}
+	pod0 := createCPUTestPod("splunk-indexer-0", "test", "4000m", true, "v2")
+	c.AddObject(pod0)
+	podList.Items = append(podList.Items, *pod0)
+
+	for i := 1; i < 6; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("splunk-indexer-%d", i), "test", "2000m", true, "v1")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+	c.ListObj = podList
+	c.AddObject(sts)
+
+	mgr := &DefaultStatefulSetPodManager{}
+	phase, err := UpdateStatefulSetPods(ctx, c, sts, mgr, 3)
+
+	if err != nil {
+		t.Errorf("Balance: unexpected error = %v", err)
+	}
+	if phase != enterpriseApi.PhaseScalingDown {
+		t.Errorf("Balance: expected PhaseScalingDown (reducing replicas), got %v", phase)
+	}
+
+	// Verify replicas were reduced by 1 (from 6 to 5)
+	if *sts.Spec.Replicas != 5 {
+		t.Errorf("Balance: expected replicas = 5, got %d", *sts.Spec.Replicas)
+	}
+}
+
+// TestInterleavedRecycle_10x1_to_2x5 tests aggressive balancing scenario
+// Scenario: 10 pods × 1CPU -> 2 pods × 5CPU (total 10 CPU preserved)
+func TestInterleavedRecycle_10x1_to_2x5(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// State: pod-0 has new spec (5 CPU), pods 1-9 have old spec (1 CPU each)
+	// totalReadyCPU = 5 + 9*1 = 14, originalTotalCPU = 10*1 = 10, excessCPU = 4
+	// excessCPU (4) / oldCPUPerPod (1) = 4 pods can be deleted
+	// But we only need to delete min(4, 10-2) = min(4, 8) = 4 pods
+	var replicas int32 = 10
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation:        "true",
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(10, 2, 1000, 5000),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "splunk"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("5000m"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: 10,
+		},
+	}
+
+	// Create pods: pod-0 has new spec (5 CPU), pods 1-9 have old spec (1 CPU)
+	podList := &corev1.PodList{}
+	pod0 := createCPUTestPod("splunk-indexer-0", "test", "5000m", true, "v2")
+	c.AddObject(pod0)
+	podList.Items = append(podList.Items, *pod0)
+
+	for i := 1; i < 10; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("splunk-indexer-%d", i), "test", "1000m", true, "v1")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+	c.ListObj = podList
+	c.AddObject(sts)
+
+	mgr := &DefaultStatefulSetPodManager{}
+	phase, err := UpdateStatefulSetPods(ctx, c, sts, mgr, 2)
+
+	if err != nil {
+		t.Errorf("Aggressive balance: unexpected error = %v", err)
+	}
+	if phase != enterpriseApi.PhaseScalingDown {
+		t.Errorf("Aggressive balance: expected PhaseScalingDown, got %v", phase)
+	}
+
+	// Verify replicas were reduced by 4 (from 10 to 6)
+	if *sts.Spec.Replicas != 6 {
+		t.Errorf("Aggressive balance: expected replicas = 6, got %d", *sts.Spec.Replicas)
+	}
+}
+
+// TestInterleavedRecycle_CompletionDetection tests the completion detection (Step 1)
+// When CPU-aware transition completes, the annotation is KEPT as a signal for the caller
+// (pod manager) to update the CR's replicas. The caller is responsible for clearing the
+// annotation after successfully updating the CR.
+func TestInterleavedRecycle_CompletionDetection(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Final state: 3 pods with new spec (4 CPU each), replicas = 3 = targetReplicas
+	var replicas int32 = 3
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation:        "true",
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(6, 3, 2000, 4000),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "splunk"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4000m"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas:   3,
+			UpdateRevision:  "v2",
+			CurrentRevision: "v2",
+		},
+	}
+
+	// All 3 pods have new spec
+	podList := &corev1.PodList{}
+	for i := 0; i < 3; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("splunk-indexer-%d", i), "test", "4000m", true, "v2")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+	c.ListObj = podList
+	c.AddObject(sts)
+
+	mgr := &DefaultStatefulSetPodManager{}
+	phase, err := UpdateStatefulSetPods(ctx, c, sts, mgr, 3)
+
+	if err != nil {
+		t.Errorf("Completion: unexpected error = %v", err)
+	}
+	if phase != enterpriseApi.PhaseReady {
+		t.Errorf("Completion: expected PhaseReady, got %v", phase)
+	}
+
+	// Verify annotation is KEPT (signals CR update pending)
+	// The caller (pod manager) is responsible for:
+	// 1. Checking the annotation via SyncCRReplicasFromCPUAwareTransition
+	// 2. Updating the CR's replicas
+	// 3. Calling ClearCPUAwareTransitionAnnotation
+	if _, exists := sts.Annotations[CPUAwareTransitionStateAnnotation]; !exists {
+		t.Errorf("Completion: expected transition state annotation to be kept for CR sync")
+	}
+}
+
+// TestBalanceCalculation_NoExcess tests that no balance occurs when there's no excess CPU
+func TestBalanceCalculation_NoExcess(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// All pods have old spec - totalReadyCPU = 12, originalTotalCPU = 12, excessCPU = 0
+	var replicas int32 = 6
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation:        "true",
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(6, 3, 2000, 4000),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "splunk"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4000m"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: 6,
+		},
+	}
+
+	// All 6 pods have old spec (2 CPU)
+	podList := &corev1.PodList{}
+	for i := 0; i < 6; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("splunk-indexer-%d", i), "test", "2000m", true, "v1")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+	c.ListObj = podList
+	c.AddObject(sts)
+
+	mgr := &DefaultStatefulSetPodManager{}
+	phase, err := UpdateStatefulSetPods(ctx, c, sts, mgr, 3)
+
+	if err != nil {
+		t.Errorf("NoExcess: unexpected error = %v", err)
+	}
+	// Should recycle pod-0 since no balance possible
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("NoExcess: expected PhaseUpdating (recycling), got %v", phase)
+	}
+
+	// Replicas should NOT be reduced (no excess CPU to balance)
+	if *sts.Spec.Replicas != 6 {
+		t.Errorf("NoExcess: expected replicas to remain 6, got %d", *sts.Spec.Replicas)
+	}
+}
+
+// TestBalanceCalculation_PartialExcess tests balance when there's a not-ready pod.
+// Pod-0 (new spec, ready) provides surplus CPU, which is enough to delete
+// one old pod (even though pod-5 is not ready).
+func TestBalanceCalculation_PartialExcess(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Scenario: 6×2CPU -> 3×4CPU
+	// State: pod-0 has 4CPU (new spec, ready), pods 1-4 have 2CPU (ready), pod-5 has 2CPU (not ready)
+	// CPU metrics:
+	// totalReadyCPU = 1×4000 + 4×2000 = 12000m (pod-5 not counted, not ready)
+	// OriginalTotalCPU = 6 × 2000 = 12000m
+	// surplusCPU = pod-0 contributes (4000 - 2000) = 2000m surplus
+	// Since surplusCPU (2000m) >= oldCPUPerPod (2000m), one old pod can be deleted
+	// Result: BALANCE (scale down) by reducing replicas from 6 to 5
+	var replicas int32 = 6
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation:        "true",
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(6, 3, 2000, 4000),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "splunk"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4000m"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: 5, // One pod not ready
+		},
+	}
+
+	// Create pods: pod-0 has new spec (4 CPU), pods 1-4 have old spec (2 CPU), pod-5 not ready
+	podList := &corev1.PodList{}
+	pod0 := createCPUTestPod("splunk-indexer-0", "test", "4000m", true, "v2")
+	c.AddObject(pod0)
+	podList.Items = append(podList.Items, *pod0)
+
+	for i := 1; i < 5; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("splunk-indexer-%d", i), "test", "2000m", true, "v1")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+	// Pod-5 not ready
+	pod5 := createCPUTestPod("splunk-indexer-5", "test", "2000m", false, "v1")
+	c.AddObject(pod5)
+	podList.Items = append(podList.Items, *pod5)
+
+	c.ListObj = podList
+	c.AddObject(sts)
+
+	mgr := &DefaultStatefulSetPodManager{}
+	phase, err := UpdateStatefulSetPods(ctx, c, sts, mgr, 3)
+
+	if err != nil {
+		t.Errorf("PartialExcess: unexpected error = %v", err)
+	}
+	// pod-0 provides 2000m surplus,
+	// which is enough to delete one old pod. So we BALANCE (scale down).
+	if phase != enterpriseApi.PhaseScalingDown {
+		t.Errorf("PartialExcess: expected PhaseScalingDown (balance due to surplus), got %v", phase)
+	}
+
+	// Verify replicas were reduced by 1 (from 6 to 5) due to balancing
+	if *sts.Spec.Replicas != 5 {
+		t.Errorf("PartialExcess: expected replicas = 5 (balanced), got %d", *sts.Spec.Replicas)
+	}
+}
+
+// TestInterleavedRecycle_ParallelUpdates tests recycling with parallelUpdates > 1
+func TestInterleavedRecycle_ParallelUpdates(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Scenario: 6×2CPU -> 3×4CPU with parallelUpdates=2
+	// All pods have old spec, should recycle 2 pods at once
+	var replicas int32 = 6
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation:        "true",
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(6, 3, 2000, 4000),
+				ParallelPodUpdatesAnnotation:      "2",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "splunk"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4000m"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: 6,
+		},
+	}
+
+	// All 6 pods have old spec (2 CPU)
+	podList := &corev1.PodList{}
+	for i := 0; i < 6; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("splunk-indexer-%d", i), "test", "2000m", true, "v1")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+	c.ListObj = podList
+	c.AddObject(sts)
+
+	mgr := &DefaultStatefulSetPodManager{}
+	phase, err := UpdateStatefulSetPods(ctx, c, sts, mgr, 3)
+
+	if err != nil {
+		t.Errorf("ParallelUpdates: unexpected error = %v", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("ParallelUpdates: expected PhaseUpdating, got %v", phase)
+	}
+
+	// Verify recycling behavior with CPU floor enforcement
+	// Current ready CPU = 6 × 2000m = 12000m
+	// OriginalTotalCPU = (3 × 4000) / 2000 × 2000 = 12000m
+	// minCPUFloor = 12000 - (2 × 2000) = 8000m
+	// After recycling pod-0: 12000 - 2000 = 10000m >= 8000m ✅ (allowed)
+	// After recycling pod-1: 10000 - 2000 = 8000m >= 8000m ✅ (allowed)
+	// Both pods can be recycled within CPU floor limits
+	deletedCount := 0
+	for i := 0; i < 2; i++ {
+		namespacedName := types.NamespacedName{Namespace: "test", Name: fmt.Sprintf("splunk-indexer-%d", i)}
+		var pod corev1.Pod
+		err := c.Get(ctx, namespacedName, &pod)
+		if err != nil {
+			deletedCount++
+		}
+	}
+	// 2 pods should be deleted since parallelUpdates=2 and CPU floor allows it
+	if deletedCount != 2 {
+		t.Errorf("ParallelUpdates: expected 2 pods deleted (parallelUpdates=2, within CPU floor), got %d", deletedCount)
+	}
+}
+
+// TestInterleavedRecycle_ParallelUpdates_WithExcessCPU tests parallel recycling when there IS excess CPU
+func TestInterleavedRecycle_ParallelUpdates_WithExcessCPU(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Scenario: 8×2CPU -> 4×4CPU with parallelUpdates=2
+	// We have 8 pods, 2 already converted to new spec, 6 still old spec
+	// Total ready = 2×4 + 6×2 = 8 + 12 = 20 CPU
+	// Original total = (4 × 4000) / 2000 × 2000 = 8 × 2000 = 16000m (floor)
+	// Excess = 20000 - 16000 = 4000m (2 old pods worth of excess)
+	// After recycling 2 pods: 20000 - 4000 = 16000 >= 16000 (OK)
+	var replicas int32 = 8
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation:        "true",
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(8, 4, 2000, 4000),
+				ParallelPodUpdatesAnnotation:      "2",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "splunk"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4000m"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: 8,
+		},
+	}
+
+	// 2 pods with new spec (4 CPU each) + 6 pods with old spec (2 CPU each)
+	podList := &corev1.PodList{}
+	for i := 0; i < 2; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("splunk-indexer-%d", i), "test", "4000m", true, "v2")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+	for i := 2; i < 8; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("splunk-indexer-%d", i), "test", "2000m", true, "v1")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+	c.ListObj = podList
+	c.AddObject(sts)
+
+	mgr := &DefaultStatefulSetPodManager{}
+	phase, err := UpdateStatefulSetPods(ctx, c, sts, mgr, 4)
+
+	if err != nil {
+		t.Errorf("ParallelUpdates with excess: unexpected error = %v", err)
+	}
+
+	// With 4000m excess CPU, the algorithm will first try to BALANCE (reduce replicas)
+	// podsCanDelete = 4000 / 2000 = 2, podsNeeded = 8 - 4 = 4, so delete min(2,4) = 2
+	if phase != enterpriseApi.PhaseScalingDown {
+		t.Errorf("ParallelUpdates with excess: expected PhaseScalingDown (balance step), got %v", phase)
+	}
+
+	// Verify replicas reduced by 2
+	if *sts.Spec.Replicas != 6 {
+		t.Errorf("ParallelUpdates with excess: expected replicas = 6, got %d", *sts.Spec.Replicas)
+	}
+}
+
+// TestInterleavedRecycle_SkipsNotReadyPods verifies that when there's sufficient
+// surplus CPU from new spec ready pods, the algorithm will BALANCE (scale down)
+// rather than recycle.
+//
+// In this scenario, pod-1 (new spec, ready) provides surplus CPU (4 - 2 = 2 CPU),
+// which is enough to delete one old pod. Balancing takes priority over recycling.
+func TestInterleavedRecycle_SkipsNotReadyPods(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Scenario: 6×2CPU -> 3×4CPU, parallelUpdates=2
+	// Pod-0: NOT ready (being recreated from previous recycle) - not counted in ready CPU
+	// Pod-1: new spec (4 CPU), ready - provides surplus of (4 - 2 = 2 CPU)
+	// Pod-2: old spec (2 CPU), ready
+	// Pod-3: old spec (2 CPU), ready
+	// Pod-4: old spec (2 CPU), ready
+	// Pod-5: old spec (2 CPU), ready
+	//
+	// CPU metrics:
+	// totalReadyCPU = 1×4000 + 4×2000 = 12000m (pod-0 not counted, not ready)
+	// OriginalTotalCPU = 6 × 2000 = 12000m
+	// surplusCPU = pod-1 contributes (4000 - 2000) = 2000m surplus
+	// Since surplusCPU (2000m) >= oldCPUPerPod (2000m), one old pod can be deleted
+	// Result: BALANCE (scale down) by reducing replicas from 6 to 5
+	var replicas int32 = 6
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation:        "true",
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(6, 3, 2000, 4000),
+				ParallelPodUpdatesAnnotation:      "2",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "splunk"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4000m"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: 5, // 5 ready (pod-0 is not ready)
+		},
+	}
+
+	podList := &corev1.PodList{}
+
+	// Pod-0: NOT ready (being recreated from previous cycle) - 4CPU new spec but not ready
+	pod0 := createCPUTestPod("splunk-indexer-0", "test", "4000m", false, "v2")
+	c.AddObject(pod0)
+	podList.Items = append(podList.Items, *pod0)
+
+	// Pod-1: new spec (4 CPU), ready
+	pod1 := createCPUTestPod("splunk-indexer-1", "test", "4000m", true, "v2")
+	c.AddObject(pod1)
+	podList.Items = append(podList.Items, *pod1)
+
+	// Pods 2-5: old spec (2 CPU each), ready
+	for i := 2; i <= 5; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("splunk-indexer-%d", i), "test", "2000m", true, "v1")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+
+	c.ListObj = podList
+	c.AddObject(sts)
+
+	mgr := &DefaultStatefulSetPodManager{}
+	phase, err := UpdateStatefulSetPods(ctx, c, sts, mgr, 3)
+
+	// The key assertion: with the new CPU-aware balancing logic,
+	// pod-1 (new spec, ready) provides 2000m surplus, which is enough
+	// to delete one old pod. So we BALANCE (scale down) instead of recycling.
+	if err != nil {
+		t.Errorf("SkipsNotReady: unexpected error = %v", err)
+	}
+	if phase != enterpriseApi.PhaseScalingDown {
+		t.Errorf("SkipsNotReady: expected PhaseScalingDown (balance due to surplus), got %v", phase)
+	}
+
+	// Verify replicas were reduced by 1 (from 6 to 5) due to balancing
+	if *sts.Spec.Replicas != 5 {
+		t.Errorf("SkipsNotReady: expected replicas = 5 (balanced), got %d", *sts.Spec.Replicas)
+	}
+
+	// Verify pod-2 was NOT deleted (balancing reduces replicas, doesn't delete kept pods)
+	namespacedName := types.NamespacedName{Namespace: "test", Name: "splunk-indexer-2"}
+	var pod corev1.Pod
+	err = c.Get(ctx, namespacedName, &pod)
+	if err != nil {
+		t.Errorf("SkipsNotReady: expected pod-2 to still exist (balancing doesn't delete kept pods), but it was deleted")
+	}
+
+	// Verify pods 3-5 still exist (balancing reduces replicas count, StatefulSet controller handles deletion)
+	for i := 3; i <= 5; i++ {
+		namespacedName := types.NamespacedName{Namespace: "test", Name: fmt.Sprintf("splunk-indexer-%d", i)}
+		err := c.Get(ctx, namespacedName, &pod)
+		if err != nil {
+			t.Errorf("SkipsNotReady: expected pod-%d to still exist (not yet deleted by STS controller), but it was deleted", i)
+		}
+	}
+}
+
+// prepareRecycleErrorPodManager is a mock pod manager that returns errors for specific pods
+type prepareRecycleErrorPodManager struct {
+	errorPodIndices map[int32]bool // Pod indices that should return errors
+}
+
+func (mgr *prepareRecycleErrorPodManager) Update(ctx context.Context, c splcommon.ControllerClient, statefulSet *appsv1.StatefulSet, desiredReplicas int32) (enterpriseApi.Phase, error) {
+	return enterpriseApi.PhaseUpdating, nil
+}
+
+func (mgr *prepareRecycleErrorPodManager) PrepareScaleDown(ctx context.Context, n int32) (bool, error) {
+	return true, nil
+}
+
+func (mgr *prepareRecycleErrorPodManager) PrepareRecycle(ctx context.Context, n int32) (bool, error) {
+	if mgr.errorPodIndices[n] {
+		return false, fmt.Errorf("Status=Restarting")
+	}
+	return true, nil
+}
+
+func (mgr *prepareRecycleErrorPodManager) FinishRecycle(ctx context.Context, n int32) (bool, error) {
+	return true, nil
+}
+
+func (mgr *prepareRecycleErrorPodManager) FinishUpgrade(ctx context.Context, n int32) error {
+	return nil
+}
+
+// TestInterleavedRecycle_PrepareRecycleError verifies that when PrepareRecycle returns an error
+// for one pod, the transition continues to check other pods instead of stopping entirely.
+func TestInterleavedRecycle_PrepareRecycleError(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Scenario: replicas=5, target=5, parallelUpdates=2
+	// Pods 0-1: new spec (4 CPU each), ready - already converted
+	// Pod-2: old spec (2 CPU), ready - but PrepareRecycle returns error ("Status=Restarting")
+	// Pod-3: old spec (2 CPU), ready - should be recycled (PrepareRecycle succeeds)
+	// Pod-4: old spec (2 CPU), ready - should be recycled (PrepareRecycle succeeds)
+	// Expected: pod-2 is skipped, pod-3 and pod-4 are recycled
+	// CPU headroom: current = 2×4000 + 3×2000 = 14000m
+	// minCPUFloor = (5×4000)/2000×2000 - 2×2000 = 20000 - 4000 = 16000m
+	// After recycling 2 pods: 14000 - 4000 = 10000m < 16000m ❌
+	// Need more new-spec pods for headroom
+	var replicas int32 = 5
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation:        "true",
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(10, 5, 2000, 4000),
+				ParallelPodUpdatesAnnotation:      "2",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "splunk"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4000m"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: 5,
+		},
+	}
+
+	podList := &corev1.PodList{}
+
+	// Pods 0-2: new spec (4 CPU each), ready
+	for i := 0; i <= 2; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("splunk-indexer-%d", i), "test", "4000m", true, "v2")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+
+	// Pods 3-4: old spec (2 CPU each), ready
+	for i := 3; i <= 4; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("splunk-indexer-%d", i), "test", "2000m", true, "v1")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+	c.ListObj = podList
+	c.AddObject(sts)
+
+	// Use custom pod manager that returns error for pod-3
+	mgr := &prepareRecycleErrorPodManager{
+		errorPodIndices: map[int32]bool{3: true}, // Only pod-3 returns error
+	}
+
+	phase, err := UpdateStatefulSetPods(ctx, c, sts, mgr, 5)
+
+	// The key assertion: we should NOT get an error because of pod-3's PrepareRecycle failure
+	// Instead, we should skip pod-3 and continue to recycle pod-4
+	if err != nil {
+		t.Errorf("PrepareRecycleError: unexpected error = %v (should skip problematic pod)", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("PrepareRecycleError: expected PhaseUpdating, got %v", phase)
+	}
+
+	// Verify pods 0-2 were NOT deleted (already have new spec)
+	for i := 0; i <= 2; i++ {
+		namespacedName := types.NamespacedName{Namespace: "test", Name: fmt.Sprintf("splunk-indexer-%d", i)}
+		var pod corev1.Pod
+		err = c.Get(ctx, namespacedName, &pod)
+		if err != nil {
+			t.Errorf("PrepareRecycleError: pod-%d should NOT be deleted (new spec), but got error: %v", i, err)
+		}
+	}
+
+	// Verify pod-3 was NOT deleted (skipped due to PrepareRecycle error)
+	namespacedName := types.NamespacedName{Namespace: "test", Name: "splunk-indexer-3"}
+	var pod3 corev1.Pod
+	err = c.Get(ctx, namespacedName, &pod3)
+	if err != nil {
+		t.Errorf("PrepareRecycleError: pod-3 should NOT be deleted (PrepareRecycle failed), but got error: %v", err)
+	}
+
+	// Verify pod-4 was deleted (recycled)
+	// Current CPU = 3×4000 + 2×2000 = 16000m
+	// minCPUFloor = 20000 - 4000 = 16000m
+	// After recycling pod-4: 16000 - 2000 = 14000m < 16000m ❌
+	// CPU floor blocks recycling, so pod-4 should NOT be deleted
+	namespacedName = types.NamespacedName{Namespace: "test", Name: "splunk-indexer-4"}
+	var pod4 corev1.Pod
+	err = c.Get(ctx, namespacedName, &pod4)
+	if err != nil {
+		t.Errorf("PrepareRecycleError: pod-4 should NOT be deleted (CPU floor blocks), but got error: %v", err)
+	}
+}
+
+// TestSyncCRReplicasFromCPUAwareTransition tests the helper function for checking if CR needs sync
+func TestSyncCRReplicasFromCPUAwareTransition(t *testing.T) {
+	testCases := []struct {
+		name          string
+		annotations   map[string]string
+		stsReplicas   int32
+		crReplicas    int32
+		wantTarget    int32
+		wantNeedsSync bool
+	}{
+		{
+			name:          "No annotation - no sync needed",
+			annotations:   nil,
+			stsReplicas:   3,
+			crReplicas:    6,
+			wantTarget:    0,
+			wantNeedsSync: false,
+		},
+		{
+			name: "Annotation present but STS not at target - no sync",
+			annotations: map[string]string{
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(6, 3, 2000, 4000),
+			},
+			stsReplicas:   5,
+			crReplicas:    6,
+			wantTarget:    0,
+			wantNeedsSync: false,
+		},
+		{
+			name: "STS at target but CR already matches - no sync",
+			annotations: map[string]string{
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(6, 3, 2000, 4000),
+			},
+			stsReplicas:   3,
+			crReplicas:    3,
+			wantTarget:    0,
+			wantNeedsSync: false,
+		},
+		{
+			name: "STS at target and CR needs update - sync required",
+			annotations: map[string]string{
+				// FinishedAt MUST be set for sync to be signaled (safety requirement)
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSONWithFinished(6, 3, 2000, 4000, "2024-01-01T12:00:00Z"),
+			},
+			stsReplicas:   3,
+			crReplicas:    6,
+			wantTarget:    3,
+			wantNeedsSync: true,
+		},
+		{
+			name: "STS at target and CR needs update but FinishedAt not set - no sync (safety)",
+			annotations: map[string]string{
+				// Without FinishedAt, sync should NOT be triggered to prevent premature CR updates
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(6, 3, 2000, 4000),
+			},
+			stsReplicas:   3,
+			crReplicas:    6,
+			wantTarget:    0,
+			wantNeedsSync: false,
+		},
+		{
+			name: "Invalid annotation value - no sync",
+			annotations: map[string]string{
+				CPUAwareTransitionStateAnnotation: "invalid-json",
+			},
+			stsReplicas:   3,
+			crReplicas:    6,
+			wantTarget:    0,
+			wantNeedsSync: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "test",
+					Annotations: tc.annotations,
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: &tc.stsReplicas,
+				},
+			}
+
+			gotTarget, gotNeedsSync := SyncCRReplicasFromCPUAwareTransition(sts, tc.crReplicas)
+
+			if gotTarget != tc.wantTarget {
+				t.Errorf("SyncCRReplicasFromCPUAwareTransition() target = %d, want %d", gotTarget, tc.wantTarget)
+			}
+			if gotNeedsSync != tc.wantNeedsSync {
+				t.Errorf("SyncCRReplicasFromCPUAwareTransition() needsSync = %v, want %v", gotNeedsSync, tc.wantNeedsSync)
+			}
+		})
+	}
+}
+
+// TestClearCPUAwareTransitionAnnotation tests the helper function for clearing the annotation
+func TestClearCPUAwareTransitionAnnotation(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("No annotations - no error", func(t *testing.T) {
+		c := spltest.NewMockClient()
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sts",
+				Namespace: "test",
+			},
+		}
+		c.AddObject(sts)
+
+		err := ClearCPUAwareTransitionAnnotation(ctx, c, sts)
+		if err != nil {
+			t.Errorf("ClearCPUAwareTransitionAnnotation() error = %v", err)
+		}
+	})
+
+	t.Run("Annotation not present - no error", func(t *testing.T) {
+		c := spltest.NewMockClient()
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sts",
+				Namespace: "test",
+				Annotations: map[string]string{
+					"other-annotation": "value",
+				},
+			},
+		}
+		c.AddObject(sts)
+
+		err := ClearCPUAwareTransitionAnnotation(ctx, c, sts)
+		if err != nil {
+			t.Errorf("ClearCPUAwareTransitionAnnotation() error = %v", err)
+		}
+	})
+
+	t.Run("Annotation present - removes it", func(t *testing.T) {
+		c := spltest.NewMockClient()
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sts",
+				Namespace: "test",
+				Annotations: map[string]string{
+					CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(6, 3, 2000, 4000),
+					"other-annotation":                "value",
+				},
+			},
+		}
+		c.AddObject(sts)
+
+		err := ClearCPUAwareTransitionAnnotation(ctx, c, sts)
+		if err != nil {
+			t.Errorf("ClearCPUAwareTransitionAnnotation() error = %v", err)
+		}
+
+		// Verify annotation was removed
+		if _, exists := sts.Annotations[CPUAwareTransitionStateAnnotation]; exists {
+			t.Errorf("ClearCPUAwareTransitionAnnotation() expected annotation to be removed")
+		}
+
+		// Verify other annotations are preserved
+		if sts.Annotations["other-annotation"] != "value" {
+			t.Errorf("ClearCPUAwareTransitionAnnotation() other annotations should be preserved")
+		}
+	})
+}
+
+// TestUpdateStatefulSetPods_CPUAwareShortCircuitCompleted tests that completed transitions
+// (with FinishedAt set) are short-circuited immediately and return PhaseReady
+func TestUpdateStatefulSetPods_CPUAwareShortCircuitCompleted(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 3
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation: "true",
+				// Transition already completed with FinishedAt set
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSONWithFinished(6, 3, 2000, 4000, "2026-01-10T11:00:00Z"),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "splunk"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: 3,
+		},
+	}
+
+	// Create pods (though they shouldn't be checked due to short-circuit)
+	podList := &corev1.PodList{}
+	for i := 0; i < 3; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("splunk-indexer-%d", i), "test", "4", true, "v2")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+	c.ListObj = podList
+
+	c.AddObject(sts)
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	// Execute - should short-circuit immediately
+	phase, err := UpdateStatefulSetPods(ctx, c, sts, mgr, 3)
+
+	if err != nil {
+		t.Errorf("UpdateStatefulSetPods() error = %v", err)
+	}
+
+	if phase != enterpriseApi.PhaseReady {
+		t.Errorf("Expected PhaseReady for completed transition (short-circuit), got %v", phase)
+	}
+
+	// Verify no pods were checked (no Get calls for pods should have been made)
+	// The short-circuit should happen before any pod inspection
+}
+
+// TestApplyStatefulSet_ClearsCompletedTransitionBeforeNewOne tests that
+// ApplyStatefulSet clears a completed transition annotation before starting a new one
+func TestApplyStatefulSet_ClearsCompletedTransitionBeforeNewOne(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var oldReplicas int32 = 3
+	current := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation: "true",
+				// Previous transition completed
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSONWithFinished(6, 3, 2000, 4000, "2026-01-10T11:00:00Z"),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &oldReplicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "splunk"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "splunk"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas:   3,
+			UpdatedReplicas: 3,
+		},
+	}
+
+	// New desired template with different CPU (8 CPU this time)
+	revised := current.DeepCopy()
+	revised.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("8")
+
+	c.AddObject(current)
+
+	// Execute ApplyStatefulSet with CPU-aware scaling
+	phase, err := ApplyStatefulSet(ctx, c, revised, nil)
+
+	if err != nil {
+		t.Fatalf("ApplyStatefulSet() error = %v", err)
+	}
+
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("Expected PhaseUpdating when starting new transition, got %v", phase)
+	}
+
+	// Verify the old completed annotation was cleared and new one created
+	var updatedSts appsv1.StatefulSet
+	if getErr := c.Get(ctx, types.NamespacedName{Name: "splunk-indexer", Namespace: "test"}, &updatedSts); getErr != nil {
+		t.Fatalf("Failed to get updated StatefulSet: %v", getErr)
+	}
+
+	stateJSON, exists := updatedSts.Annotations[CPUAwareTransitionStateAnnotation]
+	if !exists {
+		t.Fatal("Expected new transition annotation to exist")
+	}
+
+	var newState CPUAwareTransitionState
+	if unmarshalErr := json.Unmarshal([]byte(stateJSON), &newState); unmarshalErr != nil {
+		t.Fatalf("Failed to unmarshal new state: %v", unmarshalErr)
+	}
+
+	// Verify it's a NEW transition (not the old completed one)
+	if newState.FinishedAt != "" {
+		t.Error("Expected new transition to NOT have FinishedAt set")
+	}
+
+	if newState.OriginalCPUMillis != 4000 {
+		t.Errorf("Expected OriginalCPUMillis=4000 (from current spec), got %d", newState.OriginalCPUMillis)
+	}
+
+	if newState.TargetCPUMillis != 8000 {
+		t.Errorf("Expected TargetCPUMillis=8000 (new spec), got %d", newState.TargetCPUMillis)
+	}
+}
+
+// TestIsCPUPreservingScalingFinished_ChecksFinishedAt tests that the completion
+// check now uses FinishedAt field instead of replica count
+func TestIsCPUPreservingScalingFinished_ChecksFinishedAt(t *testing.T) {
+	testCases := []struct {
+		name         string
+		annotations  map[string]string
+		stsReplicas  int32
+		wantFinished bool
+	}{
+		{
+			name:         "No annotation - not finished",
+			annotations:  nil,
+			stsReplicas:  3,
+			wantFinished: false,
+		},
+		{
+			name: "Annotation without FinishedAt - not finished",
+			annotations: map[string]string{
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(6, 3, 2000, 4000),
+			},
+			stsReplicas:  3,
+			wantFinished: false,
+		},
+		{
+			name: "Annotation with FinishedAt - finished",
+			annotations: map[string]string{
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSONWithFinished(6, 3, 2000, 4000, "2026-01-10T11:00:00Z"),
+			},
+			stsReplicas:  3,
+			wantFinished: true,
+		},
+		{
+			name: "FinishedAt set but replicas don't match (shouldn't happen, but tests FinishedAt takes precedence)",
+			annotations: map[string]string{
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSONWithFinished(6, 3, 2000, 4000, "2026-01-10T11:00:00Z"),
+			},
+			stsReplicas:  6,    // Still at original replicas
+			wantFinished: true, // FinishedAt takes precedence
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-sts",
+					Namespace:   "test",
+					Annotations: tc.annotations,
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: &tc.stsReplicas,
+				},
+			}
+
+			gotFinished := IsCPUPreservingScalingFinished(sts)
+
+			if gotFinished != tc.wantFinished {
+				t.Errorf("IsCPUPreservingScalingFinished() = %v, want %v", gotFinished, tc.wantFinished)
+			}
+		})
+	}
+}
+
+// TestCheckCPUTransitionCompletion tests the shared completion probe helper
+func TestCheckCPUTransitionCompletion(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	targetReplicas := int32(3)
+	targetCPUMillis := int64(4000)
+
+	// Create 3 pods with new spec (target CPU)
+	podList := &corev1.PodList{}
+	for i := 0; i < 3; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("test-sts-%d", i), "test", "4", true, "v2")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+	c.ListObj = podList
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts",
+			Namespace: "test",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &targetReplicas,
+		},
+	}
+	c.AddObject(sts)
+
+	t.Run("All pods have new spec at target replicas - complete", func(t *testing.T) {
+		result := checkCPUTransitionCompletion(ctx, c, sts, targetReplicas, targetCPUMillis)
+		if !result {
+			t.Errorf("Expected true when all pods have new spec, got false")
+		}
+	})
+
+	t.Run("Replicas not at target - not complete", func(t *testing.T) {
+		var notAtTarget int32 = 4
+		stsNotAtTarget := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sts-2",
+				Namespace: "test",
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: &notAtTarget,
+			},
+		}
+		c.AddObject(stsNotAtTarget)
+		result := checkCPUTransitionCompletion(ctx, c, stsNotAtTarget, targetReplicas, targetCPUMillis)
+		if result {
+			t.Errorf("Expected false when replicas not at target, got true")
+		}
+	})
+
+	t.Run("Pod has old spec - not complete", func(t *testing.T) {
+		c2 := spltest.NewMockClient()
+		oldCPUPod := createCPUTestPod("test-sts-old-0", "test", "2", true, "v1") // Old CPU
+		c2.AddObject(oldCPUPod)
+
+		stsOld := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sts-old",
+				Namespace: "test",
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: func() *int32 { r := int32(1); return &r }(),
+			},
+		}
+		c2.AddObject(stsOld)
+
+		result := checkCPUTransitionCompletion(ctx, c2, stsOld, 1, targetCPUMillis)
+		if result {
+			t.Errorf("Expected false when pod has old spec (2000m vs 4000m target), got true")
+		}
+	})
+}
+
+// TestPersistCPUTransitionFinished tests the shared helper for persisting FinishedAt
+func TestPersistCPUTransitionFinished(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts-persist",
+			Namespace: "test",
+			Annotations: map[string]string{
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(6, 3, 2000, 4000),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: func() *int32 { r := int32(3); return &r }(),
+		},
+	}
+	c.AddObject(sts)
+
+	state := CPUAwareTransitionState{
+		OriginalReplicas:  6,
+		TargetReplicas:    3,
+		OriginalCPUMillis: 2000,
+		TargetCPUMillis:   4000,
+		StartedAt:         "2026-01-10T10:00:00Z",
+	}
+
+	t.Run("Persists FinishedAt and updates annotation", func(t *testing.T) {
+		err := persistCPUTransitionFinished(ctx, c, sts, &state)
+		if err != nil {
+			t.Errorf("persistCPUTransitionFinished() error = %v", err)
+		}
+
+		// Verify FinishedAt is set
+		if state.FinishedAt == "" {
+			t.Errorf("Expected FinishedAt to be set, but it's empty")
+		}
+
+		// Verify annotation contains FinishedAt
+		annotationJSON := sts.Annotations[CPUAwareTransitionStateAnnotation]
+		if annotationJSON == "" {
+			t.Errorf("Expected annotation to be updated")
+		}
+
+		var parsedState CPUAwareTransitionState
+		if err := json.Unmarshal([]byte(annotationJSON), &parsedState); err != nil {
+			t.Errorf("Failed to parse updated annotation: %v", err)
+		}
+
+		if parsedState.FinishedAt == "" {
+			t.Errorf("FinishedAt should be set in persisted annotation")
+		}
+	})
+}
+
+// TestDispatcherExplicitCompletionCheck tests that handleCPUPreservingTransition
+// handles the replicas == targetReplicas case with explicit completion check
+func TestDispatcherExplicitCompletionCheck(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var targetReplicas int32 = 3
+
+	// Create a StatefulSet at target replicas
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts-dispatch",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation: "true",
+				// In-progress transition (no FinishedAt)
+				CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(6, 3, 2000, 4000),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &targetReplicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "splunk"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: 3,
+		},
+	}
+	c.AddObject(sts)
+
+	// Create 3 pods with new spec (should trigger completion)
+	podList := &corev1.PodList{}
+	for i := 0; i < 3; i++ {
+		pod := createCPUTestPod(fmt.Sprintf("test-sts-dispatch-%d", i), "test", "4", true, "v2")
+		c.AddObject(pod)
+		podList.Items = append(podList.Items, *pod)
+	}
+	c.ListObj = podList
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	t.Run("At target replicas with all new spec - persists FinishedAt", func(t *testing.T) {
+		phase, handled, err := handleCPUPreservingTransition(ctx, c, sts, mgr, targetReplicas)
+
+		if err != nil {
+			t.Errorf("handleCPUPreservingTransition() error = %v", err)
+		}
+		if !handled {
+			t.Errorf("Expected handled=true")
+		}
+		if phase != enterpriseApi.PhaseReady {
+			t.Errorf("Expected PhaseReady after completion, got %v", phase)
+		}
+
+		// Verify FinishedAt was persisted
+		stateJSON := sts.Annotations[CPUAwareTransitionStateAnnotation]
+		var state CPUAwareTransitionState
+		if err := json.Unmarshal([]byte(stateJSON), &state); err != nil {
+			t.Errorf("Failed to parse state: %v", err)
+		}
+		if state.FinishedAt == "" {
+			t.Errorf("FinishedAt should be set after completion")
+		}
+	})
+
+	t.Run("At target replicas with old spec pods - continues transition", func(t *testing.T) {
+		c2 := spltest.NewMockClient()
+
+		// Reset annotation to in-progress
+		sts2 := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sts-dispatch2",
+				Namespace: "test",
+				Annotations: map[string]string{
+					PreserveTotalCPUAnnotation:        "true",
+					CPUAwareTransitionStateAnnotation: createTestTransitionStateJSON(6, 3, 2000, 4000),
+				},
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: &targetReplicas,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "splunk"},
+				},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "splunk",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU: resource.MustParse("4"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Status: appsv1.StatefulSetStatus{
+				ReadyReplicas: 3,
+			},
+		}
+		c2.AddObject(sts2)
+
+		// Create pods with OLD spec (should NOT trigger completion)
+		podList2 := &corev1.PodList{}
+		for i := 0; i < 3; i++ {
+			pod := createCPUTestPod(fmt.Sprintf("test-sts-dispatch2-%d", i), "test", "2", true, "v1") // OLD CPU
+			c2.AddObject(pod)
+			podList2.Items = append(podList2.Items, *pod)
+		}
+		c2.ListObj = podList2
+
+		phase, handled, err := handleCPUPreservingTransition(ctx, c2, sts2, mgr, targetReplicas)
+
+		if err != nil {
+			t.Errorf("handleCPUPreservingTransition() error = %v", err)
+		}
+		if !handled {
+			t.Errorf("Expected handled=true")
+		}
+		// Should continue with scale-down handler since completion check failed
+		// (pods have old spec), returns PhaseUpdating
+		if phase == enterpriseApi.PhaseReady {
+			t.Errorf("Expected PhaseUpdating (continue transition), got PhaseReady")
+		}
+
+		// Verify FinishedAt was NOT set
+		stateJSON := sts2.Annotations[CPUAwareTransitionStateAnnotation]
+		var state CPUAwareTransitionState
+		if err := json.Unmarshal([]byte(stateJSON), &state); err != nil {
+			t.Errorf("Failed to parse state: %v", err)
+		}
+		if state.FinishedAt != "" {
+			t.Errorf("FinishedAt should NOT be set when pods have old spec, but got: %s", state.FinishedAt)
+		}
+	})
+}

--- a/pkg/splunk/splkcontroller/statefulset_cpu_scaleup_test.go
+++ b/pkg/splunk/splkcontroller/statefulset_cpu_scaleup_test.go
@@ -1,0 +1,603 @@
+// Copyright (c) 2018-2022 Splunk Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splkcontroller
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
+	spltest "github.com/splunk/splunk-operator/pkg/splunk/test"
+)
+
+// TestComputeCPUCeiling tests the computeCPUCeiling helper function
+func TestComputeCPUCeiling(t *testing.T) {
+	tests := []struct {
+		name            string
+		state           CPUAwareTransitionState
+		parallelUpdates int32
+		expectedCeiling int64
+	}{
+		{
+			name: "basic scale-up 4x4CPU to 8x2CPU with parallelUpdates=1",
+			state: CPUAwareTransitionState{
+				OriginalReplicas:  4,
+				TargetReplicas:    8,
+				OriginalCPUMillis: 4000, // 4 CPU
+				TargetCPUMillis:   2000, // 2 CPU
+			},
+			parallelUpdates: 1,
+			// ceiling = 4*4000 + 1*2000 = 16000 + 2000 = 18000
+			expectedCeiling: 18000,
+		},
+		{
+			name: "scale-up 10x4CPU to 20x2CPU with parallelUpdates=3",
+			state: CPUAwareTransitionState{
+				OriginalReplicas:  10,
+				TargetReplicas:    20,
+				OriginalCPUMillis: 4000,
+				TargetCPUMillis:   2000,
+			},
+			parallelUpdates: 3,
+			// ceiling = 10*4000 + 3*2000 = 40000 + 6000 = 46000
+			expectedCeiling: 46000,
+		},
+		{
+			name: "scale-up with small CPU values",
+			state: CPUAwareTransitionState{
+				OriginalReplicas:  2,
+				TargetReplicas:    4,
+				OriginalCPUMillis: 500, // 500m
+				TargetCPUMillis:   250, // 250m
+			},
+			parallelUpdates: 2,
+			// ceiling = 2*500 + 2*250 = 1000 + 500 = 1500
+			expectedCeiling: 1500,
+		},
+		{
+			name: "parallelUpdates=0 should give minimal buffer",
+			state: CPUAwareTransitionState{
+				OriginalReplicas:  4,
+				TargetReplicas:    8,
+				OriginalCPUMillis: 2000,
+				TargetCPUMillis:   1000,
+			},
+			parallelUpdates: 0,
+			// ceiling = 4*2000 + 0*1000 = 8000
+			expectedCeiling: 8000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := computeCPUCeiling(tt.state, tt.parallelUpdates)
+			if result != tt.expectedCeiling {
+				t.Errorf("computeCPUCeiling() = %d, expected %d", result, tt.expectedCeiling)
+			}
+		})
+	}
+}
+
+// TestCPUAwareScaleUpDetection tests that scale-up transitions are detected and state is persisted
+func TestCPUAwareScaleUpDetection(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Create current StatefulSet with 4 replicas, 4 CPU per pod (total: 16 CPU)
+	var currentReplicas int32 = 4
+	current := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation: "up", // Enable scale-up only
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &currentReplicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	c.AddObject(current)
+
+	// Create revised StatefulSet with 2 CPU per pod
+	// Expected: target replicas should be 8 to maintain 16 CPU total
+	var revisedReplicas int32 = 4
+	revised := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation: "up",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &revisedReplicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("2"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Apply the StatefulSet
+	phase, err := ApplyStatefulSet(ctx, c, revised, nil)
+	if err != nil {
+		t.Errorf("ApplyStatefulSet() failed: %v", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("Expected PhaseUpdating, got %v", phase)
+	}
+
+	// For scale-up (4 replicas with 4 CPU -> 8 replicas with 2 CPU),
+	// replicas should remain at 4 (gradual transition)
+	expectedReplicas := int32(4)
+	if *revised.Spec.Replicas != expectedReplicas {
+		t.Errorf("Expected replicas to remain at %d for gradual scale-up, got %d", expectedReplicas, *revised.Spec.Replicas)
+	}
+
+	// Verify transition state annotation was set
+	stateJSON, exists := revised.Annotations[CPUAwareTransitionStateAnnotation]
+	if !exists {
+		t.Error("Expected transition state annotation to be set for scale-up")
+	} else {
+		var state CPUAwareTransitionState
+		if err := json.Unmarshal([]byte(stateJSON), &state); err != nil {
+			t.Errorf("Failed to parse transition state JSON: %v", err)
+		} else {
+			if state.OriginalReplicas != 4 {
+				t.Errorf("Expected original replicas to be 4, got %d", state.OriginalReplicas)
+			}
+			if state.TargetReplicas != 8 {
+				t.Errorf("Expected target replicas to be 8, got %d", state.TargetReplicas)
+			}
+			if state.OriginalCPUMillis != 4000 {
+				t.Errorf("Expected original CPU to be 4000, got %d", state.OriginalCPUMillis)
+			}
+			if state.TargetCPUMillis != 2000 {
+				t.Errorf("Expected target CPU to be 2000, got %d", state.TargetCPUMillis)
+			}
+			if state.StartedAt == "" {
+				t.Error("Expected StartedAt timestamp to be set")
+			}
+			if state.FinishedAt != "" {
+				t.Error("Expected FinishedAt to be empty (transition in progress)")
+			}
+		}
+	}
+}
+
+// TestCPUAwareScaleUpDirectionalControlUp tests that "up" only enables scale-up
+func TestCPUAwareScaleUpDirectionalControlUp(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Create current StatefulSet with 4 replicas, 4 CPU per pod
+	var currentReplicas int32 = 4
+	current := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation: "up", // Only enable scale-up
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &currentReplicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	c.AddObject(current)
+
+	// Create revised StatefulSet with 2 CPU per pod (should trigger scale-up)
+	var revisedReplicas int32 = 4
+	revised := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation: "up",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &revisedReplicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("2"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	phase, err := ApplyStatefulSet(ctx, c, revised, nil)
+	if err != nil {
+		t.Errorf("ApplyStatefulSet() failed: %v", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("Expected PhaseUpdating, got %v", phase)
+	}
+
+	// Verify transition state annotation was set (scale-up should be enabled)
+	if _, exists := revised.Annotations[CPUAwareTransitionStateAnnotation]; !exists {
+		t.Error("Expected transition state annotation for scale-up with 'up' setting")
+	}
+}
+
+// TestCPUAwareScaleUpDirectionalControlDown tests that "down" does NOT enable scale-up
+func TestCPUAwareScaleUpDirectionalControlDown(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Create current StatefulSet with 4 replicas, 4 CPU per pod
+	var currentReplicas int32 = 4
+	current := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation: "down", // Only enable scale-down
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &currentReplicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	c.AddObject(current)
+
+	// Create revised StatefulSet with 2 CPU per pod (would trigger scale-up if enabled)
+	var revisedReplicas int32 = 4
+	revised := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation: "down",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &revisedReplicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("2"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	phase, err := ApplyStatefulSet(ctx, c, revised, nil)
+	if err != nil {
+		t.Errorf("ApplyStatefulSet() failed: %v", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("Expected PhaseUpdating, got %v", phase)
+	}
+
+	// Verify NO transition state annotation (scale-up should NOT be enabled with "down")
+	if _, exists := revised.Annotations[CPUAwareTransitionStateAnnotation]; exists {
+		t.Error("Expected NO transition state annotation for scale-up with 'down' setting")
+	}
+}
+
+// TestCPUAwareScaleUpWithBoth tests that "both" enables scale-up
+func TestCPUAwareScaleUpWithBoth(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Create current StatefulSet with 4 replicas, 4 CPU per pod
+	var currentReplicas int32 = 4
+	current := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation: "both", // Enable both directions
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &currentReplicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	c.AddObject(current)
+
+	// Create revised StatefulSet with 2 CPU per pod
+	var revisedReplicas int32 = 4
+	revised := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation: "both",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &revisedReplicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("2"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	phase, err := ApplyStatefulSet(ctx, c, revised, nil)
+	if err != nil {
+		t.Errorf("ApplyStatefulSet() failed: %v", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("Expected PhaseUpdating, got %v", phase)
+	}
+
+	// Verify transition state annotation was set (scale-up enabled with "both")
+	stateJSON, exists := revised.Annotations[CPUAwareTransitionStateAnnotation]
+	if !exists {
+		t.Error("Expected transition state annotation for scale-up with 'both' setting")
+	} else {
+		var state CPUAwareTransitionState
+		if err := json.Unmarshal([]byte(stateJSON), &state); err != nil {
+			t.Errorf("Failed to parse transition state: %v", err)
+		} else if state.TargetReplicas != 8 {
+			t.Errorf("Expected target replicas to be 8, got %d", state.TargetReplicas)
+		}
+	}
+}
+
+// TestCPUAwareScaleUpWithTrue tests that "true" enables scale-up (alias for both)
+func TestCPUAwareScaleUpWithTrue(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Create current StatefulSet with 5 replicas, 4 CPU per pod
+	var currentReplicas int32 = 5
+	current := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation: "true", // Enable both directions
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &currentReplicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	c.AddObject(current)
+
+	// Create revised StatefulSet with 2 CPU per pod
+	// Target: 5 * 4 / 2 = 10 replicas
+	var revisedReplicas int32 = 5
+	revised := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation: "true",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &revisedReplicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("2"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	phase, err := ApplyStatefulSet(ctx, c, revised, nil)
+	if err != nil {
+		t.Errorf("ApplyStatefulSet() failed: %v", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("Expected PhaseUpdating, got %v", phase)
+	}
+
+	// Verify transition state annotation was set
+	stateJSON, exists := revised.Annotations[CPUAwareTransitionStateAnnotation]
+	if !exists {
+		t.Error("Expected transition state annotation for scale-up with 'true' setting")
+	} else {
+		var state CPUAwareTransitionState
+		if err := json.Unmarshal([]byte(stateJSON), &state); err != nil {
+			t.Errorf("Failed to parse transition state: %v", err)
+		} else if state.TargetReplicas != 10 {
+			t.Errorf("Expected target replicas to be 10, got %d", state.TargetReplicas)
+		}
+	}
+}
+
+// TestIsCPUPreservingScalingFinishedForScaleUp tests that IsCPUPreservingScalingFinished works for scale-up
+func TestIsCPUPreservingScalingFinishedForScaleUp(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name:        "no annotation",
+			annotations: nil,
+			expected:    false,
+		},
+		{
+			name: "scale-up in progress (no FinishedAt)",
+			annotations: map[string]string{
+				CPUAwareTransitionStateAnnotation: `{"originalReplicas":4,"targetReplicas":8,"originalCPUMillis":4000,"targetCPUMillis":2000,"startedAt":"2026-01-12T00:00:00Z"}`,
+			},
+			expected: false,
+		},
+		{
+			name: "scale-up complete (FinishedAt set)",
+			annotations: map[string]string{
+				CPUAwareTransitionStateAnnotation: `{"originalReplicas":4,"targetReplicas":8,"originalCPUMillis":4000,"targetCPUMillis":2000,"startedAt":"2026-01-12T00:00:00Z","finishedAt":"2026-01-12T00:10:00Z"}`,
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tt.annotations,
+				},
+			}
+			result := IsCPUPreservingScalingFinished(sts)
+			if result != tt.expected {
+				t.Errorf("IsCPUPreservingScalingFinished() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestScaleUpCPUMetrics tests the ScaleUpCPUMetrics struct fields
+func TestScaleUpCPUMetricsFields(t *testing.T) {
+	metrics := ScaleUpCPUMetrics{
+		TotalPodCPU:      16000,
+		OldSpecPodCount:  4,
+		NewSpecPodCount:  2,
+		OldSpecReadyPods: 3,
+	}
+
+	if metrics.TotalPodCPU != 16000 {
+		t.Errorf("Expected TotalPodCPU=16000, got %d", metrics.TotalPodCPU)
+	}
+	if metrics.OldSpecPodCount != 4 {
+		t.Errorf("Expected OldSpecPodCount=4, got %d", metrics.OldSpecPodCount)
+	}
+	if metrics.NewSpecPodCount != 2 {
+		t.Errorf("Expected NewSpecPodCount=2, got %d", metrics.NewSpecPodCount)
+	}
+	if metrics.OldSpecReadyPods != 3 {
+		t.Errorf("Expected OldSpecReadyPods=3, got %d", metrics.OldSpecReadyPods)
+	}
+}

--- a/pkg/splunk/splkcontroller/statefulset_cpu_test.go
+++ b/pkg/splunk/splkcontroller/statefulset_cpu_test.go
@@ -1,0 +1,1284 @@
+// Copyright (c) 2018-2022 Splunk Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splkcontroller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
+	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
+	spltest "github.com/splunk/splunk-operator/pkg/splunk/test"
+)
+
+func parseQuantity(s string) resource.Quantity {
+	q, _ := resource.ParseQuantity(s)
+	return q
+}
+
+func TestIsKeepTotalCPUEnabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name:        "annotation enabled with true",
+			annotations: map[string]string{PreserveTotalCPUAnnotation: "true"},
+			expected:    true,
+		},
+		{
+			name:        "annotation enabled with both",
+			annotations: map[string]string{PreserveTotalCPUAnnotation: "both"},
+			expected:    true,
+		},
+		{
+			name:        "annotation enabled with down",
+			annotations: map[string]string{PreserveTotalCPUAnnotation: "down"},
+			expected:    true,
+		},
+		{
+			name:        "annotation enabled with up",
+			annotations: map[string]string{PreserveTotalCPUAnnotation: "up"},
+			expected:    true,
+		},
+		{
+			name:        "annotation disabled with false",
+			annotations: map[string]string{PreserveTotalCPUAnnotation: "false"},
+			expected:    false,
+		},
+		{
+			name:        "annotation disabled with invalid value",
+			annotations: map[string]string{PreserveTotalCPUAnnotation: "invalid"},
+			expected:    false,
+		},
+		{
+			name:        "annotation missing",
+			annotations: map[string]string{},
+			expected:    false,
+		},
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tt.annotations,
+				},
+			}
+			result := isPreserveTotalCPUEnabled(sts)
+			if result != tt.expected {
+				t.Errorf("isPreserveTotalCPUEnabled() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetReplicaScalingDirection(t *testing.T) {
+	tests := []struct {
+		name        string
+		originalCPU int64
+		newCPU      int64
+		expected    string
+	}{
+		{
+			name:        "scale down (CPU per pod increases)",
+			originalCPU: 2000,
+			newCPU:      4000,
+			expected:    PreserveTotalCPUDown,
+		},
+		{
+			name:        "scale up (CPU per pod decreases)",
+			originalCPU: 4000,
+			newCPU:      2000,
+			expected:    PreserveTotalCPUUp,
+		},
+		{
+			name:        "no change",
+			originalCPU: 2000,
+			newCPU:      2000,
+			expected:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getReplicaScalingDirection(tt.originalCPU, tt.newCPU)
+			if result != tt.expected {
+				t.Errorf("getReplicaScalingDirection() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsCPUScalingAllowed(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		direction   string
+		expected    bool
+	}{
+		{
+			name:        "true allows down",
+			annotations: map[string]string{PreserveTotalCPUAnnotation: "true"},
+			direction:   PreserveTotalCPUDown,
+			expected:    true,
+		},
+		{
+			name:        "true allows up",
+			annotations: map[string]string{PreserveTotalCPUAnnotation: "true"},
+			direction:   PreserveTotalCPUUp,
+			expected:    true,
+		},
+		{
+			name:        "both allows down",
+			annotations: map[string]string{PreserveTotalCPUAnnotation: "both"},
+			direction:   PreserveTotalCPUDown,
+			expected:    true,
+		},
+		{
+			name:        "both allows up",
+			annotations: map[string]string{PreserveTotalCPUAnnotation: "both"},
+			direction:   PreserveTotalCPUUp,
+			expected:    true,
+		},
+		{
+			name:        "down allows down",
+			annotations: map[string]string{PreserveTotalCPUAnnotation: "down"},
+			direction:   PreserveTotalCPUDown,
+			expected:    true,
+		},
+		{
+			name:        "down blocks up",
+			annotations: map[string]string{PreserveTotalCPUAnnotation: "down"},
+			direction:   PreserveTotalCPUUp,
+			expected:    false,
+		},
+		{
+			name:        "up allows up",
+			annotations: map[string]string{PreserveTotalCPUAnnotation: "up"},
+			direction:   PreserveTotalCPUUp,
+			expected:    true,
+		},
+		{
+			name:        "up blocks down",
+			annotations: map[string]string{PreserveTotalCPUAnnotation: "up"},
+			direction:   PreserveTotalCPUDown,
+			expected:    false,
+		},
+		{
+			name:        "invalid value blocks all",
+			annotations: map[string]string{PreserveTotalCPUAnnotation: "invalid"},
+			direction:   PreserveTotalCPUDown,
+			expected:    false,
+		},
+		{
+			name:        "missing annotation blocks all",
+			annotations: map[string]string{},
+			direction:   PreserveTotalCPUDown,
+			expected:    false,
+		},
+		{
+			name:        "nil annotations blocks all",
+			annotations: nil,
+			direction:   PreserveTotalCPUDown,
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tt.annotations,
+				},
+			}
+			result := isCPUScalingAllowed(sts, tt.direction)
+			if result != tt.expected {
+				t.Errorf("isCPUScalingAllowed() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetCPURequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		podSpec  *corev1.PodSpec
+		expected int64
+	}{
+		{
+			name: "CPU request present",
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: parseQuantity("2"),
+							},
+						},
+					},
+				},
+			},
+			expected: 2000, // 2 CPU = 2000 millicores
+		},
+		{
+			name: "CPU request in millicores",
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: parseQuantity("500m"),
+							},
+						},
+					},
+				},
+			},
+			expected: 500,
+		},
+		{
+			name: "no CPU request",
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{},
+						},
+					},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name:     "nil podSpec",
+			podSpec:  nil,
+			expected: 0,
+		},
+		{
+			name: "no containers",
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{},
+			},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getCPURequest(tt.podSpec)
+			if result != tt.expected {
+				t.Errorf("getCPURequest() = %d, expected %d", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCalculateAdjustedReplicas(t *testing.T) {
+	tests := []struct {
+		name             string
+		currentReplicas  int32
+		currentCPUPerPod int64
+		newCPUPerPod     int64
+		expected         int32
+	}{
+		{
+			name:             "double CPU per pod - halve replicas",
+			currentReplicas:  10,
+			currentCPUPerPod: 2000, // 2 CPU
+			newCPUPerPod:     4000, // 4 CPU
+			expected:         5,    // 10 * 2 / 4 = 5
+		},
+		{
+			name:             "halve CPU per pod - double replicas",
+			currentReplicas:  5,
+			currentCPUPerPod: 4000, // 4 CPU
+			newCPUPerPod:     2000, // 2 CPU
+			expected:         10,   // 5 * 4 / 2 = 10
+		},
+		{
+			name:             "no change in CPU",
+			currentReplicas:  8,
+			currentCPUPerPod: 3000,
+			newCPUPerPod:     3000,
+			expected:         8,
+		},
+		{
+			name:             "round up to avoid under-provisioning",
+			currentReplicas:  10,
+			currentCPUPerPod: 5000, // 50 total CPU
+			newCPUPerPod:     7000, // 50 / 7 = 7.14... rounds up to 8
+			expected:         8,
+		},
+		{
+			name:             "zero new CPU (safety check)",
+			currentReplicas:  10,
+			currentCPUPerPod: 2000,
+			newCPUPerPod:     0,
+			expected:         10, // Should return current replicas to avoid division by zero
+		},
+		{
+			name:             "result would be zero - ensure at least 1",
+			currentReplicas:  1,
+			currentCPUPerPod: 500,  // 0.5 CPU
+			newCPUPerPod:     5000, // 5 CPU
+			expected:         1,    // Max(1, 500/5000) = 1
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calculateAdjustedReplicas(tt.currentReplicas, tt.currentCPUPerPod, tt.newCPUPerPod)
+			if result != tt.expected {
+				t.Errorf("calculateAdjustedReplicas(%d, %d, %d) = %d, expected %d",
+					tt.currentReplicas, tt.currentCPUPerPod, tt.newCPUPerPod, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCPUAwareScalingInApplyStatefulSet(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Create current StatefulSet with 10 replicas, 2 CPU per pod
+	var currentReplicas int32 = 10
+	current := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation: "true",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &currentReplicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("2"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	c.AddObject(current)
+
+	// Create revised StatefulSet with 4 CPU per pod
+	// Expected: replicas should be adjusted to 5 to maintain total 20 CPU
+	var revisedReplicas int32 = 10 // Original desired replicas
+	revised := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation: "true",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &revisedReplicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Apply the StatefulSet
+	phase, err := ApplyStatefulSet(ctx, c, revised, nil)
+	if err != nil {
+		t.Errorf("ApplyStatefulSet() failed: %v", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("Expected PhaseUpdating, got %v", phase)
+	}
+
+	// For scale-down (10 replicas with 2 CPU -> 5 replicas with 4 CPU),
+	// the replicas should remain at 10 and target should be stored in annotation
+	expectedReplicas := int32(10) // Current replicas preserved for gradual scale-down
+	if *revised.Spec.Replicas != expectedReplicas {
+		t.Errorf("Expected replicas to be %d, got %d", expectedReplicas, *revised.Spec.Replicas)
+	}
+
+	// Verify transition state annotation was set
+	stateJSON, exists := revised.Annotations[CPUAwareTransitionStateAnnotation]
+	if !exists {
+		t.Error("Expected transition state annotation to be set")
+	} else {
+		var state CPUAwareTransitionState
+		if err := json.Unmarshal([]byte(stateJSON), &state); err != nil {
+			t.Errorf("Failed to parse transition state JSON: %v", err)
+		} else if state.TargetReplicas != 5 {
+			t.Errorf("Expected target replicas to be 5, got %d", state.TargetReplicas)
+		}
+	}
+}
+
+func TestCPUAwareScalingDisabled(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Create current StatefulSet without CPU scaling annotation
+	var currentReplicas int32 = 10
+	current := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			// No PreserveTotalCPUAnnotation
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &currentReplicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("2"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	c.AddObject(current)
+
+	// Create revised StatefulSet with 4 CPU per pod but no annotation
+	var revisedReplicas int32 = 10
+	revised := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &revisedReplicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Apply the StatefulSet
+	phase, err := ApplyStatefulSet(ctx, c, revised, nil)
+	if err != nil {
+		t.Errorf("ApplyStatefulSet() failed: %v", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("Expected PhaseUpdating, got %v", phase)
+	}
+
+	// Verify replicas were NOT adjusted (annotation not set)
+	if *revised.Spec.Replicas != revisedReplicas {
+		t.Errorf("Expected replicas to remain %d, got %d", revisedReplicas, *revised.Spec.Replicas)
+	}
+}
+
+func TestCPUAwareScalingScaleUp(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Create current StatefulSet with 5 replicas, 4 CPU per pod (total: 20 CPU)
+	var currentReplicas int32 = 5
+	current := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation: "true",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &currentReplicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	c.AddObject(current)
+
+	// Create revised StatefulSet with 2 CPU per pod
+	// Expected: target replicas should be 10 to maintain total 20 CPU
+	var revisedReplicas int32 = 5
+	revised := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				PreserveTotalCPUAnnotation: "true",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &revisedReplicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "splunk",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("2"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Apply the StatefulSet
+	phase, err := ApplyStatefulSet(ctx, c, revised, nil)
+	if err != nil {
+		t.Errorf("ApplyStatefulSet() failed: %v", err)
+	}
+	// Scale-up now uses gradual transition, returns PhaseUpdating
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("Expected PhaseUpdating, got %v", phase)
+	}
+
+	// For gradual scale-up (5 replicas with 4 CPU -> 10 replicas with 2 CPU),
+	// replicas should remain at 5 (gradual transition will increase over time)
+	expectedReplicas := int32(5) // replicas unchanged initially - gradual scale-up
+	if *revised.Spec.Replicas != expectedReplicas {
+		t.Errorf("Expected replicas to remain at %d for gradual scale-up, got %d", expectedReplicas, *revised.Spec.Replicas)
+	}
+
+	// Verify transition state annotation was set with correct target
+	stateJSON, exists := revised.Annotations[CPUAwareTransitionStateAnnotation]
+	if !exists {
+		t.Error("Expected transition state annotation to be set for scale-up")
+	} else {
+		var state CPUAwareTransitionState
+		if err := json.Unmarshal([]byte(stateJSON), &state); err != nil {
+			t.Errorf("Failed to parse transition state JSON: %v", err)
+		} else if state.TargetReplicas != 10 {
+			t.Errorf("Expected target replicas to be 10, got %d", state.TargetReplicas)
+		}
+	}
+}
+
+func TestIsPodReady(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected bool
+	}{
+		{
+			name: "pod ready",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pod not ready",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "no ready condition",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isPodReady(tt.pod)
+			if result != tt.expected {
+				t.Errorf("isPodReady() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractCPUFromPod(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected int64
+	}{
+		{
+			name: "pod with CPU request",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("2"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: 2000,
+		},
+		{
+			name: "pod without containers",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{},
+				},
+			},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractCPUFromPod(tt.pod)
+			if result != tt.expected {
+				t.Errorf("extractCPUFromPod() = %d, expected %d", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHasNewSpec(t *testing.T) {
+	tests := []struct {
+		name      string
+		pod       *corev1.Pod
+		targetCPU int64
+		expected  bool
+	}{
+		{
+			name: "pod has new spec",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+			targetCPU: 4000,
+			expected:  true,
+		},
+		{
+			name: "pod has old spec",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("2"),
+								},
+							},
+						},
+					},
+				},
+			},
+			targetCPU: 4000,
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasNewSpec(tt.pod, tt.targetCPU)
+			if result != tt.expected {
+				t.Errorf("hasNewSpec() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestCPUAwareScaleDownCompletion tests completion detection for scale-down through handleCPUPreservingTransition
+func TestCPUAwareScaleDownCompletion(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Test case: replicas == targetReplicas AND all pods have new spec → PhaseReady + FinishedAt set
+	t.Run("scale-down complete when all pods have new spec", func(t *testing.T) {
+		// Setup StatefulSet at target replicas
+		var replicas int32 = 5
+		transitionState := CPUAwareTransitionState{
+			OriginalReplicas:  10,
+			TargetReplicas:    5,
+			OriginalCPUMillis: 2000, // old CPU
+			TargetCPUMillis:   4000, // new CPU (doubled)
+			StartedAt:         "2026-01-12T00:00:00Z",
+		}
+		stateJSON, _ := json.Marshal(transitionState)
+
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "splunk-test-scale-down-complete",
+				Namespace: "test",
+				Annotations: map[string]string{
+					PreserveTotalCPUAnnotation:        "true",
+					CPUAwareTransitionStateAnnotation: string(stateJSON),
+				},
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: &replicas,
+			},
+			Status: appsv1.StatefulSetStatus{
+				ReadyReplicas: replicas,
+			},
+		}
+		c.AddObject(sts)
+
+		// Create all 5 pods with new CPU spec (4000m)
+		for i := int32(0); i < 5; i++ {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "splunk-test-scale-down-complete-" + string(rune('0'+i)),
+					Namespace: "test",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("4"),
+								},
+							},
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+					},
+				},
+			}
+			c.AddObject(pod)
+		}
+
+		mgr := &MockStatefulSetPodManager{}
+		phase, handled, err := handleCPUPreservingTransition(ctx, c, sts, mgr, replicas)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if !handled {
+			t.Error("Expected handled=true for scale-down completion")
+		}
+		if phase != enterpriseApi.PhaseReady {
+			t.Errorf("Expected PhaseReady, got %v", phase)
+		}
+	})
+
+	// Test case: replicas == targetReplicas but some pods have old spec → PhaseUpdating
+	t.Run("scale-down not complete when pods have old spec", func(t *testing.T) {
+		c2 := spltest.NewMockClient()
+		var replicas int32 = 5
+		transitionState := CPUAwareTransitionState{
+			OriginalReplicas:  10,
+			TargetReplicas:    5,
+			OriginalCPUMillis: 2000,
+			TargetCPUMillis:   4000,
+			StartedAt:         "2026-01-12T00:00:00Z",
+		}
+		stateJSON, _ := json.Marshal(transitionState)
+
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "splunk-test-not-complete",
+				Namespace: "test",
+				Annotations: map[string]string{
+					PreserveTotalCPUAnnotation:        "true",
+					CPUAwareTransitionStateAnnotation: string(stateJSON),
+				},
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: &replicas,
+			},
+			Status: appsv1.StatefulSetStatus{
+				ReadyReplicas: replicas,
+			},
+		}
+		c2.AddObject(sts)
+
+		// Create 5 pods - some with old spec (2000m), some with new spec (4000m)
+		for i := int32(0); i < 5; i++ {
+			cpuValue := "4" // new spec
+			if i < 2 {
+				cpuValue = "2" // old spec for first 2 pods
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "splunk-test-not-complete-" + string(rune('0'+i)),
+					Namespace: "test",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity(cpuValue),
+								},
+							},
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+					},
+				},
+			}
+			c2.AddObject(pod)
+		}
+
+		mgr := &MockStatefulSetPodManager{}
+		phase, handled, err := handleCPUPreservingTransition(ctx, c2, sts, mgr, replicas)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if !handled {
+			t.Error("Expected handled=true")
+		}
+		// Should be PhaseUpdating since recycling is needed
+		if phase != enterpriseApi.PhaseUpdating {
+			t.Errorf("Expected PhaseUpdating (recycling needed), got %v", phase)
+		}
+	})
+}
+
+// TestCPUAwareScaleDownBalance tests the balance step during scale-down
+func TestCPUAwareScaleDownBalance(t *testing.T) {
+	ctx := context.TODO()
+
+	// Test: surplusCPU >= oldCPUPerPod → reduce replicas
+	t.Run("balance reduces replicas when surplus exists", func(t *testing.T) {
+		c := spltest.NewMockClient()
+		var replicas int32 = 10
+		transitionState := CPUAwareTransitionState{
+			OriginalReplicas:  10,
+			TargetReplicas:    5,
+			OriginalCPUMillis: 2000, // 2 CPU per pod (original: 10*2 = 20 total)
+			TargetCPUMillis:   4000, // 4 CPU per pod (target: 5*4 = 20 total)
+			StartedAt:         "2026-01-12T00:00:00Z",
+		}
+		stateJSON, _ := json.Marshal(transitionState)
+
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "splunk-test-balance",
+				Namespace: "test",
+				Annotations: map[string]string{
+					PreserveTotalCPUAnnotation:        "true",
+					CPUAwareTransitionStateAnnotation: string(stateJSON),
+				},
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: &replicas,
+			},
+			Status: appsv1.StatefulSetStatus{
+				ReadyReplicas: replicas,
+			},
+		}
+		c.AddObject(sts)
+
+		// Create pods: 2 new-spec pods (4000m) and 8 old-spec pods (2000m)
+		// New-spec pods: 2*4000 = 8000m
+		// Old-spec pods: 8*2000 = 16000m
+		// Total ready CPU: 24000m
+		// Surplus = newSpecCPU - (newSpecPods * originalCPUPerPod) = 8000 - (2*2000) = 4000m
+		// This surplus >= 2000 (oldCPUPerPod), so balance should kick in
+		for i := int32(0); i < 10; i++ {
+			cpuValue := "2" // old spec
+			if i < 2 {
+				cpuValue = "4" // new spec for first 2 pods
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "splunk-test-balance-" + string(rune('0'+i)),
+					Namespace: "test",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity(cpuValue),
+								},
+							},
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+					},
+				},
+			}
+			c.AddObject(pod)
+		}
+
+		mgr := &MockStatefulSetPodManager{}
+		phase, handled, err := handleCPUPreservingTransition(ctx, c, sts, mgr, replicas)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if !handled {
+			t.Error("Expected handled=true")
+		}
+		if phase != enterpriseApi.PhaseScalingDown {
+			t.Errorf("Expected PhaseScalingDown (balance), got %v", phase)
+		}
+	})
+}
+
+// TestCPUAwareScaleDownRecycle tests pod recycling during scale-down
+func TestCPUAwareScaleDownRecycle(t *testing.T) {
+	ctx := context.TODO()
+
+	// Test: recycle old-spec pods when no balance possible
+	t.Run("recycle old-spec ready pods", func(t *testing.T) {
+		c := spltest.NewMockClient()
+		var replicas int32 = 5
+		transitionState := CPUAwareTransitionState{
+			OriginalReplicas:  10,
+			TargetReplicas:    5,
+			OriginalCPUMillis: 2000,
+			TargetCPUMillis:   4000,
+			StartedAt:         "2026-01-12T00:00:00Z",
+		}
+		stateJSON, _ := json.Marshal(transitionState)
+
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "splunk-test-recycle",
+				Namespace: "test",
+				Annotations: map[string]string{
+					PreserveTotalCPUAnnotation:        "true",
+					CPUAwareTransitionStateAnnotation: string(stateJSON),
+					ParallelPodUpdatesAnnotation:      "1",
+				},
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: &replicas,
+			},
+			Status: appsv1.StatefulSetStatus{
+				ReadyReplicas: replicas,
+			},
+		}
+		c.AddObject(sts)
+
+		// Create 5 pods all with old spec - should trigger recycling
+		for i := int32(0); i < 5; i++ {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("splunk-test-recycle-%d", i),
+					Namespace: "test",
+					UID:       types.UID(fmt.Sprintf("test-uid-%d", i)),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("2"),
+								},
+							},
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+					},
+				},
+			}
+			c.AddObject(pod)
+		}
+
+		mgr := &MockStatefulSetPodManager{
+			PrepareRecycleReady: true,
+		}
+		phase, handled, err := handleCPUPreservingTransition(ctx, c, sts, mgr, replicas)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if !handled {
+			t.Error("Expected handled=true")
+		}
+		if phase != enterpriseApi.PhaseUpdating {
+			t.Errorf("Expected PhaseUpdating (recycling), got %v", phase)
+		}
+	})
+
+	// Test: skip non-ready pods
+	t.Run("skip non-ready pods during recycle", func(t *testing.T) {
+		c := spltest.NewMockClient()
+		var replicas int32 = 5
+		transitionState := CPUAwareTransitionState{
+			OriginalReplicas:  10,
+			TargetReplicas:    5,
+			OriginalCPUMillis: 2000,
+			TargetCPUMillis:   4000,
+			StartedAt:         "2026-01-12T00:00:00Z",
+		}
+		stateJSON, _ := json.Marshal(transitionState)
+
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "splunk-test-skip-not-ready",
+				Namespace: "test",
+				Annotations: map[string]string{
+					PreserveTotalCPUAnnotation:        "true",
+					CPUAwareTransitionStateAnnotation: string(stateJSON),
+					ParallelPodUpdatesAnnotation:      "1",
+				},
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: &replicas,
+			},
+			Status: appsv1.StatefulSetStatus{
+				ReadyReplicas: 3, // only 3 ready
+			},
+		}
+		c.AddObject(sts)
+
+		// Create pods - only some are ready
+		for i := int32(0); i < 5; i++ {
+			readyStatus := corev1.ConditionTrue
+			if i >= 3 {
+				readyStatus = corev1.ConditionFalse // not ready
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("splunk-test-skip-not-ready-%d", i),
+					Namespace: "test",
+					UID:       types.UID(fmt.Sprintf("test-uid-%d", i)),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("2"),
+								},
+							},
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: readyStatus},
+					},
+				},
+			}
+			c.AddObject(pod)
+		}
+
+		mgr := &MockStatefulSetPodManager{
+			PrepareRecycleReady: true,
+		}
+		phase, handled, err := handleCPUPreservingTransition(ctx, c, sts, mgr, replicas)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if !handled {
+			t.Error("Expected handled=true")
+		}
+		// Should still be updating (recycling the ready ones)
+		if phase != enterpriseApi.PhaseUpdating {
+			t.Errorf("Expected PhaseUpdating, got %v", phase)
+		}
+	})
+}
+
+// TestCPUAwareScaleDownParallelUpdates tests parallel update enforcement during scale-down
+func TestCPUAwareScaleDownParallelUpdates(t *testing.T) {
+	ctx := context.TODO()
+
+	// Test: parallelUpdates=3 recycles up to 3 pods per cycle
+	t.Run("parallel updates limit enforced", func(t *testing.T) {
+		c := spltest.NewMockClient()
+		var replicas int32 = 5
+		transitionState := CPUAwareTransitionState{
+			OriginalReplicas:  10,
+			TargetReplicas:    5,
+			OriginalCPUMillis: 2000,
+			TargetCPUMillis:   4000,
+			StartedAt:         "2026-01-12T00:00:00Z",
+		}
+		stateJSON, _ := json.Marshal(transitionState)
+
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "splunk-test-parallel",
+				Namespace: "test",
+				Annotations: map[string]string{
+					PreserveTotalCPUAnnotation:        "true",
+					CPUAwareTransitionStateAnnotation: string(stateJSON),
+					ParallelPodUpdatesAnnotation:      "3", // Allow 3 parallel updates
+				},
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: &replicas,
+			},
+			Status: appsv1.StatefulSetStatus{
+				ReadyReplicas: replicas,
+			},
+		}
+		c.AddObject(sts)
+
+		// Create 5 pods all with old spec
+		for i := int32(0); i < 5; i++ {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("splunk-test-parallel-%d", i),
+					Namespace: "test",
+					UID:       types.UID(fmt.Sprintf("test-uid-%d", i)),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: parseQuantity("2"),
+								},
+							},
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+					},
+				},
+			}
+			c.AddObject(pod)
+		}
+
+		// Track how many PrepareRecycle calls are made
+		mgr := &MockStatefulSetPodManager{
+			PrepareRecycleReady: true,
+		}
+		phase, handled, err := handleCPUPreservingTransition(ctx, c, sts, mgr, replicas)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if !handled {
+			t.Error("Expected handled=true")
+		}
+		if phase != enterpriseApi.PhaseUpdating {
+			t.Errorf("Expected PhaseUpdating, got %v", phase)
+		}
+	})
+}
+
+// MockStatefulSetPodManager is a mock implementation for testing
+type MockStatefulSetPodManager struct {
+	PrepareRecycleReady bool
+	PrepareRecycleError error
+}
+
+func (m *MockStatefulSetPodManager) Update(ctx context.Context, c splcommon.ControllerClient, sts *appsv1.StatefulSet, desiredReplicas int32) (enterpriseApi.Phase, error) {
+	return enterpriseApi.PhaseReady, nil
+}
+
+func (m *MockStatefulSetPodManager) PrepareScaleDown(ctx context.Context, n int32) (bool, error) {
+	return true, nil
+}
+
+func (m *MockStatefulSetPodManager) PrepareRecycle(ctx context.Context, n int32) (bool, error) {
+	return m.PrepareRecycleReady, m.PrepareRecycleError
+}
+
+func (m *MockStatefulSetPodManager) FinishRecycle(ctx context.Context, n int32) (bool, error) {
+	return true, nil
+}
+
+func (m *MockStatefulSetPodManager) FinishUpgrade(ctx context.Context, n int32) error {
+	return nil
+}

--- a/pkg/splunk/splkcontroller/statefulset_metadata_test.go
+++ b/pkg/splunk/splkcontroller/statefulset_metadata_test.go
@@ -63,7 +63,7 @@ func TestApplyStatefulSet_STSOnlyAnnotationNotPersisted(t *testing.T) {
 		revised.Annotations["amadeus.com/aaa"])
 
 	// Apply the StatefulSet
-	phase, err := ApplyStatefulSet(ctx, c, revised)
+	phase, err := ApplyStatefulSet(ctx, c, revised, nil)
 	if err != nil {
 		t.Fatalf("ApplyStatefulSet failed: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestApplyStatefulSet_MetadataOnlyChangeNoUpdate(t *testing.T) {
 	}
 
 	// Apply the StatefulSet
-	phase, err := ApplyStatefulSet(ctx, c, revised)
+	phase, err := ApplyStatefulSet(ctx, c, revised, nil)
 	if err != nil {
 		t.Fatalf("ApplyStatefulSet failed: %v", err)
 	}

--- a/pkg/splunk/splkcontroller/statefulset_metadata_test.go
+++ b/pkg/splunk/splkcontroller/statefulset_metadata_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2018-2022 Splunk Inc. All rights reserved.
+
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splkcontroller
+
+import (
+	"context"
+	"testing"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
+	spltest "github.com/splunk/splunk-operator/pkg/splunk/test"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestApplyStatefulSet_STSOnlyAnnotationNotPersisted verifies that sts-only.* annotations
+// (transformed to amadeus.com/* format by SyncParentMetaToStatefulSet) are properly
+// persisted after ApplyStatefulSet is called.
+func TestApplyStatefulSet_STSOnlyAnnotationNotPersisted(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 1
+
+	// Current StatefulSet (in cluster) - has only existing annotation
+	current := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-test-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				"existing-annotation": "existing-value",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+	}
+
+	// Add current to mock client (simulates existing StatefulSet in cluster)
+	c.Create(ctx, current)
+
+	// Revised StatefulSet (after SyncParentMetaToStatefulSet was called)
+	// This simulates the state after sts-only.amadeus.com/aaa annotation was transformed
+	revised := current.DeepCopy()
+	revised.Annotations = map[string]string{
+		"existing-annotation": "existing-value",
+		"amadeus.com/aaa":     "value1", // Added by SyncParentMetaToStatefulSet (prefix stripped)
+	}
+
+	t.Logf("Before ApplyStatefulSet - revised has annotation 'amadeus.com/aaa': %s",
+		revised.Annotations["amadeus.com/aaa"])
+
+	// Apply the StatefulSet
+	phase, err := ApplyStatefulSet(ctx, c, revised)
+	if err != nil {
+		t.Fatalf("ApplyStatefulSet failed: %v", err)
+	}
+
+	// Verify phase indicates an update was triggered
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("Expected PhaseUpdating due to annotation change, got %v", phase)
+	}
+
+	t.Logf("After ApplyStatefulSet - revised has annotation 'amadeus.com/aaa': %s",
+		revised.Annotations["amadeus.com/aaa"])
+
+	// Verify the annotation is preserved in revised (which now reflects current after merge)
+	if val, ok := revised.Annotations["amadeus.com/aaa"]; !ok || val != "value1" {
+		t.Errorf("Annotation 'amadeus.com/aaa' was lost after ApplyStatefulSet.\n"+
+			"Expected: value1\nGot: %s", val)
+	} else {
+		t.Log("Annotation 'amadeus.com/aaa' is preserved after ApplyStatefulSet")
+	}
+}
+
+// TestApplyStatefulSet_MetadataOnlyChangeNoUpdate verifies that metadata-only changes
+// (no Pod Template changes) are properly detected and trigger a StatefulSet update.
+//
+// This test ensures that MergeStatefulSetMetaUpdates is called and hasUpdates is set
+// to true even when there are no Pod Template changes.
+func TestApplyStatefulSet_MetadataOnlyChangeNoUpdate(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 1
+
+	// Current StatefulSet (in cluster)
+	current := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-test-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				"existing-annotation": "existing-value",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+	}
+
+	// Add current to mock client
+	c.Create(ctx, current)
+
+	// Revised StatefulSet - ONLY metadata changed, Pod Template is identical
+	revised := current.DeepCopy()
+	revised.Annotations = map[string]string{
+		"existing-annotation": "existing-value",
+		"new-sts-annotation":  "new-value", // Only metadata changed
+	}
+
+	// Apply the StatefulSet
+	phase, err := ApplyStatefulSet(ctx, c, revised)
+	if err != nil {
+		t.Fatalf("ApplyStatefulSet failed: %v", err)
+	}
+
+	// Verify phase indicates an update was triggered (metadata-only change should still trigger update)
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("Expected PhaseUpdating for metadata-only change, got %v", phase)
+	}
+
+	// Verify the new annotation is preserved
+	if val, ok := revised.Annotations["new-sts-annotation"]; !ok || val != "new-value" {
+		t.Errorf("Annotation 'new-sts-annotation' was lost after ApplyStatefulSet.\n"+
+			"Expected: new-value\nGot: %s", val)
+	} else {
+		t.Log("Annotation 'new-sts-annotation' is correctly preserved after ApplyStatefulSet")
+	}
+}

--- a/pkg/splunk/splkcontroller/statefulset_parallel_test.go
+++ b/pkg/splunk/splkcontroller/statefulset_parallel_test.go
@@ -1,0 +1,632 @@
+// Copyright (c) 2018-2022 Splunk Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splkcontroller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
+	spltest "github.com/splunk/splunk-operator/pkg/splunk/test"
+)
+
+func TestGetParallelPodUpdates(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		replicas    int32
+		expected    int32
+	}{
+		{
+			name:        "annotation missing",
+			annotations: nil,
+			replicas:    10,
+			expected:    1, // DefaultParallelPodUpdates
+		},
+		{
+			name:        "annotation empty",
+			annotations: map[string]string{ParallelPodUpdatesAnnotation: ""},
+			replicas:    10,
+			expected:    1,
+		},
+		{
+			name:        "annotation set to 1 (absolute)",
+			annotations: map[string]string{ParallelPodUpdatesAnnotation: "1"},
+			replicas:    10,
+			expected:    1,
+		},
+		{
+			name:        "annotation set to 3 (absolute)",
+			annotations: map[string]string{ParallelPodUpdatesAnnotation: "3"},
+			replicas:    10,
+			expected:    3,
+		},
+		{
+			name:        "annotation set to 10 (absolute)",
+			annotations: map[string]string{ParallelPodUpdatesAnnotation: "10"},
+			replicas:    10,
+			expected:    10,
+		},
+		{
+			name:        "annotation exceeds replicas (absolute)",
+			annotations: map[string]string{ParallelPodUpdatesAnnotation: "20"},
+			replicas:    10,
+			expected:    10, // Clamped to replica count
+		},
+		{
+			name:        "annotation invalid - non-numeric",
+			annotations: map[string]string{ParallelPodUpdatesAnnotation: "abc"},
+			replicas:    10,
+			expected:    1,
+		},
+		{
+			name:        "annotation invalid - negative",
+			annotations: map[string]string{ParallelPodUpdatesAnnotation: "-5"},
+			replicas:    10,
+			expected:    1,
+		},
+		{
+			name:        "annotation invalid - zero",
+			annotations: map[string]string{ParallelPodUpdatesAnnotation: "0"},
+			replicas:    10,
+			expected:    1,
+		},
+		// Floating-point percentage mode tests
+		{
+			name:        "percentage mode - 0.25 (25%)",
+			annotations: map[string]string{ParallelPodUpdatesAnnotation: "0.25"},
+			replicas:    10,
+			expected:    3, // ceil(10 * 0.25) = ceil(2.5) = 3
+		},
+		{
+			name:        "percentage mode - 0.5 (50%)",
+			annotations: map[string]string{ParallelPodUpdatesAnnotation: "0.5"},
+			replicas:    10,
+			expected:    5, // ceil(10 * 0.5) = 5
+		},
+		{
+			name:        "percentage mode - 0.1 (10%)",
+			annotations: map[string]string{ParallelPodUpdatesAnnotation: "0.1"},
+			replicas:    10,
+			expected:    1, // ceil(10 * 0.1) = 1
+		},
+		{
+			name:        "absolute mode - 1.0 treated as 1 pod",
+			annotations: map[string]string{ParallelPodUpdatesAnnotation: "1.0"},
+			replicas:    10,
+			expected:    1, // 1.0 >= 1.0 so absolute mode, round(1.0) = 1
+		},
+		{
+			name:        "percentage mode - small cluster",
+			annotations: map[string]string{ParallelPodUpdatesAnnotation: "0.5"},
+			replicas:    3,
+			expected:    2, // ceil(3 * 0.5) = ceil(1.5) = 2
+		},
+		{
+			name:        "percentage mode - very small percentage",
+			annotations: map[string]string{ParallelPodUpdatesAnnotation: "0.01"},
+			replicas:    100,
+			expected:    1, // ceil(100 * 0.01) = 1
+		},
+		{
+			name:        "absolute mode - 2.5 rounds to 3",
+			annotations: map[string]string{ParallelPodUpdatesAnnotation: "2.5"},
+			replicas:    10,
+			expected:    3, // round(2.5) = 3
+		},
+		{
+			name:        "absolute mode - 5.0",
+			annotations: map[string]string{ParallelPodUpdatesAnnotation: "5.0"},
+			replicas:    10,
+			expected:    5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tt.annotations,
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: &tt.replicas,
+				},
+			}
+			result := getParallelPodUpdates(sts)
+			if result != tt.expected {
+				t.Errorf("getParallelPodUpdates() = %d, expected %d", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParallelPodUpdatesInCheckStatefulSetPodsForUpdates(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 5
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				ParallelPodUpdatesAnnotation: "3", // Update 3 pods in parallel
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			UpdateRevision: "revision-2",
+		},
+	}
+
+	// Create 5 pods with old revision that need updating
+	for i := 0; i < 5; i++ {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%d", statefulSet.Name, i),
+				Namespace: statefulSet.Namespace,
+				Labels: map[string]string{
+					"controller-revision-hash": "revision-1", // Old revision
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Ready: true},
+				},
+			},
+		}
+		c.AddObject(pod)
+	}
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	// First reconcile: should delete 3 pods (parallel limit)
+	phase, err := CheckStatefulSetPodsForUpdates(ctx, c, statefulSet, mgr, replicas)
+	if err != nil {
+		t.Errorf("CheckStatefulSetPodsForUpdates returned unexpected error: %v", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("CheckStatefulSetPodsForUpdates() phase = %v, expected PhaseUpdating", phase)
+	}
+
+	// Verify exactly 3 pods were deleted
+	deleteCalls := c.Calls["Delete"]
+	if len(deleteCalls) != 3 {
+		t.Errorf("Expected 3 pod deletions, got %d", len(deleteCalls))
+	}
+}
+
+func TestParallelPodUpdatesSequentialMode(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 5
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			// No annotation - should default to 1
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			UpdateRevision: "revision-2",
+		},
+	}
+
+	// Create 5 pods with old revision
+	for i := 0; i < 5; i++ {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%d", statefulSet.Name, i),
+				Namespace: statefulSet.Namespace,
+				Labels: map[string]string{
+					"controller-revision-hash": "revision-1",
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Ready: true},
+				},
+			},
+		}
+		c.AddObject(pod)
+	}
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	// First reconcile: should delete only 1 pod (default behavior)
+	phase, err := CheckStatefulSetPodsForUpdates(ctx, c, statefulSet, mgr, replicas)
+	if err != nil {
+		t.Errorf("CheckStatefulSetPodsForUpdates returned unexpected error: %v", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("CheckStatefulSetPodsForUpdates() phase = %v, expected PhaseUpdating", phase)
+	}
+
+	// Verify exactly 1 pod was deleted (sequential mode)
+	deleteCalls := c.Calls["Delete"]
+	if len(deleteCalls) != 1 {
+		t.Errorf("Expected 1 pod deletion in sequential mode, got %d", len(deleteCalls))
+	}
+}
+
+func TestParallelPodUpdatesPercentageMode(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 10
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				ParallelPodUpdatesAnnotation: "0.3", // 30% = 3 pods
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			UpdateRevision: "revision-2",
+		},
+	}
+
+	// Create 10 pods all needing updates
+	for i := 0; i < 10; i++ {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%d", statefulSet.Name, i),
+				Namespace: statefulSet.Namespace,
+				Labels: map[string]string{
+					"controller-revision-hash": "revision-1",
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Ready: true},
+				},
+			},
+		}
+		c.AddObject(pod)
+	}
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	// First reconcile: should delete 3 pods (30% of 10)
+	phase, err := CheckStatefulSetPodsForUpdates(ctx, c, statefulSet, mgr, replicas)
+	if err != nil {
+		t.Errorf("CheckStatefulSetPodsForUpdates returned unexpected error: %v", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("CheckStatefulSetPodsForUpdates() phase = %v, expected PhaseUpdating", phase)
+	}
+
+	// Verify 3 pods were deleted
+	deleteCalls := c.Calls["Delete"]
+	if len(deleteCalls) != 3 {
+		t.Errorf("Expected 3 pod deletions (30%% of 10), got %d", len(deleteCalls))
+	}
+}
+
+func TestParallelPodUpdatesAllPodsNeedUpdate(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 10
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				ParallelPodUpdatesAnnotation: "5", // Update 5 pods in parallel
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			UpdateRevision: "revision-2",
+		},
+	}
+
+	// Create 10 pods all needing updates
+	for i := 0; i < 10; i++ {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%d", statefulSet.Name, i),
+				Namespace: statefulSet.Namespace,
+				Labels: map[string]string{
+					"controller-revision-hash": "revision-1",
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Ready: true},
+				},
+			},
+		}
+		c.AddObject(pod)
+	}
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	// First reconcile: should delete 5 pods
+	phase, err := CheckStatefulSetPodsForUpdates(ctx, c, statefulSet, mgr, replicas)
+	if err != nil {
+		t.Errorf("CheckStatefulSetPodsForUpdates returned unexpected error: %v", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("CheckStatefulSetPodsForUpdates() phase = %v, expected PhaseUpdating", phase)
+	}
+
+	// Verify 5 pods were deleted in first cycle
+	deleteCalls := c.Calls["Delete"]
+	if len(deleteCalls) != 5 {
+		t.Errorf("Expected 5 pod deletions in first cycle, got %d", len(deleteCalls))
+	}
+}
+
+func TestParallelPodUpdatesNoPodsNeedUpdate(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 5
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				ParallelPodUpdatesAnnotation: "3",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			UpdateRevision: "revision-2",
+		},
+	}
+
+	// Create 5 pods all with correct revision (no updates needed)
+	for i := 0; i < 5; i++ {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%d", statefulSet.Name, i),
+				Namespace: statefulSet.Namespace,
+				Labels: map[string]string{
+					"controller-revision-hash": "revision-2", // Current revision
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Ready: true},
+				},
+			},
+		}
+		c.AddObject(pod)
+	}
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	// Should return PhaseReady since all pods are up to date
+	phase, err := CheckStatefulSetPodsForUpdates(ctx, c, statefulSet, mgr, replicas)
+	if err != nil {
+		t.Errorf("CheckStatefulSetPodsForUpdates returned unexpected error: %v", err)
+	}
+	if phase != enterpriseApi.PhaseReady {
+		t.Errorf("CheckStatefulSetPodsForUpdates() phase = %v, expected PhaseReady", phase)
+	}
+
+	// Verify no pods were deleted
+	deleteCalls := c.Calls["Delete"]
+	if len(deleteCalls) != 0 {
+		t.Errorf("Expected 0 pod deletions, got %d", len(deleteCalls))
+	}
+}
+
+func TestParallelPodUpdatesPartialUpdates(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 5
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				ParallelPodUpdatesAnnotation: "3",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			UpdateRevision: "revision-2",
+		},
+	}
+
+	// Create 5 pods: 2 need updates, 3 are current
+	for i := 0; i < 5; i++ {
+		revision := "revision-2" // Current
+		if i < 2 {
+			revision = "revision-1" // Old - needs update
+		}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%d", statefulSet.Name, i),
+				Namespace: statefulSet.Namespace,
+				Labels: map[string]string{
+					"controller-revision-hash": revision,
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Ready: true},
+				},
+			},
+		}
+		c.AddObject(pod)
+	}
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	// Should delete only the 2 pods that need updates (less than parallel limit of 3)
+	phase, err := CheckStatefulSetPodsForUpdates(ctx, c, statefulSet, mgr, replicas)
+	if err != nil {
+		t.Errorf("CheckStatefulSetPodsForUpdates returned unexpected error: %v", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("CheckStatefulSetPodsForUpdates() phase = %v, expected PhaseUpdating", phase)
+	}
+
+	// Verify exactly 2 pods were deleted (not hitting the limit of 3)
+	deleteCalls := c.Calls["Delete"]
+	if len(deleteCalls) != 2 {
+		t.Errorf("Expected 2 pod deletions, got %d", len(deleteCalls))
+	}
+}
+
+func TestParallelPodUpdatesAllAtOnce(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 5
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				ParallelPodUpdatesAnnotation: "5", // Absolute 5 pods - all pods
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			UpdateRevision: "revision-2",
+		},
+	}
+
+	// Create 5 pods all needing updates
+	for i := 0; i < 5; i++ {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%d", statefulSet.Name, i),
+				Namespace: statefulSet.Namespace,
+				Labels: map[string]string{
+					"controller-revision-hash": "revision-1",
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Ready: true},
+				},
+			},
+		}
+		c.AddObject(pod)
+	}
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	// Should delete all 5 pods
+	phase, err := CheckStatefulSetPodsForUpdates(ctx, c, statefulSet, mgr, replicas)
+	if err != nil {
+		t.Errorf("CheckStatefulSetPodsForUpdates returned unexpected error: %v", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("CheckStatefulSetPodsForUpdates() phase = %v, expected PhaseUpdating", phase)
+	}
+
+	// Verify all 5 pods were deleted
+	deleteCalls := c.Calls["Delete"]
+	if len(deleteCalls) != 5 {
+		t.Errorf("Expected 5 pod deletions, got %d", len(deleteCalls))
+	}
+}
+
+func TestParallelPodUpdatesHighPercentage(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 10
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-indexer",
+			Namespace: "test",
+			Annotations: map[string]string{
+				ParallelPodUpdatesAnnotation: "0.99", // 99% - nearly all pods
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			UpdateRevision: "revision-2",
+		},
+	}
+
+	// Create 10 pods all needing updates
+	for i := 0; i < 10; i++ {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%d", statefulSet.Name, i),
+				Namespace: statefulSet.Namespace,
+				Labels: map[string]string{
+					"controller-revision-hash": "revision-1",
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Ready: true},
+				},
+			},
+		}
+		c.AddObject(pod)
+	}
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	// Should delete 10 pods (ceil(10 * 0.99) = ceil(9.9) = 10)
+	phase, err := CheckStatefulSetPodsForUpdates(ctx, c, statefulSet, mgr, replicas)
+	if err != nil {
+		t.Errorf("CheckStatefulSetPodsForUpdates returned unexpected error: %v", err)
+	}
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("CheckStatefulSetPodsForUpdates() phase = %v, expected PhaseUpdating", phase)
+	}
+
+	// Verify all 10 pods were deleted
+	deleteCalls := c.Calls["Delete"]
+	if len(deleteCalls) != 10 {
+		t.Errorf("Expected 10 pod deletions (99%%), got %d", len(deleteCalls))
+	}
+}

--- a/pkg/splunk/splkcontroller/statefulset_test.go
+++ b/pkg/splunk/splkcontroller/statefulset_test.go
@@ -107,7 +107,7 @@ func TestApplyStatefulSet(t *testing.T) {
 	revised := current.DeepCopy()
 	revised.Spec.Template.ObjectMeta.Labels = map[string]string{"one": "two"}
 	reconcile := func(c *spltest.MockClient, cr interface{}) error {
-		_, err := ApplyStatefulSet(ctx, c, cr.(*appsv1.StatefulSet))
+		_, err := ApplyStatefulSet(ctx, c, cr.(*appsv1.StatefulSet), nil)
 		return err
 	}
 	spltest.ReconcileTester(t, "TestApplyStatefulSet", current, revised, createCalls, updateCalls, reconcile, false)
@@ -122,7 +122,7 @@ func TestApplyStatefulSet(t *testing.T) {
 	revised = current.DeepCopy()
 	revised.Spec.Template.Spec.Containers = []corev1.Container{{Image: "efgh"}}
 	c.InduceErrorKind[splcommon.MockClientInduceErrorUpdate] = rerr
-	_, err := ApplyStatefulSet(ctx, c, revised)
+	_, err := ApplyStatefulSet(ctx, c, revised, nil)
 	if err == nil {
 		t.Errorf("Expected error")
 	}
@@ -414,7 +414,7 @@ func TestGetStatefulSetByName(t *testing.T) {
 		},
 	}
 
-	_, err := ApplyStatefulSet(ctx, c, &current)
+	_, err := ApplyStatefulSet(ctx, c, &current, nil)
 	if err != nil {
 		return
 	}

--- a/pkg/splunk/splkcontroller/statefulset_test.go
+++ b/pkg/splunk/splkcontroller/statefulset_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 
@@ -198,10 +199,12 @@ func TestUpdateStatefulSetPods(t *testing.T) {
 	}
 
 	// CurrentRevision = UpdateRevision
+	// With refactored logic, scale-down is prioritized over waiting for scale-up
+	// readyReplicas=2 > desiredReplicas=1, so we expect PhaseScalingDown
 	statefulSet.Status.CurrentRevision = "v1"
 	phase, err = updateStatefulSetPodsTester(t, &mgr, statefulSet, 1 /*desiredReplicas*/, statefulSet, pod)
-	if err == nil && phase != enterpriseApi.PhaseScalingUp {
-		t.Errorf("UpdateStatefulSetPods should have returned error or phase should have been PhaseError, but we got phase=%s", phase)
+	if err == nil && phase != enterpriseApi.PhaseScalingDown {
+		t.Errorf("UpdateStatefulSetPods should have returned PhaseScalingDown, but we got phase=%s", phase)
 	}
 
 	// readyReplicas > replicas
@@ -259,6 +262,18 @@ func TestUpdateStatefulSetPods(t *testing.T) {
 	errPodMgr := errTestPodManager{
 		c: c,
 	}
+	// Create the pod that will be scaled down so PrepareScaleDown is called
+	podToScaleDown := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-stack1-2",
+			Namespace: "test",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+	c.Create(ctx, podToScaleDown)
+
 	_, err = UpdateStatefulSetPods(ctx, c, statefulSet, &errPodMgr, 1)
 	if err == nil {
 		t.Errorf("Expected error")
@@ -620,4 +635,630 @@ func TestRemoveUnwantedOwnerRefSs(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected error")
 	}
+}
+
+func TestGetScaleUpReadyWaitTimeout(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotation  string
+		expected    string // Use string for easier comparison
+		expectError bool
+	}{
+		// Standard valid durations
+		{
+			name:       "valid 10m timeout",
+			annotation: "10m",
+			expected:   "10m0s",
+		},
+		{
+			name:       "valid 5m30s timeout",
+			annotation: "5m30s",
+			expected:   "5m30s",
+		},
+		{
+			name:       "valid 1h timeout",
+			annotation: "1h",
+			expected:   "1h0m0s",
+		},
+		// Short durations (previously rejected, now accepted)
+		{
+			name:       "short timeout 1s",
+			annotation: "1s",
+			expected:   "1s",
+		},
+		{
+			name:       "short timeout 5s",
+			annotation: "5s",
+			expected:   "5s",
+		},
+		{
+			name:       "short timeout 10s",
+			annotation: "10s",
+			expected:   "10s",
+		},
+		{
+			name:       "short timeout 29s (just under old min)",
+			annotation: "29s",
+			expected:   "29s",
+		},
+		// Long durations (previously capped at 24h, now accepted as-is)
+		{
+			name:       "long timeout 48h",
+			annotation: "48h",
+			expected:   "48h0m0s",
+		},
+		{
+			name:       "long timeout 72h (3 days)",
+			annotation: "72h",
+			expected:   "72h0m0s",
+		},
+		{
+			name:       "long timeout 168h (7 days)",
+			annotation: "168h",
+			expected:   "168h0m0s",
+		},
+		{
+			name:       "long timeout 720h (30 days)",
+			annotation: "720h",
+			expected:   "720h0m0s",
+		},
+		// Zero timeouts (bypass wait)
+		{
+			name:       "zero timeout",
+			annotation: "0s",
+			expected:   "0s",
+		},
+		{
+			name:       "zero timeout alternate",
+			annotation: "0",
+			expected:   "0s",
+		},
+		// Default/error cases - default is now 0 (no wait)
+		{
+			name:       "missing annotation returns 0 (no wait)",
+			annotation: "",
+			expected:   "0s",
+		},
+		{
+			name:       "invalid format returns 0 (no wait)",
+			annotation: "invalid",
+			expected:   "0s",
+		},
+		// Negative values mean wait forever
+		{
+			name:       "negative value -5m returns -5m (wait forever)",
+			annotation: "-5m",
+			expected:   "-5m0s",
+		},
+		{
+			name:       "negative value -1ns returns -1ns (wait forever)",
+			annotation: "-1ns",
+			expected:   "-1ns",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statefulSet := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-statefulset",
+					Namespace: "test",
+				},
+			}
+
+			if tt.annotation != "" {
+				statefulSet.ObjectMeta.Annotations = map[string]string{
+					ScaleUpReadyWaitTimeoutAnnotation: tt.annotation,
+				}
+			}
+
+			result := getScaleUpReadyWaitTimeout(statefulSet)
+			if result.String() != tt.expected {
+				t.Errorf("getScaleUpReadyWaitTimeout() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetScaleUpWaitStarted(t *testing.T) {
+	now := "2025-12-10T10:00:00Z"
+
+	tests := []struct {
+		name       string
+		annotation string
+		expectOk   bool
+	}{
+		{
+			name:       "valid RFC3339 timestamp",
+			annotation: now,
+			expectOk:   true,
+		},
+		{
+			name:       "missing annotation",
+			annotation: "",
+			expectOk:   false,
+		},
+		{
+			name:       "invalid format",
+			annotation: "invalid-timestamp",
+			expectOk:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statefulSet := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-statefulset",
+					Namespace: "test",
+				},
+			}
+
+			if tt.annotation != "" {
+				statefulSet.ObjectMeta.Annotations = map[string]string{
+					ScaleUpWaitStartedAnnotation: tt.annotation,
+				}
+			}
+
+			_, ok := getScaleUpWaitStarted(statefulSet)
+			if ok != tt.expectOk {
+				t.Errorf("getScaleUpWaitStarted() ok = %v, want %v", ok, tt.expectOk)
+			}
+		})
+	}
+}
+
+func TestSetAndClearScaleUpWaitStarted(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset",
+			Namespace: "test",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: func() *int32 { r := int32(3); return &r }(),
+		},
+	}
+
+	c.AddObject(statefulSet)
+
+	// Test setScaleUpWaitStarted
+	err := setScaleUpWaitStarted(ctx, c, statefulSet)
+	if err != nil {
+		t.Errorf("setScaleUpWaitStarted() error = %v", err)
+	}
+
+	// Verify timestamp was set
+	_, ok := getScaleUpWaitStarted(statefulSet)
+	if !ok {
+		t.Errorf("Expected timestamp to be set")
+	}
+
+	// Test clearScaleUpWaitStarted
+	err = clearScaleUpWaitStarted(ctx, c, statefulSet)
+	if err != nil {
+		t.Errorf("clearScaleUpWaitStarted() error = %v", err)
+	}
+
+	// Verify timestamp was cleared
+	_, ok = getScaleUpWaitStarted(statefulSet)
+	if ok {
+		t.Errorf("Expected timestamp to be cleared")
+	}
+}
+
+// TestHandleScaleUpNegativeTimeout verifies that handleScaleUp waits indefinitely
+// when a negative timeout is explicitly set via annotation
+func TestHandleScaleUpNegativeTimeout(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 3
+	var readyReplicas int32 = 2 // Not all pods are ready
+	var desiredReplicas int32 = 5
+
+	// StatefulSet WITH the scale-up-ready-wait-timeout annotation set to -1 (wait forever)
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset",
+			Namespace: "test",
+			Annotations: map[string]string{
+				ScaleUpReadyWaitTimeoutAnnotation: "-1ns",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:      replicas,
+			ReadyReplicas: readyReplicas,
+		},
+	}
+
+	c.AddObject(statefulSet)
+
+	// Verify that getScaleUpReadyWaitTimeout returns -1ns for negative annotation
+	timeout := getScaleUpReadyWaitTimeout(statefulSet)
+	if timeout != time.Duration(-1) {
+		t.Errorf("Expected timeout = -1ns for negative annotation, got %v", timeout)
+	}
+
+	// Call handleScaleUp - it should wait indefinitely (return PhaseScalingUp, not proceed with scale-up)
+	phase, err := handleScaleUp(ctx, c, statefulSet, replicas, readyReplicas, desiredReplicas)
+
+	// Should not return an error
+	if err != nil {
+		t.Errorf("handleScaleUp() error = %v, expected nil", err)
+	}
+
+	// Should return PhaseScalingUp (since readyReplicas > 0) indicating it's waiting
+	// and not proceeding with scale-up
+	if phase != enterpriseApi.PhaseScalingUp {
+		t.Errorf("Expected PhaseScalingUp while waiting indefinitely, got %v", phase)
+	}
+
+	// Verify that replicas was NOT changed (scale-up was not initiated)
+	if *statefulSet.Spec.Replicas != replicas {
+		t.Errorf("Expected replicas to remain %d, but got %d", replicas, *statefulSet.Spec.Replicas)
+	}
+
+	// Verify that the wait start annotation was set
+	_, hasStartTime := getScaleUpWaitStarted(statefulSet)
+	if !hasStartTime {
+		t.Errorf("Expected scale-up wait start time to be set")
+	}
+
+	// Call handleScaleUp again - should continue waiting (not bypass due to timeout)
+	phase, err = handleScaleUp(ctx, c, statefulSet, replicas, readyReplicas, desiredReplicas)
+
+	if err != nil {
+		t.Errorf("handleScaleUp() second call error = %v, expected nil", err)
+	}
+
+	// Should still be waiting
+	if phase != enterpriseApi.PhaseScalingUp {
+		t.Errorf("Expected PhaseScalingUp on second call (still waiting), got %v", phase)
+	}
+
+	// Verify replicas still unchanged
+	if *statefulSet.Spec.Replicas != replicas {
+		t.Errorf("Expected replicas to remain %d after second call, but got %d", replicas, *statefulSet.Spec.Replicas)
+	}
+}
+
+// TestHandleScaleUpNegativeTimeoutPhasePending verifies that handleScaleUp returns PhasePending
+// when waiting indefinitely (via negative timeout annotation) and there are no ready replicas
+func TestHandleScaleUpNegativeTimeoutPhasePending(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 3
+	var readyReplicas int32 = 0 // No pods are ready
+	var desiredReplicas int32 = 5
+
+	// StatefulSet WITH the scale-up-ready-wait-timeout annotation set to -1 (wait forever)
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset-pending",
+			Namespace: "test",
+			Annotations: map[string]string{
+				ScaleUpReadyWaitTimeoutAnnotation: "-1ns",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:      replicas,
+			ReadyReplicas: readyReplicas,
+		},
+	}
+
+	c.AddObject(statefulSet)
+
+	// Call handleScaleUp - should return PhasePending when no replicas are ready
+	phase, err := handleScaleUp(ctx, c, statefulSet, replicas, readyReplicas, desiredReplicas)
+
+	if err != nil {
+		t.Errorf("handleScaleUp() error = %v, expected nil", err)
+	}
+
+	// Should return PhasePending (since readyReplicas == 0)
+	if phase != enterpriseApi.PhasePending {
+		t.Errorf("Expected PhasePending while waiting with no ready replicas, got %v", phase)
+	}
+
+	// Verify that replicas was NOT changed
+	if *statefulSet.Spec.Replicas != replicas {
+		t.Errorf("Expected replicas to remain %d, but got %d", replicas, *statefulSet.Spec.Replicas)
+	}
+}
+
+func TestScaleDownBugFix(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Create test scenario: replicas=5, readyReplicas=2, desiredReplicas=3
+	// This tests the bug fix where we check replicas > desiredReplicas instead of readyReplicas > desiredReplicas
+	var replicas int32 = 5
+	var readyReplicas int32 = 2
+	var desiredReplicas int32 = 3
+
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset",
+			Namespace: "test",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "test",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test",
+							Image: "test:latest",
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:      replicas,
+			ReadyReplicas: readyReplicas,
+		},
+	}
+
+	c.AddObject(statefulSet)
+	mgr := &DefaultStatefulSetPodManager{}
+
+	// Call UpdateStatefulSetPods
+	phase, err := UpdateStatefulSetPods(ctx, c, statefulSet, mgr, desiredReplicas)
+
+	if err != nil {
+		t.Errorf("UpdateStatefulSetPods() error = %v", err)
+	}
+
+	// Should return PhaseScalingDown since replicas(5) > desiredReplicas(3)
+	if phase != enterpriseApi.PhaseScalingDown {
+		t.Errorf("Expected PhaseScalingDown, got %v", phase)
+	}
+
+	// Verify the scale-down logic would target the correct pod (replicas-1 = pod-4, not readyReplicas-1 = pod-1)
+	// The function should attempt to decommission pod index 4 (replicas-1)
+}
+
+// TestPrepareScaleDownAlwaysCalled verifies that PrepareScaleDown is called regardless of pod state
+func TestPrepareScaleDownAlwaysCalled(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 3
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-stack1-indexer",
+			Namespace: "test",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{ObjectMeta: metav1.ObjectMeta{Name: "pvc-etc", Namespace: "test"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pvc-var", Namespace: "test"}},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:        replicas,
+			ReadyReplicas:   replicas,
+			UpdatedReplicas: replicas,
+		},
+	}
+
+	c.AddObject(statefulSet)
+
+	// Track whether PrepareScaleDown was called
+	prepareScaleDownCalled := false
+	var calledWithIndex int32 = -1
+
+	// Custom pod manager that tracks PrepareScaleDown calls
+	mgr := &testTrackingPodManager{
+		onPrepareScaleDown: func(n int32) (bool, error) {
+			prepareScaleDownCalled = true
+			calledWithIndex = n
+			return true, nil
+		},
+	}
+
+	// Test 1: Pod exists and is running - PrepareScaleDown should be called
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-stack1-indexer-2",
+			Namespace: "test",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Ready: true},
+			},
+		},
+	}
+	c.Create(ctx, pod)
+
+	prepareScaleDownCalled = false
+	phase, err := UpdateStatefulSetPods(ctx, c, statefulSet, mgr, 2)
+	if err != nil {
+		t.Errorf("UpdateStatefulSetPods() error = %v", err)
+	}
+	if phase != enterpriseApi.PhaseScalingDown {
+		t.Errorf("Expected PhaseScalingDown, got %v", phase)
+	}
+	if !prepareScaleDownCalled {
+		t.Errorf("PrepareScaleDown was not called for running pod")
+	}
+	if calledWithIndex != 2 {
+		t.Errorf("PrepareScaleDown called with wrong index: got %d, want 2", calledWithIndex)
+	}
+
+	// Clean up for next test
+	c.Delete(ctx, pod)
+}
+
+// TestScaleDownPodPending verifies scale-down works when pod is in Pending state
+func TestScaleDownPodPending(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 3
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-stack1-indexer",
+			Namespace: "test",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{ObjectMeta: metav1.ObjectMeta{Name: "pvc-etc", Namespace: "test"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pvc-var", Namespace: "test"}},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:        replicas,
+			ReadyReplicas:   2, // Only 2 ready, one is pending
+			UpdatedReplicas: replicas,
+		},
+	}
+
+	c.AddObject(statefulSet)
+
+	// Pod exists but is in Pending state (e.g., after manual deletion and recreation)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-stack1-indexer-2",
+			Namespace: "test",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			// No container statuses since pod is pending
+		},
+	}
+	c.Create(ctx, pod)
+
+	prepareScaleDownCalled := false
+	mgr := &testTrackingPodManager{
+		onPrepareScaleDown: func(n int32) (bool, error) {
+			prepareScaleDownCalled = true
+			return true, nil
+		},
+	}
+
+	phase, err := UpdateStatefulSetPods(ctx, c, statefulSet, mgr, 2)
+	if err != nil {
+		t.Errorf("UpdateStatefulSetPods() error = %v", err)
+	}
+	if phase != enterpriseApi.PhaseScalingDown {
+		t.Errorf("Expected PhaseScalingDown, got %v", phase)
+	}
+	if !prepareScaleDownCalled {
+		t.Errorf("PrepareScaleDown was not called for pending pod")
+	}
+}
+
+// TestScaleDownPodNotExists verifies scale-down works when pod doesn't exist at all
+func TestScaleDownPodNotExists(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 3
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "splunk-stack1-indexer",
+			Namespace: "test",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{ObjectMeta: metav1.ObjectMeta{Name: "pvc-etc", Namespace: "test"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pvc-var", Namespace: "test"}},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:        replicas,
+			ReadyReplicas:   2, // Only 2 ready, one was deleted
+			UpdatedReplicas: 2,
+		},
+	}
+
+	c.AddObject(statefulSet)
+
+	// Pod doesn't exist at all (manually deleted)
+	// Don't create the pod, so it's not found
+
+	prepareScaleDownCalled := false
+	mgr := &testTrackingPodManager{
+		onPrepareScaleDown: func(n int32) (bool, error) {
+			prepareScaleDownCalled = true
+			return true, nil
+		},
+	}
+
+	phase, err := UpdateStatefulSetPods(ctx, c, statefulSet, mgr, 2)
+	if err != nil {
+		t.Errorf("UpdateStatefulSetPods() error = %v", err)
+	}
+	if phase != enterpriseApi.PhaseScalingDown {
+		t.Errorf("Expected PhaseScalingDown, got %v", phase)
+	}
+	if !prepareScaleDownCalled {
+		t.Errorf("PrepareScaleDown was not called even though pod doesn't exist")
+	}
+}
+
+// testTrackingPodManager is a test helper that tracks method calls
+type testTrackingPodManager struct {
+	onPrepareScaleDown func(n int32) (bool, error)
+	onPrepareRecycle   func(n int32) (bool, error)
+	onFinishRecycle    func(n int32) (bool, error)
+	onFinishUpgrade    func(n int32) error
+}
+
+func (mgr *testTrackingPodManager) Update(ctx context.Context, client splcommon.ControllerClient, statefulSet *appsv1.StatefulSet, desiredReplicas int32) (enterpriseApi.Phase, error) {
+	return enterpriseApi.PhaseReady, nil
+}
+
+func (mgr *testTrackingPodManager) PrepareScaleDown(ctx context.Context, n int32) (bool, error) {
+	if mgr.onPrepareScaleDown != nil {
+		return mgr.onPrepareScaleDown(n)
+	}
+	return true, nil
+}
+
+func (mgr *testTrackingPodManager) PrepareRecycle(ctx context.Context, n int32) (bool, error) {
+	if mgr.onPrepareRecycle != nil {
+		return mgr.onPrepareRecycle(n)
+	}
+	return true, nil
+}
+
+func (mgr *testTrackingPodManager) FinishRecycle(ctx context.Context, n int32) (bool, error) {
+	if mgr.onFinishRecycle != nil {
+		return mgr.onFinishRecycle(n)
+	}
+	return true, nil
+}
+
+func (mgr *testTrackingPodManager) FinishUpgrade(ctx context.Context, n int32) error {
+	if mgr.onFinishUpgrade != nil {
+		return mgr.onFinishUpgrade(n)
+	}
+	return nil
 }

--- a/pkg/splunk/splkcontroller/statefulset_transition_test.go
+++ b/pkg/splunk/splkcontroller/statefulset_transition_test.go
@@ -1,0 +1,2025 @@
+// Copyright (c) 2018-2022 Splunk Inc. All rights reserved.
+
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splkcontroller
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	spltest "github.com/splunk/splunk-operator/pkg/splunk/test"
+
+	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
+)
+
+// TestGetUnifiedTransitionState_NoAnnotation verifies that getUnifiedTransitionState returns nil when no annotation is present
+func TestGetUnifiedTransitionState_NoAnnotation(t *testing.T) {
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset",
+			Namespace: "test",
+		},
+	}
+
+	state, err := getUnifiedTransitionState(statefulSet)
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+	if state != nil {
+		t.Errorf("Expected nil state when no annotation, got: %+v", state)
+	}
+
+	// Also test with empty annotations map
+	statefulSet.Annotations = make(map[string]string)
+	state, err = getUnifiedTransitionState(statefulSet)
+	if err != nil {
+		t.Errorf("Expected no error with empty annotations, got: %v", err)
+	}
+	if state != nil {
+		t.Errorf("Expected nil state with empty annotations, got: %+v", state)
+	}
+}
+
+// TestGetUnifiedTransitionState_ValidState verifies that getUnifiedTransitionState correctly parses a valid JSON state
+func TestGetUnifiedTransitionState_ValidState(t *testing.T) {
+	stateJSON := `{
+		"cpuChange": {
+			"originalCPUMillis": 1000,
+			"targetCPUMillis": 2000,
+			"originalReplicas": 4,
+			"targetReplicas": 2
+		},
+		"vctMigration": {
+			"expectedStorageClasses": {"pvc-data": "premium"}
+		},
+		"startedAt": "2024-01-15T10:00:00Z"
+	}`
+
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset",
+			Namespace: "test",
+			Annotations: map[string]string{
+				UnifiedTransitionStateAnnotation: stateJSON,
+			},
+		},
+	}
+
+	state, err := getUnifiedTransitionState(statefulSet)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if state == nil {
+		t.Fatal("Expected non-nil state")
+	}
+
+	// Verify CPU change fields
+	if state.CPUChange == nil {
+		t.Fatal("Expected non-nil CPUChange")
+	}
+	if state.CPUChange.OriginalCPUMillis != 1000 {
+		t.Errorf("Expected OriginalCPUMillis=1000, got %d", state.CPUChange.OriginalCPUMillis)
+	}
+	if state.CPUChange.TargetCPUMillis != 2000 {
+		t.Errorf("Expected TargetCPUMillis=2000, got %d", state.CPUChange.TargetCPUMillis)
+	}
+	if state.CPUChange.OriginalReplicas != 4 {
+		t.Errorf("Expected OriginalReplicas=4, got %d", state.CPUChange.OriginalReplicas)
+	}
+	if state.CPUChange.TargetReplicas != 2 {
+		t.Errorf("Expected TargetReplicas=2, got %d", state.CPUChange.TargetReplicas)
+	}
+
+	// Verify VCT migration fields
+	if state.VCTMigration == nil {
+		t.Fatal("Expected non-nil VCTMigration")
+	}
+	if state.VCTMigration.ExpectedStorageClasses["pvc-data"] != "premium" {
+		t.Errorf("Expected ExpectedStorageClasses['pvc-data']='premium', got '%s'", state.VCTMigration.ExpectedStorageClasses["pvc-data"])
+	}
+
+	// Verify timestamp
+	if state.StartedAt != "2024-01-15T10:00:00Z" {
+		t.Errorf("Expected StartedAt='2024-01-15T10:00:00Z', got '%s'", state.StartedAt)
+	}
+}
+
+// TestGetUnifiedTransitionState_InvalidJSON verifies that getUnifiedTransitionState handles malformed JSON
+func TestGetUnifiedTransitionState_InvalidJSON(t *testing.T) {
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset",
+			Namespace: "test",
+			Annotations: map[string]string{
+				UnifiedTransitionStateAnnotation: "invalid json {{{",
+			},
+		},
+	}
+
+	state, err := getUnifiedTransitionState(statefulSet)
+	if err == nil {
+		t.Error("Expected error for invalid JSON, got nil")
+	}
+	if state != nil {
+		t.Errorf("Expected nil state for invalid JSON, got: %+v", state)
+	}
+}
+
+// TestGetUnifiedTransitionState_MigrateCPUAware verifies backward compatibility by migrating old CPUAwareTransitionState
+func TestGetUnifiedTransitionState_MigrateCPUAware(t *testing.T) {
+	// Old format annotation
+	oldStateJSON := `{
+		"originalReplicas": 8,
+		"targetReplicas": 4,
+		"originalCPUMillis": 500,
+		"targetCPUMillis": 1000,
+		"startedAt": "2024-01-15T09:00:00Z",
+		"finishedAt": "2024-01-15T09:30:00Z"
+	}`
+
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset",
+			Namespace: "test",
+			Annotations: map[string]string{
+				CPUAwareTransitionStateAnnotation: oldStateJSON,
+			},
+		},
+	}
+
+	state, err := getUnifiedTransitionState(statefulSet)
+	if err != nil {
+		t.Fatalf("Expected no error during migration, got: %v", err)
+	}
+	if state == nil {
+		t.Fatal("Expected non-nil state after migration")
+	}
+
+	// Verify migrated CPU change fields
+	if state.CPUChange == nil {
+		t.Fatal("Expected non-nil CPUChange after migration")
+	}
+	if state.CPUChange.OriginalCPUMillis != 500 {
+		t.Errorf("Expected migrated OriginalCPUMillis=500, got %d", state.CPUChange.OriginalCPUMillis)
+	}
+	if state.CPUChange.TargetCPUMillis != 1000 {
+		t.Errorf("Expected migrated TargetCPUMillis=1000, got %d", state.CPUChange.TargetCPUMillis)
+	}
+	if state.CPUChange.OriginalReplicas != 8 {
+		t.Errorf("Expected migrated OriginalReplicas=8, got %d", state.CPUChange.OriginalReplicas)
+	}
+	if state.CPUChange.TargetReplicas != 4 {
+		t.Errorf("Expected migrated TargetReplicas=4, got %d", state.CPUChange.TargetReplicas)
+	}
+
+	// Verify timestamps are preserved
+	if state.StartedAt != "2024-01-15T09:00:00Z" {
+		t.Errorf("Expected migrated StartedAt='2024-01-15T09:00:00Z', got '%s'", state.StartedAt)
+	}
+	if state.FinishedAt != "2024-01-15T09:30:00Z" {
+		t.Errorf("Expected migrated FinishedAt='2024-01-15T09:30:00Z', got '%s'", state.FinishedAt)
+	}
+
+	// Verify VCT migration is nil (old format doesn't have it)
+	if state.VCTMigration != nil {
+		t.Errorf("Expected nil VCTMigration after migration from CPU-only state, got: %+v", state.VCTMigration)
+	}
+}
+
+// TestPersistUnifiedTransitionState verifies that state is correctly persisted to the StatefulSet annotation
+func TestPersistUnifiedTransitionState(t *testing.T) {
+	ctx := context.TODO()
+
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset",
+			Namespace: "test",
+		},
+	}
+
+	state := &UnifiedTransitionState{
+		CPUChange: &CPUTransition{
+			OriginalCPUMillis: 1000,
+			TargetCPUMillis:   500,
+			OriginalReplicas:  4,
+			TargetReplicas:    8,
+		},
+		StartedAt: "2024-01-15T10:00:00Z",
+	}
+
+	// Create mock client
+	mockCalls := []spltest.MockFuncCall{
+		{MetaName: "*v1.StatefulSet-test-test-statefulset"},
+	}
+	mockClient := spltest.NewMockClient()
+	mockClient.AddObject(statefulSet)
+
+	err := persistUnifiedTransitionState(ctx, mockClient, statefulSet, state)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Verify annotation was set
+	if statefulSet.Annotations == nil {
+		t.Fatal("Expected annotations to be set")
+	}
+	savedJSON, exists := statefulSet.Annotations[UnifiedTransitionStateAnnotation]
+	if !exists {
+		t.Fatal("Expected UnifiedTransitionStateAnnotation to be set")
+	}
+
+	// Verify we can parse the saved state
+	var savedState UnifiedTransitionState
+	if err := json.Unmarshal([]byte(savedJSON), &savedState); err != nil {
+		t.Fatalf("Failed to unmarshal saved state: %v", err)
+	}
+
+	if savedState.CPUChange.OriginalCPUMillis != 1000 {
+		t.Errorf("Expected saved OriginalCPUMillis=1000, got %d", savedState.CPUChange.OriginalCPUMillis)
+	}
+
+	_ = mockCalls // suppress unused warning
+}
+
+// TestClearUnifiedTransitionState verifies that the annotation is removed correctly
+func TestClearUnifiedTransitionState(t *testing.T) {
+	ctx := context.TODO()
+
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset",
+			Namespace: "test",
+			Annotations: map[string]string{
+				UnifiedTransitionStateAnnotation:  `{"startedAt": "2024-01-15T10:00:00Z"}`,
+				CPUAwareTransitionStateAnnotation: `{"startedAt": "2024-01-15T09:00:00Z"}`,
+			},
+		},
+	}
+
+	// Create mock client
+	mockClient := spltest.NewMockClient()
+	mockClient.AddObject(statefulSet)
+
+	err := clearUnifiedTransitionState(ctx, mockClient, statefulSet)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Verify both annotations were removed
+	if _, exists := statefulSet.Annotations[UnifiedTransitionStateAnnotation]; exists {
+		t.Error("Expected UnifiedTransitionStateAnnotation to be removed")
+	}
+	if _, exists := statefulSet.Annotations[CPUAwareTransitionStateAnnotation]; exists {
+		t.Error("Expected CPUAwareTransitionStateAnnotation to be removed (backward compat)")
+	}
+}
+
+// TestUnifiedTransitionState_CPUOnly verifies handling of CPU-only transitions
+func TestUnifiedTransitionState_CPUOnly(t *testing.T) {
+	cpuChange := &CPUTransition{
+		OriginalCPUMillis: 2000,
+		TargetCPUMillis:   1000,
+		OriginalReplicas:  3,
+		TargetReplicas:    6,
+	}
+
+	state := initUnifiedTransitionState(cpuChange, nil)
+
+	if state == nil {
+		t.Fatal("Expected non-nil state")
+	}
+	if state.CPUChange == nil {
+		t.Error("Expected non-nil CPUChange")
+	}
+	if state.VCTMigration != nil {
+		t.Error("Expected nil VCTMigration for CPU-only transition")
+	}
+	if state.StartedAt == "" {
+		t.Error("Expected StartedAt to be set")
+	}
+	if state.FinishedAt != "" {
+		t.Error("Expected FinishedAt to be empty for new transition")
+	}
+	if state.CPUChange.OriginalCPUMillis != 2000 {
+		t.Errorf("Expected OriginalCPUMillis=2000, got %d", state.CPUChange.OriginalCPUMillis)
+	}
+}
+
+// TestUnifiedTransitionState_VCTOnly verifies handling of VCT-only transitions
+func TestUnifiedTransitionState_VCTOnly(t *testing.T) {
+	vctMigration := &VCTMigrationTransition{
+		ExpectedStorageClasses: map[string]string{
+			"pvc-data": "premium",
+			"pvc-logs": "fast",
+		},
+		ExpectedAccessModes: map[string][]corev1.PersistentVolumeAccessMode{
+			"pvc-data": {corev1.ReadWriteOnce},
+		},
+	}
+
+	state := initUnifiedTransitionState(nil, vctMigration)
+
+	if state == nil {
+		t.Fatal("Expected non-nil state")
+	}
+	if state.CPUChange != nil {
+		t.Error("Expected nil CPUChange for VCT-only transition")
+	}
+	if state.VCTMigration == nil {
+		t.Error("Expected non-nil VCTMigration")
+	}
+	if state.StartedAt == "" {
+		t.Error("Expected StartedAt to be set")
+	}
+	if len(state.VCTMigration.ExpectedStorageClasses) != 2 {
+		t.Errorf("Expected 2 storage classes, got %d", len(state.VCTMigration.ExpectedStorageClasses))
+	}
+	if state.VCTMigration.ExpectedStorageClasses["pvc-data"] != "premium" {
+		t.Errorf("Expected pvc-data storage class='premium', got '%s'", state.VCTMigration.ExpectedStorageClasses["pvc-data"])
+	}
+}
+
+// TestUnifiedTransitionState_Combined verifies handling of combined CPU+VCT transitions
+func TestUnifiedTransitionState_Combined(t *testing.T) {
+	cpuChange := &CPUTransition{
+		OriginalCPUMillis: 500,
+		TargetCPUMillis:   1000,
+		OriginalReplicas:  10,
+		TargetReplicas:    5,
+	}
+	vctMigration := &VCTMigrationTransition{
+		ExpectedStorageClasses: map[string]string{
+			"pvc-data": "premium-ssd",
+		},
+	}
+
+	state := initUnifiedTransitionState(cpuChange, vctMigration)
+
+	if state == nil {
+		t.Fatal("Expected non-nil state")
+	}
+	if state.CPUChange == nil {
+		t.Error("Expected non-nil CPUChange for combined transition")
+	}
+	if state.VCTMigration == nil {
+		t.Error("Expected non-nil VCTMigration for combined transition")
+	}
+	if state.StartedAt == "" {
+		t.Error("Expected StartedAt to be set")
+	}
+
+	// Verify CPU fields
+	if state.CPUChange.OriginalReplicas != 10 || state.CPUChange.TargetReplicas != 5 {
+		t.Errorf("Expected replicas 10->5, got %d->%d", state.CPUChange.OriginalReplicas, state.CPUChange.TargetReplicas)
+	}
+
+	// Verify VCT fields
+	if state.VCTMigration.ExpectedStorageClasses["pvc-data"] != "premium-ssd" {
+		t.Errorf("Expected storage class='premium-ssd', got '%s'", state.VCTMigration.ExpectedStorageClasses["pvc-data"])
+	}
+
+	// Verify tracking maps are initialized
+	if state.PodStatus == nil {
+		t.Error("Expected PodStatus map to be initialized")
+	}
+	if state.FailedPods == nil {
+		t.Error("Expected FailedPods map to be initialized")
+	}
+}
+
+// TestIsUnifiedTransitionInProgress verifies the in-progress check logic
+func TestIsUnifiedTransitionInProgress(t *testing.T) {
+	tests := []struct {
+		name       string
+		annotation string
+		expected   bool
+	}{
+		{
+			name:       "no annotation",
+			annotation: "",
+			expected:   false,
+		},
+		{
+			name:       "in progress (no FinishedAt)",
+			annotation: `{"startedAt": "2024-01-15T10:00:00Z"}`,
+			expected:   true,
+		},
+		{
+			name:       "finished (FinishedAt set)",
+			annotation: `{"startedAt": "2024-01-15T10:00:00Z", "finishedAt": "2024-01-15T11:00:00Z"}`,
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statefulSet := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-statefulset",
+					Namespace: "test",
+				},
+			}
+			if tt.annotation != "" {
+				statefulSet.Annotations = map[string]string{
+					UnifiedTransitionStateAnnotation: tt.annotation,
+				}
+			}
+
+			result := isUnifiedTransitionInProgress(statefulSet)
+			if result != tt.expected {
+				t.Errorf("isUnifiedTransitionInProgress() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestIsPodFullyUpdated_CPUOnly tests isPodFullyUpdated when only CPU change is active
+func TestIsPodFullyUpdated_CPUOnly(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Create pod with old CPU (1000m instead of target 2000m)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-0",
+			Namespace: "test",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "splunk",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1000m"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+
+	state := &UnifiedTransitionState{
+		CPUChange: &CPUTransition{
+			OriginalCPUMillis: 1000,
+			TargetCPUMillis:   2000,
+			OriginalReplicas:  4,
+			TargetReplicas:    2,
+		},
+	}
+
+	result, err := isPodFullyUpdated(ctx, c, pod, statefulSet, state)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if result {
+		t.Error("Expected isPodFullyUpdated to return false when CPU not updated")
+	}
+}
+
+// TestIsPodFullyUpdated_VCTOnly tests isPodFullyUpdated when only VCT migration is active
+func TestIsPodFullyUpdated_VCTOnly(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Create pod
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-0",
+			Namespace: "test",
+		},
+	}
+
+	// Create PVC with wrong storage class (standard instead of premium)
+	wrongStorageClass := "standard"
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-data-test-pod-0",
+			Namespace: "test",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &wrongStorageClass,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		},
+	}
+	c.AddObject(pvc)
+
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+
+	state := &UnifiedTransitionState{
+		VCTMigration: &VCTMigrationTransition{
+			ExpectedStorageClasses: map[string]string{
+				"pvc-data": "premium",
+			},
+		},
+	}
+
+	result, err := isPodFullyUpdated(ctx, c, pod, statefulSet, state)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if result {
+		t.Error("Expected isPodFullyUpdated to return false when PVC storage class is wrong")
+	}
+}
+
+// TestIsPodFullyUpdated_Combined tests isPodFullyUpdated when both CPU and VCT are active
+func TestIsPodFullyUpdated_Combined(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Create pod with CORRECT CPU (2000m)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-0",
+			Namespace: "test",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "splunk",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2000m"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Create PVC with WRONG storage class
+	wrongStorageClass := "standard"
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-data-test-pod-0",
+			Namespace: "test",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &wrongStorageClass,
+		},
+	}
+	c.AddObject(pvc)
+
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+
+	state := &UnifiedTransitionState{
+		CPUChange: &CPUTransition{
+			OriginalCPUMillis: 1000,
+			TargetCPUMillis:   2000,
+		},
+		VCTMigration: &VCTMigrationTransition{
+			ExpectedStorageClasses: map[string]string{
+				"pvc-data": "premium",
+			},
+		},
+	}
+
+	// CPU is correct, but VCT is wrong - should return false
+	result, err := isPodFullyUpdated(ctx, c, pod, statefulSet, state)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if result {
+		t.Error("Expected isPodFullyUpdated to return false when either check fails")
+	}
+}
+
+// TestIsPodFullyUpdated_AllUpdated tests isPodFullyUpdated when all updates are applied
+func TestIsPodFullyUpdated_AllUpdated(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// Create pod with CORRECT CPU (2000m)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-0",
+			Namespace: "test",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "splunk",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2000m"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Create PVC with CORRECT storage class
+	correctStorageClass := "premium"
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-data-test-pod-0",
+			Namespace: "test",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &correctStorageClass,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		},
+	}
+	c.AddObject(pvc)
+
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+
+	state := &UnifiedTransitionState{
+		CPUChange: &CPUTransition{
+			OriginalCPUMillis: 1000,
+			TargetCPUMillis:   2000,
+		},
+		VCTMigration: &VCTMigrationTransition{
+			ExpectedStorageClasses: map[string]string{
+				"pvc-data": "premium",
+			},
+			ExpectedAccessModes: map[string][]corev1.PersistentVolumeAccessMode{
+				"pvc-data": {corev1.ReadWriteOnce},
+			},
+		},
+	}
+
+	result, err := isPodFullyUpdated(ctx, c, pod, statefulSet, state)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if !result {
+		t.Error("Expected isPodFullyUpdated to return true when all updates are applied")
+	}
+}
+
+// TestPVCMatchesVCTSpec_SameStorageClass tests pvcMatchesVCTSpec when storage class matches
+func TestPVCMatchesVCTSpec_SameStorageClass(t *testing.T) {
+	storageClass := "premium"
+	pvc := &corev1.PersistentVolumeClaim{
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClass,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		},
+	}
+	vct := &corev1.PersistentVolumeClaim{
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClass,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		},
+	}
+
+	result := pvcMatchesVCTSpec(pvc, vct)
+	if !result {
+		t.Error("Expected pvcMatchesVCTSpec to return true when storage class and access modes match")
+	}
+}
+
+// TestPVCMatchesVCTSpec_DifferentStorageClass tests pvcMatchesVCTSpec when storage class differs
+func TestPVCMatchesVCTSpec_DifferentStorageClass(t *testing.T) {
+	pvcStorageClass := "standard"
+	vctStorageClass := "premium"
+	pvc := &corev1.PersistentVolumeClaim{
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &pvcStorageClass,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		},
+	}
+	vct := &corev1.PersistentVolumeClaim{
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &vctStorageClass,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		},
+	}
+
+	result := pvcMatchesVCTSpec(pvc, vct)
+	if result {
+		t.Error("Expected pvcMatchesVCTSpec to return false when storage class differs")
+	}
+}
+
+// TestPVCMatchesVCTSpec_NilStorageClass tests pvcMatchesVCTSpec with nil storage class
+func TestPVCMatchesVCTSpec_NilStorageClass(t *testing.T) {
+	// Test case 1: Both nil - should match
+	pvc1 := &corev1.PersistentVolumeClaim{
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: nil,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		},
+	}
+	vct1 := &corev1.PersistentVolumeClaim{
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: nil,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		},
+	}
+
+	if !pvcMatchesVCTSpec(pvc1, vct1) {
+		t.Error("Expected pvcMatchesVCTSpec to return true when both storage classes are nil")
+	}
+
+	// Test case 2: One nil, one set - should not match
+	storageClass := "standard"
+	pvc2 := &corev1.PersistentVolumeClaim{
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: nil,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		},
+	}
+	vct2 := &corev1.PersistentVolumeClaim{
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClass,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		},
+	}
+
+	if pvcMatchesVCTSpec(pvc2, vct2) {
+		t.Error("Expected pvcMatchesVCTSpec to return false when one storage class is nil")
+	}
+}
+
+// TestCanRecyclePodWithinCPUFloor_NoCPUChange tests canRecyclePodWithinCPUFloor when no CPU change is active
+func TestCanRecyclePodWithinCPUFloor_NoCPUChange(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-0",
+			Namespace: "test",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "splunk",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1000m"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	replicas := int32(3)
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+		},
+	}
+
+	// State with no CPU change - only VCT migration
+	state := &UnifiedTransitionState{
+		VCTMigration: &VCTMigrationTransition{
+			ExpectedStorageClasses: map[string]string{
+				"pvc-data": "premium",
+			},
+		},
+	}
+
+	result := canRecyclePodWithinCPUFloor(ctx, c, statefulSet, pod, state, 1)
+	if !result {
+		t.Error("Expected canRecyclePodWithinCPUFloor to return true when no CPU change is active")
+	}
+}
+
+// TestCanRecyclePodWithinCPUFloor_WouldViolate tests canRecyclePodWithinCPUFloor when recycling would violate floor
+func TestCanRecyclePodWithinCPUFloor_WouldViolate(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	replicas := int32(3)
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+		},
+	}
+	c.AddObject(statefulSet)
+
+	// Create only 1 ready pod (below minimum required)
+	readyPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-0",
+			Namespace: "test",
+			Labels:    map[string]string{"app": "test"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "splunk",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1000m"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	c.AddObject(readyPod)
+
+	// State with CPU change: original 3 replicas * 1000m = 3000m floor
+	// Current total: 1 pod * 1000m = 1000m
+	// After recycling: 0m (below 3000m - 1000m = 2000m floor)
+	state := &UnifiedTransitionState{
+		CPUChange: &CPUTransition{
+			OriginalCPUMillis: 1000,
+			TargetCPUMillis:   2000,
+			OriginalReplicas:  3,
+			TargetReplicas:    2,
+		},
+	}
+
+	result := canRecyclePodWithinCPUFloor(ctx, c, statefulSet, readyPod, state, 1)
+	if result {
+		t.Error("Expected canRecyclePodWithinCPUFloor to return false when recycling would violate floor")
+	}
+}
+
+// TestCanRecyclePodWithinCPUFloor_Safe tests canRecyclePodWithinCPUFloor when recycling is safe
+func TestCanRecyclePodWithinCPUFloor_Safe(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	replicas := int32(4)
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+		},
+	}
+	c.AddObject(statefulSet)
+
+	// Create 4 ready pods with 1000m CPU each
+	for i := 0; i < 4; i++ {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("test-%d", i),
+				Namespace: "test",
+				Labels:    map[string]string{"app": "test"},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "splunk",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("1000m"),
+							},
+						},
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+		c.AddObject(pod)
+	}
+
+	// The pod we want to recycle
+	podToRecycle := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-0",
+			Namespace: "test",
+			Labels:    map[string]string{"app": "test"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "splunk",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1000m"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	// State with CPU change: original 4 replicas * 1000m = 4000m floor
+	// Parallel updates = 1, so minCPUFloor = 4000m - 1000m = 3000m
+	// Current total: 4 pods * 1000m = 4000m
+	// After recycling 1 pod: 3000m (equals floor, so safe)
+	state := &UnifiedTransitionState{
+		CPUChange: &CPUTransition{
+			OriginalCPUMillis: 1000,
+			TargetCPUMillis:   2000,
+			OriginalReplicas:  4,
+			TargetReplicas:    2,
+		},
+	}
+
+	result := canRecyclePodWithinCPUFloor(ctx, c, statefulSet, podToRecycle, state, 1)
+	if !result {
+		t.Error("Expected canRecyclePodWithinCPUFloor to return true when recycling is safe")
+	}
+}
+
+// =============================================================================
+// handleUnifiedTransition Integration Tests
+// =============================================================================
+
+// TestHandleUnifiedTransition_CPUOnly tests that handleUnifiedTransition correctly handles
+// CPU-only transitions (no VCT migration).
+func TestHandleUnifiedTransition_CPUOnly(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 2
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts",
+			Namespace: "test",
+			Annotations: map[string]string{
+				UnifiedTransitionStateAnnotation: `{
+					"cpuChange": {
+						"originalCPUMillis": 1000,
+						"targetCPUMillis": 2000,
+						"originalReplicas": 2,
+						"targetReplicas": 1
+					},
+					"startedAt": "2024-01-01T00:00:00Z"
+				}`,
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+	}
+	c.AddObject(statefulSet)
+
+	// Create pods with old CPU spec
+	for i := 0; i < 2; i++ {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("test-sts-%d", i),
+				Namespace: "test",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "splunk",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("1000m"),
+							},
+						},
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+		c.AddObject(pod)
+	}
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	phase, handled, err := handleUnifiedTransition(ctx, c, statefulSet, mgr, nil)
+	if err != nil {
+		t.Errorf("handleUnifiedTransition returned error: %v", err)
+	}
+	if !handled {
+		t.Error("Expected handled=true for CPU-only transition")
+	}
+	if phase != enterpriseApi.PhaseUpdating && phase != enterpriseApi.PhaseScalingDown {
+		t.Errorf("Expected PhaseUpdating or PhaseScalingDown, got %v", phase)
+	}
+}
+
+// TestHandleUnifiedTransition_VCTOnly tests that handleUnifiedTransition correctly handles
+// VCT-only migrations (no CPU change).
+func TestHandleUnifiedTransition_VCTOnly(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 2
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts",
+			Namespace: "test",
+			Annotations: map[string]string{
+				UnifiedTransitionStateAnnotation: `{
+					"vctMigration": {
+						"expectedStorageClasses": {"pvc-data": "new-storage-class"}
+					},
+					"startedAt": "2024-01-01T00:00:00Z"
+				}`,
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			CurrentRevision: "rev-1",
+			UpdateRevision:  "rev-2",
+		},
+	}
+	c.AddObject(statefulSet)
+
+	// Create pods with PVCs
+	for i := 0; i < 2; i++ {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("test-sts-%d", i),
+				Namespace: "test",
+				Labels: map[string]string{
+					"controller-revision-hash": "rev-1", // Old revision
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "splunk"},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+		c.AddObject(pod)
+
+		// Create PVC with old storage class
+		oldSC := "old-storage-class"
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("pvc-data-test-sts-%d", i),
+				Namespace: "test",
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: &oldSC,
+			},
+		}
+		c.AddObject(pvc)
+	}
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	phase, handled, err := handleUnifiedTransition(ctx, c, statefulSet, mgr, nil)
+	if err != nil {
+		t.Errorf("handleUnifiedTransition returned error: %v", err)
+	}
+	if !handled {
+		t.Error("Expected handled=true for VCT-only transition")
+	}
+	// VCT-only transition should be in updating phase
+	if phase != enterpriseApi.PhaseUpdating {
+		t.Errorf("Expected PhaseUpdating, got %v", phase)
+	}
+}
+
+// TestHandleUnifiedTransition_Combined tests that handleUnifiedTransition correctly handles
+// combined CPU + VCT transitions.
+func TestHandleUnifiedTransition_Combined(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 2
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts",
+			Namespace: "test",
+			Annotations: map[string]string{
+				UnifiedTransitionStateAnnotation: `{
+					"cpuChange": {
+						"originalCPUMillis": 1000,
+						"targetCPUMillis": 2000,
+						"originalReplicas": 2,
+						"targetReplicas": 1
+					},
+					"vctMigration": {
+						"expectedStorageClasses": {"pvc-data": "new-storage-class"}
+					},
+					"startedAt": "2024-01-01T00:00:00Z"
+				}`,
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+	}
+	c.AddObject(statefulSet)
+
+	// Create pods
+	for i := 0; i < 2; i++ {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("test-sts-%d", i),
+				Namespace: "test",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "splunk",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("1000m"),
+							},
+						},
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+		c.AddObject(pod)
+	}
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	phase, handled, err := handleUnifiedTransition(ctx, c, statefulSet, mgr, nil)
+	if err != nil {
+		t.Errorf("handleUnifiedTransition returned error: %v", err)
+	}
+	if !handled {
+		t.Error("Expected handled=true for combined transition")
+	}
+	// Combined transition should be processing
+	if phase != enterpriseApi.PhaseUpdating && phase != enterpriseApi.PhaseScalingDown {
+		t.Errorf("Expected PhaseUpdating or PhaseScalingDown, got %v", phase)
+	}
+}
+
+// TestHandleUnifiedTransition_NoTransition tests that handleUnifiedTransition correctly returns
+// (PhaseReady, false, nil) when no transition annotation is present.
+func TestHandleUnifiedTransition_NoTransition(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 2
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts",
+			Namespace: "test",
+			// No annotations - no transition in progress
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+	}
+	c.AddObject(statefulSet)
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	phase, handled, err := handleUnifiedTransition(ctx, c, statefulSet, mgr, nil)
+	if err != nil {
+		t.Errorf("handleUnifiedTransition returned error: %v", err)
+	}
+	if handled {
+		t.Error("Expected handled=false when no transition annotation")
+	}
+	if phase != enterpriseApi.PhaseReady {
+		t.Errorf("Expected PhaseReady, got %v", phase)
+	}
+}
+
+// TestHandleUnifiedTransition_AlreadyComplete tests that handleUnifiedTransition correctly
+// clears the annotation and returns when transition is already complete.
+func TestHandleUnifiedTransition_AlreadyComplete(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	var replicas int32 = 1
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts",
+			Namespace: "test",
+			Annotations: map[string]string{
+				UnifiedTransitionStateAnnotation: `{
+					"cpuChange": {
+						"originalCPUMillis": 1000,
+						"targetCPUMillis": 2000,
+						"originalReplicas": 2,
+						"targetReplicas": 1
+					},
+					"startedAt": "2024-01-01T00:00:00Z",
+					"finishedAt": "2024-01-01T00:10:00Z"
+				}`,
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+	}
+	c.AddObject(statefulSet)
+
+	// Create pod with new spec
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts-0",
+			Namespace: "test",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "splunk",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2000m"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	c.AddObject(pod)
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	phase, handled, err := handleUnifiedTransition(ctx, c, statefulSet, mgr, nil)
+	if err != nil {
+		t.Errorf("handleUnifiedTransition returned error: %v", err)
+	}
+	if !handled {
+		t.Error("Expected handled=true for already-complete transition (to clear annotation)")
+	}
+	if phase != enterpriseApi.PhaseReady {
+		t.Errorf("Expected PhaseReady after clearing completed transition, got %v", phase)
+	}
+}
+
+// ============================================================
+// Tests for Task 5.1-5.5: Edge Cases and Error Recovery
+// ============================================================
+
+// TestIsPVCStuckInDeletion tests the helper function for detecting stuck PVCs
+func TestIsPVCStuckInDeletion(t *testing.T) {
+	tests := []struct {
+		name              string
+		deletionTimestamp *metav1.Time
+		expected          bool
+	}{
+		{
+			name:              "no deletion timestamp",
+			deletionTimestamp: nil,
+			expected:          false,
+		},
+		{
+			name: "deletion timestamp recent (not stuck)",
+			deletionTimestamp: &metav1.Time{
+				Time: time.Now().Add(-2 * time.Minute),
+			},
+			expected: false,
+		},
+		{
+			name: "deletion timestamp old (stuck)",
+			deletionTimestamp: &metav1.Time{
+				Time: time.Now().Add(-35 * time.Minute),
+			},
+			expected: true,
+		},
+		{
+			name: "deletion timestamp exactly at threshold",
+			deletionTimestamp: &metav1.Time{
+				Time: time.Now().Add(-30*time.Minute - 1*time.Second), // slightly over to account for execution time
+			},
+			expected: true, // Will be just over 30 minutes
+		},
+		{
+			name: "deletion timestamp just over threshold",
+			deletionTimestamp: &metav1.Time{
+				Time: time.Now().Add(-31 * time.Minute),
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pvc",
+					Namespace:         "test",
+					DeletionTimestamp: tt.deletionTimestamp,
+				},
+			}
+
+			result := isPVCStuckInDeletion(pvc)
+			if result != tt.expected {
+				t.Errorf("isPVCStuckInDeletion() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestIsTransitionStalled tests the helper function for detecting stalled transitions
+func TestIsTransitionStalled(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    *UnifiedTransitionState
+		timeout  time.Duration
+		expected bool
+	}{
+		{
+			name:     "nil state",
+			state:    nil,
+			timeout:  30 * time.Minute,
+			expected: false,
+		},
+		{
+			name: "empty startedAt",
+			state: &UnifiedTransitionState{
+				StartedAt: "",
+			},
+			timeout:  30 * time.Minute,
+			expected: false,
+		},
+		{
+			name: "invalid startedAt format",
+			state: &UnifiedTransitionState{
+				StartedAt: "invalid-timestamp",
+			},
+			timeout:  30 * time.Minute,
+			expected: false,
+		},
+		{
+			name: "transition started recently (not stalled)",
+			state: &UnifiedTransitionState{
+				StartedAt: time.Now().Add(-10 * time.Minute).Format(time.RFC3339),
+			},
+			timeout:  30 * time.Minute,
+			expected: false,
+		},
+		{
+			name: "transition running too long (stalled)",
+			state: &UnifiedTransitionState{
+				StartedAt: time.Now().Add(-45 * time.Minute).Format(time.RFC3339),
+			},
+			timeout:  30 * time.Minute,
+			expected: true,
+		},
+		{
+			name: "transition at timeout boundary",
+			state: &UnifiedTransitionState{
+				StartedAt: time.Now().Add(-30*time.Minute - 1*time.Second).Format(time.RFC3339), // slightly over to account for execution time
+			},
+			timeout:  30 * time.Minute,
+			expected: true, // Will be just over 30 minutes
+		},
+		{
+			name: "transition just over timeout",
+			state: &UnifiedTransitionState{
+				StartedAt: time.Now().Add(-31 * time.Minute).Format(time.RFC3339),
+			},
+			timeout:  30 * time.Minute,
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isTransitionStalled(tt.state, tt.timeout)
+			if result != tt.expected {
+				t.Errorf("isTransitionStalled() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestGetUnifiedTransitionStallTimeout tests parsing the stall timeout annotation
+func TestGetUnifiedTransitionStallTimeout(t *testing.T) {
+	tests := []struct {
+		name       string
+		annotation string
+		expected   time.Duration
+	}{
+		{
+			name:       "missing annotation uses default",
+			annotation: "",
+			expected:   DefaultUnifiedTransitionStallTimeout,
+		},
+		{
+			name:       "valid 1h timeout",
+			annotation: "1h",
+			expected:   time.Hour,
+		},
+		{
+			name:       "valid 45m timeout",
+			annotation: "45m",
+			expected:   45 * time.Minute,
+		},
+		{
+			name:       "invalid format uses default",
+			annotation: "invalid",
+			expected:   DefaultUnifiedTransitionStallTimeout,
+		},
+		{
+			name:       "zero value uses default",
+			annotation: "0s",
+			expected:   DefaultUnifiedTransitionStallTimeout,
+		},
+		{
+			name:       "negative value uses default",
+			annotation: "-10m",
+			expected:   DefaultUnifiedTransitionStallTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statefulSet := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sts",
+					Namespace: "test",
+				},
+			}
+
+			if tt.annotation != "" {
+				statefulSet.Annotations = map[string]string{
+					UnifiedTransitionStallTimeoutAnnotation: tt.annotation,
+				}
+			}
+
+			result := getUnifiedTransitionStallTimeout(statefulSet)
+			if result != tt.expected {
+				t.Errorf("getUnifiedTransitionStallTimeout() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestRecordPodFailure tests the pod failure tracking logic
+func TestRecordPodFailure(t *testing.T) {
+	tests := []struct {
+		name              string
+		initialFailedPods map[string]FailedPodInfo
+		podName           string
+		errMsg            string
+		expectedPermanent bool
+		expectedFailCount int
+	}{
+		{
+			name:              "first failure",
+			initialFailedPods: nil,
+			podName:           "test-pod-0",
+			errMsg:            "connection refused",
+			expectedPermanent: false,
+			expectedFailCount: 1,
+		},
+		{
+			name: "second failure",
+			initialFailedPods: map[string]FailedPodInfo{
+				"test-pod-0": {FailCount: 1, LastError: "first error"},
+			},
+			podName:           "test-pod-0",
+			errMsg:            "timeout",
+			expectedPermanent: false,
+			expectedFailCount: 2,
+		},
+		{
+			name: "third failure - becomes permanent",
+			initialFailedPods: map[string]FailedPodInfo{
+				"test-pod-0": {FailCount: 2, LastError: "second error"},
+			},
+			podName:           "test-pod-0",
+			errMsg:            "third failure",
+			expectedPermanent: true,
+			expectedFailCount: 3,
+		},
+		{
+			name: "different pod failure",
+			initialFailedPods: map[string]FailedPodInfo{
+				"test-pod-0": {FailCount: 2, LastError: "error"},
+			},
+			podName:           "test-pod-1",
+			errMsg:            "new pod error",
+			expectedPermanent: false,
+			expectedFailCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &UnifiedTransitionState{
+				FailedPods: tt.initialFailedPods,
+			}
+
+			permanent := recordPodFailure(state, tt.podName, tt.errMsg)
+
+			if permanent != tt.expectedPermanent {
+				t.Errorf("recordPodFailure() returned permanent=%v, want %v", permanent, tt.expectedPermanent)
+			}
+
+			if state.FailedPods == nil {
+				t.Fatal("Expected FailedPods map to be initialized")
+			}
+
+			failInfo, exists := state.FailedPods[tt.podName]
+			if !exists {
+				t.Fatalf("Expected FailedPods to contain %s", tt.podName)
+			}
+
+			if failInfo.FailCount != tt.expectedFailCount {
+				t.Errorf("Expected FailCount=%d, got %d", tt.expectedFailCount, failInfo.FailCount)
+			}
+
+			if failInfo.LastError != tt.errMsg {
+				t.Errorf("Expected LastError=%q, got %q", tt.errMsg, failInfo.LastError)
+			}
+
+			if failInfo.LastAttempt == "" {
+				t.Error("Expected LastAttempt to be set")
+			}
+		})
+	}
+}
+
+// TestIsPodPermanentlyFailed tests the helper function for checking permanent failures
+func TestIsPodPermanentlyFailed(t *testing.T) {
+	tests := []struct {
+		name       string
+		failedPods map[string]FailedPodInfo
+		podName    string
+		expected   bool
+	}{
+		{
+			name:       "nil failedPods",
+			failedPods: nil,
+			podName:    "test-pod-0",
+			expected:   false,
+		},
+		{
+			name:       "empty failedPods",
+			failedPods: map[string]FailedPodInfo{},
+			podName:    "test-pod-0",
+			expected:   false,
+		},
+		{
+			name: "pod not in failedPods",
+			failedPods: map[string]FailedPodInfo{
+				"other-pod": {FailCount: 5},
+			},
+			podName:  "test-pod-0",
+			expected: false,
+		},
+		{
+			name: "pod with 1 failure (not permanent)",
+			failedPods: map[string]FailedPodInfo{
+				"test-pod-0": {FailCount: 1},
+			},
+			podName:  "test-pod-0",
+			expected: false,
+		},
+		{
+			name: "pod with 2 failures (not permanent)",
+			failedPods: map[string]FailedPodInfo{
+				"test-pod-0": {FailCount: 2},
+			},
+			podName:  "test-pod-0",
+			expected: false,
+		},
+		{
+			name: "pod with 3 failures (permanent)",
+			failedPods: map[string]FailedPodInfo{
+				"test-pod-0": {FailCount: 3},
+			},
+			podName:  "test-pod-0",
+			expected: true,
+		},
+		{
+			name: "pod with more than 3 failures (permanent)",
+			failedPods: map[string]FailedPodInfo{
+				"test-pod-0": {FailCount: 5},
+			},
+			podName:  "test-pod-0",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &UnifiedTransitionState{
+				FailedPods: tt.failedPods,
+			}
+
+			result := isPodPermanentlyFailed(state, tt.podName)
+			if result != tt.expected {
+				t.Errorf("isPodPermanentlyFailed() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestRecyclePodForUnifiedTransition_PVCDeletionFailure tests that pod recycling
+// continues even when PVC deletion fails
+func TestRecyclePodForUnifiedTransition_PVCDeletionFailure(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	storageClass := "premium-ssd"
+	var replicas int32 = 1
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts",
+			Namespace: "test",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-data"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClass,
+					},
+				},
+			},
+		},
+	}
+	c.AddObject(statefulSet)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts-0",
+			Namespace: "test",
+			UID:       "test-uid",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "splunk",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1000m"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	c.AddObject(pod)
+
+	// Create a PVC that will trigger delete failure
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "pvc-data-test-sts-0",
+			Namespace:  "test",
+			Finalizers: []string{"kubernetes.io/pvc-protection"},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClass,
+		},
+	}
+	c.AddObject(pvc)
+
+	// Induce delete error for PVC
+	c.InduceErrorKind[splcommon.MockClientInduceErrorDelete] = errors.New("PVC deletion failed")
+
+	state := &UnifiedTransitionState{
+		VCTMigration: &VCTMigrationTransition{
+			ExpectedStorageClasses: map[string]string{
+				"pvc-data": "new-storage-class",
+			},
+		},
+		StartedAt: time.Now().Format(time.RFC3339),
+	}
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	// The function should NOT return an error even though PVC deletion fails
+	// because PVC deletion failures are logged as warnings but don't block pod deletion
+	err := recyclePodForUnifiedTransition(ctx, c, statefulSet, mgr, pod, 0, state, nil)
+
+	// Pod deletion will also fail due to the induced error, so we expect an error
+	// but the important thing is that the PVC deletion failure didn't cause an immediate return
+	if err == nil {
+		t.Log("Function completed - PVC deletion failure was handled gracefully")
+	} else if err.Error() == "PVC deletion failed" {
+		t.Error("Function returned PVC deletion error - should have continued to pod deletion")
+	} else {
+		// Expected: pod deletion error (since we induced delete errors)
+		t.Logf("Got expected error from pod deletion: %v", err)
+	}
+}
+
+// TestUnifiedTransition_MigrateFromCPUAware verifies that persisting a unified state
+// also removes the legacy CPUAwareTransitionStateAnnotation (Task 6.3)
+func TestUnifiedTransition_MigrateFromCPUAware(t *testing.T) {
+	ctx := context.TODO()
+
+	// StatefulSet with both old and potentially migrated state
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset",
+			Namespace: "test",
+			Annotations: map[string]string{
+				// Legacy annotation that would have been set by old operator version
+				CPUAwareTransitionStateAnnotation: `{
+					"originalReplicas": 6,
+					"targetReplicas": 3,
+					"originalCPUMillis": 1000,
+					"targetCPUMillis": 2000,
+					"startedAt": "2024-01-15T09:00:00Z"
+				}`,
+			},
+		},
+	}
+
+	// Create mock client
+	mockClient := spltest.NewMockClient()
+	mockClient.AddObject(statefulSet)
+
+	// Create a new unified state (simulating what happens after migration)
+	newState := &UnifiedTransitionState{
+		CPUChange: &CPUTransition{
+			OriginalCPUMillis: 1000,
+			TargetCPUMillis:   2000,
+			OriginalReplicas:  6,
+			TargetReplicas:    3,
+		},
+		StartedAt: "2024-01-15T09:00:00Z",
+	}
+
+	// Persist the new state - this should also remove the old annotation
+	err := persistUnifiedTransitionState(ctx, mockClient, statefulSet, newState)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Verify new annotation was set
+	if _, exists := statefulSet.Annotations[UnifiedTransitionStateAnnotation]; !exists {
+		t.Error("Expected UnifiedTransitionStateAnnotation to be set")
+	}
+
+	// CRITICAL: Verify old annotation was removed
+	if _, exists := statefulSet.Annotations[CPUAwareTransitionStateAnnotation]; exists {
+		t.Error("Expected CPUAwareTransitionStateAnnotation to be REMOVED after persisting unified state")
+	}
+}
+
+// TestUnifiedTransition_CPUOnlyBackwardCompat verifies that CPU-only transitions
+// using the legacy CPUAwareTransitionStateAnnotation are still handled correctly
+// by the legacy handleCPUPreservingTransition (Task 6.4)
+func TestUnifiedTransition_CPUOnlyBackwardCompat(t *testing.T) {
+	// Test that getUnifiedTransitionState correctly migrates old format
+	oldStateJSON := `{
+		"originalReplicas": 10,
+		"targetReplicas": 5,
+		"originalCPUMillis": 500,
+		"targetCPUMillis": 1000,
+		"startedAt": "2024-01-15T09:00:00Z"
+	}`
+
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset",
+			Namespace: "test",
+			Annotations: map[string]string{
+				// Only the old annotation, simulating an upgrade scenario
+				CPUAwareTransitionStateAnnotation: oldStateJSON,
+			},
+		},
+	}
+
+	// getUnifiedTransitionState should read and migrate the old format
+	state, err := getUnifiedTransitionState(statefulSet)
+	if err != nil {
+		t.Fatalf("Expected no error during migration, got: %v", err)
+	}
+	if state == nil {
+		t.Fatal("Expected non-nil state after migration")
+	}
+
+	// Verify the migrated state has correct values
+	if state.CPUChange == nil {
+		t.Fatal("Expected CPUChange to be populated from migrated state")
+	}
+
+	// Check all CPU change fields
+	if state.CPUChange.OriginalReplicas != 10 {
+		t.Errorf("Expected OriginalReplicas=10, got %d", state.CPUChange.OriginalReplicas)
+	}
+	if state.CPUChange.TargetReplicas != 5 {
+		t.Errorf("Expected TargetReplicas=5, got %d", state.CPUChange.TargetReplicas)
+	}
+	if state.CPUChange.OriginalCPUMillis != 500 {
+		t.Errorf("Expected OriginalCPUMillis=500, got %d", state.CPUChange.OriginalCPUMillis)
+	}
+	if state.CPUChange.TargetCPUMillis != 1000 {
+		t.Errorf("Expected TargetCPUMillis=1000, got %d", state.CPUChange.TargetCPUMillis)
+	}
+
+	// Verify timestamp is preserved
+	if state.StartedAt != "2024-01-15T09:00:00Z" {
+		t.Errorf("Expected StartedAt to be preserved, got '%s'", state.StartedAt)
+	}
+
+	// VCTMigration should be nil since old format doesn't have it
+	if state.VCTMigration != nil {
+		t.Error("Expected VCTMigration to be nil for CPU-only migration")
+	}
+}
+
+// TestUnifiedTransition_NewAnnotationTakesPrecedence verifies that when both
+// old and new annotations exist, the new one takes precedence
+func TestUnifiedTransition_NewAnnotationTakesPrecedence(t *testing.T) {
+	storageClass := "premium-ssd"
+	newStateJSON := `{
+		"cpuChange": {
+			"originalCPUMillis": 1000,
+			"targetCPUMillis": 2000,
+			"originalReplicas": 4,
+			"targetReplicas": 2
+		},
+		"vctMigration": {
+			"expectedStorageClasses": {
+				"pvc-data": "premium-ssd"
+			}
+		},
+		"startedAt": "2024-01-15T10:00:00Z"
+	}`
+
+	// Note: The old annotation has DIFFERENT values - we want to make sure the new one wins
+	oldStateJSON := `{
+		"originalReplicas": 8,
+		"targetReplicas": 4,
+		"originalCPUMillis": 500,
+		"targetCPUMillis": 1000,
+		"startedAt": "2024-01-14T09:00:00Z"
+	}`
+
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset",
+			Namespace: "test",
+			Annotations: map[string]string{
+				UnifiedTransitionStateAnnotation:  newStateJSON,
+				CPUAwareTransitionStateAnnotation: oldStateJSON, // Should be ignored
+			},
+		},
+	}
+
+	state, err := getUnifiedTransitionState(statefulSet)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if state == nil {
+		t.Fatal("Expected non-nil state")
+	}
+
+	// Verify we got values from the NEW annotation, not the old one
+	if state.CPUChange.OriginalCPUMillis != 1000 {
+		t.Errorf("Expected OriginalCPUMillis=1000 (from new), got %d", state.CPUChange.OriginalCPUMillis)
+	}
+	if state.CPUChange.TargetReplicas != 2 {
+		t.Errorf("Expected TargetReplicas=2 (from new), got %d", state.CPUChange.TargetReplicas)
+	}
+	if state.StartedAt != "2024-01-15T10:00:00Z" {
+		t.Errorf("Expected StartedAt from new annotation, got '%s'", state.StartedAt)
+	}
+
+	// Verify VCT migration is present (only in new format)
+	if state.VCTMigration == nil {
+		t.Error("Expected VCTMigration to be present from new annotation")
+	} else if state.VCTMigration.ExpectedStorageClasses["pvc-data"] != storageClass {
+		t.Errorf("Expected storage class 'premium-ssd', got '%s'",
+			state.VCTMigration.ExpectedStorageClasses["pvc-data"])
+	}
+}
+
+// TestHandleUnifiedTransition_LegacyCPUOnlySkipped verifies that handleUnifiedTransition
+// returns (PhaseReady, false, nil) when only the legacy annotation is present,
+// allowing handleCPUPreservingTransition to handle it instead
+func TestHandleUnifiedTransition_LegacyCPUOnlySkipped(t *testing.T) {
+	ctx := context.TODO()
+	c := spltest.NewMockClient()
+
+	// StatefulSet with ONLY the legacy annotation (no new unified annotation)
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset",
+			Namespace: "test",
+			Annotations: map[string]string{
+				CPUAwareTransitionStateAnnotation: `{
+					"originalReplicas": 6,
+					"targetReplicas": 3,
+					"originalCPUMillis": 1000,
+					"targetCPUMillis": 2000,
+					"startedAt": "2024-01-15T09:00:00Z"
+				}`,
+				PreserveTotalCPUAnnotation: "true",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: func() *int32 { r := int32(6); return &r }(),
+		},
+	}
+	c.AddObject(statefulSet)
+
+	mgr := &DefaultStatefulSetPodManager{}
+
+	// handleUnifiedTransition should skip this (only legacy annotation present)
+	phase, handled, err := handleUnifiedTransition(ctx, c, statefulSet, mgr, nil)
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// handleUnifiedTransition should NOT handle legacy-only transitions
+	if handled {
+		t.Error("Expected handled=false for legacy-only annotation")
+	}
+	if phase != enterpriseApi.PhaseReady {
+		t.Errorf("Expected PhaseReady, got %v", phase)
+	}
+}

--- a/pkg/splunk/splkcontroller/statefulset_transitions.go
+++ b/pkg/splunk/splkcontroller/statefulset_transitions.go
@@ -1,0 +1,838 @@
+// Copyright (c) 2018-2022 Splunk Inc. All rights reserved.
+
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splkcontroller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"time"
+
+	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
+	splutil "github.com/splunk/splunk-operator/pkg/splunk/util"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// This file contains logic for handling StatefulSet transitions when updating
+// Volume Claim Templates (VCT) or CPU resources. This includes:
+// - VCT comparison and migration
+// - CPU-aware scaling transitions
+// - Unified transitions (combined CPU + VCT changes)
+
+// VCTStorageChange represents a storage change for a volume claim template
+type VCTStorageChange struct {
+	TemplateName string
+	OldSize      resource.Quantity
+	NewSize      resource.Quantity
+}
+
+// VCTChange represents a change to a VolumeClaimTemplate that requires PVC migration
+type VCTChange struct {
+	TemplateName    string                              // Name of the VCT
+	ChangeType      string                              // "storage-class" or "access-modes"
+	OldStorageClass string                              // Previous storage class name
+	NewStorageClass string                              // New storage class name
+	OldAccessModes  []corev1.PersistentVolumeAccessMode // Previous access modes
+	NewAccessModes  []corev1.PersistentVolumeAccessMode // New access modes
+}
+
+// VCTCompareResult holds the result of comparing volume claim templates
+type VCTCompareResult struct {
+	RequiresRecreate     bool               // True if StatefulSet needs to be recreated
+	StorageExpansions    []VCTStorageChange // Storage expansions that can be done in-place
+	RecreateReason       string             // Reason why recreation is needed
+	RequiresPVCMigration bool               // True when storage class or access modes change
+	PVCMigrationChanges  []VCTChange        // List of VCT changes requiring migration
+}
+
+// CompareVolumeClaimTemplates compares volume claim templates between current and revised StatefulSets
+// Returns a VCTCompareResult indicating what changes are needed
+func CompareVolumeClaimTemplates(current, revised *appsv1.StatefulSet) VCTCompareResult {
+	result := VCTCompareResult{
+		RequiresRecreate:  false,
+		StorageExpansions: []VCTStorageChange{},
+	}
+
+	currentVCTs := current.Spec.VolumeClaimTemplates
+	revisedVCTs := revised.Spec.VolumeClaimTemplates
+
+	// Build map of current VCTs by name
+	currentVCTMap := make(map[string]corev1.PersistentVolumeClaim)
+	for _, vct := range currentVCTs {
+		currentVCTMap[vct.Name] = vct
+	}
+
+	// Build map of revised VCTs by name
+	revisedVCTMap := make(map[string]corev1.PersistentVolumeClaim)
+	for _, vct := range revisedVCTs {
+		revisedVCTMap[vct.Name] = vct
+	}
+
+	// Check for removed VCTs (requires recreate)
+	for name := range currentVCTMap {
+		if _, exists := revisedVCTMap[name]; !exists {
+			result.RequiresRecreate = true
+			result.RecreateReason = fmt.Sprintf("VolumeClaimTemplate '%s' was removed", name)
+			return result
+		}
+	}
+
+	// Check for added VCTs (requires recreate)
+	for name := range revisedVCTMap {
+		if _, exists := currentVCTMap[name]; !exists {
+			result.RequiresRecreate = true
+			result.RecreateReason = fmt.Sprintf("VolumeClaimTemplate '%s' was added", name)
+			return result
+		}
+	}
+
+	// Compare each VCT
+	for name, currentVCT := range currentVCTMap {
+		revisedVCT := revisedVCTMap[name]
+
+		// Check storage class change (use rolling migration)
+		currentSC := ""
+		if currentVCT.Spec.StorageClassName != nil {
+			currentSC = *currentVCT.Spec.StorageClassName
+		}
+		revisedSC := ""
+		if revisedVCT.Spec.StorageClassName != nil {
+			revisedSC = *revisedVCT.Spec.StorageClassName
+		}
+		if currentSC != revisedSC {
+			// Storage class change - use rolling migration instead of recreate
+			result.RequiresPVCMigration = true
+			result.PVCMigrationChanges = append(result.PVCMigrationChanges, VCTChange{
+				TemplateName:    name,
+				ChangeType:      "storage-class",
+				OldStorageClass: currentSC,
+				NewStorageClass: revisedSC,
+			})
+		}
+
+		// Check access modes change (use rolling migration)
+		if !reflect.DeepEqual(currentVCT.Spec.AccessModes, revisedVCT.Spec.AccessModes) {
+			// Access modes change - use rolling migration instead of recreate
+			result.RequiresPVCMigration = true
+			result.PVCMigrationChanges = append(result.PVCMigrationChanges, VCTChange{
+				TemplateName:   name,
+				ChangeType:     "access-modes",
+				OldAccessModes: currentVCT.Spec.AccessModes,
+				NewAccessModes: revisedVCT.Spec.AccessModes,
+			})
+		}
+
+		// Check storage size change
+		currentSize := currentVCT.Spec.Resources.Requests[corev1.ResourceStorage]
+		revisedSize := revisedVCT.Spec.Resources.Requests[corev1.ResourceStorage]
+
+		if !currentSize.Equal(revisedSize) {
+			// Storage size changed
+			if revisedSize.Cmp(currentSize) < 0 {
+				// Storage decrease requested - not supported
+				result.RequiresRecreate = true
+				result.RecreateReason = fmt.Sprintf("Storage decrease requested for VolumeClaimTemplate '%s' from %s to %s (not supported)", name, currentSize.String(), revisedSize.String())
+				return result
+			}
+			// Storage increase - can potentially be done in-place
+			result.StorageExpansions = append(result.StorageExpansions, VCTStorageChange{
+				TemplateName: name,
+				OldSize:      currentSize,
+				NewSize:      revisedSize,
+			})
+		}
+	}
+
+	return result
+}
+
+// ExpandPVCStorage expands the storage of existing PVCs to match the new VCT size
+// This is called when storage expansion is detected and the storage class supports volume expansion
+func ExpandPVCStorage(ctx context.Context, c splcommon.ControllerClient, statefulSet *appsv1.StatefulSet, changes []VCTStorageChange, eventPublisher splcommon.K8EventPublisher) error {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("ExpandPVCStorage").WithValues(
+		"name", statefulSet.GetName(),
+		"namespace", statefulSet.GetNamespace())
+
+	// Get all pods for this StatefulSet to find their PVCs
+	replicas := int32(1)
+	if statefulSet.Spec.Replicas != nil {
+		replicas = *statefulSet.Spec.Replicas
+	}
+
+	for _, change := range changes {
+		scopedLog.Info("Expanding PVC storage",
+			"template", change.TemplateName,
+			"oldSize", change.OldSize.String(),
+			"newSize", change.NewSize.String())
+
+		// Expand each PVC for this template
+		for i := int32(0); i < replicas; i++ {
+			pvcName := fmt.Sprintf("%s-%s-%d", change.TemplateName, statefulSet.GetName(), i)
+
+			// Get the existing PVC
+			pvc := &corev1.PersistentVolumeClaim{}
+			namespacedName := types.NamespacedName{
+				Namespace: statefulSet.GetNamespace(),
+				Name:      pvcName,
+			}
+
+			err := c.Get(ctx, namespacedName, pvc)
+			if err != nil {
+				if k8serrors.IsNotFound(err) {
+					// PVC doesn't exist yet (replica not created), skip
+					scopedLog.Info("PVC not found, skipping", "pvc", pvcName)
+					continue
+				}
+				scopedLog.Error(err, "Failed to get PVC", "pvc", pvcName)
+				return err
+			}
+
+			// Check if expansion is needed
+			currentSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+			if currentSize.Cmp(change.NewSize) >= 0 {
+				// PVC is already at or above the requested size
+				scopedLog.Info("PVC already at requested size", "pvc", pvcName, "currentSize", currentSize.String())
+				continue
+			}
+
+			// Update PVC storage request
+			pvc.Spec.Resources.Requests[corev1.ResourceStorage] = change.NewSize
+
+			err = splutil.UpdateResource(ctx, c, pvc)
+			if err != nil {
+				scopedLog.Error(err, "Failed to expand PVC", "pvc", pvcName)
+				if eventPublisher != nil {
+					eventPublisher.Warning(ctx, "PVCExpansionFailed", fmt.Sprintf("Failed to expand PVC %s: %v", pvcName, err))
+				}
+				return err
+			}
+
+			scopedLog.Info("Successfully requested PVC expansion", "pvc", pvcName, "newSize", change.NewSize.String())
+			if eventPublisher != nil {
+				eventPublisher.Normal(ctx, "PVCExpansionRequested", fmt.Sprintf("Requested PVC %s expansion to %s", pvcName, change.NewSize.String()))
+			}
+		}
+	}
+
+	return nil
+}
+
+// PVC stuck threshold - if deletion has been pending for more than 30 minutes.
+// This threshold accounts for pod decommissioning time (which can take 15+ minutes)
+// plus PVC deletion time, since PVCs cannot be deleted until the pod is fully removed.
+const stuckThreshold = 30 * time.Minute
+
+// isPVCStuckInDeletion checks if a PVC has a deletion timestamp but is not being removed.
+// A PVC is considered stuck if it has been marked for deletion for more than 30 minutes.
+// This can happen when finalizers prevent deletion or the storage backend is slow.
+// The threshold is set to accommodate pod decommissioning time before PVC deletion can complete.
+func isPVCStuckInDeletion(pvc *corev1.PersistentVolumeClaim) bool {
+	if pvc.DeletionTimestamp == nil {
+		return false
+	}
+	return time.Since(pvc.DeletionTimestamp.Time) > stuckThreshold
+}
+
+// pvcMatchesVCTSpec checks if an existing PVC matches the desired VCT specification.
+// Compares storage class and access modes, handling nil storage class names properly.
+func pvcMatchesVCTSpec(pvc *corev1.PersistentVolumeClaim, vct *corev1.PersistentVolumeClaim) bool {
+	// Compare storage class names (handling nil)
+	pvcStorageClass := ""
+	if pvc.Spec.StorageClassName != nil {
+		pvcStorageClass = *pvc.Spec.StorageClassName
+	}
+	vctStorageClass := ""
+	if vct.Spec.StorageClassName != nil {
+		vctStorageClass = *vct.Spec.StorageClassName
+	}
+	if pvcStorageClass != vctStorageClass {
+		return false
+	}
+
+	// Compare access modes
+	if !reflect.DeepEqual(pvc.Spec.AccessModes, vct.Spec.AccessModes) {
+		return false
+	}
+
+	return true
+}
+
+// UnifiedTransitionState tracks ALL concurrent transitions in a single annotation.
+// This enables recycling each pod ONCE for ALL pending changes (CPU + VCT).
+type UnifiedTransitionState struct {
+	// CPUChange tracks CPU-aware scaling transition (optional, nil if no CPU change)
+	CPUChange *CPUTransition `json:"cpuChange,omitempty"`
+
+	// VCTMigration tracks VCT migration transition (optional, nil if no VCT change)
+	VCTMigration *VCTMigrationTransition `json:"vctMigration,omitempty"`
+
+	// StartedAt is the timestamp when the transition started (RFC3339 format)
+	StartedAt string `json:"startedAt"`
+
+	// FinishedAt is the timestamp when the transition completed (RFC3339 format, empty if in progress)
+	FinishedAt string `json:"finishedAt,omitempty"`
+
+	// PodStatus tracks per-pod completion for large clusters
+	PodStatus map[string]PodTransitionStatus `json:"podStatus,omitempty"`
+
+	// FailedPods tracks pods that failed during transition
+	FailedPods map[string]FailedPodInfo `json:"failedPods,omitempty"`
+}
+
+// CPUTransition tracks CPU-aware scaling parameters
+type CPUTransition struct {
+	OriginalCPUMillis int64 `json:"originalCPUMillis"`
+	TargetCPUMillis   int64 `json:"targetCPUMillis"`
+	OriginalReplicas  int32 `json:"originalReplicas"`
+	TargetReplicas    int32 `json:"targetReplicas"`
+}
+
+// VCTMigrationTransition tracks VCT migration parameters
+type VCTMigrationTransition struct {
+	ExpectedStorageClasses map[string]string                              `json:"expectedStorageClasses"`
+	ExpectedAccessModes    map[string][]corev1.PersistentVolumeAccessMode `json:"expectedAccessModes,omitempty"`
+	PodsNeedingMigration   []int32                                        `json:"podsNeedingMigration,omitempty"`
+}
+
+// PodTransitionStatus tracks completion status for a single pod
+type PodTransitionStatus struct {
+	CPUUpdated bool   `json:"cpuUpdated,omitempty"`
+	PVCUpdated bool   `json:"pvcUpdated,omitempty"`
+	UpdatedAt  string `json:"updatedAt,omitempty"`
+}
+
+// FailedPodInfo captures details about a failed pod transition
+type FailedPodInfo struct {
+	LastError   string `json:"lastError"`
+	FailCount   int    `json:"failCount"`
+	LastAttempt string `json:"lastAttempt"`
+}
+
+// isTransitionStalled checks if the unified transition has been running too long.
+// Returns true if the transition has exceeded the configured or default timeout (30 minutes).
+// This helps detect and handle transitions that may be stuck due to external issues.
+// Note: The timeout is configurable via annotation and should account for pod decommissioning time.
+func isTransitionStalled(state *UnifiedTransitionState, timeout time.Duration) bool {
+	if state == nil || state.StartedAt == "" {
+		return false
+	}
+
+	startTime, err := time.Parse(time.RFC3339, state.StartedAt)
+	if err != nil {
+		// Cannot parse start time, consider it not stalled
+		return false
+	}
+
+	return time.Since(startTime) > timeout
+}
+
+// getUnifiedTransitionStallTimeout parses the stall timeout from the StatefulSet annotation.
+// Returns the configured timeout or DefaultUnifiedTransitionStallTimeout if not set or invalid.
+func getUnifiedTransitionStallTimeout(statefulSet *appsv1.StatefulSet) time.Duration {
+	if statefulSet.Annotations == nil {
+		return DefaultUnifiedTransitionStallTimeout
+	}
+
+	timeoutStr, exists := statefulSet.Annotations[UnifiedTransitionStallTimeoutAnnotation]
+	if !exists || timeoutStr == "" {
+		return DefaultUnifiedTransitionStallTimeout
+	}
+
+	timeout, err := time.ParseDuration(timeoutStr)
+	if err != nil || timeout <= 0 {
+		return DefaultUnifiedTransitionStallTimeout
+	}
+
+	return timeout
+}
+
+// recordPodFailure records a pod recycling failure in the transition state.
+// Returns true if the pod has exceeded MaxPodRecycleFailures and should be skipped.
+func recordPodFailure(state *UnifiedTransitionState, podName string, errMsg string) bool {
+	if state.FailedPods == nil {
+		state.FailedPods = make(map[string]FailedPodInfo)
+	}
+
+	failInfo, exists := state.FailedPods[podName]
+	if !exists {
+		failInfo = FailedPodInfo{}
+	}
+
+	failInfo.FailCount++
+	failInfo.LastError = errMsg
+	failInfo.LastAttempt = time.Now().Format(time.RFC3339)
+	state.FailedPods[podName] = failInfo
+
+	return failInfo.FailCount >= MaxPodRecycleFailures
+}
+
+// isPodPermanentlyFailed checks if a pod has exceeded the maximum failure count.
+func isPodPermanentlyFailed(state *UnifiedTransitionState, podName string) bool {
+	if state.FailedPods == nil {
+		return false
+	}
+
+	failInfo, exists := state.FailedPods[podName]
+	if !exists {
+		return false
+	}
+
+	return failInfo.FailCount >= MaxPodRecycleFailures
+}
+
+// getUnifiedTransitionState parses the UnifiedTransitionStateAnnotation and returns the state.
+// If the new annotation is not present, it checks for the old CPUAwareTransitionStateAnnotation
+// and migrates it to the new format for backward compatibility.
+// Returns nil if no transition state is found.
+func getUnifiedTransitionState(statefulSet *appsv1.StatefulSet) (*UnifiedTransitionState, error) {
+	if statefulSet.Annotations == nil {
+		return nil, nil
+	}
+
+	// Check for new annotation first
+	stateJSON, exists := statefulSet.Annotations[UnifiedTransitionStateAnnotation]
+	if exists && stateJSON != "" {
+		var state UnifiedTransitionState
+		if err := json.Unmarshal([]byte(stateJSON), &state); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal unified transition state: %w", err)
+		}
+		return &state, nil
+	}
+
+	// Fall back to old annotation (backward compatibility)
+	return migrateFromCPUAwareTransitionState(statefulSet)
+}
+
+// migrateFromCPUAwareTransitionState converts old CPUAwareTransitionState to UnifiedTransitionState.
+// This ensures backward compatibility during operator upgrades.
+func migrateFromCPUAwareTransitionState(statefulSet *appsv1.StatefulSet) (*UnifiedTransitionState, error) {
+	if statefulSet.Annotations == nil {
+		return nil, nil
+	}
+
+	oldStateJSON, exists := statefulSet.Annotations[CPUAwareTransitionStateAnnotation]
+	if !exists || oldStateJSON == "" {
+		return nil, nil
+	}
+
+	var oldState CPUAwareTransitionState
+	if err := json.Unmarshal([]byte(oldStateJSON), &oldState); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal CPU-aware transition state: %w", err)
+	}
+
+	// Convert to new format
+	newState := &UnifiedTransitionState{
+		StartedAt:  oldState.StartedAt,
+		FinishedAt: oldState.FinishedAt,
+		CPUChange: &CPUTransition{
+			OriginalCPUMillis: oldState.OriginalCPUMillis,
+			TargetCPUMillis:   oldState.TargetCPUMillis,
+			OriginalReplicas:  oldState.OriginalReplicas,
+			TargetReplicas:    oldState.TargetReplicas,
+		},
+	}
+
+	return newState, nil
+}
+
+// persistUnifiedTransitionState marshals the state and updates the StatefulSet annotation.
+// It also removes the legacy CPUAwareTransitionStateAnnotation if present, completing the
+// migration from the old format to the new unified format.
+func persistUnifiedTransitionState(ctx context.Context, c splcommon.ControllerClient,
+	statefulSet *appsv1.StatefulSet, state *UnifiedTransitionState) error {
+
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("persistUnifiedTransitionState").WithValues(
+		"name", statefulSet.GetObjectMeta().GetName(),
+		"namespace", statefulSet.GetObjectMeta().GetNamespace())
+
+	stateJSON, err := json.Marshal(state)
+	if err != nil {
+		scopedLog.Error(err, "Failed to marshal unified transition state")
+		return err
+	}
+
+	if statefulSet.Annotations == nil {
+		statefulSet.Annotations = make(map[string]string)
+	}
+	statefulSet.Annotations[UnifiedTransitionStateAnnotation] = string(stateJSON)
+
+	// Remove legacy annotation if present (migration cleanup)
+	// This ensures we don't have both old and new annotations simultaneously
+	if _, hasOldAnnotation := statefulSet.Annotations[CPUAwareTransitionStateAnnotation]; hasOldAnnotation {
+		scopedLog.Info("Removing legacy CPUAwareTransitionStateAnnotation during migration")
+		delete(statefulSet.Annotations, CPUAwareTransitionStateAnnotation)
+	}
+
+	if err := splutil.UpdateResource(ctx, c, statefulSet); err != nil {
+		scopedLog.Error(err, "Failed to persist unified transition state")
+		return err
+	}
+
+	scopedLog.Info("Persisted unified transition state", "startedAt", state.StartedAt)
+	return nil
+}
+
+// clearUnifiedTransitionState removes the UnifiedTransitionStateAnnotation from the StatefulSet.
+func clearUnifiedTransitionState(ctx context.Context, c splcommon.ControllerClient,
+	statefulSet *appsv1.StatefulSet) error {
+
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("clearUnifiedTransitionState").WithValues(
+		"name", statefulSet.GetObjectMeta().GetName(),
+		"namespace", statefulSet.GetObjectMeta().GetNamespace())
+
+	if statefulSet.Annotations == nil {
+		return nil
+	}
+
+	// Remove both new and old annotations (in case old annotation still exists)
+	_, hasNewAnnotation := statefulSet.Annotations[UnifiedTransitionStateAnnotation]
+	_, hasOldAnnotation := statefulSet.Annotations[CPUAwareTransitionStateAnnotation]
+
+	if !hasNewAnnotation && !hasOldAnnotation {
+		return nil
+	}
+
+	delete(statefulSet.Annotations, UnifiedTransitionStateAnnotation)
+	delete(statefulSet.Annotations, CPUAwareTransitionStateAnnotation)
+
+	if err := splutil.UpdateResource(ctx, c, statefulSet); err != nil {
+		scopedLog.Error(err, "Failed to clear unified transition state")
+		return err
+	}
+
+	scopedLog.Info("Cleared unified transition state")
+	return nil
+}
+
+// isUnifiedTransitionInProgress checks if any transition is active.
+// Returns true if a transition annotation exists and has not finished.
+func isUnifiedTransitionInProgress(statefulSet *appsv1.StatefulSet) bool {
+	state, err := getUnifiedTransitionState(statefulSet)
+	if err != nil || state == nil {
+		return false
+	}
+	// Transition is in progress if FinishedAt is not set
+	return state.FinishedAt == ""
+}
+
+// initUnifiedTransitionState creates an initial UnifiedTransitionState with the given transitions.
+// Either cpuChange or vctMigration (or both) should be provided.
+func initUnifiedTransitionState(cpuChange *CPUTransition, vctMigration *VCTMigrationTransition) *UnifiedTransitionState {
+	return &UnifiedTransitionState{
+		CPUChange:    cpuChange,
+		VCTMigration: vctMigration,
+		StartedAt:    time.Now().Format(time.RFC3339),
+		PodStatus:    make(map[string]PodTransitionStatus),
+		FailedPods:   make(map[string]FailedPodInfo),
+	}
+}
+
+// isPodFullyUpdated checks if a pod has ALL required updates applied.
+// Returns true only if:
+// - CPU spec matches target (if CPUChange is active)
+// - All PVC storage classes match target (if VCTMigration is active)
+// - All PVC access modes match target (if VCTMigration specifies access modes)
+func isPodFullyUpdated(
+	ctx context.Context,
+	c splcommon.ControllerClient,
+	pod *corev1.Pod,
+	statefulSet *appsv1.StatefulSet,
+	state *UnifiedTransitionState,
+) (bool, error) {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("isPodFullyUpdated").WithValues(
+		"podName", pod.GetName(),
+		"namespace", pod.GetNamespace())
+
+	// Check CPU update if CPUChange is active
+	if state.CPUChange != nil {
+		if !hasNewSpec(pod, state.CPUChange.TargetCPUMillis) {
+			currentCPU := extractCPUFromPod(pod)
+			scopedLog.Info("Pod CPU not updated",
+				"currentCPU", currentCPU,
+				"targetCPU", state.CPUChange.TargetCPUMillis)
+			return false, nil
+		}
+	}
+
+	// Check VCT migration if active
+	if state.VCTMigration != nil {
+		for vctName, expectedStorageClass := range state.VCTMigration.ExpectedStorageClasses {
+			// Build PVC name: {vctName}-{podName}
+			pvcName := fmt.Sprintf("%s-%s", vctName, pod.GetName())
+			pvcNamespacedName := types.NamespacedName{
+				Namespace: pod.GetNamespace(),
+				Name:      pvcName,
+			}
+
+			var pvc corev1.PersistentVolumeClaim
+			if err := c.Get(ctx, pvcNamespacedName, &pvc); err != nil {
+				if k8serrors.IsNotFound(err) {
+					// PVC doesn't exist yet - not updated
+					scopedLog.Info("PVC not found, pod not fully updated",
+						"pvcName", pvcName)
+					return false, nil
+				}
+				scopedLog.Error(err, "Failed to get PVC", "pvcName", pvcName)
+				return false, err
+			}
+
+			// Compare storage class
+			pvcStorageClass := ""
+			if pvc.Spec.StorageClassName != nil {
+				pvcStorageClass = *pvc.Spec.StorageClassName
+			}
+			if pvcStorageClass != expectedStorageClass {
+				scopedLog.Info("PVC storage class not updated",
+					"pvcName", pvcName,
+					"currentStorageClass", pvcStorageClass,
+					"expectedStorageClass", expectedStorageClass)
+				return false, nil
+			}
+
+			// Check access modes if specified
+			if state.VCTMigration.ExpectedAccessModes != nil {
+				expectedAccessModes, hasExpectedModes := state.VCTMigration.ExpectedAccessModes[vctName]
+				if hasExpectedModes {
+					if !reflect.DeepEqual(pvc.Spec.AccessModes, expectedAccessModes) {
+						scopedLog.Info("PVC access modes not updated",
+							"pvcName", pvcName,
+							"currentAccessModes", pvc.Spec.AccessModes,
+							"expectedAccessModes", expectedAccessModes)
+						return false, nil
+					}
+				}
+			}
+		}
+	}
+
+	scopedLog.Info("Pod is fully updated")
+	return true, nil
+}
+
+// recyclePodForUnifiedTransition handles pod recycling for combined CPU + VCT transitions.
+// Key insight: When recycling a pod, delete both the pod AND its PVCs if VCT migration is active.
+// The StatefulSet controller will recreate the pod with new spec AND new PVCs.
+//
+// Error handling:
+// - Pod deletion failures are logged and returned as errors (caller tracks failures)
+// - PVC deletion failures due to finalizers are logged as warnings and do not block pod deletion
+// - Stuck PVCs (deletion pending > 5 minutes) trigger warning events
+func recyclePodForUnifiedTransition(
+	ctx context.Context,
+	c splcommon.ControllerClient,
+	statefulSet *appsv1.StatefulSet,
+	mgr splcommon.StatefulSetPodManager,
+	pod *corev1.Pod,
+	podIndex int32,
+	state *UnifiedTransitionState,
+	eventPublisher splcommon.K8EventPublisher,
+) error {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("recyclePodForUnifiedTransition").WithValues(
+		"podName", pod.GetName(),
+		"namespace", pod.GetNamespace(),
+		"hasCPUChange", state.CPUChange != nil,
+		"hasVCTMigration", state.VCTMigration != nil)
+
+	// Step 1: Prepare for recycle (decommission Splunk peer)
+	ready, err := mgr.PrepareRecycle(ctx, podIndex)
+	if err != nil {
+		scopedLog.Error(err, "Failed to prepare pod for recycle")
+		return err
+	}
+	if !ready {
+		scopedLog.Info("Pod decommissioning in progress, will retry")
+		return nil // Will retry next reconcile
+	}
+
+	scopedLog.Info("Pod decommissioning complete, proceeding with recycle")
+
+	// Step 2: Delete PVCs first (if VCT migration is active)
+	// PVC deletion failures do NOT block pod deletion - we log warnings and continue
+	if state.VCTMigration != nil {
+		for vctName := range state.VCTMigration.ExpectedStorageClasses {
+			pvcName := fmt.Sprintf("%s-%s", vctName, pod.GetName())
+			pvc := &corev1.PersistentVolumeClaim{}
+			pvcNamespacedName := types.NamespacedName{
+				Namespace: statefulSet.GetNamespace(),
+				Name:      pvcName,
+			}
+
+			if err := c.Get(ctx, pvcNamespacedName, pvc); err != nil {
+				if k8serrors.IsNotFound(err) {
+					scopedLog.Info("PVC already deleted", "pvcName", pvcName)
+					continue
+				}
+				// Log warning but continue - PVC may be in a transient state
+				scopedLog.Info("Warning: Failed to get PVC, continuing with pod deletion",
+					"pvcName", pvcName, "error", err.Error())
+				continue
+			}
+
+			// Check if PVC is stuck in deletion
+			if isPVCStuckInDeletion(pvc) {
+				scopedLog.Info("Warning: PVC stuck in deletion",
+					"pvcName", pvcName,
+					"deletionTimestamp", pvc.DeletionTimestamp.Time,
+					"finalizers", pvc.Finalizers)
+				if eventPublisher != nil {
+					eventPublisher.Warning(ctx, "PVCStuckInDeletion",
+						fmt.Sprintf("PVC %s has been pending deletion for over 20 minutes. Finalizers: %v",
+							pvcName, pvc.Finalizers))
+				}
+				// Continue anyway - pod recreation will handle this eventually
+				continue
+			}
+
+			oldSC := "<nil>"
+			if pvc.Spec.StorageClassName != nil {
+				oldSC = *pvc.Spec.StorageClassName
+			}
+
+			scopedLog.Info("Deleting PVC for VCT migration",
+				"pvcName", pvcName,
+				"oldStorageClass", oldSC,
+				"newStorageClass", state.VCTMigration.ExpectedStorageClasses[vctName])
+
+			if err := c.Delete(ctx, pvc); err != nil {
+				if k8serrors.IsNotFound(err) {
+					// Already deleted, continue
+					continue
+				}
+				// PVC deletion failed - log warning but don't block pod deletion
+				// This handles cases like finalizers preventing deletion
+				scopedLog.Info("Warning: Failed to delete PVC, continuing with pod deletion",
+					"pvcName", pvcName, "error", err.Error())
+				if eventPublisher != nil {
+					eventPublisher.Warning(ctx, "PVCDeletionFailed",
+						fmt.Sprintf("Failed to delete PVC %s: %v. Pod deletion will proceed.",
+							pvcName, err))
+				}
+				continue
+			}
+
+			if eventPublisher != nil {
+				eventPublisher.Normal(ctx, "PVCDeleted",
+					fmt.Sprintf("Deleted PVC %s for storage class migration (old: %s, new: %s)",
+						pvcName, oldSC, state.VCTMigration.ExpectedStorageClasses[vctName]))
+			}
+		}
+	}
+
+	// Step 3: Delete pod (StatefulSet controller will recreate with new spec)
+	// New PVCs will be created with new storage class from updated VCT
+	scopedLog.Info("Deleting pod for unified transition")
+
+	preconditions := client.Preconditions{
+		UID:             &pod.ObjectMeta.UID,
+		ResourceVersion: &pod.ObjectMeta.ResourceVersion,
+	}
+	if err := c.Delete(ctx, pod, preconditions); err != nil && !k8serrors.IsNotFound(err) {
+		scopedLog.Error(err, "Failed to delete pod")
+		// Return error so caller can track this failure
+		return fmt.Errorf("failed to delete pod %s: %w", pod.GetName(), err)
+	}
+
+	if eventPublisher != nil {
+		msg := fmt.Sprintf("Deleted pod %s for unified transition", pod.GetName())
+		if state.CPUChange != nil {
+			msg += fmt.Sprintf(" (CPU: %dm->%dm)",
+				state.CPUChange.OriginalCPUMillis, state.CPUChange.TargetCPUMillis)
+		}
+		if state.VCTMigration != nil {
+			msg += fmt.Sprintf(" (VCT: %d storage classes)", len(state.VCTMigration.ExpectedStorageClasses))
+		}
+		eventPublisher.Normal(ctx, "PodRecycled", msg)
+	}
+
+	return nil
+}
+
+// canRecyclePodWithinCPUFloor checks if recycling a pod would violate the CPU floor constraint.
+// The CPU floor ensures that total ready CPU never drops below the minimum required to maintain
+// capacity during transitions.
+//
+// Returns true if:
+// - state.CPUChange is nil (no CPU transition active, no floor constraint)
+// - Recycling the pod would not drop total ready CPU below the floor
+//
+// Returns false if recycling would violate the CPU floor constraint.
+func canRecyclePodWithinCPUFloor(
+	ctx context.Context,
+	c splcommon.ControllerClient,
+	statefulSet *appsv1.StatefulSet,
+	pod *corev1.Pod,
+	state *UnifiedTransitionState,
+	parallelUpdates int32,
+) bool {
+	reqLogger := log.FromContext(ctx)
+	scopedLog := reqLogger.WithName("canRecyclePodWithinCPUFloor").WithValues(
+		"podName", pod.GetName(),
+		"namespace", pod.GetNamespace())
+
+	// If no CPU change is active, there's no CPU floor constraint
+	if state.CPUChange == nil {
+		scopedLog.Info("No CPU change active, recycling allowed")
+		return true
+	}
+
+	// Calculate CPU floor: originalCPUMillis * originalReplicas - buffer for parallel updates
+	cpuFloor := state.CPUChange.OriginalCPUMillis * int64(state.CPUChange.OriginalReplicas)
+	cpuBuffer := int64(parallelUpdates) * state.CPUChange.OriginalCPUMillis
+	minCPUFloor := cpuFloor - cpuBuffer
+
+	// Compute current total ready CPU
+	cpuState := CPUAwareTransitionState{
+		OriginalCPUMillis: state.CPUChange.OriginalCPUMillis,
+		TargetCPUMillis:   state.CPUChange.TargetCPUMillis,
+		OriginalReplicas:  state.CPUChange.OriginalReplicas,
+		TargetReplicas:    state.CPUChange.TargetReplicas,
+	}
+	metrics, err := computeReadyCPUMetricsForScaleDown(ctx, c, statefulSet, cpuState)
+	if err != nil {
+		scopedLog.Error(err, "Failed to compute CPU metrics, disallowing recycle")
+		return false
+	}
+
+	// Calculate CPU after recycling this pod
+	podCPU := extractCPUFromPod(pod)
+	cpuAfterRecycle := metrics.TotalReadyCPU - podCPU
+
+	scopedLog.Info("Checking CPU floor constraint",
+		"totalReadyCPU", metrics.TotalReadyCPU,
+		"podCPU", podCPU,
+		"cpuAfterRecycle", cpuAfterRecycle,
+		"minCPUFloor", minCPUFloor)
+
+	if cpuAfterRecycle < minCPUFloor {
+		scopedLog.Info("Recycling would violate CPU floor",
+			"deficit", minCPUFloor-cpuAfterRecycle)
+		return false
+	}
+
+	return true
+}

--- a/pkg/splunk/splkcontroller/statefulset_vtc_upgrade_test.go
+++ b/pkg/splunk/splkcontroller/statefulset_vtc_upgrade_test.go
@@ -1,0 +1,598 @@
+// Copyright (c) 2018-2022 Splunk Inc. All rights reserved.
+
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splkcontroller
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCompareVolumeClaimTemplates_NoChanges(t *testing.T) {
+	storageClass := "standard"
+	current := &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-data"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClass,
+						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("10Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	revised := current.DeepCopy()
+
+	result := CompareVolumeClaimTemplates(current, revised)
+
+	if result.RequiresRecreate {
+		t.Errorf("Expected no recreate required, got RequiresRecreate=true with reason: %s", result.RecreateReason)
+	}
+	if len(result.StorageExpansions) != 0 {
+		t.Errorf("Expected no storage expansions, got %d", len(result.StorageExpansions))
+	}
+}
+
+func TestCompareVolumeClaimTemplates_StorageExpansion(t *testing.T) {
+	storageClass := "standard"
+	current := &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-data"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClass,
+						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("10Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	revised := current.DeepCopy()
+	revised.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("20Gi")
+
+	result := CompareVolumeClaimTemplates(current, revised)
+
+	if result.RequiresRecreate {
+		t.Errorf("Expected no recreate for storage expansion, got RequiresRecreate=true with reason: %s", result.RecreateReason)
+	}
+	if len(result.StorageExpansions) != 1 {
+		t.Errorf("Expected 1 storage expansion, got %d", len(result.StorageExpansions))
+	}
+	if len(result.StorageExpansions) > 0 {
+		expansion := result.StorageExpansions[0]
+		if expansion.TemplateName != "pvc-data" {
+			t.Errorf("Expected template name 'pvc-data', got '%s'", expansion.TemplateName)
+		}
+		if expansion.OldSize.String() != "10Gi" {
+			t.Errorf("Expected old size '10Gi', got '%s'", expansion.OldSize.String())
+		}
+		if expansion.NewSize.String() != "20Gi" {
+			t.Errorf("Expected new size '20Gi', got '%s'", expansion.NewSize.String())
+		}
+	}
+}
+
+func TestCompareVolumeClaimTemplates_StorageDecrease(t *testing.T) {
+	storageClass := "standard"
+	current := &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-data"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClass,
+						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("20Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	revised := current.DeepCopy()
+	revised.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("10Gi")
+
+	result := CompareVolumeClaimTemplates(current, revised)
+
+	if !result.RequiresRecreate {
+		t.Error("Expected RequiresRecreate=true for storage decrease")
+	}
+	if result.RecreateReason == "" {
+		t.Error("Expected a reason for storage decrease recreate")
+	}
+}
+
+func TestCompareVolumeClaimTemplates_StorageClassChange(t *testing.T) {
+	storageClass1 := "standard"
+	storageClass2 := "premium"
+	current := &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-data"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClass1,
+						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("10Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	revised := current.DeepCopy()
+	revised.Spec.VolumeClaimTemplates[0].Spec.StorageClassName = &storageClass2
+
+	result := CompareVolumeClaimTemplates(current, revised)
+
+	// Storage class change should set RequiresPVCMigration, NOT RequiresRecreate
+	if result.RequiresRecreate {
+		t.Errorf("Expected RequiresRecreate=false for storage class change, but got RequiresRecreate=true with reason: %s", result.RecreateReason)
+	}
+	if !result.RequiresPVCMigration {
+		t.Error("Expected RequiresPVCMigration=true for storage class change")
+	}
+	if len(result.PVCMigrationChanges) != 1 {
+		t.Errorf("Expected 1 PVC migration change, got %d", len(result.PVCMigrationChanges))
+	}
+	if len(result.PVCMigrationChanges) > 0 {
+		change := result.PVCMigrationChanges[0]
+		if change.TemplateName != "pvc-data" {
+			t.Errorf("Expected template name 'pvc-data', got '%s'", change.TemplateName)
+		}
+		if change.ChangeType != "storage-class" {
+			t.Errorf("Expected change type 'storage-class', got '%s'", change.ChangeType)
+		}
+		if change.OldStorageClass != "standard" {
+			t.Errorf("Expected old storage class 'standard', got '%s'", change.OldStorageClass)
+		}
+		if change.NewStorageClass != "premium" {
+			t.Errorf("Expected new storage class 'premium', got '%s'", change.NewStorageClass)
+		}
+	}
+}
+
+func TestCompareVolumeClaimTemplates_VCTAdded(t *testing.T) {
+	storageClass := "standard"
+	current := &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-data"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClass,
+						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("10Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	revised := current.DeepCopy()
+	revised.Spec.VolumeClaimTemplates = append(revised.Spec.VolumeClaimTemplates, corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-logs"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClass,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("5Gi"),
+				},
+			},
+		},
+	})
+
+	result := CompareVolumeClaimTemplates(current, revised)
+
+	if !result.RequiresRecreate {
+		t.Error("Expected RequiresRecreate=true for VCT addition")
+	}
+	if result.RecreateReason == "" {
+		t.Error("Expected a reason for VCT addition recreate")
+	}
+}
+
+func TestCompareVolumeClaimTemplates_VCTRemoved(t *testing.T) {
+	storageClass := "standard"
+	current := &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-data"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClass,
+						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("10Gi"),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-logs"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClass,
+						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("5Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	revised := &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-data"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClass,
+						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("10Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := CompareVolumeClaimTemplates(current, revised)
+
+	if !result.RequiresRecreate {
+		t.Error("Expected RequiresRecreate=true for VCT removal")
+	}
+	if result.RecreateReason == "" {
+		t.Error("Expected a reason for VCT removal recreate")
+	}
+}
+
+func TestCompareVolumeClaimTemplates_AccessModesChange(t *testing.T) {
+	storageClass := "standard"
+	current := &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-data"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClass,
+						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("10Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	revised := current.DeepCopy()
+	revised.Spec.VolumeClaimTemplates[0].Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}
+
+	result := CompareVolumeClaimTemplates(current, revised)
+
+	// Access modes change should set RequiresPVCMigration, NOT RequiresRecreate
+	if result.RequiresRecreate {
+		t.Errorf("Expected RequiresRecreate=false for access modes change, but got RequiresRecreate=true with reason: %s", result.RecreateReason)
+	}
+	if !result.RequiresPVCMigration {
+		t.Error("Expected RequiresPVCMigration=true for access modes change")
+	}
+	if len(result.PVCMigrationChanges) != 1 {
+		t.Errorf("Expected 1 PVC migration change, got %d", len(result.PVCMigrationChanges))
+	}
+	if len(result.PVCMigrationChanges) > 0 {
+		change := result.PVCMigrationChanges[0]
+		if change.TemplateName != "pvc-data" {
+			t.Errorf("Expected template name 'pvc-data', got '%s'", change.TemplateName)
+		}
+		if change.ChangeType != "access-modes" {
+			t.Errorf("Expected change type 'access-modes', got '%s'", change.ChangeType)
+		}
+		if len(change.OldAccessModes) != 1 || change.OldAccessModes[0] != corev1.ReadWriteOnce {
+			t.Errorf("Expected old access modes [ReadWriteOnce], got %v", change.OldAccessModes)
+		}
+		if len(change.NewAccessModes) != 1 || change.NewAccessModes[0] != corev1.ReadWriteMany {
+			t.Errorf("Expected new access modes [ReadWriteMany], got %v", change.NewAccessModes)
+		}
+	}
+}
+
+// TestCompareVolumeClaimTemplates_StorageClassChange_Migration verifies that storage class
+// changes set RequiresPVCMigration (not RequiresRecreate) with proper VCTChange details
+func TestCompareVolumeClaimTemplates_StorageClassChange_Migration(t *testing.T) {
+	oldSC := "standard"
+	newSC := "premium-ssd"
+	current := &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "splunk-data"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &oldSC,
+						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("100Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	revised := current.DeepCopy()
+	revised.Spec.VolumeClaimTemplates[0].Spec.StorageClassName = &newSC
+
+	result := CompareVolumeClaimTemplates(current, revised)
+
+	// Verify migration flags
+	if result.RequiresRecreate {
+		t.Errorf("Storage class change should NOT require recreate, got RequiresRecreate=true with reason: %s", result.RecreateReason)
+	}
+	if !result.RequiresPVCMigration {
+		t.Error("Storage class change should set RequiresPVCMigration=true")
+	}
+
+	// Verify change details
+	if len(result.PVCMigrationChanges) != 1 {
+		t.Fatalf("Expected 1 PVC migration change, got %d", len(result.PVCMigrationChanges))
+	}
+	change := result.PVCMigrationChanges[0]
+	if change.TemplateName != "splunk-data" {
+		t.Errorf("Expected template name 'splunk-data', got '%s'", change.TemplateName)
+	}
+	if change.ChangeType != "storage-class" {
+		t.Errorf("Expected change type 'storage-class', got '%s'", change.ChangeType)
+	}
+	if change.OldStorageClass != "standard" {
+		t.Errorf("Expected old storage class 'standard', got '%s'", change.OldStorageClass)
+	}
+	if change.NewStorageClass != "premium-ssd" {
+		t.Errorf("Expected new storage class 'premium-ssd', got '%s'", change.NewStorageClass)
+	}
+}
+
+// TestCompareVolumeClaimTemplates_AccessModesChange_Migration verifies that access modes
+// changes set RequiresPVCMigration (not RequiresRecreate) with proper VCTChange details
+func TestCompareVolumeClaimTemplates_AccessModesChange_Migration(t *testing.T) {
+	storageClass := "standard"
+	current := &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "splunk-logs"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClass,
+						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("50Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	revised := current.DeepCopy()
+	revised.Spec.VolumeClaimTemplates[0].Spec.AccessModes = []corev1.PersistentVolumeAccessMode{
+		corev1.ReadWriteMany,
+	}
+
+	result := CompareVolumeClaimTemplates(current, revised)
+
+	// Verify migration flags
+	if result.RequiresRecreate {
+		t.Errorf("Access modes change should NOT require recreate, got RequiresRecreate=true with reason: %s", result.RecreateReason)
+	}
+	if !result.RequiresPVCMigration {
+		t.Error("Access modes change should set RequiresPVCMigration=true")
+	}
+
+	// Verify change details
+	if len(result.PVCMigrationChanges) != 1 {
+		t.Fatalf("Expected 1 PVC migration change, got %d", len(result.PVCMigrationChanges))
+	}
+	change := result.PVCMigrationChanges[0]
+	if change.TemplateName != "splunk-logs" {
+		t.Errorf("Expected template name 'splunk-logs', got '%s'", change.TemplateName)
+	}
+	if change.ChangeType != "access-modes" {
+		t.Errorf("Expected change type 'access-modes', got '%s'", change.ChangeType)
+	}
+	if len(change.OldAccessModes) != 1 || change.OldAccessModes[0] != corev1.ReadWriteOnce {
+		t.Errorf("Expected old access modes [ReadWriteOnce], got %v", change.OldAccessModes)
+	}
+	if len(change.NewAccessModes) != 1 || change.NewAccessModes[0] != corev1.ReadWriteMany {
+		t.Errorf("Expected new access modes [ReadWriteMany], got %v", change.NewAccessModes)
+	}
+}
+
+// TestCompareVolumeClaimTemplates_MultipleChanges verifies that multiple VCT changes
+// are all captured in PVCMigrationChanges (storage class + access modes on different VCTs)
+func TestCompareVolumeClaimTemplates_MultipleChanges(t *testing.T) {
+	oldSC := "standard"
+	newSC := "premium"
+	current := &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-data"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &oldSC,
+						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("100Gi"),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-logs"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &oldSC,
+						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("50Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	revised := current.DeepCopy()
+	// Change storage class on pvc-data
+	revised.Spec.VolumeClaimTemplates[0].Spec.StorageClassName = &newSC
+	// Change access modes on pvc-logs
+	revised.Spec.VolumeClaimTemplates[1].Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}
+
+	result := CompareVolumeClaimTemplates(current, revised)
+
+	// Verify migration flags
+	if result.RequiresRecreate {
+		t.Errorf("Multiple migration changes should NOT require recreate, got RequiresRecreate=true with reason: %s", result.RecreateReason)
+	}
+	if !result.RequiresPVCMigration {
+		t.Error("Multiple changes should set RequiresPVCMigration=true")
+	}
+
+	// Verify all changes are captured
+	if len(result.PVCMigrationChanges) != 2 {
+		t.Fatalf("Expected 2 PVC migration changes, got %d", len(result.PVCMigrationChanges))
+	}
+
+	// Check that we have both types of changes (order may vary due to map iteration)
+	hasStorageClassChange := false
+	hasAccessModesChange := false
+	for _, change := range result.PVCMigrationChanges {
+		if change.ChangeType == "storage-class" && change.TemplateName == "pvc-data" {
+			hasStorageClassChange = true
+			if change.OldStorageClass != "standard" || change.NewStorageClass != "premium" {
+				t.Errorf("Storage class change has wrong values: old='%s', new='%s'", change.OldStorageClass, change.NewStorageClass)
+			}
+		}
+		if change.ChangeType == "access-modes" && change.TemplateName == "pvc-logs" {
+			hasAccessModesChange = true
+			if len(change.OldAccessModes) != 1 || change.OldAccessModes[0] != corev1.ReadWriteOnce {
+				t.Errorf("Access modes change has wrong old values: %v", change.OldAccessModes)
+			}
+			if len(change.NewAccessModes) != 1 || change.NewAccessModes[0] != corev1.ReadWriteMany {
+				t.Errorf("Access modes change has wrong new values: %v", change.NewAccessModes)
+			}
+		}
+	}
+	if !hasStorageClassChange {
+		t.Error("Missing storage-class change for pvc-data")
+	}
+	if !hasAccessModesChange {
+		t.Error("Missing access-modes change for pvc-logs")
+	}
+}
+
+// TestCompareVolumeClaimTemplates_BothStorageClassAndAccessModes verifies that when both
+// storage class AND access modes change on the SAME VCT, two separate VCTChange entries are created
+func TestCompareVolumeClaimTemplates_BothStorageClassAndAccessModes(t *testing.T) {
+	oldSC := "standard"
+	newSC := "premium"
+	current := &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pvc-data"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &oldSC,
+						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("100Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	revised := current.DeepCopy()
+	// Change both storage class and access modes on same VCT
+	revised.Spec.VolumeClaimTemplates[0].Spec.StorageClassName = &newSC
+	revised.Spec.VolumeClaimTemplates[0].Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}
+
+	result := CompareVolumeClaimTemplates(current, revised)
+
+	// Verify migration flags
+	if result.RequiresRecreate {
+		t.Errorf("Combined changes should NOT require recreate, got RequiresRecreate=true with reason: %s", result.RecreateReason)
+	}
+	if !result.RequiresPVCMigration {
+		t.Error("Combined changes should set RequiresPVCMigration=true")
+	}
+
+	// Verify both changes are captured separately
+	if len(result.PVCMigrationChanges) != 2 {
+		t.Fatalf("Expected 2 PVC migration changes (storage-class + access-modes), got %d", len(result.PVCMigrationChanges))
+	}
+
+	hasStorageClassChange := false
+	hasAccessModesChange := false
+	for _, change := range result.PVCMigrationChanges {
+		if change.ChangeType == "storage-class" {
+			hasStorageClassChange = true
+		}
+		if change.ChangeType == "access-modes" {
+			hasAccessModesChange = true
+		}
+	}
+	if !hasStorageClassChange || !hasAccessModesChange {
+		t.Errorf("Expected both storage-class and access-modes changes, got hasStorageClass=%v, hasAccessModes=%v", hasStorageClassChange, hasAccessModesChange)
+	}
+}

--- a/pkg/splunk/test/controller.go
+++ b/pkg/splunk/test/controller.go
@@ -799,6 +799,9 @@ func PodManagerTester(t *testing.T, method string, mgr splcommon.StatefulSetPodM
 	PodManagerUpdateTester(t, methodPlus, mgr, 1, enterpriseApi.PhasePending, revised, scaleUpCalls, nil, current)
 
 	// test scale up (1 ready scaling to 2; wait for ready)
+	// Now includes Update+Get for setScaleUpWaitStarted annotation tracking
+	// Reset revised to avoid carrying annotations from previous test
+	revised = current.DeepCopy()
 	replicas = 2
 	current.Status.Replicas = 2
 	current.Status.ReadyReplicas = 1
@@ -806,6 +809,8 @@ func PodManagerTester(t *testing.T, method string, mgr splcommon.StatefulSetPodM
 	PodManagerUpdateTester(t, methodPlus, mgr, 2, enterpriseApi.PhaseScalingUp, revised, scaleUpCalls, nil, current, pod)
 
 	// test scale up (1 ready scaling to 2)
+	// Reset revised to avoid carrying annotations from previous test
+	revised = current.DeepCopy()
 	replicas = 1
 	current.Status.Replicas = 1
 	current.Status.ReadyReplicas = 1
@@ -814,6 +819,8 @@ func PodManagerTester(t *testing.T, method string, mgr splcommon.StatefulSetPodM
 	PodManagerUpdateTester(t, methodPlus, mgr, 2, enterpriseApi.PhaseScalingUp, revised, updateCalls, nil, current, pod)
 
 	// test scale down (2 ready, 1 desired)
+	// Reset revised to avoid carrying annotations from previous test
+	revised = current.DeepCopy()
 	replicas = 1
 	current.Status.Replicas = 1
 	current.Status.ReadyReplicas = 2
@@ -822,6 +829,8 @@ func PodManagerTester(t *testing.T, method string, mgr splcommon.StatefulSetPodM
 	PodManagerUpdateTester(t, methodPlus, mgr, 1, enterpriseApi.PhaseScalingDown, revised, scaleUpCalls, nil, current, pod)
 
 	// test scale down (2 ready scaling down to 1)
+	// Reset revised to avoid carrying annotations from previous test
+	revised = current.DeepCopy()
 	pvcCalls := []MockFuncCall{
 		{MetaName: "*v1.PersistentVolumeClaim-test-pvc-etc-splunk-stack1-1"},
 		{MetaName: "*v1.PersistentVolumeClaim-test-pvc-var-splunk-stack1-1"},
@@ -842,6 +851,8 @@ func PodManagerTester(t *testing.T, method string, mgr splcommon.StatefulSetPodM
 	PodManagerUpdateTester(t, methodPlus, mgr, 1, enterpriseApi.PhaseScalingDown, revised, scaleDownCalls, nil, current, pod, pvcList[0], pvcList[1])
 
 	// test pod not found
+	// Reset revised to avoid carrying annotations from previous test
+	revised = current.DeepCopy()
 	replicas = 1
 	current.Status.Replicas = 1
 	current.Status.ReadyReplicas = 1


### PR DESCRIPTION
There are several different changes in this PR, in some dedicated commits.
As they have some overlapped parts, it is difficult to split them into different PRs.

**Notes**: Why do we mainly use annotations to control some behavior of the operator instead of updating the CR fileds? Quick answer, to maintain the patches of the CRDs are nightmare for us. Moreover, the CRD deployment is out of our control, and we often need to wait for them to be deployed. This process takes time and slow down our development process.

---
# 1.0. Prefix-based metadata filtering 
### Description

This PR implements prefix-based metadata filtering to give users control over how labels and annotations propagate from the Custom Resource (CR) to the underlying StatefulSet and Pods.

Previously, almost all metadata was copied everywhere. Now you can use specific prefixes to target where you want your labels to go:

*   **`sts-only.*`**: Keys starting with this are added *only* to the StatefulSet metadata (and the prefix is stripped!). They won't appear on the Pod Template, so adding them won't trigger a pod rollout.
*   **`pod-only.*`**: Keys are added *only* to the Pod Template (and excluded from the StatefulSet metadata).
*   **System prefixes**: We now automatically exclude `kubectl.kubernetes.io/*` and `operator.splunk.com/*` prefixes to prevent clutter and conflicts.

Regular labels without these prefixes work exactly as before—propagatating to both.

### Key Changes

*   **`pkg/splunk/common/util.go`**: Added the core filtering logic. It checks for `sts-only.` and `pod-only.` prefixes.
*   **`pkg/splunk/common/statefulset_util.go`**: Implemented `SyncParentMetaToStatefulSet` which handles the transformation (stripping `sts-only.`) and syncing logic.
*   **`pkg/splunk/enterprise/configuration.go`**: Updated the main reconciliation loop to use these new syncing functions instead of the old blind copy.
*   **`pkg/splunk/splkcontroller/statefulset.go`**: Added logic to detect if *only* StatefulSet metadata changed (so we can update the STS object without touching the Pod specs).

### Testing and Verification

Many unit tests are implemented.

For E2E validation:
1.  Update the existing Splunk CR.
2.  Add a label `sts-only.my-tag: true`.
    *   **Verifed**: The StatefulSet has `my-tag: true`.
    *   **Verifed**: The Pods do *not* have `my-tag` (and thus no rollout if added later).
3.  Add a label `pod-only.scrapper: true`.
    *   **Verified**: The Pods have `pod-only.scrapper: true`.
    *   **Verified**: The StatefulSet does *not* have this label.
4.  Add a generic label `environment: prod`.
    *   **Verified**: Both STS and Pods have `environment: prod`.

### Related Issues
https://github.com/splunk/splunk-operator/issues/1652

### PR Checklist

- [x] Code changes adhere to the project's coding standards.
- [x] Relevant unit and integration tests are included.
- [x] Documentation has been updated accordingly.
- [x] All tests pass locally.
- [x] The PR description follows the project's guidelines.

# 2.0. Flexible scaling
### Description

Makes StatefulSet scaling more flexible by fixing two annoying behaviors:

1. **Scale-down no longer blocks on unhealthy pods** - Previously the operator waited for all pods to be ready before scaling down, which doesn't make sense since removing pods doesn't need healthy pods. Now it just checks if we have more replicas than desired and proceeds.

2. **Scale-up has configurable timeout** - Instead of waiting forever for pods to be ready, users can now set a timeout via annotation. After the timeout, scale-up proceeds anyway (with a warning logged). Default is still "wait forever" to maintain backward compat.

Also includes some defensive improvements to scale-down:
- Better bounds checking in `PrepareScaleDown()` to handle edge cases like manually deleted pods
- Fallback mechanism to query Cluster Manager directly when CR status is stale
- Empty peer status now treated as "decommission complete" instead of blocking

### Key Changes
**New annotations:**
- `operator.splunk.com/scale-up-ready-wait-timeout`: time of waiting for all pods to be ready before scaling up
- `operator.splunk.com/scale-up-wait-started`: **internal** tracking the starting time of scale up wait


**Behavior at a glance** of the new annotation `operator.splunk.com/scale-up-ready-wait-timeout`:

| Annotation value | Result |
| --- | --- |
| (missing) | proceed immediately |
| `"invalid"` | proceed immediately |
| `"0"` or `"0s"` | proceed immediately |
| `"5m"` | wait up to 5 minutes |
| `"-1"` or any negative | wait forever |


### Testing and Verification

**Unit tests added:**
Please check the code for more information.

**Manual E2E testing:**
Was done by scaling up and down cluster often and quickly.



### Related Issues

https://github.com/splunk/splunk-operator/issues/1646

### PR Checklist

- [x] Code changes adhere to the project's coding standards.
- [x] Relevant unit and integration tests are included.
- [x] Documentation has been updated accordingly.
- [x] All tests pass locally.
- [x] The PR description follows the project's guidelines.


---

# 3.0. Support updating CPU or changing VCT with CPU-awareness option
### Description

This PR introduces 3 major enhancements for better scaling and updates when changing the CPU or Volume Claim Template:

1.  **CPU-aware scaling**: Keeps your total cluster CPU capacity constant when you change Pod sizes. It automatically adjusts replica counts up or down to match the new Pod specs.
2.  **Parallel pod updates**: Speeds up rolling restarts by updating multiple pods at once (e.g., 25%).
3.  **Automatic VolumeClaimTemplate Updates**: Safely handles changes to `VolumeClaimTemplates` (which are normally immutable in K8s).
    *   **Storage Expansion**: Automatically expands PVCs.
    *   **Immutable Changes**: Safely recreates the StatefulSet (orphaning pods) or manages migration for changes like StorageClass or access modes.

We also handles the safe ordering of scaling operations (scale-up first, then scale-down, or vice versa) to ensure capacity is never lost.

This change is fully backward compatible.

### Key Changes

**New Annotations:**
- `operator.splunk.com/preserve-total-cpu` - enables CPU-preserving replica adjustment
- `operator.splunk.com/parallel-pod-updates` - controls concurrent pod updates (< 1.0 = percentage, >= 1.0 = absolute count)

**Behavior:**
- Scale-up: happens immediately when CPU decreases per pod (more pods needed)
- Scale-down: happens gradually with safety checks (waits for new-spec pods to be ready, respects CPU bounds)
- Parallel updates: defaults to 1 pod at a time, configurable via annotation

### Testing and Verification

- Added unit tests for all new helper functions
- Added integration-style tests for CPU-aware scaling scenarios
- Added tests for percentage and absolute parallel update modes
- Existing tests updated to reflect new scale-down prioritization behavior
...

### Related Issues
https://github.com/splunk/splunk-operator/issues/1645
https://github.com/splunk/splunk-operator/issues/1647

### PR Checklist

- [x] Code changes adhere to the project's coding standards.
- [x] Relevant unit and integration tests are included.
- [x] Documentation has been updated accordingly.
- [x] All tests pass locally.
- [x] The PR description follows the project's guidelines.

---
# 4.0 Supporting improving startup performance on large persistent volumes by configuring `fsGroupChangePolicy`

### Description

This PR adds support for configuring `fsGroupChangePolicy` on Splunk pod security contexts to improve startup performance on large persistent volumes.

When pods with large PVs start up, Kubernetes can spend a long time recursively changing ownership/permissions on all files. By setting the policy to `OnRootMismatch`, we skip this expensive operation if the root dir already has the correct fsGroup - which is the case for most restarts.

### Key Changes

- **api/v4/common_types.go**: Added `FSGroupChangePolicy` field to the common Spec struct. Users can now set this in their CR spec with validation for `Always` or `OnRootMismatch` values.

- **pkg/splunk/enterprise/configuration.go**: Added `getFSGroupChangePolicy()` helper that implements the precedence logic (annotation > spec > default). The default is now `OnRootMismatch` for better out-of-the-box perf.

- **pkg/splunk/splkcontroller/statefulset.go**: Added the `FSGroupChangePolicyAnnotation` constant for the `operator.splunk.com/fs-group-change-policy` annotation.

- **docs/CustomResources.md**: Added docs explaining the feature, configuration options (spec field vs annotation), and the precedence rules.

- **CRD yaml files**: Updated all CRD definitions to include the new field (generated from `make generate` and command `make manifest`

### Testing and Verification

- Added unit tests for `getFSGroupChangePolicy()` covering all precedence scenarios
- Tested with both spec field and annotation configurations
- Verified invalid annotation values fall back gracefully with warning log
- Manual testing on cluster with large PVs showed significant startup time improvement

### Related Issues

https://github.com/splunk/splunk-operator/issues/1648

### PR Checklist

- [x] Code changes adhere to the project's coding standards.
- [x] Relevant unit and integration tests are included.
- [x] Documentation has been updated accordingly.
- [x] All tests pass locally.
- [x] The PR description follows the project's guidelines.
