### PR TITLE
Revert "CSPL-4372: Update GitHub workflows to use pull_request_target event"

### DIFF
--- a/.github/workflows/build-test-push-workflow.yml
+++ b/.github/workflows/build-test-push-workflow.yml
@@ -1,6 +1,6 @@
 name: Build and Test
 on:
-  pull_request_target: {}
+  pull_request: {}
   push:
     branches:
     - main

--- a/.github/workflows/distroless-build-test-push-workflow.yml
+++ b/.github/workflows/distroless-build-test-push-workflow.yml
@@ -1,6 +1,6 @@
 name: Build and Test Distroless
 on:
-  pull_request_target: {}
+  pull_request: {}
   push:
     branches:
     - main

--- a/.github/workflows/prodsec-workflow.yml
+++ b/.github/workflows/prodsec-workflow.yml
@@ -1,5 +1,5 @@
 on:
-  pull_request_target: {}
+  pull_request: {}
   push:
     branches:
     - main


### PR DESCRIPTION
Reverts splunk/splunk-operator#1656

Why? This was done for experiment with different workflow triggers - let's restore it to original state