### PR TITLE
feat: support overriding remote queue type for ingestor + indexer clusters

### DIFF
--- a/api/v4/queue_types.go
+++ b/api/v4/queue_types.go
@@ -65,6 +65,12 @@ type SQSSpec struct {
 	Endpoint string `json:"endpoint"`
 
 	// +optional
+	// +kubebuilder:validation:Enum=sqs_smartbus;sqs_smartbus_cp
+	// +kubebuilder:default=sqs_smartbus
+	// Splunk remote queue type. Defaults to sqs_smartbus.
+	RemoteQueueType string `json:"remoteQueueType,omitempty"`
+
+	// +optional
 	// List of remote storage volumes
 	VolList []VolumeSpec `json:"volumes,omitempty"`
 }

--- a/config/crd/bases/enterprise.splunk.com_queues.yaml
+++ b/config/crd/bases/enterprise.splunk.com_queues.yaml
@@ -78,6 +78,13 @@ spec:
                     description: Name of the queue
                     minLength: 1
                     type: string
+                  remoteQueueType:
+                    default: sqs_smartbus
+                    description: Splunk remote queue type. Defaults to sqs_smartbus.
+                    enum:
+                    - sqs_smartbus
+                    - sqs_smartbus_cp
+                    type: string
                   volumes:
                     description: List of remote storage volumes
                     items:

--- a/docs/CustomResources.md
+++ b/docs/CustomResources.md
@@ -313,6 +313,7 @@ SQS message queue inputs can be found in the table below.
 | region   | string | [Required] Region where the queue is located  |
 | endpoint   | string | [Optional, if not provided formed based on region] AWS SQS Service endpoint
 | dlq   | string | [Required] Name of the dead letter queue |
+| remoteQueueType | string | [Optional] Splunk remote queue type. Allowed values: `sqs_smartbus`, `sqs_smartbus_cp`. Defaults to `sqs_smartbus`. |
 
 Change of any of the queue inputs triggers the restart of Splunk so that appropriate .conf files are correctly refreshed and consumed.
 

--- a/docs/IndexIngestionSeparation.md
+++ b/docs/IndexIngestionSeparation.md
@@ -47,6 +47,7 @@ SQS message queue inputs can be found in the table below.
 | authRegion   | string | [Required] Region where the queue is located  |
 | endpoint   | string | [Optional, if not provided formed based on authRegion] AWS SQS Service endpoint
 | dlq   | string | [Required] Name of the dead letter queue |
+| remoteQueueType | string | [Optional] Splunk remote queue type. Allowed values: `sqs_smartbus`, `sqs_smartbus_cp`. Defaults to `sqs_smartbus`. |
 | volumes | []VolumeSpec | [Optional] List of remote storage volumes used to mount the credentials for queue and bucket access (must contain s3_access_key and s3_secret_key) |
 
 **SOK doesn't support update of any of the Queue inputs except from the volumes which allow the change of secrets.**

--- a/helm-chart/splunk-enterprise/templates/enterprise_v4_queues.yaml
+++ b/helm-chart/splunk-enterprise/templates/enterprise_v4_queues.yaml
@@ -29,6 +29,9 @@ spec:
     {{- if .authRegion }}
     authRegion: {{ .authRegion | quote }}
     {{- end }}
+    {{- if .remoteQueueType }}
+    remoteQueueType: {{ .remoteQueueType | quote }}
+    {{- end }}
     {{- if .volumes }}
     volumes:
     {{ toYaml . | indent 4 }}

--- a/pkg/splunk/enterprise/indexercluster.go
+++ b/pkg/splunk/enterprise/indexercluster.go
@@ -1401,7 +1401,10 @@ func getQueueAndObjectStorageInputsForIndexerConfFiles(queue *enterpriseApi.Queu
 	endpoint := ""
 	dlq := ""
 	if queue.Provider == "sqs" {
-		queueProvider = "sqs_smartbus"
+		queueProvider = queue.SQS.RemoteQueueType
+		if queueProvider == "" {
+			queueProvider = "sqs_smartbus"
+		}
 		authRegion = queue.SQS.AuthRegion
 		endpoint = queue.SQS.Endpoint
 		dlq = queue.SQS.DLQ
@@ -1411,7 +1414,7 @@ func getQueueAndObjectStorageInputsForIndexerConfFiles(queue *enterpriseApi.Queu
 	osEndpoint := ""
 	osProvider := ""
 	if os.Provider == "s3" {
-		osProvider = "sqs_smartbus"
+		osProvider = queueProvider
 		osEndpoint = os.S3.Endpoint
 		path = os.S3.Path
 		if !strings.HasPrefix(path, "s3://") {

--- a/pkg/splunk/enterprise/indexercluster_test.go
+++ b/pkg/splunk/enterprise/indexercluster_test.go
@@ -2186,6 +2186,77 @@ func TestGetQueueAndPipelineInputsForIndexerConfFiles(t *testing.T) {
 	}, pipelineChangedFields)
 }
 
+func TestGetQueueAndPipelineInputsForIndexerConfFilesWithRemoteQueueTypeCP(t *testing.T) {
+	provider := "sqs_smartbus_cp"
+
+	queue := &enterpriseApi.Queue{
+		Spec: enterpriseApi.QueueSpec{
+			Provider: "sqs",
+			SQS: enterpriseApi.SQSSpec{
+				Name:            "test-queue",
+				AuthRegion:      "us-west-2",
+				Endpoint:        "https://sqs.us-west-2.amazonaws.com",
+				DLQ:             "sqs-dlq-test",
+				RemoteQueueType: "sqs_smartbus_cp",
+			},
+		},
+	}
+
+	os := &enterpriseApi.ObjectStorage{
+		Spec: enterpriseApi.ObjectStorageSpec{
+			Provider: "s3",
+			S3: enterpriseApi.S3Spec{
+				Endpoint: "https://s3.us-west-2.amazonaws.com",
+				Path:     "bucket/key",
+			},
+		},
+	}
+
+	key := "key"
+	secret := "secret"
+
+	queueChangedFieldsInputs, queueChangedFieldsOutputs, pipelineChangedFields := getQueueAndPipelineInputsForIndexerConfFiles(&queue.Spec, &os.Spec, key, secret)
+
+	assert.Equal(t, 10, len(queueChangedFieldsInputs))
+	assert.Equal(t, [][]string{
+		{"remote_queue.type", provider},
+		{fmt.Sprintf("remote_queue.%s.auth_region", provider), queue.Spec.SQS.AuthRegion},
+		{fmt.Sprintf("remote_queue.%s.endpoint", provider), queue.Spec.SQS.Endpoint},
+		{fmt.Sprintf("remote_queue.%s.large_message_store.endpoint", provider), os.Spec.S3.Endpoint},
+		{fmt.Sprintf("remote_queue.%s.large_message_store.path", provider), "s3://" + os.Spec.S3.Path},
+		{fmt.Sprintf("remote_queue.%s.dead_letter_queue.name", provider), queue.Spec.SQS.DLQ},
+		{fmt.Sprintf("remote_queue.%s.max_count.max_retries_per_part", provider), "4"},
+		{fmt.Sprintf("remote_queue.%s.retry_policy", provider), "max_count"},
+		{fmt.Sprintf("remote_queue.%s.access_key", provider), key},
+		{fmt.Sprintf("remote_queue.%s.secret_key", provider), secret},
+	}, queueChangedFieldsInputs)
+
+	assert.Equal(t, 12, len(queueChangedFieldsOutputs))
+	assert.Equal(t, [][]string{
+		{"remote_queue.type", provider},
+		{fmt.Sprintf("remote_queue.%s.auth_region", provider), queue.Spec.SQS.AuthRegion},
+		{fmt.Sprintf("remote_queue.%s.endpoint", provider), queue.Spec.SQS.Endpoint},
+		{fmt.Sprintf("remote_queue.%s.large_message_store.endpoint", provider), os.Spec.S3.Endpoint},
+		{fmt.Sprintf("remote_queue.%s.large_message_store.path", provider), "s3://" + os.Spec.S3.Path},
+		{fmt.Sprintf("remote_queue.%s.dead_letter_queue.name", provider), queue.Spec.SQS.DLQ},
+		{fmt.Sprintf("remote_queue.%s.max_count.max_retries_per_part", provider), "4"},
+		{fmt.Sprintf("remote_queue.%s.retry_policy", provider), "max_count"},
+		{fmt.Sprintf("remote_queue.%s.access_key", provider), key},
+		{fmt.Sprintf("remote_queue.%s.secret_key", provider), secret},
+		{fmt.Sprintf("remote_queue.%s.send_interval", provider), "5s"},
+		{fmt.Sprintf("remote_queue.%s.encoding_format", provider), "s2s"},
+	}, queueChangedFieldsOutputs)
+
+	assert.Equal(t, 5, len(pipelineChangedFields))
+	assert.Equal(t, [][]string{
+		{"pipeline:remotequeueruleset", "disabled", "false"},
+		{"pipeline:ruleset", "disabled", "true"},
+		{"pipeline:remotequeuetyping", "disabled", "false"},
+		{"pipeline:remotequeueoutput", "disabled", "false"},
+		{"pipeline:typing", "disabled", "true"},
+	}, pipelineChangedFields)
+}
+
 func TestUpdateIndexerConfFiles(t *testing.T) {
 	c := spltest.NewMockClient()
 	ctx := context.TODO()

--- a/pkg/splunk/enterprise/ingestorcluster.go
+++ b/pkg/splunk/enterprise/ingestorcluster.go
@@ -422,7 +422,10 @@ func getQueueAndObjectStorageInputsForIngestorConfFiles(queue *enterpriseApi.Que
 	endpoint := ""
 	dlq := ""
 	if queue.Provider == "sqs" {
-		queueProvider = "sqs_smartbus"
+		queueProvider = queue.SQS.RemoteQueueType
+		if queueProvider == "" {
+			queueProvider = "sqs_smartbus"
+		}
 		authRegion = queue.SQS.AuthRegion
 		endpoint = queue.SQS.Endpoint
 		dlq = queue.SQS.DLQ
@@ -432,7 +435,7 @@ func getQueueAndObjectStorageInputsForIngestorConfFiles(queue *enterpriseApi.Que
 	osEndpoint := ""
 	osProvider := ""
 	if os.Provider == "s3" {
-		osProvider = "sqs_smartbus"
+		osProvider = queueProvider
 		osEndpoint = os.S3.Endpoint
 		path = os.S3.Path
 		if !strings.HasPrefix(path, "s3://") {

--- a/pkg/splunk/enterprise/ingestorcluster_test.go
+++ b/pkg/splunk/enterprise/ingestorcluster_test.go
@@ -478,6 +478,64 @@ func TestGetQueueAndPipelineInputsForIngestorConfFiles(t *testing.T) {
 	}, pipelineInputs)
 }
 
+func TestGetQueueAndPipelineInputsForIngestorConfFilesWithRemoteQueueTypeCP(t *testing.T) {
+	provider := "sqs_smartbus_cp"
+
+	queue := enterpriseApi.Queue{
+		Spec: enterpriseApi.QueueSpec{
+			Provider: "sqs",
+			SQS: enterpriseApi.SQSSpec{
+				Name:            "test-queue",
+				AuthRegion:      "us-west-2",
+				Endpoint:        "https://sqs.us-west-2.amazonaws.com",
+				DLQ:             "sqs-dlq-test",
+				RemoteQueueType: "sqs_smartbus_cp",
+			},
+		},
+	}
+
+	os := enterpriseApi.ObjectStorage{
+		Spec: enterpriseApi.ObjectStorageSpec{
+			Provider: "s3",
+			S3: enterpriseApi.S3Spec{
+				Endpoint: "https://s3.us-west-2.amazonaws.com",
+				Path:     "bucket/key",
+			},
+		},
+	}
+
+	key := "key"
+	secret := "secret"
+
+	queueInputs, pipelineInputs := getQueueAndPipelineInputsForIngestorConfFiles(&queue.Spec, &os.Spec, key, secret)
+
+	assert.Equal(t, 12, len(queueInputs))
+	assert.Equal(t, [][]string{
+		{"remote_queue.type", provider},
+		{fmt.Sprintf("remote_queue.%s.auth_region", provider), queue.Spec.SQS.AuthRegion},
+		{fmt.Sprintf("remote_queue.%s.endpoint", provider), queue.Spec.SQS.Endpoint},
+		{fmt.Sprintf("remote_queue.%s.large_message_store.endpoint", provider), os.Spec.S3.Endpoint},
+		{fmt.Sprintf("remote_queue.%s.large_message_store.path", provider), "s3://" + os.Spec.S3.Path},
+		{fmt.Sprintf("remote_queue.%s.dead_letter_queue.name", provider), queue.Spec.SQS.DLQ},
+		{fmt.Sprintf("remote_queue.%s.encoding_format", provider), "s2s"},
+		{fmt.Sprintf("remote_queue.%s.max_count.max_retries_per_part", provider), "4"},
+		{fmt.Sprintf("remote_queue.%s.retry_policy", provider), "max_count"},
+		{fmt.Sprintf("remote_queue.%s.send_interval", provider), "5s"},
+		{fmt.Sprintf("remote_queue.%s.access_key", provider), key},
+		{fmt.Sprintf("remote_queue.%s.secret_key", provider), secret},
+	}, queueInputs)
+
+	assert.Equal(t, 6, len(pipelineInputs))
+	assert.Equal(t, [][]string{
+		{"pipeline:remotequeueruleset", "disabled", "false"},
+		{"pipeline:ruleset", "disabled", "true"},
+		{"pipeline:remotequeuetyping", "disabled", "false"},
+		{"pipeline:remotequeueoutput", "disabled", "false"},
+		{"pipeline:typing", "disabled", "true"},
+		{"pipeline:indexerPipe", "disabled", "true"},
+	}, pipelineInputs)
+}
+
 func TestUpdateIngestorConfFiles(t *testing.T) {
 	c := spltest.NewMockClient()
 	ctx := context.TODO()


### PR DESCRIPTION
### Description

Supports overriding remote queue type to ensure we can adjust for cloud builds

### Key Changes

Adds new optional `remoteQueueType` field for queue types

### Testing and Verification

Units tests

### Related Issues

### PR Checklist

- [ ] Code changes adhere to the project's coding standards.
- [x] Relevant unit and integration tests are included.
- [x] Documentation has been updated accordingly.
- [x] All tests pass locally.
- [ ] The PR description follows the project's guidelines.
