### PR TITLE
Revert "Fix app_tel_for_sok app.conf install stanza header (#1724)"

### DIFF
--- a/.github/workflows/arm-AL2023-build-test-push-workflow-AL2023.yml
+++ b/.github/workflows/arm-AL2023-build-test-push-workflow-AL2023.yml
@@ -49,7 +49,6 @@ jobs:
      - name: Run Unit Tests
        run: make test
      - name: Run Code Coverage
-       if: ${{ secrets.COVERALLS_TOKEN != '' }}
        run: goveralls -coverprofile=coverage.out -service=circle-ci -repotoken ${{ secrets.COVERALLS_TOKEN }}
      - name: Upload Coverage artifacts
        uses: actions/upload-artifact@v4.4.0

--- a/.github/workflows/arm-Ubuntu-build-test-push-workflow.yml
+++ b/.github/workflows/arm-Ubuntu-build-test-push-workflow.yml
@@ -49,7 +49,6 @@ jobs:
      - name: Run Unit Tests
        run: make test
      - name: Run Code Coverage
-       if: ${{ secrets.COVERALLS_TOKEN != '' }}
        run: goveralls -coverprofile=coverage.out -service=circle-ci -repotoken ${{ secrets.COVERALLS_TOKEN }}
      - name: Upload Coverage artifacts
        uses: actions/upload-artifact@v4.4.0

--- a/.github/workflows/build-test-push-workflow.yml
+++ b/.github/workflows/build-test-push-workflow.yml
@@ -61,7 +61,6 @@ jobs:
         run: |
           make test
       - name: Run Code Coverage
-        if: ${{ secrets.COVERALLS_TOKEN != '' }}
         run: goveralls -shallow -coverprofile=coverage.out -service=circle-ci -repotoken ${{ secrets.COVERALLS_TOKEN }}
       - name: Upload Coverage artifacts
         uses: actions/upload-artifact@v4.4.0

--- a/.github/workflows/distroless-build-test-push-workflow.yml
+++ b/.github/workflows/distroless-build-test-push-workflow.yml
@@ -55,7 +55,6 @@ jobs:
       - name: Run Unit Tests
         run: make test
       - name: Run Code Coverage
-        if: ${{ secrets.COVERALLS_TOKEN != '' }}
         run: goveralls -shallow -coverprofile=coverage.out -service=circle-ci -repotoken ${{ secrets.COVERALLS_TOKEN }}
       - name: Upload Coverage artifacts
         uses: actions/upload-artifact@v4.4.0

--- a/.github/workflows/prodsec-workflow.yml
+++ b/.github/workflows/prodsec-workflow.yml
@@ -39,7 +39,6 @@ jobs:
       id: dotenv
       uses: falti/dotenv-action@d4d12eaa0e1dd06d5bdc3d7af3bf4c8c93cb5359
     - name: Run FOSSA Test
-      if: ${{ secrets.FOSSA_API_TOKEN != '' }}
       uses: fossas/fossa-action@main
       with:
         api-key: ${{secrets.FOSSA_API_TOKEN}}

--- a/pkg/splunk/enterprise/names.go
+++ b/pkg/splunk/enterprise/names.go
@@ -201,10 +201,10 @@ access = read : [ * ], write : [ admin ]
 `
 
 	// Command to create telemetry app on non SHC scenarios
-	createTelAppNonShcString = "mkdir -p /opt/splunk/etc/apps/app_tel_for_sok/default/; mkdir -p /opt/splunk/etc/apps/app_tel_for_sok/metadata/; printf '%%s' \"%s\" > /opt/splunk/etc/apps/app_tel_for_sok/default/app.conf; printf '%%s' \"%s\" > /opt/splunk/etc/apps/app_tel_for_sok/metadata/default.meta"
+	createTelAppNonShcString = "mkdir -p /opt/splunk/etc/apps/app_tel_for_sok/default/; mkdir -p /opt/splunk/etc/apps/app_tel_for_sok/metadata/; echo -e \"%s\" > /opt/splunk/etc/apps/app_tel_for_sok/default/app.conf; echo -e \"%s\" > /opt/splunk/etc/apps/app_tel_for_sok/metadata/default.meta"
 
 	// Command to create telemetry app on SHC scenarios
-	createTelAppShcString = "mkdir -p %s/app_tel_for_sok/default/; mkdir -p %s/app_tel_for_sok/metadata/; printf '%%s' \"%s\" > %s/app_tel_for_sok/default/app.conf; printf '%%s' \"%s\" > %s/app_tel_for_sok/metadata/default.meta"
+	createTelAppShcString = "mkdir -p %s/app_tel_for_sok/default/; mkdir -p %s/app_tel_for_sok/metadata/; echo -e \"%s\" > %s/app_tel_for_sok/default/app.conf; echo -e \"%s\" > %s/app_tel_for_sok/metadata/default.meta"
 
 	// Command to reload app configuration
 	telAppReloadString = "curl -k -u admin:`cat /mnt/splunk-secrets/password` https://localhost:8089/services/apps/local/_reload"

--- a/pkg/splunk/enterprise/names.go
+++ b/pkg/splunk/enterprise/names.go
@@ -201,10 +201,10 @@ access = read : [ * ], write : [ admin ]
 `
 
 	// Command to create telemetry app on non SHC scenarios
-	createTelAppNonShcString = "mkdir -p /opt/splunk/etc/apps/app_tel_for_sok/default/; mkdir -p /opt/splunk/etc/apps/app_tel_for_sok/metadata/; echo -e \"%s\" > /opt/splunk/etc/apps/app_tel_for_sok/default/app.conf; echo -e \"%s\" > /opt/splunk/etc/apps/app_tel_for_sok/metadata/default.meta"
+	createTelAppNonShcString = "mkdir -p /opt/splunk/etc/apps/app_tel_for_sok/default/; mkdir -p /opt/splunk/etc/apps/app_tel_for_sok/metadata/; printf '%%s' \"%s\" > /opt/splunk/etc/apps/app_tel_for_sok/default/app.conf; printf '%%s' \"%s\" > /opt/splunk/etc/apps/app_tel_for_sok/metadata/default.meta"
 
 	// Command to create telemetry app on SHC scenarios
-	createTelAppShcString = "mkdir -p %s/app_tel_for_sok/default/; mkdir -p %s/app_tel_for_sok/metadata/; echo -e \"%s\" > %s/app_tel_for_sok/default/app.conf; echo -e \"%s\" > %s/app_tel_for_sok/metadata/default.meta"
+	createTelAppShcString = "mkdir -p %s/app_tel_for_sok/default/; mkdir -p %s/app_tel_for_sok/metadata/; printf '%%s' \"%s\" > %s/app_tel_for_sok/default/app.conf; printf '%%s' \"%s\" > %s/app_tel_for_sok/metadata/default.meta"
 
 	// Command to reload app configuration
 	telAppReloadString = "curl -k -u admin:`cat /mnt/splunk-secrets/password` https://localhost:8089/services/apps/local/_reload"


### PR DESCRIPTION
This reverts commit `7fa8698921a131ac7f120d8afb57a5e82d55f60c` from PR #1724.

Reason:
- Push workflows on `develop` started failing at workflow startup (no jobs created) after #1724 merged.
- #1724 bundled workflow secret-guard changes together with the telemetry app change, so this revert restores a healthy baseline first.

After this revert merges, I will recreate a clean PR with only the intended telemetry app fix in `pkg/splunk/enterprise/names.go`.
