### PR TITLE
feat: Add comprehensive webhook validations for CRD configuration

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -303,6 +303,7 @@ func main() {
 			Validators:   validation.DefaultValidators,
 			ReadTimeout:  readTimeout,
 			WriteTimeout: writeTimeout,
+			Client:       mgr.GetClient(),
 		})
 
 		// Add webhook server as a runnable to the manager

--- a/docs/ValidationWebhook.md
+++ b/docs/ValidationWebhook.md
@@ -83,6 +83,16 @@ The webhook validates the following spec fields:
 | `spec.varVolumeStorageConfig.storageCapacity` | Must match format `^[0-9]+Gi$` | must be in Gi format (e.g., '10Gi', '100Gi') |
 | `spec.etcVolumeStorageConfig.storageClassName` | Required when `ephemeralStorage=false` and `storageCapacity` is set | storageClassName is required when using persistent storage |
 | `spec.varVolumeStorageConfig.storageClassName` | Required when `ephemeralStorage=false` and `storageCapacity` is set | storageClassName is required when using persistent storage |
+| `spec.etcVolumeStorageConfig.ephemeralStorage` | Mutually exclusive with `storageClassName` and `storageCapacity` | storageClassName/storageCapacity cannot be set when ephemeralStorage is true |
+| `spec.varVolumeStorageConfig.ephemeralStorage` | Mutually exclusive with `storageClassName` and `storageCapacity` | storageClassName/storageCapacity cannot be set when ephemeralStorage is true |
+| `spec.extraEnv[*].name` | Must be unique across all entries | duplicate environment variable |
+| `spec.imagePullSecrets[*].name` | Must be unique across all entries | duplicate secret reference |
+| `spec.imagePullSecrets[*].name` | Must reference an existing Secret in the namespace | not found |
+| `spec.livenessProbe.initialDelaySeconds` | Must be ≥ 0 | must be non-negative |
+| `spec.readinessProbe.initialDelaySeconds` | Must be ≥ 0 | must be non-negative |
+| `spec.startupProbe.initialDelaySeconds` | Must be ≥ 0 | must be non-negative |
+| `spec.resources.requests.cpu` | Must be ≤ `limits.cpu` | request must be less than or equal to limit |
+| `spec.resources.requests.memory` | Must be ≤ `limits.memory` | request must be less than or equal to limit |
 
 ### CRD-Specific Fields
 
@@ -111,6 +121,9 @@ AppFramework configuration is validated only when provided:
 |-------|-----------------|
 | `spec.appRepo.appSources[*].name` | Required (non-empty) |
 | `spec.appRepo.appSources[*].location` | Required (non-empty) |
+| `spec.appRepo.appSources[*]` | Combination of `location` + `scope` must be unique across all appSources |
+| `spec.appRepo.appSources[*].premiumAppsProps` | Required when `scope=premiumApps` |
+| `spec.appRepo.appsRepoPollIntervalSeconds` | Must be ≥ 0 |
 | `spec.appRepo.volumes[*].name` | Required (non-empty) |
 
 ## Example Validation Errors
@@ -165,6 +178,42 @@ spec:
 Error:
 ```
 The Standalone "example" is invalid: spec.smartstore.volumes[0].name: Required value: volume name is required
+```
+
+### Non-Existent ImagePullSecret
+
+```yaml
+apiVersion: enterprise.splunk.com/v4
+kind: Standalone
+metadata:
+  name: example
+  namespace: splunk
+spec:
+  imagePullSecrets:
+    - name: my-registry-secret  # Invalid: secret does not exist in namespace
+```
+
+Error:
+```
+The Standalone "example" is invalid: spec.imagePullSecrets[0].name: Not found: "my-registry-secret"
+```
+
+### Ephemeral Storage with StorageClassName
+
+```yaml
+apiVersion: enterprise.splunk.com/v4
+kind: Standalone
+metadata:
+  name: example
+spec:
+  etcVolumeStorageConfig:
+    ephemeralStorage: true
+    storageClassName: "standard"  # Invalid: cannot set with ephemeralStorage=true
+```
+
+Error:
+```
+The Standalone "example" is invalid: spec.etcVolumeStorageConfig.storageClassName: Invalid value: "standard": storageClassName cannot be set when ephemeralStorage is true
 ```
 
 ## Verifying Webhook Deployment
@@ -263,6 +312,121 @@ The validation webhook consists of:
 4. Webhook server validates the spec fields
 5. Webhook returns Allowed/Denied response
 6. If allowed, the resource is persisted; if denied, user receives error
+
+## Adding a New CRD to the Webhook
+
+To add validation for a new CRD, follow these steps:
+
+### 1. Create Validation Functions
+
+Create a new file `pkg/splunk/enterprise/validation/<crd>_validation.go`:
+
+```go
+package validation
+
+import (
+    "k8s.io/apimachinery/pkg/util/validation/field"
+    enterpriseApi "github.com/splunk/splunk-operator/api/v4"
+)
+
+// Validate<CRD>Create validates a <CRD> on CREATE
+func Validate<CRD>Create(obj *enterpriseApi.<CRD>) field.ErrorList {
+    var allErrs field.ErrorList
+    // Add validation logic
+    allErrs = append(allErrs, validateCommonSplunkSpec(&obj.Spec.CommonSplunkSpec, field.NewPath("spec"))...)
+    return allErrs
+}
+
+// Validate<CRD>CreateWithContext validates with access to Kubernetes API
+// Use this for validations that need to check if resources exist (e.g., Secrets)
+func Validate<CRD>CreateWithContext(obj *enterpriseApi.<CRD>, vc *ValidationContext) field.ErrorList {
+    allErrs := Validate<CRD>Create(obj)
+    if len(obj.Spec.ImagePullSecrets) > 0 {
+        allErrs = append(allErrs, ValidateImagePullSecretsExistence(
+            obj.Spec.ImagePullSecrets, vc, field.NewPath("spec").Child("imagePullSecrets"))...)
+    }
+    return allErrs
+}
+
+// Validate<CRD>Update validates a <CRD> on UPDATE
+func Validate<CRD>Update(obj, oldObj *enterpriseApi.<CRD>) field.ErrorList {
+    return Validate<CRD>Create(obj)
+}
+
+// Validate<CRD>UpdateWithContext validates on UPDATE with Kubernetes API access
+func Validate<CRD>UpdateWithContext(obj, oldObj *enterpriseApi.<CRD>, vc *ValidationContext) field.ErrorList {
+    return Validate<CRD>CreateWithContext(obj, vc)
+}
+
+// Get<CRD>WarningsOnCreate returns warnings for CREATE
+func Get<CRD>WarningsOnCreate(obj *enterpriseApi.<CRD>) []string {
+    return getCommonWarnings(&obj.Spec.CommonSplunkSpec)
+}
+
+// Get<CRD>WarningsOnUpdate returns warnings for UPDATE
+func Get<CRD>WarningsOnUpdate(obj, oldObj *enterpriseApi.<CRD>) []string {
+    return Get<CRD>WarningsOnCreate(obj)
+}
+```
+
+### 2. Register the Validator
+
+Add the GVR and validator to `pkg/splunk/enterprise/validation/registry.go`:
+
+```go
+// Add GVR constant
+var <CRD>GVR = schema.GroupVersionResource{
+    Group:    "enterprise.splunk.com",
+    Version:  "v4",
+    Resource: "<crd>s",  // plural, lowercase
+}
+
+// Add to DefaultValidators map
+var DefaultValidators = map[schema.GroupVersionResource]Validator{
+    // ... existing validators ...
+    
+    <CRD>GVR: &GenericValidator[*enterpriseApi.<CRD>]{
+        ValidateCreateFunc:            Validate<CRD>Create,
+        ValidateUpdateFunc:            Validate<CRD>Update,
+        ValidateCreateWithContextFunc: Validate<CRD>CreateWithContext,  // Optional: for resource lookups
+        ValidateUpdateWithContextFunc: Validate<CRD>UpdateWithContext,  // Optional: for resource lookups
+        WarningsOnCreateFunc:          Get<CRD>WarningsOnCreate,
+        WarningsOnUpdateFunc:          Get<CRD>WarningsOnUpdate,
+        GroupKind: schema.GroupKind{
+            Group: "enterprise.splunk.com",
+            Kind:  "<CRD>",
+        },
+    },
+}
+```
+
+### 3. Add Unit Tests
+
+Create `pkg/splunk/enterprise/validation/<crd>_validation_test.go` with test cases.
+
+### 4. Update ValidatingWebhookConfiguration
+
+Add the new resource to `config/webhook/manifests.yaml`:
+
+```yaml
+webhooks:
+  - name: validate.enterprise.splunk.com
+    rules:
+      - apiGroups: ["enterprise.splunk.com"]
+        apiVersions: ["v4"]
+        operations: ["CREATE", "UPDATE"]
+        resources:
+          - standalones
+          - indexerclusters
+          - <crd>s  # Add new resource here
+```
+
+### Context-Aware vs Basic Validation
+
+- **Basic validation** (`ValidateCreateFunc`): For validations that only need the CR itself (field formats, required fields, cross-field rules)
+- **Context-aware validation** (`ValidateCreateWithContextFunc`): For validations that need to query the Kubernetes API (checking if Secrets, ConfigMaps, or other resources exist)
+
+If your CRD doesn't need context-aware validation, you can omit `ValidateCreateWithContextFunc` and `ValidateUpdateWithContextFunc` - the webhook will automatically fall back to the basic validation functions.
 
 ## Disabling the Webhook
 

--- a/pkg/splunk/enterprise/validation/clustermanager_validation.go
+++ b/pkg/splunk/enterprise/validation/clustermanager_validation.go
@@ -42,10 +42,25 @@ func ValidateClusterManagerCreate(obj *enterpriseApi.ClusterManager) field.Error
 	return allErrs
 }
 
+// ValidateClusterManagerCreateWithContext validates a ClusterManager on CREATE with ValidationContext
+func ValidateClusterManagerCreateWithContext(obj *enterpriseApi.ClusterManager, vc *ValidationContext) field.ErrorList {
+	allErrs := ValidateClusterManagerCreate(obj)
+	if len(obj.Spec.ImagePullSecrets) > 0 {
+		allErrs = append(allErrs, ValidateImagePullSecretsExistence(
+			obj.Spec.ImagePullSecrets, vc, field.NewPath("spec").Child("imagePullSecrets"))...)
+	}
+	return allErrs
+}
+
 // ValidateClusterManagerUpdate validates a ClusterManager on UPDATE
 // TODO: Add immutable field validation here (e.g., compare obj vs oldObj for fields that cannot change after creation)
 func ValidateClusterManagerUpdate(obj, oldObj *enterpriseApi.ClusterManager) field.ErrorList {
 	return ValidateClusterManagerCreate(obj)
+}
+
+// ValidateClusterManagerUpdateWithContext validates a ClusterManager on UPDATE with ValidationContext
+func ValidateClusterManagerUpdateWithContext(obj, oldObj *enterpriseApi.ClusterManager, vc *ValidationContext) field.ErrorList {
+	return ValidateClusterManagerCreateWithContext(obj, vc)
 }
 
 // GetClusterManagerWarningsOnCreate returns warnings for ClusterManager CREATE

--- a/pkg/splunk/enterprise/validation/common_validation.go
+++ b/pkg/splunk/enterprise/validation/common_validation.go
@@ -358,3 +358,35 @@ func getCommonWarnings(spec *enterpriseApi.CommonSplunkSpec) []string {
 
 	return warnings
 }
+
+// ValidateImagePullSecretsExistence validates that imagePullSecrets reference existing secrets
+// This function requires a ValidationContext with a Kubernetes client
+func ValidateImagePullSecretsExistence(secrets []corev1.LocalObjectReference, vc *ValidationContext, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if vc == nil || vc.Client == nil {
+		// Skip existence validation if no client is available
+		return allErrs
+	}
+
+	for i, secret := range secrets {
+		if secret.Name == "" {
+			continue // Empty names are validated elsewhere
+		}
+
+		exists, err := vc.SecretExists(secret.Name)
+		if err != nil {
+			// Log the error but don't fail validation for transient errors
+			// This prevents webhook failures due to temporary API issues
+			continue
+		}
+
+		if !exists {
+			allErrs = append(allErrs, field.NotFound(
+				fldPath.Index(i).Child("name"),
+				secret.Name))
+		}
+	}
+
+	return allErrs
+}

--- a/pkg/splunk/enterprise/validation/common_validation_test.go
+++ b/pkg/splunk/enterprise/validation/common_validation_test.go
@@ -922,6 +922,53 @@ func TestValidateStorageConfig(t *testing.T) {
 	}
 }
 
+func TestValidateImagePullSecretsExistence(t *testing.T) {
+	tests := []struct {
+		name         string
+		secrets      []corev1.LocalObjectReference
+		vc           *ValidationContext
+		wantErrCount int
+	}{
+		{
+			name:         "nil context - skip validation",
+			secrets:      []corev1.LocalObjectReference{{Name: "my-secret"}},
+			vc:           nil,
+			wantErrCount: 0,
+		},
+		{
+			name:         "nil client - skip validation",
+			secrets:      []corev1.LocalObjectReference{{Name: "my-secret"}},
+			vc:           &ValidationContext{Client: nil, Namespace: "default"},
+			wantErrCount: 0,
+		},
+		{
+			name:         "empty secrets list - no errors",
+			secrets:      []corev1.LocalObjectReference{},
+			vc:           nil,
+			wantErrCount: 0,
+		},
+		{
+			name:         "empty secret name - skipped",
+			secrets:      []corev1.LocalObjectReference{{Name: ""}},
+			vc:           nil,
+			wantErrCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidateImagePullSecretsExistence(tt.secrets, tt.vc, field.NewPath("spec").Child("imagePullSecrets"))
+
+			if len(errs) != tt.wantErrCount {
+				t.Errorf("ValidateImagePullSecretsExistence() got %d errors, want %d", len(errs), tt.wantErrCount)
+				for _, e := range errs {
+					t.Logf("  error: %s", e.Error())
+				}
+			}
+		})
+	}
+}
+
 func TestGetCommonWarnings(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/pkg/splunk/enterprise/validation/context.go
+++ b/pkg/splunk/enterprise/validation/context.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2018-2026 Splunk Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ValidationContext provides context for validation operations that may need
+// to access Kubernetes resources
+type ValidationContext struct {
+	// Client is the Kubernetes client for resource lookups
+	Client client.Client
+
+	// Namespace is the namespace of the object being validated
+	Namespace string
+
+	// Ctx is the context for API calls
+	Ctx context.Context
+}
+
+// NewValidationContext creates a new ValidationContext
+func NewValidationContext(c client.Client, namespace string) *ValidationContext {
+	return &ValidationContext{
+		Client:    c,
+		Namespace: namespace,
+		Ctx:       context.Background(),
+	}
+}
+
+// SecretExists checks if a secret with the given name exists in the namespace
+func (vc *ValidationContext) SecretExists(name string) (bool, error) {
+	if vc.Client == nil {
+		// If no client is available, skip existence check
+		return true, nil
+	}
+
+	secret := &corev1.Secret{}
+	err := vc.Client.Get(vc.Ctx, types.NamespacedName{
+		Name:      name,
+		Namespace: vc.Namespace,
+	}, secret)
+
+	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			// Secret not found
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}

--- a/pkg/splunk/enterprise/validation/indexercluster_validation.go
+++ b/pkg/splunk/enterprise/validation/indexercluster_validation.go
@@ -40,10 +40,25 @@ func ValidateIndexerClusterCreate(obj *enterpriseApi.IndexerCluster) field.Error
 	return allErrs
 }
 
+// ValidateIndexerClusterCreateWithContext validates an IndexerCluster on CREATE with ValidationContext
+func ValidateIndexerClusterCreateWithContext(obj *enterpriseApi.IndexerCluster, vc *ValidationContext) field.ErrorList {
+	allErrs := ValidateIndexerClusterCreate(obj)
+	if len(obj.Spec.ImagePullSecrets) > 0 {
+		allErrs = append(allErrs, ValidateImagePullSecretsExistence(
+			obj.Spec.ImagePullSecrets, vc, field.NewPath("spec").Child("imagePullSecrets"))...)
+	}
+	return allErrs
+}
+
 // ValidateIndexerClusterUpdate validates an IndexerCluster on UPDATE
 // TODO: Add immutable field validation here (e.g., compare obj vs oldObj for fields that cannot change after creation)
 func ValidateIndexerClusterUpdate(obj, oldObj *enterpriseApi.IndexerCluster) field.ErrorList {
 	return ValidateIndexerClusterCreate(obj)
+}
+
+// ValidateIndexerClusterUpdateWithContext validates an IndexerCluster on UPDATE with ValidationContext
+func ValidateIndexerClusterUpdateWithContext(obj, oldObj *enterpriseApi.IndexerCluster, vc *ValidationContext) field.ErrorList {
+	return ValidateIndexerClusterCreateWithContext(obj, vc)
 }
 
 // GetIndexerClusterWarningsOnCreate returns warnings for IndexerCluster CREATE

--- a/pkg/splunk/enterprise/validation/licensemanager_validation.go
+++ b/pkg/splunk/enterprise/validation/licensemanager_validation.go
@@ -32,10 +32,25 @@ func ValidateLicenseManagerCreate(obj *enterpriseApi.LicenseManager) field.Error
 	return allErrs
 }
 
+// ValidateLicenseManagerCreateWithContext validates a LicenseManager on CREATE with ValidationContext
+func ValidateLicenseManagerCreateWithContext(obj *enterpriseApi.LicenseManager, vc *ValidationContext) field.ErrorList {
+	allErrs := ValidateLicenseManagerCreate(obj)
+	if len(obj.Spec.ImagePullSecrets) > 0 {
+		allErrs = append(allErrs, ValidateImagePullSecretsExistence(
+			obj.Spec.ImagePullSecrets, vc, field.NewPath("spec").Child("imagePullSecrets"))...)
+	}
+	return allErrs
+}
+
 // ValidateLicenseManagerUpdate validates a LicenseManager on UPDATE
 // TODO: Add immutable field validation here (e.g., compare obj vs oldObj for fields that cannot change after creation)
 func ValidateLicenseManagerUpdate(obj, oldObj *enterpriseApi.LicenseManager) field.ErrorList {
 	return ValidateLicenseManagerCreate(obj)
+}
+
+// ValidateLicenseManagerUpdateWithContext validates a LicenseManager on UPDATE with ValidationContext
+func ValidateLicenseManagerUpdateWithContext(obj, oldObj *enterpriseApi.LicenseManager, vc *ValidationContext) field.ErrorList {
+	return ValidateLicenseManagerCreateWithContext(obj, vc)
 }
 
 // GetLicenseManagerWarningsOnCreate returns warnings for LicenseManager CREATE

--- a/pkg/splunk/enterprise/validation/monitoringconsole_validation.go
+++ b/pkg/splunk/enterprise/validation/monitoringconsole_validation.go
@@ -32,10 +32,25 @@ func ValidateMonitoringConsoleCreate(obj *enterpriseApi.MonitoringConsole) field
 	return allErrs
 }
 
+// ValidateMonitoringConsoleCreateWithContext validates a MonitoringConsole on CREATE with ValidationContext
+func ValidateMonitoringConsoleCreateWithContext(obj *enterpriseApi.MonitoringConsole, vc *ValidationContext) field.ErrorList {
+	allErrs := ValidateMonitoringConsoleCreate(obj)
+	if len(obj.Spec.ImagePullSecrets) > 0 {
+		allErrs = append(allErrs, ValidateImagePullSecretsExistence(
+			obj.Spec.ImagePullSecrets, vc, field.NewPath("spec").Child("imagePullSecrets"))...)
+	}
+	return allErrs
+}
+
 // ValidateMonitoringConsoleUpdate validates a MonitoringConsole on UPDATE
 // TODO: Add immutable field validation here (e.g., compare obj vs oldObj for fields that cannot change after creation)
 func ValidateMonitoringConsoleUpdate(obj, oldObj *enterpriseApi.MonitoringConsole) field.ErrorList {
 	return ValidateMonitoringConsoleCreate(obj)
+}
+
+// ValidateMonitoringConsoleUpdateWithContext validates a MonitoringConsole on UPDATE with ValidationContext
+func ValidateMonitoringConsoleUpdateWithContext(obj, oldObj *enterpriseApi.MonitoringConsole, vc *ValidationContext) field.ErrorList {
+	return ValidateMonitoringConsoleCreateWithContext(obj, vc)
 }
 
 // GetMonitoringConsoleWarningsOnCreate returns warnings for MonitoringConsole CREATE

--- a/pkg/splunk/enterprise/validation/registry.go
+++ b/pkg/splunk/enterprise/validation/registry.go
@@ -76,10 +76,12 @@ var (
 // DefaultValidators is the registry of validators for all Splunk Enterprise CRDs
 var DefaultValidators = map[schema.GroupVersionResource]Validator{
 	StandaloneGVR: &GenericValidator[*enterpriseApi.Standalone]{
-		ValidateCreateFunc:   ValidateStandaloneCreate,
-		ValidateUpdateFunc:   ValidateStandaloneUpdate,
-		WarningsOnCreateFunc: GetStandaloneWarningsOnCreate,
-		WarningsOnUpdateFunc: GetStandaloneWarningsOnUpdate,
+		ValidateCreateFunc:            ValidateStandaloneCreate,
+		ValidateUpdateFunc:            ValidateStandaloneUpdate,
+		ValidateCreateWithContextFunc: ValidateStandaloneCreateWithContext,
+		ValidateUpdateWithContextFunc: ValidateStandaloneUpdateWithContext,
+		WarningsOnCreateFunc:          GetStandaloneWarningsOnCreate,
+		WarningsOnUpdateFunc:          GetStandaloneWarningsOnUpdate,
 		GroupKind: schema.GroupKind{
 			Group: "enterprise.splunk.com",
 			Kind:  "Standalone",
@@ -87,10 +89,12 @@ var DefaultValidators = map[schema.GroupVersionResource]Validator{
 	},
 
 	IndexerClusterGVR: &GenericValidator[*enterpriseApi.IndexerCluster]{
-		ValidateCreateFunc:   ValidateIndexerClusterCreate,
-		ValidateUpdateFunc:   ValidateIndexerClusterUpdate,
-		WarningsOnCreateFunc: GetIndexerClusterWarningsOnCreate,
-		WarningsOnUpdateFunc: GetIndexerClusterWarningsOnUpdate,
+		ValidateCreateFunc:            ValidateIndexerClusterCreate,
+		ValidateUpdateFunc:            ValidateIndexerClusterUpdate,
+		ValidateCreateWithContextFunc: ValidateIndexerClusterCreateWithContext,
+		ValidateUpdateWithContextFunc: ValidateIndexerClusterUpdateWithContext,
+		WarningsOnCreateFunc:          GetIndexerClusterWarningsOnCreate,
+		WarningsOnUpdateFunc:          GetIndexerClusterWarningsOnUpdate,
 		GroupKind: schema.GroupKind{
 			Group: "enterprise.splunk.com",
 			Kind:  "IndexerCluster",
@@ -98,10 +102,12 @@ var DefaultValidators = map[schema.GroupVersionResource]Validator{
 	},
 
 	SearchHeadClusterGVR: &GenericValidator[*enterpriseApi.SearchHeadCluster]{
-		ValidateCreateFunc:   ValidateSearchHeadClusterCreate,
-		ValidateUpdateFunc:   ValidateSearchHeadClusterUpdate,
-		WarningsOnCreateFunc: GetSearchHeadClusterWarningsOnCreate,
-		WarningsOnUpdateFunc: GetSearchHeadClusterWarningsOnUpdate,
+		ValidateCreateFunc:            ValidateSearchHeadClusterCreate,
+		ValidateUpdateFunc:            ValidateSearchHeadClusterUpdate,
+		ValidateCreateWithContextFunc: ValidateSearchHeadClusterCreateWithContext,
+		ValidateUpdateWithContextFunc: ValidateSearchHeadClusterUpdateWithContext,
+		WarningsOnCreateFunc:          GetSearchHeadClusterWarningsOnCreate,
+		WarningsOnUpdateFunc:          GetSearchHeadClusterWarningsOnUpdate,
 		GroupKind: schema.GroupKind{
 			Group: "enterprise.splunk.com",
 			Kind:  "SearchHeadCluster",
@@ -109,10 +115,12 @@ var DefaultValidators = map[schema.GroupVersionResource]Validator{
 	},
 
 	ClusterManagerGVR: &GenericValidator[*enterpriseApi.ClusterManager]{
-		ValidateCreateFunc:   ValidateClusterManagerCreate,
-		ValidateUpdateFunc:   ValidateClusterManagerUpdate,
-		WarningsOnCreateFunc: GetClusterManagerWarningsOnCreate,
-		WarningsOnUpdateFunc: GetClusterManagerWarningsOnUpdate,
+		ValidateCreateFunc:            ValidateClusterManagerCreate,
+		ValidateUpdateFunc:            ValidateClusterManagerUpdate,
+		ValidateCreateWithContextFunc: ValidateClusterManagerCreateWithContext,
+		ValidateUpdateWithContextFunc: ValidateClusterManagerUpdateWithContext,
+		WarningsOnCreateFunc:          GetClusterManagerWarningsOnCreate,
+		WarningsOnUpdateFunc:          GetClusterManagerWarningsOnUpdate,
 		GroupKind: schema.GroupKind{
 			Group: "enterprise.splunk.com",
 			Kind:  "ClusterManager",
@@ -121,10 +129,12 @@ var DefaultValidators = map[schema.GroupVersionResource]Validator{
 
 	// ClusterMaster is an alias for ClusterManager (deprecated)
 	ClusterMasterGVR: &GenericValidator[*enterpriseApi.ClusterManager]{
-		ValidateCreateFunc:   ValidateClusterManagerCreate,
-		ValidateUpdateFunc:   ValidateClusterManagerUpdate,
-		WarningsOnCreateFunc: GetClusterManagerWarningsOnCreate,
-		WarningsOnUpdateFunc: GetClusterManagerWarningsOnUpdate,
+		ValidateCreateFunc:            ValidateClusterManagerCreate,
+		ValidateUpdateFunc:            ValidateClusterManagerUpdate,
+		ValidateCreateWithContextFunc: ValidateClusterManagerCreateWithContext,
+		ValidateUpdateWithContextFunc: ValidateClusterManagerUpdateWithContext,
+		WarningsOnCreateFunc:          GetClusterManagerWarningsOnCreate,
+		WarningsOnUpdateFunc:          GetClusterManagerWarningsOnUpdate,
 		GroupKind: schema.GroupKind{
 			Group: "enterprise.splunk.com",
 			Kind:  "ClusterManager",
@@ -132,10 +142,12 @@ var DefaultValidators = map[schema.GroupVersionResource]Validator{
 	},
 
 	LicenseManagerGVR: &GenericValidator[*enterpriseApi.LicenseManager]{
-		ValidateCreateFunc:   ValidateLicenseManagerCreate,
-		ValidateUpdateFunc:   ValidateLicenseManagerUpdate,
-		WarningsOnCreateFunc: GetLicenseManagerWarningsOnCreate,
-		WarningsOnUpdateFunc: GetLicenseManagerWarningsOnUpdate,
+		ValidateCreateFunc:            ValidateLicenseManagerCreate,
+		ValidateUpdateFunc:            ValidateLicenseManagerUpdate,
+		ValidateCreateWithContextFunc: ValidateLicenseManagerCreateWithContext,
+		ValidateUpdateWithContextFunc: ValidateLicenseManagerUpdateWithContext,
+		WarningsOnCreateFunc:          GetLicenseManagerWarningsOnCreate,
+		WarningsOnUpdateFunc:          GetLicenseManagerWarningsOnUpdate,
 		GroupKind: schema.GroupKind{
 			Group: "enterprise.splunk.com",
 			Kind:  "LicenseManager",
@@ -144,10 +156,12 @@ var DefaultValidators = map[schema.GroupVersionResource]Validator{
 
 	// LicenseMaster is an alias for LicenseManager (deprecated)
 	LicenseMasterGVR: &GenericValidator[*enterpriseApi.LicenseManager]{
-		ValidateCreateFunc:   ValidateLicenseManagerCreate,
-		ValidateUpdateFunc:   ValidateLicenseManagerUpdate,
-		WarningsOnCreateFunc: GetLicenseManagerWarningsOnCreate,
-		WarningsOnUpdateFunc: GetLicenseManagerWarningsOnUpdate,
+		ValidateCreateFunc:            ValidateLicenseManagerCreate,
+		ValidateUpdateFunc:            ValidateLicenseManagerUpdate,
+		ValidateCreateWithContextFunc: ValidateLicenseManagerCreateWithContext,
+		ValidateUpdateWithContextFunc: ValidateLicenseManagerUpdateWithContext,
+		WarningsOnCreateFunc:          GetLicenseManagerWarningsOnCreate,
+		WarningsOnUpdateFunc:          GetLicenseManagerWarningsOnUpdate,
 		GroupKind: schema.GroupKind{
 			Group: "enterprise.splunk.com",
 			Kind:  "LicenseManager",
@@ -155,10 +169,12 @@ var DefaultValidators = map[schema.GroupVersionResource]Validator{
 	},
 
 	MonitoringConsoleGVR: &GenericValidator[*enterpriseApi.MonitoringConsole]{
-		ValidateCreateFunc:   ValidateMonitoringConsoleCreate,
-		ValidateUpdateFunc:   ValidateMonitoringConsoleUpdate,
-		WarningsOnCreateFunc: GetMonitoringConsoleWarningsOnCreate,
-		WarningsOnUpdateFunc: GetMonitoringConsoleWarningsOnUpdate,
+		ValidateCreateFunc:            ValidateMonitoringConsoleCreate,
+		ValidateUpdateFunc:            ValidateMonitoringConsoleUpdate,
+		ValidateCreateWithContextFunc: ValidateMonitoringConsoleCreateWithContext,
+		ValidateUpdateWithContextFunc: ValidateMonitoringConsoleUpdateWithContext,
+		WarningsOnCreateFunc:          GetMonitoringConsoleWarningsOnCreate,
+		WarningsOnUpdateFunc:          GetMonitoringConsoleWarningsOnUpdate,
 		GroupKind: schema.GroupKind{
 			Group: "enterprise.splunk.com",
 			Kind:  "MonitoringConsole",

--- a/pkg/splunk/enterprise/validation/searchheadcluster_validation.go
+++ b/pkg/splunk/enterprise/validation/searchheadcluster_validation.go
@@ -45,10 +45,25 @@ func ValidateSearchHeadClusterCreate(obj *enterpriseApi.SearchHeadCluster) field
 	return allErrs
 }
 
+// ValidateSearchHeadClusterCreateWithContext validates a SearchHeadCluster on CREATE with ValidationContext
+func ValidateSearchHeadClusterCreateWithContext(obj *enterpriseApi.SearchHeadCluster, vc *ValidationContext) field.ErrorList {
+	allErrs := ValidateSearchHeadClusterCreate(obj)
+	if len(obj.Spec.ImagePullSecrets) > 0 {
+		allErrs = append(allErrs, ValidateImagePullSecretsExistence(
+			obj.Spec.ImagePullSecrets, vc, field.NewPath("spec").Child("imagePullSecrets"))...)
+	}
+	return allErrs
+}
+
 // ValidateSearchHeadClusterUpdate validates a SearchHeadCluster on UPDATE
 // TODO: Add immutable field validation here (e.g., compare obj vs oldObj for fields that cannot change after creation)
 func ValidateSearchHeadClusterUpdate(obj, oldObj *enterpriseApi.SearchHeadCluster) field.ErrorList {
 	return ValidateSearchHeadClusterCreate(obj)
+}
+
+// ValidateSearchHeadClusterUpdateWithContext validates a SearchHeadCluster on UPDATE with ValidationContext
+func ValidateSearchHeadClusterUpdateWithContext(obj, oldObj *enterpriseApi.SearchHeadCluster, vc *ValidationContext) field.ErrorList {
+	return ValidateSearchHeadClusterCreateWithContext(obj, vc)
 }
 
 // GetSearchHeadClusterWarningsOnCreate returns warnings for SearchHeadCluster CREATE

--- a/pkg/splunk/enterprise/validation/server.go
+++ b/pkg/splunk/enterprise/validation/server.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -56,6 +57,9 @@ type WebhookServerOptions struct {
 
 	// WriteTimeout is the maximum duration before timing out writes of the response (default: 10s)
 	WriteTimeout time.Duration
+
+	// Client is the Kubernetes client for resource lookups (optional)
+	Client client.Client
 }
 
 // WebhookServer is the HTTP server for validation webhooks
@@ -170,7 +174,7 @@ func (s *WebhookServer) handleValidate(w http.ResponseWriter, r *http.Request) {
 			"user", admissionReview.Request.UserInfo.Username)
 	}
 
-	warnings, validationErr := Validate(&admissionReview, s.options.Validators)
+	warnings, validationErr := ValidateWithClient(&admissionReview, s.options.Validators, s.options.Client)
 
 	response := &admissionv1.AdmissionResponse{
 		UID: admissionReview.Request.UID,

--- a/pkg/splunk/enterprise/validation/standalone_validation.go
+++ b/pkg/splunk/enterprise/validation/standalone_validation.go
@@ -50,10 +50,32 @@ func ValidateStandaloneCreate(obj *enterpriseApi.Standalone) field.ErrorList {
 	return allErrs
 }
 
+// ValidateStandaloneCreateWithContext validates a Standalone on CREATE with ValidationContext
+// This enables resource existence checks (e.g., verifying imagePullSecrets exist)
+func ValidateStandaloneCreateWithContext(obj *enterpriseApi.Standalone, vc *ValidationContext) field.ErrorList {
+	// First, run all non-context validations
+	allErrs := ValidateStandaloneCreate(obj)
+
+	// Then, run context-aware validations
+	if len(obj.Spec.ImagePullSecrets) > 0 {
+		allErrs = append(allErrs, ValidateImagePullSecretsExistence(
+			obj.Spec.ImagePullSecrets,
+			vc,
+			field.NewPath("spec").Child("imagePullSecrets"))...)
+	}
+
+	return allErrs
+}
+
 // ValidateStandaloneUpdate validates a Standalone on UPDATE
 // TODO: Add immutable field validation here (e.g., compare obj vs oldObj for fields that cannot change after creation)
 func ValidateStandaloneUpdate(obj, oldObj *enterpriseApi.Standalone) field.ErrorList {
 	return ValidateStandaloneCreate(obj)
+}
+
+// ValidateStandaloneUpdateWithContext validates a Standalone on UPDATE with ValidationContext
+func ValidateStandaloneUpdateWithContext(obj, oldObj *enterpriseApi.Standalone, vc *ValidationContext) field.ErrorList {
+	return ValidateStandaloneCreateWithContext(obj, vc)
 }
 
 // GetStandaloneWarningsOnCreate returns warnings for Standalone CREATE

--- a/pkg/splunk/enterprise/validation/validate.go
+++ b/pkg/splunk/enterprise/validation/validate.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 )
@@ -42,6 +43,13 @@ func init() {
 // Validate performs validation on an AdmissionReview request
 // Returns warnings (even on success) and an error if validation fails
 func Validate(ar *admissionv1.AdmissionReview, validators map[schema.GroupVersionResource]Validator) ([]string, error) {
+	return ValidateWithClient(ar, validators, nil)
+}
+
+// ValidateWithClient performs validation on an AdmissionReview request with a Kubernetes client
+// The client enables resource existence checks (e.g., verifying secrets exist)
+// Returns warnings (even on success) and an error if validation fails
+func ValidateWithClient(ar *admissionv1.AdmissionReview, validators map[schema.GroupVersionResource]Validator, k8sClient client.Client) ([]string, error) {
 	if ar == nil || ar.Request == nil {
 		return nil, fmt.Errorf("admission review or request is nil")
 	}
@@ -76,17 +84,31 @@ func Validate(ar *admissionv1.AdmissionReview, validators map[schema.GroupVersio
 		}
 	}
 
+	// Create validation context if client is available
+	var vc *ValidationContext
+	if k8sClient != nil {
+		vc = NewValidationContext(k8sClient, req.Namespace)
+	}
+
 	var fieldErrs field.ErrorList
 	var warnings []string
 
 	// Perform validation based on operation
 	switch req.Operation {
 	case admissionv1.Create:
-		fieldErrs = validator.ValidateCreate(obj)
+		if vc != nil {
+			fieldErrs = validator.ValidateCreateWithContext(obj, vc)
+		} else {
+			fieldErrs = validator.ValidateCreate(obj)
+		}
 		warnings = validator.GetWarningsOnCreate(obj)
 
 	case admissionv1.Update:
-		fieldErrs = validator.ValidateUpdate(obj, oldObj)
+		if vc != nil {
+			fieldErrs = validator.ValidateUpdateWithContext(obj, oldObj, vc)
+		} else {
+			fieldErrs = validator.ValidateUpdate(obj, oldObj)
+		}
 		warnings = validator.GetWarningsOnUpdate(obj, oldObj)
 
 	default:

--- a/pkg/splunk/enterprise/validation/validator.go
+++ b/pkg/splunk/enterprise/validation/validator.go
@@ -38,6 +38,13 @@ type Validator interface {
 	// ValidateUpdate validates an object on UPDATE operation
 	ValidateUpdate(obj, oldObj runtime.Object) field.ErrorList
 
+	// ValidateCreateWithContext validates an object on CREATE operation with ValidationContext
+	// This allows validators to perform resource lookups (e.g., checking if secrets exist)
+	ValidateCreateWithContext(obj runtime.Object, vc *ValidationContext) field.ErrorList
+
+	// ValidateUpdateWithContext validates an object on UPDATE operation with ValidationContext
+	ValidateUpdateWithContext(obj, oldObj runtime.Object, vc *ValidationContext) field.ErrorList
+
 	// GetGroupKind returns the GroupKind for the object
 	GetGroupKind(obj runtime.Object) schema.GroupKind
 
@@ -58,6 +65,14 @@ type GenericValidator[T ValidatableObject] struct {
 
 	// ValidateUpdateFunc is the function to validate on UPDATE
 	ValidateUpdateFunc func(obj, oldObj T) field.ErrorList
+
+	// ValidateCreateWithContextFunc is the function to validate on CREATE with ValidationContext
+	// If set, this is used instead of ValidateCreateFunc when a context is available
+	ValidateCreateWithContextFunc func(obj T, vc *ValidationContext) field.ErrorList
+
+	// ValidateUpdateWithContextFunc is the function to validate on UPDATE with ValidationContext
+	// If set, this is used instead of ValidateUpdateFunc when a context is available
+	ValidateUpdateWithContextFunc func(obj T, oldObj T, vc *ValidationContext) field.ErrorList
 
 	// WarningsOnCreateFunc returns warnings on CREATE
 	WarningsOnCreateFunc func(obj T) []string
@@ -98,6 +113,41 @@ func (v *GenericValidator[T]) ValidateUpdate(obj, oldObj runtime.Object) field.E
 			&TypeAssertionError{Expected: new(T), Actual: oldObj})}
 	}
 	return v.ValidateUpdateFunc(typedObj, typedOldObj)
+}
+
+// ValidateCreateWithContext implements Validator interface
+// Uses ValidateCreateWithContextFunc if set, otherwise falls back to ValidateCreate
+func (v *GenericValidator[T]) ValidateCreateWithContext(obj runtime.Object, vc *ValidationContext) field.ErrorList {
+	if v.ValidateCreateWithContextFunc != nil {
+		typedObj, ok := obj.(T)
+		if !ok {
+			return field.ErrorList{field.InternalError(nil,
+				&TypeAssertionError{Expected: new(T), Actual: obj})}
+		}
+		return v.ValidateCreateWithContextFunc(typedObj, vc)
+	}
+	// Fall back to non-context validation
+	return v.ValidateCreate(obj)
+}
+
+// ValidateUpdateWithContext implements Validator interface
+// Uses ValidateUpdateWithContextFunc if set, otherwise falls back to ValidateUpdate
+func (v *GenericValidator[T]) ValidateUpdateWithContext(obj, oldObj runtime.Object, vc *ValidationContext) field.ErrorList {
+	if v.ValidateUpdateWithContextFunc != nil {
+		typedObj, ok := obj.(T)
+		if !ok {
+			return field.ErrorList{field.InternalError(nil,
+				&TypeAssertionError{Expected: new(T), Actual: obj})}
+		}
+		typedOldObj, ok := oldObj.(T)
+		if !ok {
+			return field.ErrorList{field.InternalError(nil,
+				&TypeAssertionError{Expected: new(T), Actual: oldObj})}
+		}
+		return v.ValidateUpdateWithContextFunc(typedObj, typedOldObj, vc)
+	}
+	// Fall back to non-context validation
+	return v.ValidateUpdate(obj, oldObj)
 }
 
 // GetGroupKind implements Validator interface


### PR DESCRIPTION
### Description

This PR enhances the Splunk Operator's webhook validation layer with comprehensive validation rules to catch configuration errors early and provide clear error messages to users.

### Key Changes

- appsRepoPollInterval: Validates range (0 or 60-86400 seconds)
- appSources uniqueness: Ensures Location + Scope combinations are unique
- premiumAppsProps: Requires premiumAppsProps.type when scope=premiumApps
- extraEnv uniqueness: Prevents duplicate environment variable names
- imagePullSecrets uniqueness: Prevents duplicate secret references
- Probe fields: Validates minimum values for probe configuration fields
- IndexerCluster replicas: Adds kubebuilder default=3 and minimum=3 annotations
- Resource requirements: Validates that CPU/memory requests do not exceed limits
- SmartStore: Validates that indexes have volumes configured, volumeName references exist, and volumeName is provided (directly or via defaults)
- StorageClassSpec: Validates mutual exclusivity between ephemeralStorage and storageClassName/storageCapacity

### Testing and Verification

Added Unit tests

### Related Issues

N/A

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [x] Relevant unit and integration tests are included.
- [x] Documentation has been updated accordingly.
- [x] All tests pass locally.
- [x] The PR description follows the project's guidelines.
