### PR TITLE
[SPIKE] Gate secret-dependent workflows for fork PRs

### DIFF
--- a/.github/workflows/build-test-push-workflow.yml
+++ b/.github/workflows/build-test-push-workflow.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           go-version: ${{ steps.dotenv.outputs.GO_VERSION }}
       - name: Install goveralls
+        if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.COVERALLS_TOKEN != '' }}
         run: |
           go version
           go install github.com/mattn/goveralls@latest
@@ -61,7 +62,7 @@ jobs:
         run: |
           make test
       - name: Run Code Coverage
-        if: ${{ secrets.COVERALLS_TOKEN != '' }}
+        if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.COVERALLS_TOKEN != '' }}
         run: goveralls -shallow -coverprofile=coverage.out -service=circle-ci -repotoken ${{ secrets.COVERALLS_TOKEN }}
       - name: Upload Coverage artifacts
         uses: actions/upload-artifact@v4.4.0
@@ -69,6 +70,7 @@ jobs:
           name: coverage.out
           path: coverage.out
   build-operator-image:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     needs: [check-formating, unit-tests]
     env:
@@ -121,6 +123,7 @@ jobs:
         COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
         COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
   vulnerability-scan:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       actions: read
       contents: read
@@ -175,6 +178,7 @@ jobs:
       with:
         sarif_file: 'trivy-results.sarif'
   smoke-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: vulnerability-scan
     strategy:
       fail-fast: false

--- a/.github/workflows/distroless-build-test-push-workflow.yml
+++ b/.github/workflows/distroless-build-test-push-workflow.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           go-version: ${{ steps.dotenv.outputs.GO_VERSION }}
       - name: Install goveralls
+        if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.COVERALLS_TOKEN != '' }}
         run: |
           go version
           go install github.com/mattn/goveralls@latest
@@ -55,7 +56,7 @@ jobs:
       - name: Run Unit Tests
         run: make test
       - name: Run Code Coverage
-        if: ${{ secrets.COVERALLS_TOKEN != '' }}
+        if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.COVERALLS_TOKEN != '' }}
         run: goveralls -shallow -coverprofile=coverage.out -service=circle-ci -repotoken ${{ secrets.COVERALLS_TOKEN }}
       - name: Upload Coverage artifacts
         uses: actions/upload-artifact@v4.4.0
@@ -63,6 +64,7 @@ jobs:
           name: coverage.out
           path: coverage.out
   build-operator-image:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     needs: unit-tests
     env:
@@ -170,6 +172,7 @@ jobs:
 #        with:
 #          sarif_file: 'trivy-results.sarif'
   smoke-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: build-operator-image
     strategy:
       fail-fast: false

--- a/.github/workflows/prodsec-workflow.yml
+++ b/.github/workflows/prodsec-workflow.yml
@@ -17,6 +17,7 @@ on:
     - '*.md'
 jobs:
   semgrep:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     name: Semgrep Scanner
     runs-on: ubuntu-24.04
     env:
@@ -27,6 +28,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: semgrep ci
   FOSSA-scanner:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     env:
       SPLUNK_ENTERPRISE_IMAGE: ${{ secrets.SPLUNK_ENTERPRISE_IMAGE }}


### PR DESCRIPTION
## Summary
This spike updates PR workflows so external fork PRs do not fail on missing secrets.

## What changed
- Added trust guards for secret-dependent jobs in:
  - `.github/workflows/build-test-push-workflow.yml`
  - `.github/workflows/distroless-build-test-push-workflow.yml`
  - `.github/workflows/prodsec-workflow.yml`
- Coveralls/FOSSA and AWS/ECR dependent jobs now run only for:
  - push events, or
  - pull requests where `head.repo.full_name == github.repository`

## Expected behavior
- External contributors from forks: non-secret checks run; secret-dependent jobs are skipped.
- Internal PRs and branch pushes: full pipeline remains active.

## Notes
This is intentionally a spike PR to validate required-check behavior with branch protection settings.
