### PR TITLE
VULN-61850: golang version upgrade 

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 OPERATOR_SDK_VERSION=v1.42.0
 REVIEWERS=vivekr-splunk,rlieberman-splunk,patrykw-splunk,Igor-splunk,kasiakoziol,kubabuczak,gabrielm-splunk,minjieqiu,qingw-splunk
-GO_VERSION=1.25.6
+GO_VERSION=1.25.7
 AWSCLI_URL=https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.8.6.zip
 KUBECTL_VERSION=v1.29.1
 AZ_CLI_VERSION=2.79.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG BASE_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal
 ARG BASE_IMAGE_VERSION=8.10-1770223153
 
 # Build the manager binary
-FROM golang:1.25.6 AS builder
+FROM golang:1.25.7 AS builder
 
 WORKDIR /workspace
 

--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25.6 AS builder
+FROM golang:1.25.7 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/splunk/splunk-operator
 
-go 1.25.6
+go 1.25.7
 
 require (
 	cloud.google.com/go/storage v1.36.0


### PR DESCRIPTION
### Description

This PR updates the golang version to fix security vulnerabilities.

Library | Remediated Version | Details
-- | -- | --
stdlib | 1.25.7 | During session resumption in crypto/tls, if the underlying Config has its ClientCAs or RootCAs fields mutated between the initial handshake and the resumed handshake, the resumed handshake may succeed when it should have failed. This may happen when a user calls Config.Clone and mutates the returned Config, or uses Config.GetConfigForClient. This can cause a client to resume a session with a server that it would not have resumed with during the initial handshake, or cause a server to resume a session with a client that it would not have resumed with during the initial handshake.

### Key Changes

- Update golang version and dependencies

### Testing and Verification

- Smoke tests (part of PR verification)

### Related Issues

- https://splunk.atlassian.net/browse/VULN-61850

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [X] Relevant unit and integration tests are included.
- [X] Documentation has been updated accordingly.
- [X] All tests pass locally.
- [X] The PR description follows the project's guidelines.
