### PR TITLE
Recreate telemetry app install stanza fix from #1724

### DIFF
--- a/pkg/splunk/enterprise/names.go
+++ b/pkg/splunk/enterprise/names.go
@@ -201,10 +201,10 @@ access = read : [ * ], write : [ admin ]
 `
 
 	// Command to create telemetry app on non SHC scenarios
-	createTelAppNonShcString = "mkdir -p /opt/splunk/etc/apps/app_tel_for_sok/default/; mkdir -p /opt/splunk/etc/apps/app_tel_for_sok/metadata/; echo -e \"%s\" > /opt/splunk/etc/apps/app_tel_for_sok/default/app.conf; echo -e \"%s\" > /opt/splunk/etc/apps/app_tel_for_sok/metadata/default.meta"
+	createTelAppNonShcString = "mkdir -p /opt/splunk/etc/apps/app_tel_for_sok/default/; mkdir -p /opt/splunk/etc/apps/app_tel_for_sok/metadata/; printf '%%s' \"%s\" > /opt/splunk/etc/apps/app_tel_for_sok/default/app.conf; printf '%%s' \"%s\" > /opt/splunk/etc/apps/app_tel_for_sok/metadata/default.meta"
 
 	// Command to create telemetry app on SHC scenarios
-	createTelAppShcString = "mkdir -p %s/app_tel_for_sok/default/; mkdir -p %s/app_tel_for_sok/metadata/; echo -e \"%s\" > %s/app_tel_for_sok/default/app.conf; echo -e \"%s\" > %s/app_tel_for_sok/metadata/default.meta"
+	createTelAppShcString = "mkdir -p %s/app_tel_for_sok/default/; mkdir -p %s/app_tel_for_sok/metadata/; printf '%%s' \"%s\" > %s/app_tel_for_sok/default/app.conf; printf '%%s' \"%s\" > %s/app_tel_for_sok/metadata/default.meta"
 
 	// Command to reload app configuration
 	telAppReloadString = "curl -k -u admin:`cat /mnt/splunk-secrets/password` https://localhost:8089/services/apps/local/_reload"


### PR DESCRIPTION
This PR recreates only the intended telemetry app fix from #1724:
- `pkg/splunk/enterprise/names.go`

It intentionally excludes the workflow secret-guard edits that caused workflow startup failures on `develop`.

Base is set to `revert-pr-1724-telemetry-workflow-guards` so this can be reviewed in sequence with the revert PR #1728.
After #1728 merges, retarget this PR to `develop` and merge.
