### PR TITLE
Finalizers for postgrescluster

### DIFF
--- a/api/v4/postgrescluster_types.go
+++ b/api/v4/postgrescluster_types.go
@@ -45,7 +45,7 @@ type ManagedRole struct {
 // Validation rules ensure immutability of Class, and that Storage and PostgresVersion can only be set once and cannot be removed or downgraded.
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.postgresVersion) || (has(self.postgresVersion) && int(self.postgresVersion.split('.')[0]) >= int(oldSelf.postgresVersion.split('.')[0]))",messageExpression="!has(self.postgresVersion) ? 'postgresVersion cannot be removed once set (was: ' + oldSelf.postgresVersion + ')' : 'postgresVersion major version cannot be downgraded (from: ' + oldSelf.postgresVersion + ', to: ' + self.postgresVersion + ')'"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.storage) || (has(self.storage) && quantity(self.storage).compareTo(quantity(oldSelf.storage)) >= 0)",messageExpression="!has(self.storage) ? 'storage cannot be removed once set (was: ' + string(oldSelf.storage) + ')' : 'storage size cannot be decreased (from: ' + string(oldSelf.storage) + ', to: ' + string(self.storage) + ')'"
-// +kubebuilder:validation:XValidation:rule="!has(self.connectionPoolerEnabled) || !self.connectionPoolerEnabled || has(self.connectionPoolerConfig)",message="connectionPoolerConfig must be set when connectionPoolerEnabled is true"
+// +kubebuilder:validation:XValidation:rule="!has(self.connectionPoolerConfig)",message="connectionPoolerConfig cannot be overridden on PostgresCluster"
 type PostgresClusterSpec struct {
 	// This field is IMMUTABLE after creation.
 	// +kubebuilder:validation:Required
@@ -97,7 +97,6 @@ type PostgresClusterSpec struct {
 	// +optional
 	ConnectionPoolerEnabled *bool `json:"connectionPoolerEnabled,omitempty"`
 
-	// ConnectionPoolerConfig overrides the connection pooler configuration from the class.
 	// Only takes effect when connection pooling is enabled.
 	// +optional
 	ConnectionPoolerConfig *ConnectionPoolerConfig `json:"connectionPoolerConfig,omitempty"`
@@ -109,6 +108,12 @@ type PostgresClusterSpec struct {
 	// +listType=map
 	// +listMapKey=name
 	ManagedRoles []ManagedRole `json:"managedRoles,omitempty"`
+
+	// ClusterDeletionPolicy controls the deletion behavior of the underlying CNPG Cluster when the PostgresCluster is deleted.
+	// +kubebuilder:validation:Enum=Delete;Retain
+	// +kubebuilder:default=Retain
+	// +optional
+	ClusterDeletionPolicy string `json:"clusterDeletionPolicy,omitempty"`
 }
 
 // PostgresClusterResources defines references to Kubernetes resources related to the PostgresCluster, such as ConfigMaps and Secrets.

--- a/api/v4/postgresclusterclass_types.go
+++ b/api/v4/postgresclusterclass_types.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// +kubebuilder:validation:XValidation:rule="!has(self.config) || !has(self.config.connectionPoolerEnabled) || !self.config.connectionPoolerEnabled || (has(self.cnpg) && has(self.cnpg.connectionPooler))",message="cnpg.connectionPooler must be set when config.connectionPoolerEnabled is true"
 // PostgresClusterClassSpec defines the desired state of PostgresClusterClass.
 // PostgresClusterClass is immutable after creation - it serves as a template for Cluster CRs.
 type PostgresClusterClassSpec struct {

--- a/config/crd/bases/enterprise.splunk.com_postgresclusterclasses.yaml
+++ b/config/crd/bases/enterprise.splunk.com_postgresclusterclasses.yaml
@@ -244,6 +244,11 @@ spec:
             required:
             - provisioner
             type: object
+            x-kubernetes-validations:
+            - message: cnpg.connectionPooler must be set when config.connectionPoolerEnabled
+                is true
+              rule: '!has(self.config) || !has(self.config.connectionPoolerEnabled)
+                || !self.config.connectionPoolerEnabled || (has(self.cnpg) && has(self.cnpg.connectionPooler))'
           status:
             description: PostgresClusterClassStatus defines the observed state of
               PostgresClusterClass.

--- a/config/crd/bases/enterprise.splunk.com_postgresclusters.yaml
+++ b/config/crd/bases/enterprise.splunk.com_postgresclusters.yaml
@@ -58,10 +58,65 @@ spec:
                 x-kubernetes-validations:
                 - message: class is immutable
                   rule: self == oldSelf
+              cnpg:
+                description: CNPG contains the resolved CloudNativePG-specific configuration,
+                  merged from the class.
+                properties:
+                  connectionPooler:
+                    description: |-
+                      ConnectionPooler contains PgBouncer connection pooler configuration.
+                      When enabled, creates RW and RO pooler deployments for clusters using this class.
+                    properties:
+                      config:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Config contains PgBouncer configuration parameters.
+                          Passed directly to CNPG Pooler spec.pgbouncer.parameters.
+                          See: https://cloudnative-pg.io/docs/1.28/connection_pooling/#pgbouncer-configuration-options
+                        type: object
+                      instances:
+                        default: 3
+                        description: |-
+                          Instances is the number of PgBouncer pod replicas.
+                          Higher values provide better availability and load distribution.
+                        format: int32
+                        maximum: 10
+                        minimum: 1
+                        type: integer
+                      mode:
+                        default: transaction
+                        description: Mode defines the connection pooling strategy.
+                        enum:
+                        - session
+                        - transaction
+                        - statement
+                        type: string
+                    type: object
+                  primaryUpdateMethod:
+                    default: switchover
+                    description: |-
+                      PrimaryUpdateMethod determines how the primary instance is updated.
+                      "restart" - tolerate brief downtime (suitable for development)
+                      "switchover" - minimal downtime via automated failover (production-grade)
+
+                      NOTE: When using "switchover", ensure clusterConfig.instances > 1.
+                      Switchover requires at least one replica to fail over to.
+                    enum:
+                    - restart
+                    - switchover
+                    type: string
+                type: object
+              cnpgDeletionPolicy:
+                default: Retain
+                description: CNPGDeletionPolicy controls the deletion behavior of
+                  the underlying CNPG Cluster when the PostgresCluster is deleted.
+                enum:
+                - Delete
+                - Retain
+                type: string
               connectionPoolerConfig:
-                description: |-
-                  ConnectionPoolerConfig overrides the connection pooler configuration from the class.
-                  Only takes effect when connection pooling is enabled.
+                description: Only takes effect when connection pooling is enabled.
                 properties:
                   config:
                     additionalProperties:
@@ -258,10 +313,8 @@ spec:
                 '' + string(self.storage) + '')'''
               rule: '!has(oldSelf.storage) || (has(self.storage) && quantity(self.storage).compareTo(quantity(oldSelf.storage))
                 >= 0)'
-            - message: connectionPoolerConfig must be set when connectionPoolerEnabled
-                is true
-              rule: '!self.connectionPoolerEnabled || self.connectionPoolerConfig
-                != null'
+            - message: connectionPoolerConfig cannot be overridden on PostgresCluster
+              rule: '!has(self.connectionPoolerConfig)'
           status:
             description: PostgresClusterStatus defines the observed state of PostgresCluster.
             properties:

--- a/config/samples/enterprise_v4_postgrescluster_override.yaml
+++ b/config/samples/enterprise_v4_postgrescluster_override.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   # Reference the ClusterClass to inherit defaults - this is required, immutable, and must match the name of an existing ClusterClass
   class: postgresql-dev
+  # ClusterDeletionPolicy is set to "Retain" to keep the underlying CNPG Cluster when this PostgresCluster is deleted
+  clusterDeletionPolicy: Delete
   instances: 2
   # Storage and PostgreSQL version are overridden from the ClusterClass defaults. Validation rules on the PostgresCluster resource will prevent removing these fields or setting them to lower values than the original overrides.
   storage: 1Gi

--- a/internal/controller/postgrescluster_controller.go
+++ b/internal/controller/postgrescluster_controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logs "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -41,6 +42,12 @@ import (
 type PostgresClusterReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+}
+
+// Used for applying changes both from PostgresCluster and PostgresClusterClass.
+type MergedConfig struct {
+	Spec *enterprisev4.PostgresClusterSpec
+	CNPG *enterprisev4.CNPGConfig
 }
 
 // +kubebuilder:rbac:groups=enterprise.splunk.com,resources=postgresclusters,verbs=get;list;watch;create;update;patch;delete
@@ -74,6 +81,35 @@ func (r *PostgresClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// helper function to update status with less boilerplate.
 	updateStatus := func(conditionType conditionTypes, status metav1.ConditionStatus, reason conditionReasons, message string, clusterPhase reconcileClusterPhases) error {
 		return (r.updateStatus(ctx, postgresCluster, conditionType, status, reason, message, clusterPhase))
+	}
+
+	// finalizer handling must be done before any other processing, to ensure cleanup on deletion and to prevent creating CNPG clusters for PostgresCluster instances that are being deleted.
+	finalizerErr := r.handleFinalizer(ctx, postgresCluster)
+	if finalizerErr != nil {
+		logger.Error(finalizerErr, "Failed to handle finalizer")
+		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterDeleteFailed, fmt.Sprintf("Failed to delete resources during cleanup: %v", finalizerErr), failedClusterPhase); statusErr != nil {
+			logger.Error(statusErr, "Failed to update status")
+		}
+		return ctrl.Result{}, finalizerErr
+	}
+	if postgresCluster.GetDeletionTimestamp() != nil {
+		logger.Info("PostgresCluster is being deleted, cleanup complete")
+		return ctrl.Result{}, nil
+	}
+
+	// Add finalizer if not present
+	if !controllerutil.ContainsFinalizer(postgresCluster, postgresClusterFinalizerName) {
+		controllerutil.AddFinalizer(postgresCluster, postgresClusterFinalizerName)
+		if err := r.Update(ctx, postgresCluster); err != nil {
+			if apierrors.IsConflict(err) {
+				logger.Info("Conflict while adding finalizer, will retry on next reconcile")
+				return ctrl.Result{Requeue: true}, nil
+			}
+			logger.Error(err, "Failed to add finalizer to PostgresCluster")
+			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
+		}
+		logger.Info("Finalizer added successfully")
+		return ctrl.Result{}, nil
 	}
 
 	// 2. Load the referenced PostgresClusterClass.
@@ -170,8 +206,8 @@ func (r *PostgresClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// 7. If CNPG Cluster exists, compare the current spec with the desired spec and update if necessary.
 	cnpgCluster = existingCNPG
-	currentNormalizedSpec := normalizeCNPGClusterSpec(cnpgCluster.Spec, mergedConfig.PostgreSQLConfig)
-	desiredNormalizedSpec := normalizeCNPGClusterSpec(desiredSpec, mergedConfig.PostgreSQLConfig)
+	currentNormalizedSpec := normalizeCNPGClusterSpec(cnpgCluster.Spec, mergedConfig.Spec.PostgreSQLConfig)
+	desiredNormalizedSpec := normalizeCNPGClusterSpec(desiredSpec, mergedConfig.Spec.PostgreSQLConfig)
 
 	if !equality.Semantic.DeepEqual(currentNormalizedSpec, desiredNormalizedSpec) {
 		logger.Info("Detected drift in CNPG Cluster spec, patching", "name", cnpgCluster.Name)
@@ -206,7 +242,7 @@ func (r *PostgresClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// 7b. Reconcile Connection Pooler
-	poolerEnabled = mergedConfig.ConnectionPoolerEnabled != nil && *mergedConfig.ConnectionPoolerEnabled
+	poolerEnabled = mergedConfig.Spec.ConnectionPoolerEnabled != nil && *mergedConfig.Spec.ConnectionPoolerEnabled
 	switch {
 	case !poolerEnabled:
 		// Pooler disabled — delete if they exist
@@ -221,7 +257,7 @@ func (r *PostgresClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		meta.RemoveStatusCondition(&postgresCluster.Status.Conditions, string(poolerReady))
 
 	case !r.poolerExists(ctx, postgresCluster, readWriteEndpoint) || !r.poolerExists(ctx, postgresCluster, readOnlyEndpoint):
-		if mergedConfig.ConnectionPoolerConfig == nil {
+		if mergedConfig.CNPG.ConnectionPooler == nil {
 			logger.Info("Connection pooler enabled but no config found in class or cluster spec, skipping",
 				"class", postgresCluster.Spec.Class,
 				"cluster", postgresCluster.Name,
@@ -237,7 +273,7 @@ func (r *PostgresClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 
 		if cnpgCluster.Status.Phase != cnpgv1.PhaseHealthy {
-			logger.Info("CNPG Cluster not healthy yet, skipping pooler creation", "clusterPhase", cnpgCluster.Status.Phase)
+			logger.Info("CNPG Cluster not healthy yet, pending pooler creation", "clusterPhase", cnpgCluster.Status.Phase)
 			if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonCNPGClusterNotHealthy,
 				"Waiting for CNPG cluster to become healthy before creating poolers", pendingClusterPhase,
 			); statusErr != nil {
@@ -336,10 +372,9 @@ func (r *PostgresClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 }
 
 // getMergedConfig merges the configuration from the PostgresClusterClass into the PostgresClusterSpec, giving precedence to the PostgresClusterSpec values.
-func (r *PostgresClusterReconciler) getMergedConfig(clusterClass *enterprisev4.PostgresClusterClass, cluster *enterprisev4.PostgresCluster) (*enterprisev4.PostgresClusterSpec, error) {
+func (r *PostgresClusterReconciler) getMergedConfig(clusterClass *enterprisev4.PostgresClusterClass, cluster *enterprisev4.PostgresCluster) (*MergedConfig, error) {
 	resultConfig := cluster.Spec.DeepCopy()
 	classDefaults := clusterClass.Spec.Config
-	CNPGDefaults := clusterClass.Spec.CNPG
 
 	if resultConfig.Instances == nil {
 		resultConfig.Instances = classDefaults.Instances
@@ -364,46 +399,34 @@ func (r *PostgresClusterReconciler) getMergedConfig(clusterClass *enterprisev4.P
 		return nil, fmt.Errorf("invalid configuration for class %s: instances, postgresVersion and storage are required", clusterClass.Name)
 	}
 
-	// Ensure that maps and slices are initialized to empty if they are still nil after merging, to prevent potential nil pointer dereferences later on.
 	if resultConfig.PostgreSQLConfig == nil {
 		resultConfig.PostgreSQLConfig = make(map[string]string)
 	}
 	if resultConfig.PgHBA == nil {
 		resultConfig.PgHBA = make([]string, 0)
 	}
-	// Ensure that Resources is initialized to an empty struct if it's still nil after merging, to prevent potential nil pointer dereferences later on.
 	if resultConfig.Resources == nil {
 		resultConfig.Resources = &corev1.ResourceRequirements{}
 	}
-	// Check if connection pooler is enabled and set the field accordingly, giving precedence to the cluster spec over class defaults.
-	if cluster.Spec.ConnectionPoolerEnabled != nil {
-		resultConfig.ConnectionPoolerEnabled = cluster.Spec.ConnectionPoolerEnabled
-	} else if classDefaults.ConnectionPoolerEnabled != nil {
-		resultConfig.ConnectionPoolerEnabled = classDefaults.ConnectionPoolerEnabled
-	}
 
-	// Merge ConnectionPooler config: cluster spec takes precedence over class
-	if cluster.Spec.ConnectionPoolerConfig != nil {
-		resultConfig.ConnectionPoolerConfig = cluster.Spec.ConnectionPoolerConfig
-	} else if CNPGDefaults != nil && CNPGDefaults.ConnectionPooler != nil {
-		resultConfig.ConnectionPoolerConfig = CNPGDefaults.ConnectionPooler
-	}
-
-	return resultConfig, nil
+	return &MergedConfig{
+		Spec: resultConfig,
+		CNPG: clusterClass.Spec.CNPG, 
+	}, nil
 }
 
 // buildCNPGClusterSpec builds the desired CNPG ClusterSpec.
 // IMPORTANT: any field added here must also be added to normalizedCNPGClusterSpec and normalizeCNPGClusterSpec,
 // otherwise it will not be included in drift detection and changes will be silently ignored.
-func (r *PostgresClusterReconciler) buildCNPGClusterSpec(mergedConfig *enterprisev4.PostgresClusterSpec, secretName string) cnpgv1.ClusterSpec {
+func (r *PostgresClusterReconciler) buildCNPGClusterSpec(mergedConfig *MergedConfig, secretName string) cnpgv1.ClusterSpec {
 
 	// 3. Build the Spec
 	spec := cnpgv1.ClusterSpec{
-		ImageName: fmt.Sprintf("ghcr.io/cloudnative-pg/postgresql:%s", *mergedConfig.PostgresVersion),
-		Instances: int(*mergedConfig.Instances),
+		ImageName: fmt.Sprintf("ghcr.io/cloudnative-pg/postgresql:%s", *mergedConfig.Spec.PostgresVersion),
+		Instances: int(*mergedConfig.Spec.Instances),
 		PostgresConfiguration: cnpgv1.PostgresConfiguration{
-			Parameters: mergedConfig.PostgreSQLConfig,
-			PgHBA:      mergedConfig.PgHBA,
+			Parameters: mergedConfig.Spec.PostgreSQLConfig,
+			PgHBA:      mergedConfig.Spec.PgHBA,
 		},
 		SuperuserSecret: &cnpgv1.LocalObjectReference{
 			Name: secretName,
@@ -420,9 +443,9 @@ func (r *PostgresClusterReconciler) buildCNPGClusterSpec(mergedConfig *enterpris
 			},
 		},
 		StorageConfiguration: cnpgv1.StorageConfiguration{
-			Size: mergedConfig.Storage.String(),
+			Size: mergedConfig.Spec.Storage.String(),
 		},
-		Resources: *mergedConfig.Resources,
+		Resources: *mergedConfig.Spec.Resources,
 	}
 
 	return spec
@@ -431,7 +454,7 @@ func (r *PostgresClusterReconciler) buildCNPGClusterSpec(mergedConfig *enterpris
 // build CNPGCluster builds the CNPG Cluster object based on the PostgresCluster resource and merged configuration.
 func (r *PostgresClusterReconciler) buildCNPGCluster(
 	postgresCluster *enterprisev4.PostgresCluster,
-	mergedConfig *enterprisev4.PostgresClusterSpec,
+	mergedConfig *MergedConfig,
 	secretName string,
 ) *cnpgv1.Cluster {
 	cnpgCluster := &cnpgv1.Cluster{
@@ -454,7 +477,7 @@ func poolerResourceName(clusterName, poolerType string) string {
 func (r *PostgresClusterReconciler) createOrUpdateConnectionPooler(
 	ctx context.Context,
 	postgresCluster *enterprisev4.PostgresCluster,
-	mergedConfig *enterprisev4.PostgresClusterSpec,
+	mergedConfig *MergedConfig,
 	cnpgCluster *cnpgv1.Cluster,
 ) error {
 	// Create/Update RW Pooler
@@ -522,7 +545,7 @@ func (r *PostgresClusterReconciler) deleteConnectionPoolers(ctx context.Context,
 func (r *PostgresClusterReconciler) createConnectionPooler(
 	ctx context.Context,
 	postgresCluster *enterprisev4.PostgresCluster,
-	mergedConfig *enterprisev4.PostgresClusterSpec,
+	mergedConfig *MergedConfig,
 	cnpgCluster *cnpgv1.Cluster,
 	poolerType string,
 ) error {
@@ -547,11 +570,11 @@ func (r *PostgresClusterReconciler) createConnectionPooler(
 // buildCNPGPooler constructs a CNPG Pooler object.
 func (r *PostgresClusterReconciler) buildCNPGPooler(
 	postgresCluster *enterprisev4.PostgresCluster,
-	mergedConfig *enterprisev4.PostgresClusterSpec,
+	mergedConfig *MergedConfig,
 	cnpgCluster *cnpgv1.Cluster,
 	poolerType string,
 ) *cnpgv1.Pooler {
-	cfg := mergedConfig.ConnectionPoolerConfig
+	cfg := mergedConfig.CNPG.ConnectionPooler
 	poolerName := poolerResourceName(postgresCluster.Name, poolerType)
 
 	instances := *cfg.Instances
@@ -864,6 +887,8 @@ func (r *PostgresClusterReconciler) reconcileManagedRoles(ctx context.Context, p
 	return nil
 }
 
+// normalizedCNPGClusterSpec is a subset of cnpgv1.ClusterSpec fields that we care about for drift detection.
+// Any field that is included in buildCNPGClusterSpec and should be considered for drift detection must be added here, and populated in normalizeCNPGClusterSpec.
 func normalizeCNPGClusterSpec(spec cnpgv1.ClusterSpec, customDefinedParameters map[string]string) normalizedCNPGClusterSpec {
 	normalizedConf := normalizedCNPGClusterSpec{
 		ImageName: spec.ImageName,
@@ -997,6 +1022,89 @@ func generateRandomSuffix() (string, error) {
 		return "", err
 	}
 	return strings.ToLower(suff), nil
+}
+
+// deleteCNPGCluster deletes the CNPG cluster and its associated resources if they exist.
+func (r *PostgresClusterReconciler) deleteCNPGCluster(ctx context.Context, cnpgCluster *cnpgv1.Cluster) error {
+	logger := logs.FromContext(ctx)
+	// TODO: add logic to decide to delete cluster if one has customer DBs configured, to prevent data loss
+	if cnpgCluster == nil {
+		logger.Info("CNPG Cluster not found, skipping deletion")
+		return nil
+	}
+	logger.Info("Deleting CNPG Cluster", "name", cnpgCluster.Name)
+	if err := r.Delete(ctx, cnpgCluster); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete CNPG Cluster: %w", err)
+	}
+	return nil
+}
+
+// Adding finalizer logic here to ensure poolers and other resources are cleaned up when PostgresCluster is deleted.
+
+func (r *PostgresClusterReconciler) handleFinalizer(ctx context.Context, postgresCluster *enterprisev4.PostgresCluster) error {
+	logger := logs.FromContext(ctx)
+
+	if postgresCluster.GetDeletionTimestamp() == nil {
+		return nil
+	}
+	if !controllerutil.ContainsFinalizer(postgresCluster, postgresClusterFinalizerName) {
+		return nil
+	}
+
+	logger.Info("Processing finalizer cleanup for PostgresCluster")
+
+	// Fetch the CNPG cluster for cleanup
+	var cnpgCluster *cnpgv1.Cluster
+	existingCNPG := &cnpgv1.Cluster{}
+	err := r.Get(ctx, types.NamespacedName{Name: postgresCluster.Name, Namespace: postgresCluster.Namespace}, existingCNPG)
+	if err == nil {
+		cnpgCluster = existingCNPG
+	} else if !apierrors.IsNotFound(err) {
+		logger.Error(err, "Failed to fetch CNPG cluster during cleanup")
+		return fmt.Errorf("failed to fetch CNPG cluster during cleanup: %w", err)
+	}
+
+	// Handle CNPG cluster based on deletion policy
+	if cnpgCluster != nil {
+		if postgresCluster.Spec.ClusterDeletionPolicy == clusterDeletionPolicyDelete {
+			logger.Info("ClusterDeletionPolicy is set to 'Delete', deleting CNPG Cluster", "policy", postgresCluster.Spec.ClusterDeletionPolicy)
+			if err := r.deleteCNPGCluster(ctx, cnpgCluster); err != nil {
+				logger.Error(err, "Failed to delete CNPG Cluster")
+				return fmt.Errorf("failed to delete CNPG Cluster: %w", err)
+			}
+		} else {
+			logger.Info("ClusterDeletionPolicy is set to 'Retain', retaining CNPG Cluster", "policy", postgresCluster.Spec.ClusterDeletionPolicy)
+			originalCluster := cnpgCluster.DeepCopy()
+			if err := controllerutil.RemoveOwnerReference(postgresCluster, cnpgCluster, r.Scheme); err != nil {
+				logger.Error(err, "Failed to remove owner reference from CNPG Cluster")
+				return fmt.Errorf("failed to remove owner reference: %w", err)
+			}
+			// Update the CNPG cluster immediately after removing owner reference
+			if err := r.Patch(ctx, cnpgCluster, client.MergeFrom(originalCluster)); err != nil {
+				logger.Error(err, "Failed to update CNPG Cluster after removing owner reference")
+				return fmt.Errorf("failed to update CNPG cluster: %w", err)
+			}
+			logger.Info("Removed owner reference from CNPG Cluster")
+		}
+	} else {
+		logger.Info("CNPG Cluster not found, skipping owner reference removal")
+	}
+
+	// Delete connection poolers
+	if err := r.deleteConnectionPoolers(ctx, postgresCluster); err != nil {
+		logger.Error(err, "Failed to delete connection poolers during cleanup")
+		return fmt.Errorf("failed to delete connection poolers: %w", err)
+	}
+
+	// Remove finalizer after successful cleanup
+	controllerutil.RemoveFinalizer(postgresCluster, postgresClusterFinalizerName)
+	if err := r.Update(ctx, postgresCluster); err != nil {
+		logger.Error(err, "Failed to remove finalizer from PostgresCluster")
+		return fmt.Errorf("failed to remove finalizer: %w", err)
+	}
+
+	logger.Info("Finalizer removed, cleanup complete")
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/postgresdatabase_controller.go
+++ b/internal/controller/postgresdatabase_controller.go
@@ -83,7 +83,7 @@ func (r *PostgresDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	logger.Info("PostgresDatabase CR Fetched successfully", "generation", postgresDB.Generation)
 
 	// Closure captures postgresDB so call sites don't repeat it on every status update.
-	updateStatus := func(conditionType conditionTypes, conditionStatus metav1.ConditionStatus, reason conditionReasons, message string, phase reconcilePhases) error {
+	updateStatus := func(conditionType conditionTypes, conditionStatus metav1.ConditionStatus, reason conditionReasons, message string, phase reconcileDBPhases) error {
 		return r.updateStatus(ctx, postgresDB, conditionType, conditionStatus, reason, message, phase)
 	}
 
@@ -119,7 +119,7 @@ func (r *PostgresDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	cluster, clusterStatus, err = r.ensureClusterReady(ctx, postgresDB)
 	if err != nil {
-		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterInfoFetchFailed, "Can't reach Cluster CR due to transient errors", pending); statusErr != nil {
+		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterInfoFetchFailed, "Can't reach Cluster CR due to transient errors", pendingDBPhase); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status")
 		}
 		return ctrl.Result{}, err
@@ -128,19 +128,19 @@ func (r *PostgresDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	logger.Info("Cluster validation done", "clusterName", cluster.Name, "status", clusterStatus)
 	switch clusterStatus {
 	case ClusterNotFound:
-		if err := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterNotFound, "Cluster CR not found", pending); err != nil {
+		if err := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterNotFound, "Cluster CR not found", pendingDBPhase); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: clusterNotFoundRetryDelay}, nil
 
 	case ClusterNotReady, ClusterNoProvisionerRef:
-		if err := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterProvisioning, "Cluster is not in ready state yet", pending); err != nil {
+		if err := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterProvisioning, "Cluster is not in ready state yet", pendingDBPhase); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: retryDelay}, nil
 
 	case ClusterReady:
-		if err := updateStatus(clusterReady, metav1.ConditionTrue, reasonClusterAvailable, "Cluster is operational", provisioning); err != nil {
+		if err := updateStatus(clusterReady, metav1.ConditionTrue, reasonClusterAvailable, "Cluster is operational", provisioningDBPhase); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -159,13 +159,13 @@ func (r *PostgresDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// 2. Secrets must exist before roles are patched — CNPG rejects a PasswordSecretRef pointing at a missing secret.
 	if err := r.reconcileUserSecrets(ctx, postgresDB); err != nil {
 		if statusErr := updateStatus(secretsReady, metav1.ConditionFalse, reasonSecretsCreationFailed,
-			fmt.Sprintf("Failed to reconcile user secrets: %v", err), provisioning); statusErr != nil {
+			fmt.Sprintf("Failed to reconcile user secrets: %v", err), provisioningDBPhase); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status")
 		}
 		return ctrl.Result{}, err
 	}
 	if err := updateStatus(secretsReady, metav1.ConditionTrue, reasonSecretsCreated,
-		fmt.Sprintf("All secrets provisioned for %d databases", len(postgresDB.Spec.Databases)), provisioning); err != nil {
+		fmt.Sprintf("All secrets provisioned for %d databases", len(postgresDB.Spec.Databases)), provisioningDBPhase); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -185,7 +185,8 @@ func (r *PostgresDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			logger.Error(err, "Failed to patch users in CNPG Cluster")
 			return ctrl.Result{}, err
 		}
-		if err := updateStatus(usersReady, metav1.ConditionFalse, reasonWaitingForCNPG, fmt.Sprintf("Waiting for %d users to be reconciled", len(desiredUsers)), provisioning); err != nil {
+		// Spec updated, requeue to check status
+		if err := updateStatus(usersReady, metav1.ConditionFalse, reasonWaitingForCNPG, fmt.Sprintf("Waiting for %d users to be reconciled", len(desiredUsers)), provisioningDBPhase); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: retryDelay}, nil
@@ -193,7 +194,7 @@ func (r *PostgresDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	allUsersReady, notReadyUsers, err := r.verifyUsersReady(ctx, postgresDB, cnpgCluster)
 	if err != nil {
-		if statusErr := updateStatus(usersReady, metav1.ConditionFalse, reasonUsersCreationFailed, fmt.Sprintf("User creation failed: %v", err), failed); statusErr != nil {
+		if statusErr := updateStatus(usersReady, metav1.ConditionFalse, reasonUsersCreationFailed, fmt.Sprintf("User creation failed: %v", err), failedDBPhase); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status")
 		}
 		return ctrl.Result{}, err
@@ -201,13 +202,14 @@ func (r *PostgresDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	if !allUsersReady {
 		logger.Info("Users in CNPG spec but not reconciled yet", "pending", notReadyUsers)
-		if err := updateStatus(usersReady, metav1.ConditionFalse, reasonWaitingForCNPG, fmt.Sprintf("Waiting for %d users to be reconciled", len(notReadyUsers)), provisioning); err != nil {
+		if err := updateStatus(usersReady, metav1.ConditionFalse, reasonWaitingForCNPG, fmt.Sprintf("Waiting for %d users to be reconciled", len(notReadyUsers)), provisioningDBPhase); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: retryDelay}, nil
 	}
 
-	if err := updateStatus(usersReady, metav1.ConditionTrue, reasonUsersAvailable, fmt.Sprintf("All %d users in PostgreSQL", len(desiredUsers)), provisioning); err != nil {
+	// All users present in spec and reconciled in status
+	if err := updateStatus(usersReady, metav1.ConditionTrue, reasonUsersAvailable, fmt.Sprintf("All %d users in PostgreSQL", len(desiredUsers)), provisioningDBPhase); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -231,7 +233,8 @@ func (r *PostgresDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			logger.Error(err, "Failed to patch database in CNPG Cluster")
 			return ctrl.Result{}, err
 		}
-		if err := updateStatus(databasesReady, metav1.ConditionFalse, reasonWaitingForCNPG, fmt.Sprintf("Waiting for %d database to be reconciled", len(desiredDatabases)), provisioning); err != nil {
+		// Spec updated, requeue to check status
+		if err := updateStatus(databasesReady, metav1.ConditionFalse, reasonWaitingForCNPG, fmt.Sprintf("Waiting for %d database to be reconciled", len(desiredDatabases)), provisioningDBPhase); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: retryDelay}, nil
@@ -245,7 +248,8 @@ func (r *PostgresDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	if !allDatabasesReady {
 		logger.Info("Databases in CNPG spec but not reconciled yet")
-		if err := updateStatus(databasesReady, metav1.ConditionFalse, reasonWaitingForCNPG, "Waiting for databases to be ready", provisioning); err != nil {
+		// Databases in spec but not yet reconciled by CNPG - wait
+		if err := updateStatus(databasesReady, metav1.ConditionFalse, reasonWaitingForCNPG, "Waiting for databases to be ready", provisioningDBPhase); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: retryDelay}, nil
@@ -254,7 +258,7 @@ func (r *PostgresDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	databasesInfo := populateDatabaseStatus(postgresDB)
 	postgresDB.Status.Databases = databasesInfo
 	postgresDB.Status.ObservedGeneration = postgresDB.Generation
-	if err := updateStatus(databasesReady, metav1.ConditionTrue, reasonDatabasesAvailable, fmt.Sprintf("All %d databases ready", len(postgresDB.Spec.Databases)), ready); err != nil {
+	if err := updateStatus(databasesReady, metav1.ConditionTrue, reasonDatabasesAvailable, fmt.Sprintf("All %d databases ready", len(postgresDB.Spec.Databases)), readyDBPhase); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -543,7 +547,7 @@ func (r *PostgresDatabaseReconciler) updateStatus(
 	conditionStatus metav1.ConditionStatus,
 	reason conditionReasons,
 	message string,
-	phase reconcilePhases,
+	phase reconcileDBPhases,
 ) error {
 	meta.SetStatusCondition(&db.Status.Conditions, metav1.Condition{
 		Type:               string(conditionType),
@@ -564,12 +568,12 @@ func (r *PostgresDatabaseReconciler) handleDeletion(ctx context.Context, postgre
 	logger := log.FromContext(ctx)
 
 	if err := r.removeDatabases(ctx, postgresDB); err != nil {
-		r.updateStatus(ctx, postgresDB, databasesReady, metav1.ConditionFalse, reasonDatabasesCleanupFailed, fmt.Sprintf("Failed to clean up databases: %v", err), failed)
+		r.updateStatus(ctx, postgresDB, databasesReady, metav1.ConditionFalse, reasonDatabasesCleanupFailed, fmt.Sprintf("Failed to clean up databases: %v", err), failedDBPhase) 
 		return err
 	}
 
 	if err := r.removeUsersFromCluster(ctx, postgresDB); err != nil {
-		r.updateStatus(ctx, postgresDB, usersReady, metav1.ConditionFalse, reasonUsersCleanupFailed, fmt.Sprintf("Failed to clean up users: %v", err), failed)
+		r.updateStatus(ctx, postgresDB, usersReady, metav1.ConditionFalse, reasonUsersCleanupFailed, fmt.Sprintf("Failed to clean up users: %v", err), failedDBPhase)
 		return err
 	}
 

--- a/internal/controller/postgresoperator_common_types.go
+++ b/internal/controller/postgresoperator_common_types.go
@@ -20,7 +20,7 @@ type normalizedCNPGClusterSpec struct {
 	Resources               corev1.ResourceRequirements
 }
 
-type reconcilePhases string
+type reconcileDBPhases string
 type reconcileClusterPhases string
 type conditionTypes string
 type conditionReasons string
@@ -36,19 +36,21 @@ const (
 	readOnlyEndpoint  string = "ro"
 	readWriteEndpoint string = "rw"
 	// default database name
-	defaultDatabaseName           string = "postgres"
+	defaultDatabaseName                    string = "postgres"
 	postgresDatabaseFinalizerName string = "postgresdatabases.enterprise.splunk.com/finalizer"
 	defaultSecretSuffix           string = "-secret-"
 	defaultPoolerSuffix           string = "-pooler-"
 	defaultConfigSuffix           string = "-config-"
 	defaultPort                   string = "5432"
-	superUsername                 string = "postgres"
+	superUsername                          string = "postgres"
+	postgresClusterFinalizerName string = "postgresclusters.enterprise.splunk.com/finalizer"
+	clusterDeletionPolicyDelete  string = "Delete"
 
 	// phases
-	ready        reconcilePhases = "Ready"
-	pending      reconcilePhases = "Pending"
-	provisioning reconcilePhases = "Provisioning"
-	failed       reconcilePhases = "Failed"
+	readyDBPhase        reconcileDBPhases = "Ready"
+	pendingDBPhase      reconcileDBPhases = "Pending"
+	provisioningDBPhase reconcileDBPhases = "Provisioning"
+	failedDBPhase       reconcileDBPhases = "Failed"
 
 	// cluster phases
 	readyClusterPhase        reconcileClusterPhases = "Ready"
@@ -113,6 +115,7 @@ const (
 	reasonCNPGProvisioningFailed conditionReasons = "CNPGProvisioningFailed"
 	reasonCNPGPluginError        conditionReasons = "CNPGPluginError"
 	reasonCNPGImageError         conditionReasons = "CNPGImageError"
+	reasonClusterDeleteFailed    conditionReasons = "ClusterDeleteFailed"
 
 	// Cluster status
 	ClusterNotFound         clusterReadyStatus = "NotFound"


### PR DESCRIPTION
### Description

_What does this PR have in it?_

### Key Changes
Update `postgrescluster_controller.go` to let `mergedConfig` use both `ClusterSpec` and inherit Class config. Used `controllerutil` built-in functionality instead of custom method.  

### Testing and Verification

#### Condensed logs showing workflow. 
```
=== DELETION CYCLE #1 (ClusterDeletionPolicy: Retain) ===
Reconciling PostgresCluster	 "reconcileID": "6b7ca7f7-951e-42c5-b447-6be25fa1176c", "name": "postgresql-cluster-dev-overridden", "namespace": "test-1"}
ClusterDeletionPolicy is set to 'Retain', retaining CNPG Cluster	 "reconcileID": "6b7ca7f7-951e-42c5-b447-6be25fa1176c", "policy": "Retain"}
CNPG Cluster not found, skipping owner reference removal	 "reconcileID": "6b7ca7f7-951e-42c5-b447-6be25fa1176c"}
Finalizer removed, cleanup complete	 "reconcileID": "6b7ca7f7-951e-42c5-b447-6be25fa1176c"}
PostgresCluster is being deleted, cleanup complete	 "reconcileID": "6b7ca7f7-951e-42c5-b447-6be25fa1176c"}
PostgresCluster deleted, skipping reconciliation	 "reconcileID": "3b4cea2b-cf45-4cf3-b4bf-1b9fd0eb852f"}

=== CREATION CYCLE #1 ===
Reconciling PostgresCluster	 "reconcileID": "881e6e9d-a756-42e8-82e9-ae4ae4691ca3", "name": "postgresql-cluster-dev-overridden", "namespace": "test-1"}
Finalizer added	 "reconcileID": "881e6e9d-a756-42e8-82e9-ae4ae4691ca3"}
CNPG Cluster not found, creating	 "reconcileID": "881e6e9d-a756-42e8-82e9-ae4ae4691ca3", "name": "postgresql-cluster-dev-overridden"}
CNPG Cluster created successfully, requeueing for status update	 "reconcileID": "881e6e9d-a756-42e8-82e9-ae4ae4691ca3", "name": "postgresql-cluster-dev-overridden"}
No managed roles to reconcile	 "reconcileID": "a8b7fa97-b489-419a-bc26-54d28b0ee37e"}
CNPG Cluster not healthy yet, pending pooler creation	 "reconcileID": "bf31c74d-b91a-438f-8676-893f7b2dba73", "clusterPhase": "Creating a new replica"}
Creating CNPG Pooler	 "reconcileID": "9317376d-8896-48a2-acf2-b7e619adf263", "name": "postgresql-cluster-dev-overridden-pooler-ro", "type": "ro"}
Connection Poolers created, requeueing to check readiness	 "reconcileID": "9317376d-8896-48a2-acf2-b7e619adf263"}
Connection Poolers are not ready yet, requeueing	 "reconcileID": "824c8361-a110-48c4-b562-0a72ef1fcbd2"}
No managed roles to reconcile	 "reconcileID": "50f1ce32-9227-4ad6-861c-3c308e9ee6b3"}

=== DELETION CYCLE #2 (ClusterDeletionPolicy: Retain with poolers) ===
ClusterDeletionPolicy is set to 'Retain', retaining CNPG Cluster	 "reconcileID": "7d3bf886-f227-434c-ac06-9044887be9fb", "policy": "Retain"}
Removed owner reference from CNPG Cluster	 "reconcileID": "7d3bf886-f227-434c-ac06-9044887be9fb"}
Deleting CNPG Pooler	 "reconcileID": "7d3bf886-f227-434c-ac06-9044887be9fb", "name": "postgresql-cluster-dev-overridden-pooler-ro"}
Finalizer removed, cleanup complete	 "reconcileID": "7d3bf886-f227-434c-ac06-9044887be9fb"}
PostgresCluster is being deleted, cleanup complete	 "reconcileID": "7d3bf886-f227-434c-ac06-9044887be9fb"}
PostgresCluster deleted, skipping reconciliation	 "reconcileID": "3bc55a4d-a578-4c22-a910-02f976c2aacd"}

=== CREATION CYCLE #2 (with existing CNPG cluster) ===
Finalizer added	 "reconcileID": "4706d5c1-0a36-4693-8b73-fbd8eff94c8d"}
No managed roles to reconcile	 "reconcileID": "4706d5c1-0a36-4693-8b73-fbd8eff94c8d"}
Creating CNPG Pooler	 "reconcileID": "4706d5c1-0a36-4693-8b73-fbd8eff94c8d", "name": "postgresql-cluster-dev-overridden-pooler-rw", "type": "rw"}
Creating CNPG Pooler	 "reconcileID": "4706d5c1-0a36-4693-8b73-fbd8eff94c8d", "name": "postgresql-cluster-dev-overridden-pooler-ro", "type": "ro"}
Connection Poolers created, requeueing to check readiness	 "reconcileID": "4706d5c1-0a36-4693-8b73-fbd8eff94c8d"}
Connection Poolers are not ready yet, requeueing	 "reconcileID": "43c0f132-357c-4ffc-8637-6bed177f02bd"}

=== DELETION CYCLE #3 (ClusterDeletionPolicy: Delete) ===
ClusterDeletionPolicy is set to 'Delete', deleting CNPG Cluster	 "reconcileID": "8c1e145f-7d6a-46b0-a49c-505306e99522", "policy": "Delete"}
Deleting CNPG Cluster	 "reconcileID": "8c1e145f-7d6a-46b0-a49c-505306e99522", "name": "postgresql-cluster-dev-overridden"}
Deleting CNPG Pooler	 "reconcileID": "8c1e145f-7d6a-46b0-a49c-505306e99522", "name": "postgresql-cluster-dev-overridden-pooler-rw"}
Finalizer removed, cleanup complete	 "reconcileID": "8c1e145f-7d6a-46b0-a49c-505306e99522"}
PostgresCluster is being deleted, cleanup complete	 "reconcileID": "8c1e145f-7d6a-46b0-a49c-505306e99522"}
PostgresCluster deleted, skipping reconciliation	 "reconcileID": "10d5a3c8-00ea-4e6c-9229-2af5daf04b68"}

=== CREATION CYCLE #3 (full workflow) ===
Finalizer added	 "reconcileID": "c61434bb-429e-4071-ab50-f65278377201"}
CNPG Cluster not found, creating	 "reconcileID": "c61434bb-429e-4071-ab50-f65278377201", "name": "postgresql-cluster-dev-overridden"}
CNPG Cluster created successfully, requeueing for status update	 "reconcileID": "c61434bb-429e-4071-ab50-f65278377201", "name": "postgresql-cluster-dev-overridden"}
No managed roles to reconcile	 "reconcileID": "0e56e330-835e-422a-b700-24493ba18cb1"}
CNPG Cluster not healthy yet, pending pooler creation	 "reconcileID": "d710c76e-aefb-4e17-bb5e-b7c5abb8176f", "clusterPhase": "Creating a new replica"}
Creating CNPG Pooler	 "reconcileID": "6d06c190-e7ad-4c95-b370-e3b108e6ee4b", "name": "postgresql-cluster-dev-overridden-pooler-ro", "type": "ro"}
Connection Poolers created, requeueing to check readiness	 "reconcileID": "6d06c190-e7ad-4c95-b370-e3b108e6ee4b"}
Connection Poolers are not ready yet, requeueing	 "reconcileID": "0d69f690-077e-4b83-a0ef-01bc76c60ca8"}

=== DELETION OF POOLERS (partial deletion) ===
Deleting CNPG Pooler	 "reconcileID": "802af909-37c4-497d-83b6-e50c179e8b93", "name": "postgresql-cluster-dev-overridden-pooler-rw"}
Deleting CNPG Pooler	 "reconcileID": "802af909-37c4-497d-83b6-e50c179e8b93", "name": "postgresql-cluster-dev-overridden-pooler-ro"}

=== RECREATION OF POOLERS ===
Creating CNPG Pooler	 "reconcileID": "1196b9ed-ac67-43ac-a084-6661c1742975", "name": "postgresql-cluster-dev-overridden-pooler-rw", "type": "rw"}
Creating CNPG Pooler	 "reconcileID": "1196b9ed-ac67-43ac-a084-6661c1742975", "name": "postgresql-cluster-dev-overridden-pooler-ro", "type": "ro"}

```

### Related Issues

[JIRA: CPI-1901](https://splunk.atlassian.net/browse/CPI-1901)

### PR Checklist

- [ ] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [ ] All tests pass locally.
- [ ] The PR description follows the project's guidelines.
