### PR TITLE
docs: modernize CONTRIBUTING guide for current SOK workflow

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -3,205 +3,216 @@ title: CONTRIBUTING
 nav_order: 7
 ---
 
-# Contributing to the Project
+# Contributing to Splunk Operator for Kubernetes
 
-This document is the single source of truth on contributing towards this codebase. Feel free to browse the [open issues](https://github.com/splunk/splunk-operator/issues) and file new ones - all feedback is welcome!
+Thanks for contributing to Splunk Operator for Kubernetes (SOK).
+This guide describes how to contribute changes that are easy to review, safe to run, and aligned with this repository's workflow.
 
-## Navigation
+## Table of Contents
 
-- [Contributing to the Project](#contributing-to-the-project)
-  - [Navigation](#navigation)
-  - [Prerequisites](#prerequisites)
-      - [Contributor License Agreement](#contributor-license-agreement)
-      - [Code of Conduct](#code-of-conduct)
-  - [Contribution Workflow](#contribution-workflow)
-      - [Bug reports and feature requests](#bug-reports-and-feature-requests)
-      - [Fixing issues](#fixing-issues)
-      - [Pull requests](#pull-requests)
-      - [Maintainer Workflow for External Contributions](#maintainer-workflow-for-external-contributions)
-      - [Code Review](#code-review)
-      - [Testing](#testing)
-      - [Documentation](#documentation)
-  - [Maintainers](#maintainers)
+- [Quick Start](#quick-start)
+- [Before You Start](#before-you-start)
+- [Local Development Setup](#local-development-setup)
+- [Contribution Workflow](#contribution-workflow)
+- [Testing Expectations](#testing-expectations)
+- [Pull Request Expectations](#pull-request-expectations)
+- [Maintainer Workflow for External Contributions](#maintainer-workflow-for-external-contributions)
+- [Code Review and Merge Criteria](#code-review-and-merge-criteria)
+- [Documentation Contributions](#documentation-contributions)
+- [Security Reporting](#security-reporting)
+- [Getting Help](#getting-help)
 
-## Prerequisites
-When contributing to this repository, first discuss the issue with a [repository maintainer](#maintainers) via GitHub issue, Slack message, or email.
+## Quick Start
 
-#### Contributor License Agreement
-We only accept pull requests submitted from:
-* Splunk employees
-* Individuals who have signed the [Splunk Contributor License Agreement](https://www.splunk.com/en_us/form/contributions.html)
+1. Fork the repository and branch from `develop`.
+1. Implement your change.
+1. Run local validation:
+   ```bash
+   make fmt vet
+   make test
+   make build
+   ```
+1. If you changed API types (`api/**`), regenerate generated artifacts:
+   ```bash
+   make manifests generate
+   ```
+1. Open a PR against `develop` using the repository PR template.
 
-#### Code of Conduct
-All contributors are expected to read our [Code of Conduct](contributing/code-of-conduct.md) and observe it in all interactions involving this project.
+## Before You Start
+
+### Align on non-trivial changes
+
+For medium/large features, behavior changes, or refactors, open or discuss an issue first.
+This reduces rework and helps align scope, implementation, and testing strategy.
+
+### Contributor License Agreement (CLA)
+
+Contributions are accepted from:
+- Splunk employees
+- External contributors who have signed the Splunk CLA
+
+CLA workflow is enforced by GitHub checks.
+
+### Code of Conduct (COC)
+
+All contributors must follow the Code of Conduct:
+https://github.com/splunk/cla-agreement/blob/main/CODE_OF_CONDUCT.md
+
+COC acceptance is also enforced by GitHub checks.
+
+### How to satisfy CLA/COC checks
+
+If checks fail, add the exact PR comments below:
+
+- `I have read the CLA Document and I hereby sign the CLA`
+- `I have read the Code of Conduct and I hereby sign the COC`
+
+You can retrigger the agreements workflow with:
+
+- `recheck`
+
+## Local Development Setup
+
+Key tool versions are maintained in `.env` (for example `GO_VERSION`, `OPERATOR_SDK_VERSION`).
+
+Useful commands:
+
+```bash
+make help
+make fmt
+make vet
+make test
+make build
+```
+
+If you modify user-facing behavior, update documentation in `docs/`.
 
 ## Contribution Workflow
-Help is always welcome! For example, documentation can always use improvement. There's always code that can be clarified, functionality that can be extended, and tests to be added to guarantee behavior. If you see something you think should be fixed, don't be afraid to own it.
 
-#### Bug reports and feature requests
-Have ideas on improvements? See something that needs work? While the community encourages everyone to contribute code, it is also appreciated when someone reports an issue. Please report any issues or bugs you find through our [issue tracker](https://github.com/splunk/splunk-operator/issues).
+### Branching
 
-If you are reporting a bug, please include:
-* Your operating system name and version
-* Details about your local setup that might be helpful in troubleshooting (e.g. Kubernetes Version, Container Platform, Ansible version, etc.)
-* Detailed steps to reproduce the bug
+- Base branch: `develop`
+- Use one short-lived branch per change
+- Keep each PR focused on one logical objective
 
-We'd also like to hear your feature suggestions. Feel free to submit them as issues by:
-* Explaining in detail how they should work
-* Keeping the scope as narrow as possible. This will make it easier to implement
+Example:
 
-#### Fixing issues
-Look through our [issue tracker](https://github.com/splunk/splunk-operator/issues) to find problems to fix! Feel free to comment and tag corresponding stakeholders or full-time maintainers of this project with any questions or concerns.
-
-#### Pull requests
-A pull request informs the project's core developers about the changes you want to review and merge. Once you submit a pull request, it enters a stage of code review where you and others can discuss its potential modifications and add more commits later on.
-
-To learn more, see [Proposing changes to your work with pull requests
-](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/proposing-changes-to-your-work-with-pull-requests) in the [GitHub Help Center](https://help.github.com/).
-
-To make a pull request against this project:
-1. Fork the [splunk-operator GitHub repository](https://github.com/splunk/splunk-operator/).
-1. Clone your fork and create a branch off of `develop`.
-    ```
-    # Create a local copy (or clone) of the repository
-    $ git clone git@github.com:YOUR_GITHUB_USERNAME/splunk-operator.git
-    $ cd splunk-operator
-
-    # Create your feature/bugfix branch
-    $ git checkout -b your-branch-name develop
-    ```
-1. Run tests to verify your environment.
-    ```
-    $ cd splunk-operator
-    $ make test
-    ```
-1. Push your changes once your tests have passed.
-    ```
-    # Add the files to the queue of changes
-    $ git add <modified file(s)>
-
-    # Commit the change to your repo with a log message
-    $ git commit -m "<helpful commit message>"
-
-    # Push the change to the remote repository
-    $ git push
-    ```
-1. Submit a pull request through the GitHub website using the changes from your forked codebase
-
-#### Maintainer Workflow for External Contributions
-
-When a pull request is submitted from a forked repository (external contributor), the CI/CD pipeline running on the fork will not have access to our internal test infrastructure. To properly test these contributions, maintainers should follow this workflow:
-
-1. **Initial Review**: Before running any code on internal infrastructure, thoroughly review the pull request to verify it is safe to execute. Check for:
-   - **Security concerns**: No malicious code, credential harvesting, or unauthorized access attempts
-   - **Resource safety**: No code that could damage or overload internal infrastructure
-   - **Code quality**: Adherence to project standards and coding conventions
-   - **Overall approach**: Changes align with project goals and architecture
-   
-   **Only proceed to the next step if you are confident the changes are safe to run on internal infrastructure.**
-
-2. **Pull and Push to Internal Branch**: Once the initial review is satisfactory and you want to run the full test suite:
-   ```bash
-   # Add the contributor's fork as a remote (one-time setup per contributor)
-   $ git remote add contributor-name https://github.com/CONTRIBUTOR_USERNAME/splunk-operator.git
-
-   # Fetch the contributor's branch
-   $ git fetch contributor-name their-branch-name
-
-   # Create a new branch in the main repository based on their work
-   $ git checkout -b external/contributor-name/their-branch-name contributor-name/their-branch-name
-
-   # Push to the main repository
-   $ git push origin external/contributor-name/their-branch-name
-   ```
-
-3. **Run CI/CD Pipeline**: The pipeline will now run with full access to internal test infrastructure, including:
-   - Integration tests requiring cloud provider credentials
-   - Access to private test clusters
-   - Internal performance testing environments
-
-4. **Review Test Results**: Monitor the pipeline execution and review all test results.
-
-5. **Communicate Findings**: If tests fail or changes are needed:
-   - Comment on the original pull request with detailed feedback
-   - Request changes from the contributor
-   - Once the contributor updates their PR, repeat this process
-
-6. **Merge**: Once all tests pass and the code is approved:
-   - Merge the original pull request from the fork (not the internal branch)
-   - Delete the internal test branch
-   ```bash
-   $ git push origin --delete external/contributor-name/their-branch-name
-   ```
-
-**Important Notes:**
-- Always maintain clear communication with external contributors about the testing process
-- The internal test branch is temporary and should be deleted after the PR is merged or closed
-- This workflow ensures external contributions receive the same level of testing as internal changes
-- Never merge the internal test branch directly; always merge the original PR from the fork
-
-#### Code Review
-There are two aspects of code review: giving and receiving.
-
-A PR is easy to review if you:
-* Follow the project coding conventions.
-* Write good commit messages, concise and descriptive.
-* Break large changes into a logical series of smaller patches. Patches individually make easily understandable changes, and in aggregate, solve a broader issue.
-
-Reviewers are highly encouraged to revisit the [Code of Conduct](contributing/code-of-conduct.md) and must go above and beyond to promote a collaborative, respectful community.
-
-When reviewing PRs from others, [The Gentle Art of Patch Review](http://sage.thesharps.us/2014/09/01/the-gentle-art-of-patch-review/) suggests an iterative series of focuses, designed to lead new contributors to positive collaboration without inundating them initially with nuances:
-* Is the idea behind the contribution sound?
-* Is the contribution architected correctly?
-* Is the contribution polished?
-
-Merge requirements for this project:
-* at least 2 approvals
-* a passing build from our continuous integration system.
-
-Any new commits to an open pull request will automatically dismiss old reviews and trigger another build.
-
-#### Testing
-Testing is the responsibility of all contributors. To run Unit Tests in Splunk Operator code, you can run below command -
-```
-$ make test
+```bash
+git checkout develop
+git pull
+git checkout -b your-branch-name
 ```
 
-#### Documentation
-We can always use improvements to our documentation! Anyone can contribute to these docs, whether you identify as a developer, an end user, or someone who just can’t stand seeing typos. What exactly is needed?
+### Commits
 
-1. More complementary documentation. Have you found something unclear?
-1. More examples or generic templates that others can use.
-1. Blog posts, articles and such – they’re all very appreciated.
+- Keep commits small and coherent
+- Use clear commit messages
+- Avoid mixing unrelated cleanup with functional changes
 
-You can also edit documentation files directly in the GitHub web interface, without creating a local copy. This can be convenient for small typos or grammar fixes.
+### Push and open PR
 
-## Maintainers
-
-If you need help, tag one of the active maintainers of this project in a post or comment. We'll do our best to reach out to you as quickly as we can.
-
+```bash
+git add <files>
+git commit -m "<concise and descriptive message>"
+git push -u origin your-branch-name
 ```
-# Active maintainers marked with (*)
 
-(*) Vivek Reddy
-(*) Raizel Lieberman
-(*) Patryk Wasielewski
-(*) Igor Grzankowski
-(*) Kasia Kozioł
-(*) Jakub Buczak
-(*) Qing Wang
-(*) Gabriel Mendoza
-(*) Minjie Qiu
-(*) Yuhan Yang
-() Sirish Mohan
-() Gaurav Gupta
-() Subba Gontla
-() Arjun Kondur
-() Kriti Ashok
-() Param Dhanoya
-() Victor Ebken
-() Ajeet Kumar
-() Jeff Rybczynski
-() Patrick Ogdin
+Then open a PR against `develop`.
 
+## Testing Expectations
+
+At minimum, run for code changes:
+
+```bash
+make fmt vet
+make test
+make build
 ```
+
+For API/CRD changes:
+
+```bash
+make manifests generate
+```
+
+Integration test suites are located under `test/` and workflow-based integration jobs run in GitHub Actions.
+Use targeted test runs when possible and include evidence in your PR description.
+
+## Pull Request Expectations
+
+A strong PR includes:
+
+- Clear problem statement and scope
+- Summary of key changes
+- Test evidence (commands + outcomes)
+- Related issue/Jira/support references
+- Documentation updates when behavior changes
+
+Use `.github/pull_request_template.md` as the baseline checklist.
+
+## Maintainer Workflow for External Contributions
+
+PRs from forks do not have access to all internal credentials and environments.
+When full internal validation is needed, maintainers should:
+
+1. Perform an initial safety review (security, resource usage, overall approach).
+1. Fetch contributor branch and push it to a temporary internal branch.
+1. Run full CI/internal test workflows from that temporary branch.
+1. Report results on the original PR and request updates if needed.
+1. Merge the original PR when approved.
+1. Delete the temporary internal branch.
+
+Example:
+
+```bash
+git remote add contributor-name https://github.com/CONTRIBUTOR_USERNAME/splunk-operator.git
+git fetch contributor-name their-branch-name
+git checkout -b external/contributor-name/their-branch-name contributor-name/their-branch-name
+git push origin external/contributor-name/their-branch-name
+```
+
+Cleanup:
+
+```bash
+git push origin --delete external/contributor-name/their-branch-name
+```
+
+Never merge the temporary internal branch directly.
+
+## Code Review and Merge Criteria
+
+Review principles:
+
+- Validate design correctness first
+- Validate behavior and test coverage second
+- Validate polish/maintainability third
+
+Current merge requirements:
+
+- At least 2 approvals
+- Passing required CI checks
+
+New commits can dismiss previous approvals and retrigger checks.
+
+## Documentation Contributions
+
+Documentation updates are welcome and encouraged:
+
+- Clarify existing behavior
+- Add examples and troubleshooting
+- Fix typos, stale instructions, or broken links
+
+For docs-only changes, editing directly in GitHub is acceptable for small fixes.
+
+## Security Reporting
+
+Do not post sensitive vulnerability details publicly.
+If you are a Splunk customer, report via Splunk Support:
+https://www.splunk.com/support
+
+For regular bug reports and non-sensitive issues, use GitHub Issues.
+
+## Getting Help
+
+Use GitHub Issues for questions, bugs, and enhancement discussions.
+Please use the appropriate issue template in `.github/ISSUE_TEMPLATE/` whenever possible.


### PR DESCRIPTION
## Summary

Rewrites `docs/CONTRIBUTING.md` to align with the current Splunk Operator workflow and open source contribution best practices.

## What Changed

- Replaced the old, long-form guide with a task-oriented structure:
  - Quick start
  - Local setup
  - Branching/PR flow
  - Testing expectations
  - External contributor CI/maintainer flow
  - Review and merge criteria
  - Security reporting and support path
- Added explicit CLA/COC signing instructions, including exact comment text and `recheck` behavior.
- Updated commands and expectations to match this repository (`make fmt vet test build`, `make manifests generate` for API changes).
- Removed static maintainer roster (which can go stale) in favor of process-oriented guidance.

## Why

The previous guide had useful content but mixed contributor and maintainer details with older references and less actionable structure. This rewrite improves:

- discoverability for new contributors,
- consistency with current CI/CD behavior,
- clarity of merge expectations,
- maintainability of docs over time.

## Scope

Docs only. No code or workflow logic changes.
