### PR TITLE
CSPL-4372: Update GitHub workflows to use pull_request_target event

### DIFF
--- a/.github/workflows/build-test-push-workflow.yml
+++ b/.github/workflows/build-test-push-workflow.yml
@@ -1,6 +1,6 @@
 name: Build and Test
 on:
-  pull_request: {}
+  pull_request_target: {}
   push:
     branches:
     - main

--- a/.github/workflows/distroless-build-test-push-workflow.yml
+++ b/.github/workflows/distroless-build-test-push-workflow.yml
@@ -1,6 +1,6 @@
 name: Build and Test Distroless
 on:
-  pull_request: {}
+  pull_request_target: {}
   push:
     branches:
     - main

--- a/.github/workflows/prodsec-workflow.yml
+++ b/.github/workflows/prodsec-workflow.yml
@@ -1,5 +1,5 @@
 on:
-  pull_request: {}
+  pull_request_target: {}
   push:
     branches:
     - main


### PR DESCRIPTION
### Description

Enable discovery of new target pull request github actions triggers.

### Key Changes

Change `pull_request` to `pull_request_target`

### Testing and Verification

This PR is for testing new way of running PRs for external contributors. 
To execute `pull_request_target` the workflow needs to be merged to default PR - for this repo it's `main`

