### PR TITLE
Extract App Framework pipeline into reusable internal engine

### DIFF
--- a/api/v4/common_types.go
+++ b/api/v4/common_types.go
@@ -47,6 +47,9 @@ const (
 	RepoStatePassive
 )
 
+// ScopeType represent the scope of the App Source
+type ScopeType string
+
 // Values to represent the App Source scope
 const (
 	ScopeLocal                = "local"

--- a/pkg/splunk/enterprise/appengine.go
+++ b/pkg/splunk/enterprise/appengine.go
@@ -1,0 +1,59 @@
+package enterprise
+
+import (
+	"context"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
+	splcommon "github.com/splunk/splunk-operator/pkg/splunk/common"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// AppFrameworkEngine provides a stable internal API boundary for the app framework pipeline.
+type AppFrameworkEngine struct{}
+
+// DefaultAppFrameworkEngine is the shared engine instance for reconcilers.
+var DefaultAppFrameworkEngine = &AppFrameworkEngine{}
+
+// EngineInput bundles app framework inputs for pipeline calls.
+type EngineInput struct {
+	Ctx                context.Context
+	Client             splcommon.ControllerClient
+	Target             splcommon.MetaObject
+	AppFrameworkConfig *enterpriseApi.AppFrameworkSpec
+	AppDeployContext   *enterpriseApi.AppDeploymentContext
+	Scope              enterpriseApi.ScopeType
+	Phase              enterpriseApi.Phase
+	PodTemplateSpec    *corev1.PodTemplateSpec
+}
+
+// EngineOutput wraps pipeline outputs to keep the API stable.
+type EngineOutput struct {
+	Result *reconcile.Result
+}
+
+// EnsureAppFrameworkStatus validates and migrates app framework status when needed.
+func (e *AppFrameworkEngine) EnsureAppFrameworkStatus(input EngineInput) error {
+	return checkAndMigrateAppDeployStatus(input.Ctx, input.Client, input.Target, input.AppDeployContext, input.AppFrameworkConfig, input.Scope == enterpriseApi.ScopeLocal)
+}
+
+// EnsureAppRepoState initializes clients and checks remote app status when app framework is configured.
+func (e *AppFrameworkEngine) EnsureAppRepoState(input EngineInput) error {
+	return initAndCheckAppInfoStatus(input.Ctx, input.Client, input.Target, input.AppFrameworkConfig, input.AppDeployContext)
+}
+
+// RunAppFrameworkIfReady runs the app framework pipeline only when the CR is ready.
+func (e *AppFrameworkEngine) RunAppFrameworkIfReady(input EngineInput) EngineOutput {
+	if input.Phase != enterpriseApi.PhaseReady {
+		return EngineOutput{Result: nil}
+	}
+
+	return EngineOutput{
+		Result: handleAppFrameworkActivity(input.Ctx, input.Client, input.Target, input.AppDeployContext, input.AppFrameworkConfig),
+	}
+}
+
+// EnsureAppFrameworkStagingVolume adds the app framework staging volume when configured.
+func (e *AppFrameworkEngine) EnsureAppFrameworkStagingVolume(input EngineInput) {
+	setupAppsStagingVolume(input.Ctx, input.Client, input.Target, input.PodTemplateSpec, input.AppFrameworkConfig)
+}

--- a/pkg/splunk/enterprise/clustermanager.go
+++ b/pkg/splunk/enterprise/clustermanager.go
@@ -103,7 +103,15 @@ func ApplyClusterManager(ctx context.Context, client splcommon.ControllerClient,
 	}
 
 	// If needed, Migrate the app framework status
-	err = checkAndMigrateAppDeployStatus(ctx, client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig, false)
+	appEngineInput := EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             cr,
+		AppFrameworkConfig: &cr.Spec.AppFrameworkConfig,
+		AppDeployContext:   &cr.Status.AppContext,
+		Scope:              enterpriseApi.ScopeCluster,
+	}
+	err = DefaultAppFrameworkEngine.EnsureAppFrameworkStatus(appEngineInput)
 	if err != nil {
 		return result, err
 	}
@@ -112,7 +120,7 @@ func ApplyClusterManager(ctx context.Context, client splcommon.ControllerClient,
 	// 1. Initialize the S3Clients based on providers
 	// 2. Check the status of apps on remote storage.
 	if len(cr.Spec.AppFrameworkConfig.AppSources) != 0 {
-		err := initAndCheckAppInfoStatus(ctx, client, cr, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext)
+		err := DefaultAppFrameworkEngine.EnsureAppRepoState(appEngineInput)
 		if err != nil {
 			eventPublisher.Warning(ctx, "initAndCheckAppInfoStatus", fmt.Sprintf("init and check app info status failed %s", err.Error()))
 			cr.Status.AppContext.IsDeploymentInProgress = false
@@ -246,8 +254,11 @@ func ApplyClusterManager(ctx context.Context, client splcommon.ControllerClient,
 			return result, err
 		}
 
-		finalResult := handleAppFrameworkActivity(ctx, client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig)
-		result = *finalResult
+		appEngineInput.Phase = cr.Status.Phase
+		finalResult := DefaultAppFrameworkEngine.RunAppFrameworkIfReady(appEngineInput)
+		if finalResult.Result != nil {
+			result = *finalResult.Result
+		}
 
 		// trigger MonitoringConsole reconcile by changing the splunk/image-tag annotation
 		err = changeMonitoringConsoleAnnotations(ctx, client, cr)
@@ -312,7 +323,15 @@ func getClusterManagerStatefulSet(ctx context.Context, client splcommon.Controll
 		setupInitContainer(&ss.Spec.Template, cr.Spec.Image, cr.Spec.ImagePullPolicy, commandForCMSmartstore, cr.Spec.CommonSplunkSpec.EtcVolumeStorageConfig.EphemeralStorage)
 	}
 	// Setup App framework staging volume for apps
-	setupAppsStagingVolume(ctx, client, cr, &ss.Spec.Template, &cr.Spec.AppFrameworkConfig)
+	appEngineInput := EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             cr,
+		AppFrameworkConfig: &cr.Spec.AppFrameworkConfig,
+		AppDeployContext:   &cr.Status.AppContext,
+		PodTemplateSpec:    &ss.Spec.Template,
+	}
+	DefaultAppFrameworkEngine.EnsureAppFrameworkStagingVolume(appEngineInput)
 
 	return ss, err
 }

--- a/pkg/splunk/enterprise/clustermaster.go
+++ b/pkg/splunk/enterprise/clustermaster.go
@@ -100,7 +100,15 @@ func ApplyClusterMaster(ctx context.Context, client splcommon.ControllerClient, 
 	}
 
 	// If needed, Migrate the app framework status
-	err = checkAndMigrateAppDeployStatus(ctx, client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig, false)
+	appEngineInput := EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             cr,
+		AppFrameworkConfig: &cr.Spec.AppFrameworkConfig,
+		AppDeployContext:   &cr.Status.AppContext,
+		Scope:              enterpriseApi.ScopeCluster,
+	}
+	err = DefaultAppFrameworkEngine.EnsureAppFrameworkStatus(appEngineInput)
 	if err != nil {
 		return result, err
 	}
@@ -109,7 +117,7 @@ func ApplyClusterMaster(ctx context.Context, client splcommon.ControllerClient, 
 	// 1. Initialize the S3Clients based on providers
 	// 2. Check the status of apps on remote storage.
 	if len(cr.Spec.AppFrameworkConfig.AppSources) != 0 {
-		err := initAndCheckAppInfoStatus(ctx, client, cr, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext)
+		err := DefaultAppFrameworkEngine.EnsureAppRepoState(appEngineInput)
 		if err != nil {
 			eventPublisher.Warning(ctx, "initAndCheckAppInfoStatus", fmt.Sprintf("init and check app info status failed %s", err.Error()))
 			cr.Status.AppContext.IsDeploymentInProgress = false
@@ -233,8 +241,11 @@ func ApplyClusterMaster(ctx context.Context, client splcommon.ControllerClient, 
 			return result, err
 		}
 
-		finalResult := handleAppFrameworkActivity(ctx, client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig)
-		result = *finalResult
+		appEngineInput.Phase = cr.Status.Phase
+		finalResult := DefaultAppFrameworkEngine.RunAppFrameworkIfReady(appEngineInput)
+		if finalResult.Result != nil {
+			result = *finalResult.Result
+		}
 	}
 	// RequeueAfter if greater than 0, tells the Controller to requeue the reconcile key after the Duration.
 	// Implies that Requeue is true, there is no need to set Requeue to true at the same time as RequeueAfter.
@@ -293,7 +304,15 @@ func getClusterMasterStatefulSet(ctx context.Context, client splcommon.Controlle
 		setupInitContainer(&ss.Spec.Template, cr.Spec.Image, cr.Spec.ImagePullPolicy, commandForCMSmartstore, cr.Spec.CommonSplunkSpec.EtcVolumeStorageConfig.EphemeralStorage)
 	}
 	// Setup App framework staging volume for apps
-	setupAppsStagingVolume(ctx, client, cr, &ss.Spec.Template, &cr.Spec.AppFrameworkConfig)
+	appEngineInput := EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             cr,
+		AppFrameworkConfig: &cr.Spec.AppFrameworkConfig,
+		AppDeployContext:   &cr.Status.AppContext,
+		PodTemplateSpec:    &ss.Spec.Template,
+	}
+	DefaultAppFrameworkEngine.EnsureAppFrameworkStagingVolume(appEngineInput)
 
 	return ss, err
 }

--- a/pkg/splunk/enterprise/licensemanager.go
+++ b/pkg/splunk/enterprise/licensemanager.go
@@ -65,7 +65,15 @@ func ApplyLicenseManager(ctx context.Context, client splcommon.ControllerClient,
 	}
 
 	// If needed, Migrate the app framework status
-	err = checkAndMigrateAppDeployStatus(ctx, client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig, true)
+	appEngineInput := EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             cr,
+		AppFrameworkConfig: &cr.Spec.AppFrameworkConfig,
+		AppDeployContext:   &cr.Status.AppContext,
+		Scope:              enterpriseApi.ScopeLocal,
+	}
+	err = DefaultAppFrameworkEngine.EnsureAppFrameworkStatus(appEngineInput)
 	if err != nil {
 		return result, err
 	}
@@ -74,7 +82,7 @@ func ApplyLicenseManager(ctx context.Context, client splcommon.ControllerClient,
 	// 1. Initialize the S3Clients based on providers
 	// 2. Check the status of apps on remote storage.
 	if len(cr.Spec.AppFrameworkConfig.AppSources) != 0 {
-		err := initAndCheckAppInfoStatus(ctx, client, cr, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext)
+		err := DefaultAppFrameworkEngine.EnsureAppRepoState(appEngineInput)
 		if err != nil {
 			eventPublisher.Warning(ctx, "initAndCheckAppInfoStatus", fmt.Sprintf("init and check app info status failed %s", err.Error()))
 			cr.Status.AppContext.IsDeploymentInProgress = false
@@ -175,8 +183,11 @@ func ApplyLicenseManager(ctx context.Context, client splcommon.ControllerClient,
 			cr.Status.TelAppInstalled = true
 		}
 
-		finalResult := handleAppFrameworkActivity(ctx, client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig)
-		result = *finalResult
+		appEngineInput.Phase = cr.Status.Phase
+		finalResult := DefaultAppFrameworkEngine.RunAppFrameworkIfReady(appEngineInput)
+		if finalResult.Result != nil {
+			result = *finalResult.Result
+		}
 
 		// trigger ClusterManager reconcile by changing the splunk/image-tag annotation
 		err = changeClusterManagerAnnotations(ctx, client, cr)
@@ -201,7 +212,15 @@ func getLicenseManagerStatefulSet(ctx context.Context, client splcommon.Controll
 	}
 
 	// Setup App framework staging volume for apps
-	setupAppsStagingVolume(ctx, client, cr, &ss.Spec.Template, &cr.Spec.AppFrameworkConfig)
+	appEngineInput := EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             cr,
+		AppFrameworkConfig: &cr.Spec.AppFrameworkConfig,
+		AppDeployContext:   &cr.Status.AppContext,
+		PodTemplateSpec:    &ss.Spec.Template,
+	}
+	DefaultAppFrameworkEngine.EnsureAppFrameworkStagingVolume(appEngineInput)
 
 	return ss, err
 }

--- a/pkg/splunk/enterprise/licensemaster.go
+++ b/pkg/splunk/enterprise/licensemaster.go
@@ -65,7 +65,15 @@ func ApplyLicenseMaster(ctx context.Context, client splcommon.ControllerClient, 
 	}
 
 	// If needed, Migrate the app framework status
-	err = checkAndMigrateAppDeployStatus(ctx, client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig, true)
+	appEngineInput := EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             cr,
+		AppFrameworkConfig: &cr.Spec.AppFrameworkConfig,
+		AppDeployContext:   &cr.Status.AppContext,
+		Scope:              enterpriseApi.ScopeLocal,
+	}
+	err = DefaultAppFrameworkEngine.EnsureAppFrameworkStatus(appEngineInput)
 	if err != nil {
 		return result, err
 	}
@@ -74,7 +82,7 @@ func ApplyLicenseMaster(ctx context.Context, client splcommon.ControllerClient, 
 	// 1. Initialize the S3Clients based on providers
 	// 2. Check the status of apps on remote storage.
 	if len(cr.Spec.AppFrameworkConfig.AppSources) != 0 {
-		err := initAndCheckAppInfoStatus(ctx, client, cr, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext)
+		err := DefaultAppFrameworkEngine.EnsureAppRepoState(appEngineInput)
 		if err != nil {
 			eventPublisher.Warning(ctx, "initAndCheckAppInfoStatus", fmt.Sprintf("init and check app info status failed %s", err.Error()))
 			cr.Status.AppContext.IsDeploymentInProgress = false
@@ -175,8 +183,11 @@ func ApplyLicenseMaster(ctx context.Context, client splcommon.ControllerClient, 
 			cr.Status.TelAppInstalled = true
 		}
 
-		finalResult := handleAppFrameworkActivity(ctx, client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig)
-		result = *finalResult
+		appEngineInput.Phase = cr.Status.Phase
+		finalResult := DefaultAppFrameworkEngine.RunAppFrameworkIfReady(appEngineInput)
+		if finalResult.Result != nil {
+			result = *finalResult.Result
+		}
 	}
 	// RequeueAfter if greater than 0, tells the Controller to requeue the reconcile key after the Duration.
 	// Implies that Requeue is true, there is no need to set Requeue to true at the same time as RequeueAfter.
@@ -194,7 +205,15 @@ func getLicenseMasterStatefulSet(ctx context.Context, client splcommon.Controlle
 	}
 
 	// Setup App framework staging volume for apps
-	setupAppsStagingVolume(ctx, client, cr, &ss.Spec.Template, &cr.Spec.AppFrameworkConfig)
+	appEngineInput := EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             cr,
+		AppFrameworkConfig: &cr.Spec.AppFrameworkConfig,
+		AppDeployContext:   &cr.Status.AppContext,
+		PodTemplateSpec:    &ss.Spec.Template,
+	}
+	DefaultAppFrameworkEngine.EnsureAppFrameworkStagingVolume(appEngineInput)
 
 	return ss, err
 }

--- a/pkg/splunk/enterprise/monitoringconsole.go
+++ b/pkg/splunk/enterprise/monitoringconsole.go
@@ -73,7 +73,15 @@ func ApplyMonitoringConsole(ctx context.Context, client splcommon.ControllerClie
 	}
 
 	// If needed, Migrate the app framework status
-	err = checkAndMigrateAppDeployStatus(ctx, client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig, true)
+	appEngineInput := EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             cr,
+		AppFrameworkConfig: &cr.Spec.AppFrameworkConfig,
+		AppDeployContext:   &cr.Status.AppContext,
+		Scope:              enterpriseApi.ScopeLocal,
+	}
+	err = DefaultAppFrameworkEngine.EnsureAppFrameworkStatus(appEngineInput)
 	if err != nil {
 		return result, err
 	}
@@ -82,7 +90,7 @@ func ApplyMonitoringConsole(ctx context.Context, client splcommon.ControllerClie
 	// 1. Initialize the S3Clients based on providers
 	// 2. Check the status of apps on remote storage.
 	if len(cr.Spec.AppFrameworkConfig.AppSources) != 0 {
-		err := initAndCheckAppInfoStatus(ctx, client, cr, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext)
+		err := DefaultAppFrameworkEngine.EnsureAppRepoState(appEngineInput)
 		if err != nil {
 			eventPublisher.Warning(ctx, "initAndCheckAppInfoStatus", fmt.Sprintf("init and check app info status failed %s", err.Error()))
 			cr.Status.AppContext.IsDeploymentInProgress = false
@@ -161,8 +169,11 @@ func ApplyMonitoringConsole(ctx context.Context, client splcommon.ControllerClie
 
 	// no need to requeue if everything is ready
 	if cr.Status.Phase == enterpriseApi.PhaseReady {
-		finalResult := handleAppFrameworkActivity(ctx, client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig)
-		result = *finalResult
+		appEngineInput.Phase = cr.Status.Phase
+		finalResult := DefaultAppFrameworkEngine.RunAppFrameworkIfReady(appEngineInput)
+		if finalResult.Result != nil {
+			result = *finalResult.Result
+		}
 
 	}
 	// RequeueAfter if greater than 0, tells the Controller to requeue the reconcile key after the Duration.
@@ -202,7 +213,15 @@ func getMonitoringConsoleStatefulSet(ctx context.Context, client splcommon.Contr
 	ss.Spec.Template.ObjectMeta.Annotations[monitoringConsoleConfigRev] = monitoringConsoleConfigMap.ResourceVersion
 
 	// Setup App framework staging volume for apps
-	setupAppsStagingVolume(ctx, client, cr, &ss.Spec.Template, &cr.Spec.AppFrameworkConfig)
+	appEngineInput := EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             cr,
+		AppFrameworkConfig: &cr.Spec.AppFrameworkConfig,
+		AppDeployContext:   &cr.Status.AppContext,
+		PodTemplateSpec:    &ss.Spec.Template,
+	}
+	DefaultAppFrameworkEngine.EnsureAppFrameworkStagingVolume(appEngineInput)
 	return ss, nil
 }
 

--- a/pkg/splunk/enterprise/searchheadcluster.go
+++ b/pkg/splunk/enterprise/searchheadcluster.go
@@ -69,7 +69,15 @@ func ApplySearchHeadCluster(ctx context.Context, client splcommon.ControllerClie
 	}
 
 	// If needed, Migrate the app framework status
-	err = checkAndMigrateAppDeployStatus(ctx, client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig, false)
+	appEngineInput := EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             cr,
+		AppFrameworkConfig: &cr.Spec.AppFrameworkConfig,
+		AppDeployContext:   &cr.Status.AppContext,
+		Scope:              enterpriseApi.ScopeCluster,
+	}
+	err = DefaultAppFrameworkEngine.EnsureAppFrameworkStatus(appEngineInput)
 	if err != nil {
 		return result, err
 	}
@@ -86,7 +94,7 @@ func ApplySearchHeadCluster(ctx context.Context, client splcommon.ControllerClie
 	// 1. Initialize the S3Clients based on providers
 	// 2. Check the status of apps on remote storage.
 	if len(cr.Spec.AppFrameworkConfig.AppSources) != 0 {
-		err := initAndCheckAppInfoStatus(ctx, client, cr, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext)
+		err := DefaultAppFrameworkEngine.EnsureAppRepoState(appEngineInput)
 		if err != nil {
 			eventPublisher.Warning(ctx, "initAndCheckAppInfoStatus", fmt.Sprintf("init and check app info status failed %s", err.Error()))
 			cr.Status.AppContext.IsDeploymentInProgress = false
@@ -208,7 +216,8 @@ func ApplySearchHeadCluster(ctx context.Context, client splcommon.ControllerClie
 
 	var finalResult *reconcile.Result
 	if cr.Status.DeployerPhase == enterpriseApi.PhaseReady {
-		finalResult = handleAppFrameworkActivity(ctx, client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig)
+		appEngineInput.Phase = cr.Status.Phase
+		finalResult = DefaultAppFrameworkEngine.RunAppFrameworkIfReady(appEngineInput).Result
 	}
 
 	// no need to requeue if everything is ready
@@ -481,7 +490,15 @@ func getDeployerStatefulSet(ctx context.Context, client splcommon.ControllerClie
 	}
 
 	// Setup App framework staging volume for apps
-	setupAppsStagingVolume(ctx, client, cr, &ss.Spec.Template, &cr.Spec.AppFrameworkConfig)
+	appEngineInput := EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             cr,
+		AppFrameworkConfig: &cr.Spec.AppFrameworkConfig,
+		AppDeployContext:   &cr.Status.AppContext,
+		PodTemplateSpec:    &ss.Spec.Template,
+	}
+	DefaultAppFrameworkEngine.EnsureAppFrameworkStagingVolume(appEngineInput)
 
 	return ss, err
 }

--- a/pkg/splunk/enterprise/standalone.go
+++ b/pkg/splunk/enterprise/standalone.go
@@ -71,7 +71,15 @@ func ApplyStandalone(ctx context.Context, client splcommon.ControllerClient, cr 
 	cr.Status.Replicas = cr.Spec.Replicas
 
 	// If needed, Migrate the app framework status
-	err = checkAndMigrateAppDeployStatus(ctx, client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig, true)
+	appEngineInput := EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             cr,
+		AppFrameworkConfig: &cr.Spec.AppFrameworkConfig,
+		AppDeployContext:   &cr.Status.AppContext,
+		Scope:              enterpriseApi.ScopeLocal,
+	}
+	err = DefaultAppFrameworkEngine.EnsureAppFrameworkStatus(appEngineInput)
 	if err != nil {
 		return result, err
 	}
@@ -96,7 +104,7 @@ func ApplyStandalone(ctx context.Context, client splcommon.ControllerClient, cr 
 	// 1. Initialize the S3Clients based on providers
 	// 2. Check the status of apps on remote storage.
 	if len(cr.Spec.AppFrameworkConfig.AppSources) != 0 {
-		err := initAndCheckAppInfoStatus(ctx, client, cr, &cr.Spec.AppFrameworkConfig, &cr.Status.AppContext)
+		err := DefaultAppFrameworkEngine.EnsureAppRepoState(appEngineInput)
 		if err != nil {
 			eventPublisher.Warning(ctx, "initAndCheckAppInfoStatus", fmt.Sprintf("init and check app info status failed %s", err.Error()))
 			cr.Status.AppContext.IsDeploymentInProgress = false
@@ -241,8 +249,11 @@ func ApplyStandalone(ctx context.Context, client splcommon.ControllerClient, cr 
 			}
 		}
 
-		finalResult := handleAppFrameworkActivity(ctx, client, cr, &cr.Status.AppContext, &cr.Spec.AppFrameworkConfig)
-		result = *finalResult
+		appEngineInput.Phase = cr.Status.Phase
+		finalResult := DefaultAppFrameworkEngine.RunAppFrameworkIfReady(appEngineInput)
+		if finalResult.Result != nil {
+			result = *finalResult.Result
+		}
 
 		// Add a splunk operator telemetry app
 		if cr.Spec.EtcVolumeStorageConfig.EphemeralStorage || !cr.Status.TelAppInstalled {
@@ -280,7 +291,15 @@ func getStandaloneStatefulSet(ctx context.Context, client splcommon.ControllerCl
 	}
 
 	// Setup App framework staging volume for apps
-	setupAppsStagingVolume(ctx, client, cr, &ss.Spec.Template, &cr.Spec.AppFrameworkConfig)
+	appEngineInput := EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             cr,
+		AppFrameworkConfig: &cr.Spec.AppFrameworkConfig,
+		AppDeployContext:   &cr.Status.AppContext,
+		PodTemplateSpec:    &ss.Spec.Template,
+	}
+	DefaultAppFrameworkEngine.EnsureAppFrameworkStagingVolume(appEngineInput)
 
 	return ss, nil
 }

--- a/pkg/splunk/enterprise/util_test.go
+++ b/pkg/splunk/enterprise/util_test.go
@@ -738,7 +738,14 @@ func TestInitAndCheckAppInfoStatusShouldNotFail(t *testing.T) {
 
 	var appDeployContext enterpriseApi.AppDeploymentContext
 	appDeployContext.AppFrameworkConfig = cr.Spec.AppFrameworkConfig
-	err = initAndCheckAppInfoStatus(ctx, client, &cr, &cr.Spec.AppFrameworkConfig, &appDeployContext)
+	appEngineInput := EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             &cr,
+		AppFrameworkConfig: &cr.Spec.AppFrameworkConfig,
+		AppDeployContext:   &appDeployContext,
+	}
+	err = DefaultAppFrameworkEngine.EnsureAppRepoState(appEngineInput)
 	if err != nil {
 		t.Errorf("initAndCheckAppInfoStatus should not have returned error")
 	}
@@ -760,7 +767,14 @@ func TestInitAndCheckAppInfoStatusShouldNotFail(t *testing.T) {
 
 	var appDeployContext2 enterpriseApi.AppDeploymentContext
 	appDeployContext2.AppFrameworkConfig = revised.Spec.AppFrameworkConfig
-	err = initAndCheckAppInfoStatus(ctx, client, &revised, &revised.Spec.AppFrameworkConfig, &appDeployContext2)
+	appEngineInput = EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             &revised,
+		AppFrameworkConfig: &revised.Spec.AppFrameworkConfig,
+		AppDeployContext:   &appDeployContext2,
+	}
+	err = DefaultAppFrameworkEngine.EnsureAppRepoState(appEngineInput)
 	if err != nil {
 		t.Errorf("initAndCheckAppInfoStatus should not have returned error")
 	}
@@ -802,7 +816,14 @@ func TestInitAndCheckAppInfoStatusShouldNotFail(t *testing.T) {
 		t.Errorf("Unable to set owner reference for configMap: %s", configMap.Name)
 	}
 
-	err = initAndCheckAppInfoStatus(ctx, client, &revised, &revised.Spec.AppFrameworkConfig, &appDeployContext2)
+	appEngineInput = EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             &revised,
+		AppFrameworkConfig: &revised.Spec.AppFrameworkConfig,
+		AppDeployContext:   &appDeployContext2,
+	}
+	err = DefaultAppFrameworkEngine.EnsureAppRepoState(appEngineInput)
 	if err != nil {
 		t.Errorf("initAndCheckAppInfoStatus should not have returned error")
 	}
@@ -815,7 +836,14 @@ func TestInitAndCheckAppInfoStatusShouldNotFail(t *testing.T) {
 	}
 
 	appDeployContext2.IsDeploymentInProgress = false
-	err = initAndCheckAppInfoStatus(ctx, client, &cr, &cr.Spec.AppFrameworkConfig, &appDeployContext2)
+	appEngineInput = EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             &cr,
+		AppFrameworkConfig: &cr.Spec.AppFrameworkConfig,
+		AppDeployContext:   &appDeployContext2,
+	}
+	err = DefaultAppFrameworkEngine.EnsureAppRepoState(appEngineInput)
 	if err != nil {
 		t.Errorf("initAndCheckAppInfoStatus should not have returned error")
 	}
@@ -875,7 +903,14 @@ func TestInitAndCheckAppInfoStatusShouldFail(t *testing.T) {
 	var appDeployContext enterpriseApi.AppDeploymentContext
 	appDeployContext.AppFrameworkConfig = cr.Spec.AppFrameworkConfig
 
-	initAndCheckAppInfoStatus(ctx, client, &cr, &cr.Spec.AppFrameworkConfig, &appDeployContext)
+	appEngineInput := EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             &cr,
+		AppFrameworkConfig: &cr.Spec.AppFrameworkConfig,
+		AppDeployContext:   &appDeployContext,
+	}
+	DefaultAppFrameworkEngine.EnsureAppRepoState(appEngineInput)
 	if appDeployContext.LastAppInfoCheckTime != 0 {
 		t.Errorf("We should not have updated the LastAppInfoCheckTime as polling of apps repo is disabled.")
 	}
@@ -2476,7 +2511,15 @@ func TestCheckAndMigrateAppDeployStatus(t *testing.T) {
 		},
 	}
 
-	err := checkAndMigrateAppDeployStatus(ctx, client, cr, appDeployContext, appFrameworkConfig, true)
+	appEngineInput := EngineInput{
+		Ctx:                ctx,
+		Client:             client,
+		Target:             cr,
+		AppFrameworkConfig: appFrameworkConfig,
+		AppDeployContext:   appDeployContext,
+		Scope:              enterpriseApi.ScopeLocal,
+	}
+	err := DefaultAppFrameworkEngine.EnsureAppFrameworkStatus(appEngineInput)
 	if err != nil {
 		t.Errorf("When the app deploy context is nil, should not return an error")
 	}
@@ -2498,6 +2541,7 @@ func TestCheckAndMigrateAppDeployStatus(t *testing.T) {
 	}
 
 	appDeployContext.AppsSrcDeployStatus["appSrc1"] = appSrcDeploymentInfo
+	appEngineInput.AppDeployContext = appDeployContext
 
 	statefulSetName := "splunk-stack1-standalone"
 	var replicas int32 = 4
@@ -2532,7 +2576,8 @@ func TestCheckAndMigrateAppDeployStatus(t *testing.T) {
 		}
 	}
 
-	err = checkAndMigrateAppDeployStatus(ctx, client, cr, appDeployContext, appFrameworkConfig, true)
+	appEngineInput.AppDeployContext = appDeployContext
+	err = DefaultAppFrameworkEngine.EnsureAppFrameworkStatus(appEngineInput)
 	if err != nil {
 		t.Errorf("With proper app spec and status contexts, migration should happen. error: %v", err)
 	}


### PR DESCRIPTION
### Description

This PR is a proposition of introducing the app engine - internal component that wraps the app framework pipeline and separates its logic without changing observable behavior.

### Key Changes

This PR introduces `appengine.go` file, adds the engine and changes the app framework calls to app engine calls.

### Testing and Verification

_How did you test these changes? What automated tests are added?_

### Related Issues

_Jira tickets, GitHub issues, Support tickets..._

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [X] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [ ] All tests pass locally.
- [ ] The PR description follows the project's guidelines.
