### PR TITLE
fix reconciliation storm issue for postgrescluster

### DIFF
--- a/config/samples/enterprise_v4_postgrescluster_dev.yaml
+++ b/config/samples/enterprise_v4_postgrescluster_dev.yaml
@@ -7,13 +7,12 @@ metadata:
   labels:
     app.kubernetes.io/name: splunk-operator
     app.kubernetes.io/managed-by: kustomize
-  name: postgresql-cluster-dev-overridden
+  name: postgresql-cluster-dev
 spec:
   # Reference the ClusterClass to inherit defaults - this is required, immutable, and must match the name of an existing ClusterClass
   class: postgresql-dev
-  # ClusterDeletionPolicy is set to "Retain" to keep the underlying CNPG Cluster when this PostgresCluster is deleted
   clusterDeletionPolicy: Retain
-  instances: 2
+  instances: 3
   # Storage and PostgreSQL version are overridden from the ClusterClass defaults. Validation rules on the PostgresCluster resource will prevent removing these fields or setting them to lower values than the original overrides.
   storage: 1Gi
   postgresVersion: "15.10"

--- a/config/samples/enterprise_v4_postgresdatabase.yaml
+++ b/config/samples/enterprise_v4_postgresdatabase.yaml
@@ -2,7 +2,7 @@ apiVersion: enterprise.splunk.com/v4
 kind: PostgresDatabase
 metadata:
   name: splunk-databases
-  namespace: default
+  # namespace: default
 spec:
   clusterRef:
     name: postgresql-cluster-dev
@@ -11,7 +11,7 @@ spec:
       extensions:
         - pg_stat_statements
         - pgcrypto
-      deletionPolicy: Retain
+      deletionPolicy: Delete
     - name: analytics
       extensions:
         - pg_trgm

--- a/internal/controller/postgrescluster_controller.go
+++ b/internal/controller/postgrescluster_controller.go
@@ -31,21 +31,34 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	logs "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// PostgresClusterReconciler reconciles a PostgresCluster object
+// PostgresClusterReconciler reconciles PostgresCluster resources.
 type PostgresClusterReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 }
 
-// Used for applying changes both from PostgresCluster and PostgresClusterClass.
-type MergedConfig struct {
-	Spec *enterprisev4.PostgresClusterSpec
-	CNPG *enterprisev4.CNPGConfig
+// EffectiveClusterConfig holds the effective PostgresCluster spec and CNPG settings after class defaults are applied.
+type EffectiveClusterConfig struct {
+	ClusterSpec       *enterprisev4.PostgresClusterSpec
+	ProvisionerConfig *enterprisev4.CNPGConfig
+}
+
+// normalizedManagedRole holds only the fields this controller sets on a CNPG RoleConfiguration.
+// CNPG's admission webhook populates defaults (ConnectionLimit: -1, Inherit: true) that would
+// cause equality.Semantic.DeepEqual to always report a diff — we compare only what we own.
+type normalizedManagedRole struct {
+	Name           string
+	Ensure         cnpgv1.EnsureOption
+	Login          bool
+	PasswordSecret string
 }
 
 // +kubebuilder:rbac:groups=enterprise.splunk.com,resources=postgresclusters,verbs=get;list;watch;create;update;patch;delete
@@ -57,7 +70,7 @@ type MergedConfig struct {
 // +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=poolers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=poolers/status,verbs=get
 
-// Main reconciliation loop for PostgresCluster.
+// Reconcile drives PostgresCluster toward the desired CNPG resources and status.
 func (r *PostgresClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := logs.FromContext(ctx)
 	logger.Info("Reconciling PostgresCluster", "name", req.Name, "namespace", req.Namespace)
@@ -67,7 +80,7 @@ func (r *PostgresClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	var postgresSecretName string
 	secret := &corev1.Secret{}
 
-	// 1. Fetch the PostgresCluster instance, stop, if not found.
+	// Phase: ResourceFetch
 	postgresCluster := &enterprisev4.PostgresCluster{}
 	if getPGClusterErr := r.Get(ctx, req.NamespacedName, postgresCluster); getPGClusterErr != nil {
 		if apierrors.IsNotFound(getPGClusterErr) {
@@ -77,69 +90,93 @@ func (r *PostgresClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		logger.Error(getPGClusterErr, "Unable to fetch PostgresCluster")
 		return ctrl.Result{}, getPGClusterErr
 	}
+	persistedStatus := postgresCluster.Status.DeepCopy()
+
 	if postgresCluster.Status.Resources == nil {
 		postgresCluster.Status.Resources = &enterprisev4.PostgresClusterResources{}
 	}
 
-	// helper function to update status with less boilerplate.
-	updateStatus := func(conditionType conditionTypes, status metav1.ConditionStatus, reason conditionReasons, message string, clusterPhase reconcileClusterPhases) error {
-		return (r.updateStatus(ctx, postgresCluster, conditionType, status, reason, message, clusterPhase))
+	// Keep condition and phase updates consistent across the reconcile flow.
+	updateStatus := func(
+		conditionType conditionTypes,
+		status metav1.ConditionStatus,
+		reason conditionReasons,
+		message string,
+		phase reconcileClusterPhases) {
+		r.updateStatus(postgresCluster, conditionType, status, reason, message, phase)
 	}
 
-	// finalizer handling must be done before any other processing, to ensure cleanup on deletion and to prevent creating CNPG clusters for PostgresCluster instances that are being deleted.
-	finalizerErr := r.handleFinalizer(ctx, postgresCluster, secret)
+	// Phase: FinalizerHandling
+	// Handle deletion before any create or patch path so cleanup wins over reconciliation.
+	finalizerErr := r.handleFinalizer(ctx, postgresCluster, secret, cnpgCluster)
 	if finalizerErr != nil {
 		if apierrors.IsNotFound(finalizerErr) {
 			logger.Info("PostgresCluster already deleted, skipping finalizer update")
 			return ctrl.Result{}, nil
 		}
+
 		logger.Error(finalizerErr, "Failed to handle finalizer")
-		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterDeleteFailed, fmt.Sprintf("Failed to delete resources during cleanup: %v", finalizerErr), failedClusterPhase); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
-		}
+		updateStatus(
+			clusterReady,
+			metav1.ConditionFalse,
+			reasonClusterDeleteFailed,
+			fmt.Sprintf("Failed to delete resources during cleanup: %v", finalizerErr),
+			failedClusterPhase)
+		_ = r.persistStatusIfChanged(ctx, postgresCluster, persistedStatus)
 		return ctrl.Result{}, finalizerErr
 	}
+
 	if postgresCluster.GetDeletionTimestamp() != nil {
 		logger.Info("PostgresCluster is being deleted, cleanup complete")
 		return ctrl.Result{}, nil
 	}
 
-	// Add finalizer if not present
+	// Register the finalizer before creating managed resources.
 	if !controllerutil.ContainsFinalizer(postgresCluster, postgresClusterFinalizerName) {
 		controllerutil.AddFinalizer(postgresCluster, postgresClusterFinalizerName)
-		if err := r.Update(ctx, postgresCluster); err != nil {
-			if apierrors.IsConflict(err) {
+		if updateErr := r.Update(ctx, postgresCluster); updateErr != nil {
+			if apierrors.IsConflict(updateErr) {
 				logger.Info("Conflict while adding finalizer, will retry on next reconcile")
 				return ctrl.Result{Requeue: true}, nil
 			}
-			logger.Error(err, "Failed to add finalizer to PostgresCluster")
-			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
+			logger.Error(updateErr, "Failed to add finalizer to PostgresCluster")
+			return ctrl.Result{}, updateErr
 		}
 		logger.Info("Finalizer added successfully")
-		return ctrl.Result{}, nil
+		return ctrl.Result{Requeue: true}, nil
 	}
 
-	// 2. Load the referenced PostgresClusterClass.
+	// Phase: ClassResolution
 	postgresClusterClass := &enterprisev4.PostgresClusterClass{}
 	if getClusterClassErr := r.Get(ctx, client.ObjectKey{Name: postgresCluster.Spec.Class}, postgresClusterClass); getClusterClassErr != nil {
 		logger.Error(getClusterClassErr, "Unable to fetch referenced PostgresClusterClass", "className", postgresCluster.Spec.Class)
-		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterClassNotFound, fmt.Sprintf("ClusterClass %s not found: %v", postgresCluster.Spec.Class, getClusterClassErr), failedClusterPhase); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
-		}
+		updateStatus(
+			clusterReady,
+			metav1.ConditionFalse,
+			reasonClusterClassNotFound,
+			fmt.Sprintf("ClusterClass %s not found: %v", postgresCluster.Spec.Class, getClusterClassErr),
+			failedClusterPhase)
+		_ = r.persistStatusIfChanged(ctx, postgresCluster, persistedStatus)
 		return ctrl.Result{}, getClusterClassErr
 	}
 
-	// 3. Create the merged configuration by overlaying PostgresClusterSpec on top of PostgresClusterClass defaults.
+	// Phase: ConfigurationMerging
+	// Merge PostgresCluster overrides on top of PostgresClusterClass defaults.
 	mergedConfig, mergeErr := r.getMergedConfig(postgresClusterClass, postgresCluster)
 	if mergeErr != nil {
 		logger.Error(mergeErr, "Failed to merge PostgresCluster configuration")
-		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonInvalidConfiguration, fmt.Sprintf("Failed to merge configuration: %v", mergeErr), failedClusterPhase); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
-		}
+		updateStatus(
+			clusterReady,
+			metav1.ConditionFalse,
+			reasonInvalidConfiguration,
+			fmt.Sprintf("Failed to merge configuration: %v", mergeErr),
+			failedClusterPhase)
+		_ = r.persistStatusIfChanged(ctx, postgresCluster, persistedStatus)
 		return ctrl.Result{}, mergeErr
 	}
 
-	// 4. Ensure PostgresCluster secret exists before creating CNPG cluster and create if required.
+	// Phase: CredentialProvisioning
+	// The superuser secret must exist before the CNPG Cluster can be created or updated.
 	if postgresCluster.Status.Resources != nil && postgresCluster.Status.Resources.SecretRef != nil {
 		postgresSecretName = postgresCluster.Status.Resources.SecretRef.Name
 		logger.Info("Using existing secret from status", "name", postgresSecretName)
@@ -147,276 +184,362 @@ func (r *PostgresClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		postgresSecretName = fmt.Sprintf("%s%s", postgresCluster.Name, defaultSecretSuffix)
 		logger.Info("Generating new secret name", "name", postgresSecretName)
 	}
-
 	postgresClusterSecretExists, secretExistErr := r.clusterSecretExists(ctx, postgresCluster.Namespace, postgresSecretName, secret)
 	if secretExistErr != nil {
 		logger.Error(secretExistErr, "Failed to check if PostgresCluster secret exists", "name", postgresSecretName)
-		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonUserSecretFailed, fmt.Sprintf("Failed to check secret existence: %v", secretExistErr), failedClusterPhase); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
-		}
+		updateStatus(
+			clusterReady,
+			metav1.ConditionFalse,
+			reasonUserSecretFailed,
+			fmt.Sprintf("Failed to check secret existence: %v", secretExistErr),
+			failedClusterPhase)
+		_ = r.persistStatusIfChanged(ctx, postgresCluster, persistedStatus)
 		return ctrl.Result{}, secretExistErr
 	}
+
 	if !postgresClusterSecretExists {
 		logger.Info("Creating PostgresCluster secret", "name", postgresSecretName)
-		if generateSecretErr := r.generateSecret(ctx, postgresCluster, postgresSecretName, secret); generateSecretErr != nil {
+		if generateSecretErr := r.generateSecret(ctx, postgresCluster, postgresSecretName); generateSecretErr != nil {
 			logger.Error(generateSecretErr, "Failed to ensure PostgresCluster secret", "name", postgresSecretName)
-			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonUserSecretFailed, fmt.Sprintf("Failed to generate PostgresCluster secret: %v", generateSecretErr), failedClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
+			updateStatus(
+				clusterReady,
+				metav1.ConditionFalse,
+				reasonUserSecretFailed,
+				fmt.Sprintf("Failed to generate PostgresCluster secret: %v", generateSecretErr),
+				failedClusterPhase)
+			_ = r.persistStatusIfChanged(ctx, postgresCluster, persistedStatus)
 			return ctrl.Result{}, generateSecretErr
 		}
-		if err := r.Status().Update(ctx, postgresCluster); err != nil {
-			if apierrors.IsConflict(err) {
-				logger.Info("Conflict after secret creation, will requeue")
-				return ctrl.Result{Requeue: true}, nil
-			}
-			logger.Error(err, "Failed to update status after secret creation")
-			return ctrl.Result{}, err
-		}
-		logger.Info("SecretRef persisted to status")
-	}
-	// We need to restore OwnerReference for existing secret, if it was removed, otherwise secret will be orphaned
-	hasOwnerRef, ownerRefErr := controllerutil.HasOwnerReference(secret.GetOwnerReferences(), postgresCluster, r.Scheme)
-
-	if ownerRefErr != nil {
-		logger.Error(ownerRefErr, "Failed to check owner reference on Secret")
-		return ctrl.Result{}, fmt.Errorf("failed to check owner reference on secret: %w", ownerRefErr)
+		logger.Info("PostgresCluster secret created successfully", "name", postgresSecretName)
 	}
 
-	if postgresClusterSecretExists && !hasOwnerRef {
-		logger.Info("Connecting existing secret to PostgresCluster by adding owner reference", "name", postgresSecretName)
-		originalSecret := secret.DeepCopy()
-		if err := ctrl.SetControllerReference(postgresCluster, secret, r.Scheme); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set controller reference on existing secret: %w", err)
+	// Re-link an existing secret if its owner reference was removed.
+	if postgresClusterSecretExists {
+		restoredSecretOwnerRef, restoreErr := r.restoreOwnerRef(ctx, postgresCluster, secret, "Secret")
+		if restoreErr != nil {
+			logger.Error(restoreErr, "Failed to restore owner reference on Secret")
+			updateStatus(
+				clusterReady,
+				metav1.ConditionFalse,
+				reasonSuperUserSecretFailed,
+				fmt.Sprintf("Failed to link existing secret: %v", restoreErr),
+				failedClusterPhase)
+			_ = r.persistStatusIfChanged(ctx, postgresCluster, persistedStatus)
+			return ctrl.Result{}, restoreErr
 		}
-		logger.Info("Successfully connected existing Secret to PostgresCluster", "secret", secret.Name, "cluster", postgresCluster.Name)
-
-		if err := r.patchObject(ctx, originalSecret, secret, "Secret"); err != nil {
-			logger.Error(err, "failed to patch existing secret with controller reference.")
-			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonSuperUserSecretFailed, fmt.Sprintf("Failed to patch existing secret: %v", err), failedClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
-			return ctrl.Result{}, err
+		if restoredSecretOwnerRef {
+			logger.Info("Existing secret linked successfully")
 		}
-		logger.Info("Existing secret linked successfully")
 	}
 
+	if postgresCluster.Status.Resources == nil {
+		postgresCluster.Status.Resources = &enterprisev4.PostgresClusterResources{}
+	}
 	if postgresCluster.Status.Resources.SecretRef == nil {
 		postgresCluster.Status.Resources.SecretRef = &corev1.LocalObjectReference{Name: postgresSecretName}
+		return r.persistStatus(ctx, postgresCluster, persistedStatus)
 	}
 
-	// 5. Build the desired CNPG Cluster spec based on the merged configuration.
+	// Phase: ClusterSpecConstruction
 	desiredSpec := r.buildCNPGClusterSpec(mergedConfig, postgresSecretName)
 
-	// 6. Fetch existing CNPG Cluster or create it if it doesn't exist yet.
+	// Phase: ClusterReconciliation
+	// Create the CNPG Cluster on first reconcile, otherwise compare and patch drift.
 	existingCNPG := &cnpgv1.Cluster{}
-	err := r.Get(ctx, types.NamespacedName{Name: postgresCluster.Name, Namespace: postgresCluster.Namespace}, existingCNPG)
-	switch {
-	case apierrors.IsNotFound(err):
-		// CNPG Cluster doesn't exist, create it and requeue for status update.
+	getErr := r.Get(ctx, types.NamespacedName{Name: postgresCluster.Name, Namespace: postgresCluster.Namespace}, existingCNPG)
+
+	if apierrors.IsNotFound(getErr) {
+		// CNPG Cluster doesn't exist yet. Create it and return so status can be observed on the next pass.
 		logger.Info("CNPG Cluster not found, creating", "name", postgresCluster.Name)
 		newCluster := r.buildCNPGCluster(postgresCluster, mergedConfig, postgresSecretName)
-		if err = r.Create(ctx, newCluster); err != nil {
-			logger.Error(err, "Failed to create CNPG Cluster")
-			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterBuildFailed, fmt.Sprintf("Failed to create CNPG Cluster: %v", err), failedClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
-			return ctrl.Result{}, err
+		if createErr := r.Create(ctx, newCluster); createErr != nil {
+			logger.Error(createErr, "Failed to create CNPG Cluster")
+			updateStatus(
+				clusterReady,
+				metav1.ConditionFalse,
+				reasonClusterBuildFailed,
+				fmt.Sprintf("Failed to create CNPG Cluster: %v", createErr),
+				failedClusterPhase)
+			_ = r.persistStatusIfChanged(ctx, postgresCluster, persistedStatus)
+			return ctrl.Result{}, createErr
 		}
-		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterBuildSucceeded, "CNPG Cluster created", pendingClusterPhase); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
+
+		updateStatus(
+			clusterReady,
+			metav1.ConditionFalse,
+			reasonClusterBuildSucceeded,
+			"CNPG Cluster created",
+			provisioningClusterPhase)
+		if result, persistErr := r.persistStatus(ctx, postgresCluster, persistedStatus); persistErr != nil || result != (ctrl.Result{}) {
+			return result, persistErr
 		}
-		logger.Info("CNPG Cluster created successfully, requeueing for status update", "name", postgresCluster.Name)
-		return ctrl.Result{RequeueAfter: retryDelay}, nil
-	case err != nil:
-		logger.Error(err, "Failed to get CNPG Cluster")
-		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterGetFailed, fmt.Sprintf("Failed to get CNPG Cluster: %v", err), failedClusterPhase); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
-		}
-		return ctrl.Result{}, err
+		logger.Info("CNPG Cluster created successfully,", "name", postgresCluster.Name)
+		return ctrl.Result{}, nil
+
+	}
+	if getErr != nil {
+		logger.Error(getErr, "Failed to get CNPG Cluster")
+		updateStatus(
+			clusterReady,
+			metav1.ConditionFalse,
+			reasonClusterGetFailed,
+			fmt.Sprintf("Failed to get CNPG Cluster: %v", getErr),
+			failedClusterPhase)
+		_ = r.persistStatusIfChanged(ctx, postgresCluster, persistedStatus)
+		return ctrl.Result{}, getErr
 	}
 
-	// 7. If CNPG Cluster exists, compare the current spec with the desired spec and update if necessary.
 	cnpgCluster = existingCNPG
-	currentNormalizedSpec := normalizeCNPGClusterSpec(cnpgCluster.Spec, mergedConfig.Spec.PostgreSQLConfig)
-	desiredNormalizedSpec := normalizeCNPGClusterSpec(desiredSpec, mergedConfig.Spec.PostgreSQLConfig)
+	// Re-link an existing CNPG Cluster if its owner reference was removed.
+	if restoredClusterOwnerRef, restoreErr := r.restoreOwnerRef(ctx, postgresCluster, cnpgCluster, "CNPGCluster"); restoreErr != nil {
+		logger.Error(restoreErr, "Failed to restore owner reference on CNPG Cluster")
+		updateStatus(
+			clusterReady,
+			metav1.ConditionFalse,
+			reasonClusterPatchFailed,
+			fmt.Sprintf("Failed to link existing CNPG Cluster: %v", restoreErr),
+			failedClusterPhase)
+		_ = r.persistStatusIfChanged(ctx, postgresCluster, persistedStatus)
+		return ctrl.Result{}, restoreErr
+	} else if restoredClusterOwnerRef {
+		logger.Info("Existing CNPG Cluster linked successfully", "cluster", cnpgCluster.Name)
+	}
+
+	// Patch the CNPG Cluster when the live spec differs from the desired spec.
+	currentNormalizedSpec := normalizeCNPGClusterSpec(cnpgCluster.Spec, mergedConfig.ClusterSpec.PostgreSQLConfig)
+	desiredNormalizedSpec := normalizeCNPGClusterSpec(desiredSpec, mergedConfig.ClusterSpec.PostgreSQLConfig)
 
 	if !equality.Semantic.DeepEqual(currentNormalizedSpec, desiredNormalizedSpec) {
 		logger.Info("Detected drift in CNPG Cluster spec, patching", "name", cnpgCluster.Name)
 		originalCluster := cnpgCluster.DeepCopy()
 		cnpgCluster.Spec = desiredSpec
-
-		switch patchErr := r.patchObject(ctx, originalCluster, cnpgCluster, "CNPGCluster"); {
-		case apierrors.IsConflict(patchErr):
-			logger.Info("Conflict occurred while updating CNPG Cluster, requeueing", "name", cnpgCluster.Name)
-			return ctrl.Result{Requeue: true}, nil
-
-		case patchErr != nil:
+		if patchErr := r.patchObject(ctx, originalCluster, cnpgCluster, "CNPGCluster"); patchErr != nil {
+			if apierrors.IsConflict(patchErr) {
+				logger.Info("Conflict occurred while updating CNPG Cluster, requeueing", "name", cnpgCluster.Name)
+				return ctrl.Result{Requeue: true}, nil
+			}
 			logger.Error(patchErr, "Failed to patch CNPG Cluster", "name", cnpgCluster.Name)
-			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterPatchFailed, fmt.Sprintf("Failed to patch CNPG Cluster: %v", patchErr), failedClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
+			updateStatus(
+				clusterReady,
+				metav1.ConditionFalse,
+				reasonClusterPatchFailed,
+				fmt.Sprintf("Failed to patch CNPG Cluster: %v", patchErr),
+				failedClusterPhase)
+			_ = r.persistStatusIfChanged(ctx, postgresCluster, persistedStatus)
 			return ctrl.Result{}, patchErr
-
-		default:
-			logger.Info("CNPG Cluster patched successfully, requeueing for status update", "name", cnpgCluster.Name)
-			return ctrl.Result{RequeueAfter: retryDelay}, nil
 		}
+		logger.Info("CNPG Cluster patched successfully", "name", cnpgCluster.Name)
+		return ctrl.Result{}, nil
 	}
 
-	// 7a. Reconcile ManagedRoles from PostgresCluster to CNPG Cluster
-	if err := r.reconcileManagedRoles(ctx, postgresCluster, cnpgCluster); err != nil {
-		logger.Error(err, "Failed to reconcile managed roles")
-		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonManagedRolesFailed, fmt.Sprintf("Failed to reconcile managed roles: %v", err), failedClusterPhase); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
-		}
-		return ctrl.Result{}, err
+	// Phase: ManagedRoleReconciliation
+	if managedRolesErr := r.reconcileManagedRoles(ctx, postgresCluster, cnpgCluster); managedRolesErr != nil {
+		logger.Error(managedRolesErr, "Failed to reconcile managed roles")
+		updateStatus(
+			clusterReady,
+			metav1.ConditionFalse,
+			reasonManagedRolesFailed,
+			fmt.Sprintf("Failed to reconcile managed roles: %v", managedRolesErr),
+			failedClusterPhase)
+		_ = r.persistStatusIfChanged(ctx, postgresCluster, persistedStatus)
+		return ctrl.Result{}, managedRolesErr
 	}
 
-	// 7b. Reconcile Connection Pooler
-	poolerEnabled = mergedConfig.Spec.ConnectionPoolerEnabled != nil && *mergedConfig.Spec.ConnectionPoolerEnabled
-	switch {
-	case !poolerEnabled:
-		// Pooler disabled — delete if they exist
-		if err := r.deleteConnectionPoolers(ctx, postgresCluster); err != nil {
-			logger.Error(err, "Failed to delete connection poolers")
-			if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerReconciliationFailed, fmt.Sprintf("Failed to delete connection poolers: %v", err), failedClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
-			return ctrl.Result{}, err
-		}
-		postgresCluster.Status.ConnectionPoolerStatus = nil
-		meta.RemoveStatusCondition(&postgresCluster.Status.Conditions, string(poolerReady))
+	// Phase: ClusterStatusProjection
+	// Project CNPG status before later phase-specific early returns so cluster status stays current.
+	clusterConditionStatus, clusterReason, clusterMessage, clusterPhase := r.syncStatus(postgresCluster, cnpgCluster)
 
-	case !r.poolerExists(ctx, postgresCluster, readWriteEndpoint) || !r.poolerExists(ctx, postgresCluster, readOnlyEndpoint):
-		if mergedConfig.CNPG.ConnectionPooler == nil {
-			logger.Info("Connection pooler enabled but no config found in class or cluster spec, skipping",
+	logger.Info(
+		"Mapped CNPG status to PostgresCluster", "cnpgPhase",
+		cnpgCluster.Status.Phase, "postgresClusterPhase",
+		clusterPhase, "conditionStatus",
+		clusterConditionStatus, "reason",
+		clusterReason, "message",
+		clusterMessage)
+
+	updateStatus(
+		clusterReady,
+		clusterConditionStatus,
+		clusterReason,
+		clusterMessage,
+		clusterPhase,
+	)
+
+	// Phase: PoolerReconciliation
+	poolerEnabled = mergedConfig.ClusterSpec.ConnectionPoolerEnabled != nil && *mergedConfig.ClusterSpec.ConnectionPoolerEnabled
+	if poolerEnabled {
+		if mergedConfig.ProvisionerConfig.ConnectionPooler == nil {
+			logger.Info("Connection pooler enabled but no config found in class or cluster spec",
 				"class", postgresCluster.Spec.Class,
 				"cluster", postgresCluster.Name,
 			)
-			if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerConfigMissing,
+			updateStatus(
+				poolerReady,
+				metav1.ConditionFalse,
+				reasonPoolerConfigMissing,
 				fmt.Sprintf("Connection pooler is enabled but no config found in class %q or cluster %q",
 					postgresCluster.Spec.Class, postgresCluster.Name),
 				failedClusterPhase,
-			); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
-			return ctrl.Result{}, nil
+			)
+			return r.persistStatus(ctx, postgresCluster, persistedStatus)
 		}
-		if cnpgCluster.Status.Phase != cnpgv1.PhaseHealthy {
-			logger.Info("CNPG Cluster not healthy yet, pending pooler creation", "clusterPhase", cnpgCluster.Status.Phase)
-			if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonCNPGClusterNotHealthy,
-				"Waiting for CNPG cluster to become healthy before creating poolers", pendingClusterPhase,
-			); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
+		if createPoolerErr := r.createConnectionPoolers(ctx, postgresCluster, mergedConfig, cnpgCluster); createPoolerErr != nil {
+			logger.Error(createPoolerErr, "Failed to create connection poolers")
+			updateStatus(
+				poolerReady,
+				metav1.ConditionFalse,
+				reasonPoolerReconciliationFailed,
+				fmt.Sprintf("Failed to create connection poolers: %v", createPoolerErr),
+				failedClusterPhase,
+			)
+			_ = r.persistStatusIfChanged(ctx, postgresCluster, persistedStatus)
+			return ctrl.Result{}, createPoolerErr
+		}
+		if !r.arePoolersReady(ctx, postgresCluster) {
+			logger.Info("Connection poolers are not ready yet, requeueing")
+			updateStatus(
+				poolerReady,
+				metav1.ConditionFalse,
+				reasonPoolerCreating,
+				"Connection poolers are being provisioned",
+				provisioningClusterPhase,
+			)
+			if result, persistErr := r.persistStatus(ctx, postgresCluster, persistedStatus); persistErr != nil || result != (ctrl.Result{}) {
+				return result, persistErr
 			}
 			return ctrl.Result{RequeueAfter: retryDelay}, nil
 		}
-		if err := r.createOrUpdateConnectionPooler(ctx, postgresCluster, mergedConfig, cnpgCluster); err != nil {
-			logger.Error(err, "Failed to reconcile connection pooler")
-			if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerReconciliationFailed,
-				fmt.Sprintf("Failed to reconcile connection pooler: %v", err), failedClusterPhase,
-			); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
-			return ctrl.Result{}, err
-		}
-		logger.Info("Connection Poolers created, requeueing to check readiness")
-		if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerCreating,
-			"Connection poolers are being provisioned", provisioningClusterPhase,
-		); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
-		}
-		return ctrl.Result{RequeueAfter: retryDelay}, nil
-	case !r.arePoolersReady(ctx, postgresCluster):
-		// Poolers exist but not ready yet
-		logger.Info("Connection Poolers are not ready yet, requeueing")
-		if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerCreating, "Connection poolers are being provisioned", pendingClusterPhase); statusErr != nil {
-			if apierrors.IsConflict(statusErr) {
-				logger.Info("Conflict updating pooler status, will requeue")
-				return ctrl.Result{Requeue: true}, nil
-			}
-		}
-		return ctrl.Result{RequeueAfter: retryDelay}, nil
-	default:
-		if err := r.syncPoolerStatus(ctx, postgresCluster); err != nil {
-			logger.Error(err, "Failed to sync pooler status")
-			if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerReconciliationFailed, fmt.Sprintf("Failed to sync pooler status: %v", err), failedClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
-			return ctrl.Result{}, err
-		}
-	}
 
-	// 8. If CNPG cluster is ready, generate ConfigMap or use existing
-	if cnpgCluster.Status.Phase == cnpgv1.PhaseHealthy {
-		logger.Info("CNPG Cluster is ready, reconciling ConfigMap for connection details")
-		desiredConfigMap, err := r.generateConfigMap(ctx, postgresCluster, cnpgCluster, postgresSecretName)
+		message, err := r.syncPoolerStatus(ctx, postgresCluster)
 		if err != nil {
-			logger.Error(err, "Failed to generate ConfigMap")
-			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonConfigMapFailed, fmt.Sprintf("Failed to generate ConfigMap: %v", err), failedClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
+			updateStatus(
+				poolerReady,
+				metav1.ConditionFalse,
+				reasonPoolerReconciliationFailed,
+				fmt.Sprintf("Failed to sync pooler status: %v", err),
+				failedClusterPhase,
+			)
+			_ = r.persistStatusIfChanged(ctx, postgresCluster, persistedStatus)
 			return ctrl.Result{}, err
 		}
-		configMap := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      desiredConfigMap.Name,
-				Namespace: desiredConfigMap.Namespace,
-			},
-		}
-		createOrUpdateResult, err := controllerutil.CreateOrUpdate(ctx, r.Client, configMap, func() error {
-			configMap.Data = desiredConfigMap.Data
-			configMap.Annotations = desiredConfigMap.Annotations
-			configMap.Labels = desiredConfigMap.Labels
 
-			if !metav1.IsControlledBy(configMap, postgresCluster) {
-				if err := ctrl.SetControllerReference(postgresCluster, configMap, r.Scheme); err != nil {
-					return fmt.Errorf("set controller reference failed: %w", err)
-				}
-			}
-			return nil
-		})
-
-		if err != nil {
-			logger.Error(err, "Failed to reconcile ConfigMap", "name", desiredConfigMap.Name)
-			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonConfigMapFailed, fmt.Sprintf("Failed to reconcile ConfigMap: %v", err), failedClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
+		updateStatus(
+			poolerReady,
+			metav1.ConditionTrue,
+			reasonAllInstancesReady,
+			fmt.Sprintf("All connection poolers are ready: %s", message),
+			clusterPhase,
+		)
+	} else {
+		if err := r.deleteConnectionPoolers(ctx, postgresCluster); err != nil {
+			logger.Error(err, "Failed to delete connection poolers")
+			updateStatus(
+				poolerReady,
+				metav1.ConditionFalse,
+				reasonPoolerReconciliationFailed,
+				"Failed to delete connection poolers",
+				failedClusterPhase,
+			)
+			_ = r.persistStatusIfChanged(ctx, postgresCluster, persistedStatus)
 			return ctrl.Result{}, err
 		}
-		switch createOrUpdateResult {
-		case controllerutil.OperationResultCreated:
-			logger.Info("ConfigMap created", "name", desiredConfigMap.Name)
-		case controllerutil.OperationResultUpdated:
-			logger.Info("ConfigMap updated", "name", desiredConfigMap.Name)
-		default:
-			logger.Info("ConfigMap unchanged", "name", desiredConfigMap.Name)
+		if r.poolerExists(ctx, postgresCluster, readWriteEndpoint) || r.poolerExists(ctx, postgresCluster, readOnlyEndpoint) {
+			updateStatus(
+				poolerReady,
+				metav1.ConditionFalse,
+				reasonPoolerCreating,
+				"Connection poolers are being deleted",
+				provisioningClusterPhase,
+			)
+			if result, persistErr := r.persistStatus(ctx, postgresCluster, persistedStatus); persistErr != nil || result != (ctrl.Result{}) {
+				return result, persistErr
+			}
+			return ctrl.Result{RequeueAfter: retryDelay}, nil
 		}
-		if postgresCluster.Status.Resources.ConfigMapRef == nil {
-			postgresCluster.Status.Resources.ConfigMapRef = &corev1.LocalObjectReference{Name: desiredConfigMap.Name}
-		}
+		postgresCluster.Status.ConnectionPoolerStatus = nil
+		meta.RemoveStatusCondition(&postgresCluster.Status.Conditions, string(poolerReady))
 	}
 
-	// 9. Final status update and sync
-	if err := r.syncStatus(ctx, postgresCluster, cnpgCluster); err != nil {
-		logger.Error(err, "Failed to sync status")
-		if apierrors.IsConflict(err) {
-			logger.Info("Conflict during status update, will requeue")
-			return ctrl.Result{Requeue: true}, nil // Don't return error, just requeue
-		}
-		return ctrl.Result{}, fmt.Errorf("failed to sync status: %w", err)
+	// Phase: ConnectionMetadata
+	// Publish connection details after the cluster and optional poolers reach the desired state.
+	desiredConfigMap, err := r.generateConfigMap(postgresCluster, postgresSecretName, poolerEnabled)
+	if err != nil {
+		logger.Error(err, "Failed to generate ConfigMap")
+		updateStatus(
+			configMapReady,
+			metav1.ConditionFalse,
+			reasonConfigMapFailed,
+			fmt.Sprintf("Failed to generate ConfigMap: %v", err),
+			failedClusterPhase,
+		)
+		_ = r.persistStatusIfChanged(ctx, postgresCluster, persistedStatus)
+		return ctrl.Result{}, err
 	}
-	if cnpgCluster.Status.Phase == cnpgv1.PhaseHealthy && r.arePoolersReady(ctx, postgresCluster) {
-		logger.Info("Poolers are ready, syncing pooler status")
-		r.syncPoolerStatus(ctx, postgresCluster)
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      desiredConfigMap.Name,
+			Namespace: desiredConfigMap.Namespace,
+		},
+	}
+
+	createOrUpdateResult, err := controllerutil.CreateOrUpdate(ctx, r.Client, configMap, func() error {
+		configMap.Data = desiredConfigMap.Data
+		configMap.Labels = desiredConfigMap.Labels
+		configMap.Annotations = desiredConfigMap.Annotations
+
+		if !metav1.IsControlledBy(configMap, postgresCluster) {
+			if err := ctrl.SetControllerReference(postgresCluster, configMap, r.Scheme); err != nil {
+				return fmt.Errorf("set controller reference failed: %w", err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		logger.Error(err, "Failed to reconcile ConfigMap", "name", desiredConfigMap.Name)
+		updateStatus(
+			configMapReady,
+			metav1.ConditionFalse,
+			reasonConfigMapFailed,
+			fmt.Sprintf("Failed to reconcile ConfigMap: %v", err),
+			failedClusterPhase,
+		)
+		_ = r.persistStatusIfChanged(ctx, postgresCluster, persistedStatus)
+		return ctrl.Result{}, err
+	}
+
+	switch createOrUpdateResult {
+	case controllerutil.OperationResultCreated:
+		logger.Info("ConfigMap created", "name", desiredConfigMap.Name)
+	case controllerutil.OperationResultUpdated:
+		logger.Info("ConfigMap updated", "name", desiredConfigMap.Name)
+	case controllerutil.OperationResultNone:
+		logger.Info("ConfigMap unchanged", "name", desiredConfigMap.Name)
+	}
+
+	if postgresCluster.Status.Resources.ConfigMapRef == nil ||
+		postgresCluster.Status.Resources.ConfigMapRef.Name != desiredConfigMap.Name {
+		postgresCluster.Status.Resources.ConfigMapRef = &corev1.LocalObjectReference{Name: desiredConfigMap.Name}
+		logger.Info("ConfigMap reference updated in status", "configMap", desiredConfigMap.Name)
+	}
+	// Phase: ReadyStatus
+	// Persist the final ConfigMap status update and finish the reconcile pass.
+	updateStatus(
+		configMapReady,
+		metav1.ConditionTrue,
+		reasonConfigMapsCreated,
+		fmt.Sprintf("ConfigMap is ready: %s", desiredConfigMap.Name),
+		clusterPhase,
+	)
+	if result, persistErr := r.persistStatus(ctx, postgresCluster, persistedStatus); persistErr != nil || result != (ctrl.Result{}) {
+		return result, persistErr
 	}
 	logger.Info("Reconciliation complete")
 	return ctrl.Result{}, nil
 }
 
-// getMergedConfig merges the configuration from the PostgresClusterClass into the PostgresClusterSpec, giving precedence to the PostgresClusterSpec values.
-func (r *PostgresClusterReconciler) getMergedConfig(clusterClass *enterprisev4.PostgresClusterClass, cluster *enterprisev4.PostgresCluster) (*MergedConfig, error) {
+// getMergedConfig applies PostgresClusterClass defaults and validates the required resulting fields.
+func (r *PostgresClusterReconciler) getMergedConfig(clusterClass *enterprisev4.PostgresClusterClass, cluster *enterprisev4.PostgresCluster) (*EffectiveClusterConfig, error) {
 	resultConfig := cluster.Spec.DeepCopy()
 	classDefaults := clusterClass.Spec.Config
 
@@ -453,24 +576,24 @@ func (r *PostgresClusterReconciler) getMergedConfig(clusterClass *enterprisev4.P
 		resultConfig.Resources = &corev1.ResourceRequirements{}
 	}
 
-	return &MergedConfig{
-		Spec: resultConfig,
-		CNPG: clusterClass.Spec.CNPG,
+	return &EffectiveClusterConfig{
+		ClusterSpec:       resultConfig,
+		ProvisionerConfig: clusterClass.Spec.CNPG,
 	}, nil
 }
 
-// buildCNPGClusterSpec builds the desired CNPG ClusterSpec.
+// buildCNPGClusterSpec builds the desired CNPG ClusterSpec from the merged configuration.
 // IMPORTANT: any field added here must also be added to normalizedCNPGClusterSpec and normalizeCNPGClusterSpec,
 // otherwise it will not be included in drift detection and changes will be silently ignored.
-func (r *PostgresClusterReconciler) buildCNPGClusterSpec(mergedConfig *MergedConfig, secretName string) cnpgv1.ClusterSpec {
+func (r *PostgresClusterReconciler) buildCNPGClusterSpec(mergedConfig *EffectiveClusterConfig, secretName string) cnpgv1.ClusterSpec {
 
 	// 3. Build the Spec
 	spec := cnpgv1.ClusterSpec{
-		ImageName: fmt.Sprintf("ghcr.io/cloudnative-pg/postgresql:%s", *mergedConfig.Spec.PostgresVersion),
-		Instances: int(*mergedConfig.Spec.Instances),
+		ImageName: fmt.Sprintf("ghcr.io/cloudnative-pg/postgresql:%s", *mergedConfig.ClusterSpec.PostgresVersion),
+		Instances: int(*mergedConfig.ClusterSpec.Instances),
 		PostgresConfiguration: cnpgv1.PostgresConfiguration{
-			Parameters: mergedConfig.Spec.PostgreSQLConfig,
-			PgHBA:      mergedConfig.Spec.PgHBA,
+			Parameters: mergedConfig.ClusterSpec.PostgreSQLConfig,
+			PgHBA:      mergedConfig.ClusterSpec.PgHBA,
 		},
 		SuperuserSecret: &cnpgv1.LocalObjectReference{
 			Name: secretName,
@@ -487,18 +610,18 @@ func (r *PostgresClusterReconciler) buildCNPGClusterSpec(mergedConfig *MergedCon
 			},
 		},
 		StorageConfiguration: cnpgv1.StorageConfiguration{
-			Size: mergedConfig.Spec.Storage.String(),
+			Size: mergedConfig.ClusterSpec.Storage.String(),
 		},
-		Resources: *mergedConfig.Spec.Resources,
+		Resources: *mergedConfig.ClusterSpec.Resources,
 	}
 
 	return spec
 }
 
-// build CNPGCluster builds the CNPG Cluster object based on the PostgresCluster resource and merged configuration.
+// buildCNPGCluster builds the CNPG Cluster object for the merged PostgresCluster configuration.
 func (r *PostgresClusterReconciler) buildCNPGCluster(
 	postgresCluster *enterprisev4.PostgresCluster,
-	mergedConfig *MergedConfig,
+	mergedConfig *EffectiveClusterConfig,
 	secretName string,
 ) *cnpgv1.Cluster {
 	cnpgCluster := &cnpgv1.Cluster{
@@ -517,19 +640,19 @@ func poolerResourceName(clusterName, poolerType string) string {
 	return fmt.Sprintf("%s%s%s", clusterName, defaultPoolerSuffix, poolerType)
 }
 
-// createOrUpdateConnectionPooler creates or updates CNPG Pooler resources.
-func (r *PostgresClusterReconciler) createOrUpdateConnectionPooler(
+// createConnectionPoolers ensures both RW and RO CNPG Pooler resources exist by creating missing poolers.
+func (r *PostgresClusterReconciler) createConnectionPoolers(
 	ctx context.Context,
 	postgresCluster *enterprisev4.PostgresCluster,
-	mergedConfig *MergedConfig,
+	mergedConfig *EffectiveClusterConfig,
 	cnpgCluster *cnpgv1.Cluster,
 ) error {
-	// Create/Update RW Pooler
+	// Ensure the RW pooler exists.
 	if err := r.createConnectionPooler(ctx, postgresCluster, mergedConfig, cnpgCluster, readWriteEndpoint); err != nil {
 		return fmt.Errorf("failed to reconcile RW pooler: %w", err)
 	}
 
-	// Create/Update RO Pooler
+	// Ensure the RO pooler exists.
 	if err := r.createConnectionPooler(ctx, postgresCluster, mergedConfig, cnpgCluster, readOnlyEndpoint); err != nil {
 		return fmt.Errorf("failed to reconcile RO pooler: %w", err)
 	}
@@ -537,7 +660,7 @@ func (r *PostgresClusterReconciler) createOrUpdateConnectionPooler(
 	return nil
 }
 
-// poolerExists checks if a pooler resource exists and returns it
+// poolerExists reports whether the named pooler resource exists.
 func (r *PostgresClusterReconciler) poolerExists(ctx context.Context, postgresCluster *enterprisev4.PostgresCluster, poolerType string) bool {
 	pooler := &cnpgv1.Pooler{}
 	err := r.Get(ctx, types.NamespacedName{
@@ -585,11 +708,12 @@ func (r *PostgresClusterReconciler) deleteConnectionPoolers(ctx context.Context,
 	return nil
 }
 
-// createConnectionPooler creates a CNPG Pooler resource if it doesn't exist.
+// createConnectionPooler creates a CNPG Pooler resource when it is missing.
+// Existing poolers are left unchanged by design.
 func (r *PostgresClusterReconciler) createConnectionPooler(
 	ctx context.Context,
 	postgresCluster *enterprisev4.PostgresCluster,
-	mergedConfig *MergedConfig,
+	mergedConfig *EffectiveClusterConfig,
 	cnpgCluster *cnpgv1.Cluster,
 	poolerType string,
 ) error {
@@ -603,7 +727,6 @@ func (r *PostgresClusterReconciler) createConnectionPooler(
 
 	if apierrors.IsNotFound(err) {
 		logs.FromContext(ctx).Info("Creating CNPG Pooler", "name", poolerName, "type", poolerType)
-		r.updateStatus(ctx, postgresCluster, poolerReady, metav1.ConditionFalse, reasonPoolerCreating, fmt.Sprintf("Creating %s pooler", poolerType), pendingClusterPhase)
 		pooler := r.buildCNPGPooler(postgresCluster, mergedConfig, cnpgCluster, poolerType)
 		return r.Create(ctx, pooler)
 	}
@@ -611,14 +734,14 @@ func (r *PostgresClusterReconciler) createConnectionPooler(
 	return err
 }
 
-// buildCNPGPooler constructs a CNPG Pooler object.
+// buildCNPGPooler builds the desired CNPG Pooler object for the given pooler type.
 func (r *PostgresClusterReconciler) buildCNPGPooler(
 	postgresCluster *enterprisev4.PostgresCluster,
-	mergedConfig *MergedConfig,
+	mergedConfig *EffectiveClusterConfig,
 	cnpgCluster *cnpgv1.Cluster,
 	poolerType string,
 ) *cnpgv1.Pooler {
-	cfg := mergedConfig.CNPG.ConnectionPooler
+	cfg := mergedConfig.ProvisionerConfig.ConnectionPooler
 	poolerName := poolerResourceName(postgresCluster.Name, poolerType)
 
 	instances := *cfg.Instances
@@ -646,10 +769,11 @@ func (r *PostgresClusterReconciler) buildCNPGPooler(
 	return pooler
 }
 
-// syncStatus maps CNPG Cluster state to PostgresCluster object and handles pooler status.
-func (r *PostgresClusterReconciler) syncStatus(ctx context.Context, postgresCluster *enterprisev4.PostgresCluster, cnpgCluster *cnpgv1.Cluster) error {
-
-	// 1. Set ProvisionerRef
+// syncStatus maps CNPG Cluster state onto PostgresCluster status and refreshes ProvisionerRef.
+func (r *PostgresClusterReconciler) syncStatus(
+	postgresCluster *enterprisev4.PostgresCluster,
+	cnpgCluster *cnpgv1.Cluster,
+) (metav1.ConditionStatus, conditionReasons, string, reconcileClusterPhases) {
 	postgresCluster.Status.ProvisionerRef = &corev1.ObjectReference{
 		APIVersion: "postgresql.cnpg.io/v1",
 		Kind:       "Cluster",
@@ -763,21 +887,33 @@ func (r *PostgresClusterReconciler) syncStatus(ctx context.Context, postgresClus
 		reason = reasonCNPGProvisioning
 		message = fmt.Sprintf("CNPG cluster clusterPhase: %s", cnpgCluster.Status.Phase)
 	}
+	return conditionStatus, reason, message, clusterPhase
 
-	return r.updateStatus(ctx, postgresCluster, clusterReady, conditionStatus, reason, message, clusterPhase)
 }
 
-// updateStatus sets the clusterPhase, condition and persists the status to Kubernetes.
+// updateStatus is a convenience wrapper that updates a condition and the phase together.
+// For cases where you need to update multiple conditions before persisting, use updateCondition instead.
 func (r *PostgresClusterReconciler) updateStatus(
-	ctx context.Context,
 	postgresCluster *enterprisev4.PostgresCluster,
 	conditionType conditionTypes,
 	status metav1.ConditionStatus,
 	reason conditionReasons,
 	message string,
-	clusterPhase reconcileClusterPhases,
-) error {
-	postgresCluster.Status.Phase = string(clusterPhase)
+	phase reconcileClusterPhases,
+) {
+	r.updateCondition(postgresCluster, conditionType, status, reason, message)
+	postgresCluster.Status.Phase = string(phase)
+}
+
+// updateCondition updates a single status condition in memory without persisting.
+// Call persistStatus after updating all desired conditions.
+func (r *PostgresClusterReconciler) updateCondition(
+	postgresCluster *enterprisev4.PostgresCluster,
+	conditionType conditionTypes,
+	status metav1.ConditionStatus,
+	reason conditionReasons,
+	message string,
+) {
 	meta.SetStatusCondition(&postgresCluster.Status.Conditions, metav1.Condition{
 		Type:               string(conditionType),
 		Status:             status,
@@ -785,21 +921,44 @@ func (r *PostgresClusterReconciler) updateStatus(
 		Message:            message,
 		ObservedGeneration: postgresCluster.Generation,
 	})
-	if err := r.Status().Update(ctx, postgresCluster); err != nil {
-		return fmt.Errorf("failed to update PostgresCluster status: %w", err)
+}
+
+// persistStatus persists status changes and converts update conflicts into reconcile retries.
+func (r *PostgresClusterReconciler) persistStatus(
+	ctx context.Context,
+	postgresCluster *enterprisev4.PostgresCluster,
+	persistedStatus *enterprisev4.PostgresClusterStatus,
+) (ctrl.Result, error) {
+	if persistErr := r.persistStatusIfChanged(ctx, postgresCluster, persistedStatus); persistErr != nil {
+		if apierrors.IsConflict(persistErr) {
+			logs.FromContext(ctx).Info("Conflict while updating status, will retry on next reconcile")
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, persistErr
+	}
+	return ctrl.Result{}, nil
+}
+
+// persistStatusIfChanged updates status only when it differs from the last persisted snapshot.
+func (r *PostgresClusterReconciler) persistStatusIfChanged(ctx context.Context, postgresCluster *enterprisev4.PostgresCluster, lastPostgresClusterStatus *enterprisev4.PostgresClusterStatus) error {
+	if !equality.Semantic.DeepEqual(postgresCluster.Status, *lastPostgresClusterStatus) {
+		if err := r.Status().Update(ctx, postgresCluster); err != nil {
+			return err
+		}
+		*lastPostgresClusterStatus = *postgresCluster.Status.DeepCopy()
 	}
 	return nil
 }
 
-// syncPoolerStatus populates ConnectionPoolerStatus and the PoolerReady condition.
-// Called only when poolers are confirmed ready by the reconciler.
-func (r *PostgresClusterReconciler) syncPoolerStatus(ctx context.Context, postgresCluster *enterprisev4.PostgresCluster) error {
+// syncPoolerStatus populates ConnectionPoolerStatus and returns a summary message.
+// Callers are responsible for updating PoolerReady after this succeeds.
+func (r *PostgresClusterReconciler) syncPoolerStatus(ctx context.Context, postgresCluster *enterprisev4.PostgresCluster) (string, error) {
 	rwPooler := &cnpgv1.Pooler{}
 	if rwErr := r.Get(ctx, types.NamespacedName{
 		Name:      poolerResourceName(postgresCluster.Name, readWriteEndpoint),
 		Namespace: postgresCluster.Namespace,
 	}, rwPooler); rwErr != nil {
-		return rwErr
+		return "", rwErr
 	}
 
 	roPooler := &cnpgv1.Pooler{}
@@ -807,7 +966,7 @@ func (r *PostgresClusterReconciler) syncPoolerStatus(ctx context.Context, postgr
 		Name:      poolerResourceName(postgresCluster.Name, readOnlyEndpoint),
 		Namespace: postgresCluster.Namespace,
 	}, roPooler); roErr != nil {
-		return roErr
+		return "", roErr
 	}
 
 	postgresCluster.Status.ConnectionPoolerStatus = &enterprisev4.ConnectionPoolerStatus{
@@ -817,17 +976,10 @@ func (r *PostgresClusterReconciler) syncPoolerStatus(ctx context.Context, postgr
 	rwDesired, rwScheduled := r.getPoolerInstanceCount(rwPooler)
 	roDesired, roScheduled := r.getPoolerInstanceCount(roPooler)
 
-	if err := r.updateStatus(
-		ctx,
-		postgresCluster,
-		poolerReady,
-		metav1.ConditionTrue,
-		reasonAllInstancesReady,
-		fmt.Sprintf("%s: %d/%d, %s: %d/%d", readWriteEndpoint, rwScheduled, rwDesired, readOnlyEndpoint, roScheduled, roDesired),
-		readyClusterPhase); err != nil {
-		return err
-	}
-	return nil
+	return fmt.Sprintf("%s: %d/%d, %s: %d/%d",
+		readWriteEndpoint, rwScheduled, rwDesired,
+		readOnlyEndpoint, roScheduled, roDesired,
+	), nil
 }
 
 // isPoolerReady checks if a pooler has all instances scheduled.
@@ -869,66 +1021,81 @@ func (r *PostgresClusterReconciler) arePoolersReady(ctx context.Context, postgre
 	return r.isPoolerReady(rwPooler, rwErr) && r.isPoolerReady(roPooler, roErr)
 }
 
-// reconcileManagedRoles synchronizes ManagedRoles from PostgresCluster spec to CNPG Cluster managed.roles using diff-based patching
+// normalizeManagedRole projects a CNPG RoleConfiguration down to only the fields this controller controls.
+// CNPG's admission webhook populates defaults on the live object (ConnectionLimit: -1, Inherit: true)
+// that are absent from our desired slice — normalizing both sides before comparison prevents a
+// permanent diff that would re-patch on every reconcile.
+func normalizeManagedRole(r cnpgv1.RoleConfiguration) normalizedManagedRole {
+	secret := ""
+	if r.PasswordSecret != nil {
+		secret = r.PasswordSecret.Name
+	}
+	return normalizedManagedRole{
+		Name:           r.Name,
+		Ensure:         r.Ensure,
+		Login:          r.Login,
+		PasswordSecret: secret,
+	}
+}
+
+// normalizeManagedRoles applies normalizeManagedRole to each RoleConfiguration in the slice.
+func normalizeManagedRoles(roles []cnpgv1.RoleConfiguration) []normalizedManagedRole {
+	result := make([]normalizedManagedRole, 0, len(roles))
+	for _, r := range roles {
+		result = append(result, normalizeManagedRole(r))
+	}
+	return result
+}
+
+// buildCNPGRole converts a single PostgresCluster ManagedRole to its CNPG RoleConfiguration equivalent.
+// Absent roles are marked for removal; Login is only meaningful for present roles.
+func buildCNPGRole(role enterprisev4.ManagedRole) cnpgv1.RoleConfiguration {
+	cnpgRole := cnpgv1.RoleConfiguration{
+		Name: role.Name,
+	}
+	if role.Ensure == "absent" {
+		cnpgRole.Ensure = cnpgv1.EnsureAbsent
+	} else {
+		cnpgRole.Ensure = cnpgv1.EnsurePresent
+		cnpgRole.Login = true
+	}
+	if role.PasswordSecretRef != nil {
+		cnpgRole.PasswordSecret = &cnpgv1.LocalObjectReference{Name: role.PasswordSecretRef.Name}
+	}
+	return cnpgRole
+}
+
+// reconcileManagedRoles synchronizes ManagedRoles from PostgresCluster spec to CNPG Cluster managed.roles.
 func (r *PostgresClusterReconciler) reconcileManagedRoles(ctx context.Context, postgresCluster *enterprisev4.PostgresCluster, cnpgCluster *cnpgv1.Cluster) error {
 	logger := logs.FromContext(ctx)
 
-	// If no managed roles in PostgresCluster spec, nothing to do for now
-	// TODO: Should we remove roles from CNPG if they're removed from PostgresCluster?
-	if len(postgresCluster.Spec.ManagedRoles) == 0 {
-		logger.Info("No managed roles to reconcile")
-		return nil
-	}
-
-	// Convert PostgresCluster ManagedRoles to CNPG RoleConfiguration format
-	desiredRoles := []cnpgv1.RoleConfiguration{}
+	desired := make([]cnpgv1.RoleConfiguration, 0, len(postgresCluster.Spec.ManagedRoles))
 	for _, role := range postgresCluster.Spec.ManagedRoles {
-		cnpgRole := cnpgv1.RoleConfiguration{
-			Name: role.Name,
-		}
-
-		if role.Ensure == "absent" {
-			cnpgRole.Ensure = cnpgv1.EnsureAbsent
-		} else {
-			cnpgRole.Ensure = cnpgv1.EnsurePresent
-			cnpgRole.Login = true
-		}
-
-		if role.PasswordSecretRef != nil {
-			cnpgRole.PasswordSecret = &cnpgv1.LocalObjectReference{
-				Name: role.PasswordSecretRef.Name,
-			}
-		}
-
-		desiredRoles = append(desiredRoles, cnpgRole)
+		desired = append(desired, buildCNPGRole(role))
 	}
 
-	var currentRoles []cnpgv1.RoleConfiguration
-	if cnpgCluster.Spec.Managed != nil && cnpgCluster.Spec.Managed.Roles != nil {
-		currentRoles = cnpgCluster.Spec.Managed.Roles
+	var current []cnpgv1.RoleConfiguration
+	if cnpgCluster.Spec.Managed != nil {
+		current = cnpgCluster.Spec.Managed.Roles
 	}
 
-	if equality.Semantic.DeepEqual(currentRoles, desiredRoles) {
+	if equality.Semantic.DeepEqual(normalizeManagedRoles(current), normalizeManagedRoles(desired)) {
 		logger.Info("CNPG Cluster roles already match desired state, no update needed")
 		return nil
 	}
 
-	logger.Info("CNPG Cluster roles differ from desired state, updating",
-		"currentCount", len(currentRoles),
-		"desiredCount", len(desiredRoles))
-
+	logger.Info("Detected drift in managed roles, patching", "count", len(desired))
 	originalCluster := cnpgCluster.DeepCopy()
-
 	if cnpgCluster.Spec.Managed == nil {
 		cnpgCluster.Spec.Managed = &cnpgv1.ManagedConfiguration{}
 	}
-	cnpgCluster.Spec.Managed.Roles = desiredRoles
+	cnpgCluster.Spec.Managed.Roles = desired
 
-	if err := r.Patch(ctx, cnpgCluster, client.MergeFrom(originalCluster)); err != nil {
-		return fmt.Errorf("failed to patch CNPG Cluster with managed roles: %w", err)
+	if err := r.patchObject(ctx, originalCluster, cnpgCluster, "CNPGCluster"); err != nil {
+		return fmt.Errorf("patching managed roles: %w", err)
 	}
 
-	logger.Info("Successfully updated CNPG Cluster with managed roles", "roleCount", len(desiredRoles))
+	logger.Info("Successfully updated managed roles", "count", len(desired))
 	return nil
 }
 
@@ -960,24 +1127,29 @@ func normalizeCNPGClusterSpec(spec cnpgv1.ClusterSpec, customDefinedParameters m
 	return normalizedConf
 }
 
-// generateConfigMap generates a ConfigMap with connection details for the PostgresCluster.
-func (r *PostgresClusterReconciler) generateConfigMap(ctx context.Context, postgresCluster *enterprisev4.PostgresCluster, cnpgCluster *cnpgv1.Cluster, secretName string) (*corev1.ConfigMap, error) {
+// generateConfigMap builds the desired ConfigMap with connection details for the PostgresCluster.
+func (r *PostgresClusterReconciler) generateConfigMap(
+	postgresCluster *enterprisev4.PostgresCluster,
+	secretName string,
+	poolerEnabled bool,
+) (*corev1.ConfigMap, error) {
 	configMapName := fmt.Sprintf("%s%s", postgresCluster.Name, defaultConfigMapSuffix)
 	if postgresCluster.Status.Resources != nil && postgresCluster.Status.Resources.ConfigMapRef != nil {
 		configMapName = postgresCluster.Status.Resources.ConfigMapRef.Name
 	}
 
 	data := map[string]string{
-		"CLUSTER_RW_ENDPOINT":   fmt.Sprintf("%s-rw.%s", cnpgCluster.Name, cnpgCluster.Namespace),
-		"CLUSTER_RO_ENDPOINT":   fmt.Sprintf("%s-ro.%s", cnpgCluster.Name, cnpgCluster.Namespace),
-		"CLUSTER_R_ENDPOINT":    fmt.Sprintf("%s-r.%s", cnpgCluster.Name, cnpgCluster.Namespace),
+		"CLUSTER_RW_ENDPOINT":   fmt.Sprintf("%s-rw.%s", postgresCluster.Name, postgresCluster.Namespace),
+		"CLUSTER_RO_ENDPOINT":   fmt.Sprintf("%s-ro.%s", postgresCluster.Name, postgresCluster.Namespace),
+		"CLUSTER_R_ENDPOINT":    fmt.Sprintf("%s-r.%s", postgresCluster.Name, postgresCluster.Namespace),
 		"DEFAULT_CLUSTER_PORT":  defaultPort,
 		"SUPER_USER_NAME":       superUsername,
 		"SUPER_USER_SECRET_REF": secretName,
 	}
-	if r.poolerExists(ctx, postgresCluster, readWriteEndpoint) && r.poolerExists(ctx, postgresCluster, readOnlyEndpoint) {
-		data["CLUSTER_POOLER_RW_ENDPOINT"] = fmt.Sprintf("%s.%s", poolerResourceName(cnpgCluster.Name, readWriteEndpoint), cnpgCluster.Namespace)
-		data["CLUSTER_POOLER_RO_ENDPOINT"] = fmt.Sprintf("%s.%s", poolerResourceName(cnpgCluster.Name, readOnlyEndpoint), cnpgCluster.Namespace)
+
+	if poolerEnabled {
+		data["CLUSTER_POOLER_RW_ENDPOINT"] = fmt.Sprintf("%s.%s", poolerResourceName(postgresCluster.Name, readWriteEndpoint), postgresCluster.Namespace)
+		data["CLUSTER_POOLER_RO_ENDPOINT"] = fmt.Sprintf("%s.%s", poolerResourceName(postgresCluster.Name, readOnlyEndpoint), postgresCluster.Namespace)
 	}
 
 	configMap := &corev1.ConfigMap{
@@ -994,9 +1166,10 @@ func (r *PostgresClusterReconciler) generateConfigMap(ctx context.Context, postg
 	return configMap, nil
 }
 
-// generateSecret creates a Kubernetes Secret with credentials for the default postgres user if it doesn't already exist.
-func (r *PostgresClusterReconciler) generateSecret(ctx context.Context, postgresCluster *enterprisev4.PostgresCluster, secretName string, secret *corev1.Secret) error {
-	err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: postgresCluster.Namespace}, secret)
+// generateSecret creates the superuser Secret when it is missing.
+func (r *PostgresClusterReconciler) generateSecret(ctx context.Context, postgresCluster *enterprisev4.PostgresCluster, secretName string) error {
+	existing := &corev1.Secret{}
+	err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: postgresCluster.Namespace}, existing)
 
 	// If secret does not exist, create it
 	if apierrors.IsNotFound(err) {
@@ -1015,6 +1188,7 @@ func (r *PostgresClusterReconciler) generateSecret(ctx context.Context, postgres
 			},
 			Type: corev1.SecretTypeOpaque,
 		}
+		// Set owner reference
 		if err := ctrl.SetControllerReference(postgresCluster, secret, r.Scheme); err != nil {
 			return err
 		}
@@ -1024,15 +1198,10 @@ func (r *PostgresClusterReconciler) generateSecret(ctx context.Context, postgres
 	} else if err != nil {
 		return err
 	}
-	if postgresCluster.Status.Resources == nil {
-		postgresCluster.Status.Resources = &enterprisev4.PostgresClusterResources{}
-	}
-	postgresCluster.Status.Resources.SecretRef = &corev1.LocalObjectReference{Name: secretName}
-
 	return nil
 }
 
-// deleteCNPGCluster deletes the CNPG cluster and its associated resources if they exist.
+// deleteCNPGCluster deletes the CNPG Cluster resource if it exists.
 func (r *PostgresClusterReconciler) deleteCNPGCluster(ctx context.Context, cnpgCluster *cnpgv1.Cluster) error {
 	logger := logs.FromContext(ctx)
 	// TODO: add logic to decide to delete cluster if one has customer DBs configured, to prevent data loss
@@ -1047,8 +1216,8 @@ func (r *PostgresClusterReconciler) deleteCNPGCluster(ctx context.Context, cnpgC
 	return nil
 }
 
-// handleFinalizer processes the finalizer logic when a PostgresCluster is being deleted, including cleanup of associated CNPG Cluster and connection poolers based on the specified deletion policy.
-func (r *PostgresClusterReconciler) handleFinalizer(ctx context.Context, postgresCluster *enterprisev4.PostgresCluster, secret *corev1.Secret) error {
+// handleFinalizer performs deletion-time cleanup and removes the finalizer when cleanup succeeds.
+func (r *PostgresClusterReconciler) handleFinalizer(ctx context.Context, postgresCluster *enterprisev4.PostgresCluster, secret *corev1.Secret, cnpgCluster *cnpgv1.Cluster) error {
 	logger := logs.FromContext(ctx)
 	if postgresCluster.GetDeletionTimestamp() == nil {
 		logger.Info("PostgresCluster not marked for deletion, skipping finalizer logic")
@@ -1058,8 +1227,10 @@ func (r *PostgresClusterReconciler) handleFinalizer(ctx context.Context, postgre
 		logger.Info("Finalizer not present on PostgresCluster, skipping finalizer logic")
 		return nil
 	}
+	if cnpgCluster == nil {
+		cnpgCluster = &cnpgv1.Cluster{}
+	}
 
-	cnpgCluster := &cnpgv1.Cluster{}
 	err := r.Get(ctx, types.NamespacedName{
 		Name:      postgresCluster.Name,
 		Namespace: postgresCluster.Namespace,
@@ -1089,23 +1260,24 @@ func (r *PostgresClusterReconciler) handleFinalizer(ctx context.Context, postgre
 				return fmt.Errorf("failed to delete CNPG Cluster during finalizer cleanup: %w", err)
 			}
 		}
-		logger.Info("CNPG Cluster not found, skipping deletion")
+		logger.Info("CNPG Cluster not found")
 	case clusterDeletionPolicyRetain:
 		logger.Info("ClusterDeletionPolicy is 'Retain', proceeding to remove owner references and retain CNPG Cluster")
 		// Remove owner reference from CNPG Cluster to prevent its deletion.
-		originalCNPG := cnpgCluster.DeepCopy()
-		refRemoved, err := r.removeOwnerRef(postgresCluster, cnpgCluster, "CNPGCluster")
-		if err != nil {
-			return fmt.Errorf("failed to remove owner reference from CNPG cluster: %w", err)
+		if cnpgCluster != nil {
+			originalCNPG := cnpgCluster.DeepCopy()
+			refRemoved, err := r.removeOwnerRef(postgresCluster, cnpgCluster, "CNPGCluster")
+			if err != nil {
+				return fmt.Errorf("failed to remove owner reference from CNPG cluster: %w", err)
+			}
+			if !refRemoved {
+				logger.Info("Owner reference already removed/not set from CNPG Cluster, skipping patch")
+			}
+			if err := r.patchObject(ctx, originalCNPG, cnpgCluster, "CNPGCluster"); err != nil {
+				return fmt.Errorf("failed to patch CNPG cluster after removing owner reference: %w", err)
+			}
+			logger.Info("Removed owner reference from CNPG Cluster")
 		}
-		if !refRemoved {
-			logger.Info("Owner reference already removed/not set from CNPG Cluster, skipping patch")
-		}
-		if err := r.patchObject(ctx, originalCNPG, cnpgCluster, "CNPGCluster"); err != nil {
-			return fmt.Errorf("failed to patch CNPG cluster after removing owner reference: %w", err)
-		}
-		logger.Info("Removed owner reference from CNPG Cluster")
-
 		// Remove owner reference from Secret to prevent its  deletion.
 		if postgresCluster.Status.Resources != nil && postgresCluster.Status.Resources.SecretRef != nil {
 			secretName := postgresCluster.Status.Resources.SecretRef.Name
@@ -1118,7 +1290,7 @@ func (r *PostgresClusterReconciler) handleFinalizer(ctx context.Context, postgre
 			}
 			if secret != nil {
 				originalSecret := secret.DeepCopy()
-				refRemoved, err = r.removeOwnerRef(postgresCluster, secret, "Secret")
+				refRemoved, err := r.removeOwnerRef(postgresCluster, secret, "Secret")
 				if err != nil {
 					return fmt.Errorf("failed to remove owner reference from Secret: %w", err)
 				}
@@ -1149,8 +1321,7 @@ func (r *PostgresClusterReconciler) handleFinalizer(ctx context.Context, postgre
 	return nil
 }
 
-// clusterSecretExists treats any non-NotFound error as absence — the subsequent Create will
-// surface the real API error if the cluster has a deeper problem.
+// clusterSecretExists returns whether the secret is present and propagates lookup errors.
 func (r *PostgresClusterReconciler) clusterSecretExists(ctx context.Context, namespace, secretName string, secret *corev1.Secret) (clusterSecretExists bool, secretExistErr error) {
 	logger := logs.FromContext(ctx)
 	err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret)
@@ -1165,7 +1336,7 @@ func (r *PostgresClusterReconciler) clusterSecretExists(ctx context.Context, nam
 	return true, nil
 }
 
-// removeOwnerRef removes the owner reference from the object and returns whether it was removed or not.
+// removeOwnerRef removes the owner's reference from the object and reports whether it changed the object.
 func (r *PostgresClusterReconciler) removeOwnerRef(owner client.Object, obj client.Object, objKind objectKind) (bool, error) {
 	hasOwnerRef, err := controllerutil.HasOwnerReference(obj.GetOwnerReferences(), owner, r.Scheme)
 
@@ -1181,7 +1352,36 @@ func (r *PostgresClusterReconciler) removeOwnerRef(owner client.Object, obj clie
 	return true, nil
 }
 
-// patchObject attempts to patch the object and treats NotFound as a non-error, since the object may have already been deleted by Kubernetes.
+// restoreOwnerRef adds the PostgresCluster owner reference back to an existing object when it is missing.
+func (r *PostgresClusterReconciler) restoreOwnerRef(ctx context.Context, owner client.Object, obj client.Object, objKind objectKind) (bool, error) {
+	hasOwnerRef, err := controllerutil.HasOwnerReference(obj.GetOwnerReferences(), owner, r.Scheme)
+	if err != nil {
+		return false, fmt.Errorf("failed to check owner reference on %s: %w", objKind, err)
+	}
+	if hasOwnerRef {
+		return false, nil
+	}
+
+	logger := logs.FromContext(ctx)
+	logger.Info("Connecting existing object to PostgresCluster by adding owner reference", "kind", objKind, "name", obj.GetName())
+
+	originalObj, ok := obj.DeepCopyObject().(client.Object)
+	if !ok {
+		return false, fmt.Errorf("failed to deep copy %s object", objKind)
+	}
+
+	if err := ctrl.SetControllerReference(owner, obj, r.Scheme); err != nil {
+		return false, fmt.Errorf("failed to set controller reference on existing %s: %w", objKind, err)
+	}
+
+	if err := r.patchObject(ctx, originalObj, obj, objKind); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// patchObject applies a merge patch and treats NotFound as already converged.
 func (r *PostgresClusterReconciler) patchObject(ctx context.Context, original client.Object, obj client.Object, objKind objectKind) error {
 	logger := logs.FromContext(ctx)
 	if err := r.Patch(ctx, obj, client.MergeFrom(original)); err != nil {
@@ -1195,14 +1395,150 @@ func (r *PostgresClusterReconciler) patchObject(ctx context.Context, original cl
 	return nil
 }
 
-// SetupWithManager sets up the controller with the Manager.
+// SetupWithManager registers the controller for PostgresCluster resources and owned CNPG Clusters.
 func (r *PostgresClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&enterprisev4.PostgresCluster{}).
-		Owns(&cnpgv1.Cluster{}).
-		Owns(&cnpgv1.Pooler{}).
-		Owns(&corev1.ConfigMap{}).
-		Owns(&corev1.Secret{}).
+		For(&enterprisev4.PostgresCluster{}, builder.WithPredicates(postgresClusterPredicator())).
+		Owns(&cnpgv1.Cluster{}, builder.WithPredicates(cnpgClusterPredicator())).
+		Owns(&cnpgv1.Pooler{}, builder.WithPredicates(cnpgPoolerPredicator())).
+		Owns(&corev1.Secret{}, builder.WithPredicates(secretPredicator())).
+		Owns(&corev1.ConfigMap{}, builder.WithPredicates(configMapPredicator())).
 		Named("postgresCluster").
 		Complete(r)
+}
+
+func deletionTimestampChanged(oldObj, newObj metav1.Object) bool {
+	return !equality.Semantic.DeepEqual(oldObj.GetDeletionTimestamp(), newObj.GetDeletionTimestamp())
+}
+
+func ownerReferencesChanged(oldObj, newObj metav1.Object) bool {
+	return !equality.Semantic.DeepEqual(oldObj.GetOwnerReferences(), newObj.GetOwnerReferences())
+}
+
+// cnpgClusterPredicator filters CNPG Cluster events to only trigger reconciles on creation, deletion, or phase changes.
+func cnpgClusterPredicator() predicate.Predicate {
+
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldObj, oldTypeOK := e.ObjectOld.(*cnpgv1.Cluster)
+			newObj, newTypeOK := e.ObjectNew.(*cnpgv1.Cluster)
+			if !oldTypeOK || !newTypeOK {
+				return true
+			}
+			return oldObj.Status.Phase != newObj.Status.Phase ||
+				ownerReferencesChanged(oldObj, newObj)
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+// postgresClusterPredicator filters PostgresCluster events to trigger reconciles on creation, deletion, generation changes, deletion timestamp changes, or finalizer changes.
+func postgresClusterPredicator() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldObj, oldTypeOK := e.ObjectOld.(*enterprisev4.PostgresCluster)
+			newObj, newTypeOK := e.ObjectNew.(*enterprisev4.PostgresCluster)
+			if !oldTypeOK || !newTypeOK {
+				return true
+			}
+			if oldObj.Generation != newObj.Generation {
+				return true
+			}
+			if deletionTimestampChanged(oldObj, newObj) {
+				return true
+			}
+			if postgresClusterFinalizerName != "" && (controllerutil.ContainsFinalizer(oldObj, postgresClusterFinalizerName) != controllerutil.ContainsFinalizer(newObj, postgresClusterFinalizerName)) {
+				return true
+			}
+			return false
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+// cnpgPoolerPredicator filters CNPG Pooler events to trigger reconciles on creation, deletion, or instance count changes.
+func cnpgPoolerPredicator() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldObj, oldTypeOK := e.ObjectOld.(*cnpgv1.Pooler)
+			newObj, newTypeOK := e.ObjectNew.(*cnpgv1.Pooler)
+			if !oldTypeOK || !newTypeOK {
+				return true
+			}
+			return oldObj.Status.Instances != newObj.Status.Instances
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+// secretPredicator filters Secret events to trigger reconciles on creation, deletion, or owner reference changes.
+func secretPredicator() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldObj, oldTypeOK := e.ObjectOld.(*corev1.Secret)
+			newObj, newTypeOK := e.ObjectNew.(*corev1.Secret)
+			if !oldTypeOK || !newTypeOK {
+				return true
+			}
+			return ownerReferencesChanged(oldObj, newObj)
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+// configMapPredicator filters ConfigMap events to trigger reconciles on creation, deletion, data/label/annotation changes, or owner reference changes.
+func configMapPredicator() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldObj, oldTypeOK := e.ObjectOld.(*corev1.ConfigMap)
+			newObj, newTypeOK := e.ObjectNew.(*corev1.ConfigMap)
+			if !oldTypeOK || !newTypeOK {
+				return true
+			}
+			return !equality.Semantic.DeepEqual(oldObj.Data, newObj.Data) ||
+				!equality.Semantic.DeepEqual(oldObj.Labels, newObj.Labels) ||
+				!equality.Semantic.DeepEqual(oldObj.Annotations, newObj.Annotations) ||
+				ownerReferencesChanged(oldObj, newObj)
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
 }

--- a/internal/controller/postgresoperator_common_types.go
+++ b/internal/controller/postgresoperator_common_types.go
@@ -1,9 +1,8 @@
 package controller
 
 import (
-	"time"
-
 	corev1 "k8s.io/api/core/v1"
+	"time"
 )
 
 // This struct is used to compare the merged configuration from PostgresClusterClass and PostgresClusterSpec
@@ -75,6 +74,7 @@ const (
 	databasesReady  conditionTypes = "DatabasesReady"
 	secretsReady    conditionTypes = "SecretsReady"
 	configMapsReady conditionTypes = "ConfigMapsReady"
+	configMapReady  conditionTypes = "ConfigMapReady"
 	privilegesReady conditionTypes = "PrivilegesReady"
 
 	// Condition reasons
@@ -113,7 +113,6 @@ const (
 	reasonAllInstancesReady          conditionReasons = "AllInstancesReady"
 
 	// Additional condition reasons for mapping CNPG cluster statuses
-	reasonCNPGClusterNotHealthy  conditionReasons = "CNPGClusterNotHealthy"
 	reasonCNPGClusterHealthy     conditionReasons = "CNPGClusterHealthy"
 	reasonCNPGProvisioning       conditionReasons = "CNPGClusterProvisioning"
 	reasonCNPGSwitchover         conditionReasons = "CNPGSwitchover"

--- a/test/connect-to-postgres-cluster.sh
+++ b/test/connect-to-postgres-cluster.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# filepath: scripts/test-postgres-connection.sh
+
+set -e
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Default values
+NAMESPACE="${NAMESPACE:-default}"
+POSTGRES_CLUSTER_NAME="${1:-}"
+
+if [ -z "$POSTGRES_CLUSTER_NAME" ]; then
+    echo -e "${RED}Error: PostgresCluster name is required${NC}"
+    echo "Usage: $0 <postgres-cluster-name> [namespace]"
+    echo "Example: $0 my-postgres-cluster default"
+    exit 1
+fi
+
+if [ -n "$2" ]; then
+    NAMESPACE="$2"
+fi
+
+echo -e "${YELLOW}Connecting to PostgresCluster: $POSTGRES_CLUSTER_NAME in namespace: $NAMESPACE${NC}"
+
+# Get ConfigMap name from PostgresCluster status
+CONFIGMAP_NAME=$(kubectl get postgrescluster "$POSTGRES_CLUSTER_NAME" -n "$NAMESPACE" \
+    -o jsonpath='{.status.resources.configMapRef.name}' 2>/dev/null)
+
+if [ -z "$CONFIGMAP_NAME" ]; then
+    echo -e "${RED}Error: ConfigMap reference not found in PostgresCluster status${NC}"
+    echo "Make sure the PostgresCluster is ready and the ConfigMap has been created"
+    exit 1
+fi
+
+# Get Secret name from PostgresCluster status
+SECRET_NAME=$(kubectl get postgrescluster "$POSTGRES_CLUSTER_NAME" -n "$NAMESPACE" \
+    -o jsonpath='{.status.resources.secretRef.name}' 2>/dev/null)
+
+if [ -z "$SECRET_NAME" ]; then
+    echo -e "${RED}Error: Secret reference not found in PostgresCluster status${NC}"
+    echo "Make sure the PostgresCluster is ready and the Secret has been created"
+    exit 1
+fi
+
+echo -e "${GREEN}Found ConfigMap: $CONFIGMAP_NAME${NC}"
+echo -e "${GREEN}Found Secret: $SECRET_NAME${NC}"
+
+# Extract connection details from ConfigMap (using correct uppercase keys)
+echo -e "\n${YELLOW}Extracting connection details...${NC}"
+DB_PORT=$(kubectl get configmap "$CONFIGMAP_NAME" -n "$NAMESPACE" -o jsonpath='{.data.DEFAULT_CLUSTER_PORT}')
+DB_USER=$(kubectl get configmap "$CONFIGMAP_NAME" -n "$NAMESPACE" -o jsonpath='{.data.SUPER_USER_NAME}')
+RW_SERVICE_FQDN=$(kubectl get configmap "$CONFIGMAP_NAME" -n "$NAMESPACE" -o jsonpath='{.data.CLUSTER_RW_ENDPOINT}')
+RO_SERVICE_FQDN=$(kubectl get configmap "$CONFIGMAP_NAME" -n "$NAMESPACE" -o jsonpath='{.data.CLUSTER_RO_ENDPOINT}')
+R_SERVICE_FQDN=$(kubectl get configmap "$CONFIGMAP_NAME" -n "$NAMESPACE" -o jsonpath='{.data.CLUSTER_R_ENDPOINT}')
+
+# Extract just the service name (first part before the dot)
+RW_SERVICE=$(echo "$RW_SERVICE_FQDN" | cut -d'.' -f1)
+RO_SERVICE=$(echo "$RO_SERVICE_FQDN" | cut -d'.' -f1)
+R_SERVICE=$(echo "$R_SERVICE_FQDN" | cut -d'.' -f1)
+
+# Extract password from Secret
+DB_PASSWORD=$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" -o jsonpath='{.data.password}' | base64 -d)
+
+# Get database name from CNPG cluster (assuming it matches the PostgresCluster name or is 'app')
+DB_NAME=$(kubectl get cluster "$POSTGRES_CLUSTER_NAME" -n "$NAMESPACE" -o jsonpath='{.spec.bootstrap.initdb.database}' 2>/dev/null || echo "postgres")
+
+echo -e "${GREEN}Connection Details:${NC}"
+echo "  RW Service: $RW_SERVICE_FQDN"
+echo "  RO Service: $RO_SERVICE_FQDN"
+echo "  R Service: $R_SERVICE_FQDN"
+echo "  Port: $DB_PORT"
+echo "  Database: $DB_NAME"
+echo "  User: $DB_USER"
+
+# Check if psql is installed
+if ! command -v psql &> /dev/null; then
+    echo -e "\n${YELLOW}psql client not found. Using kubectl run with postgres image...${NC}"
+    
+    echo -e "${YELLOW}Creating temporary pod for connection test...${NC}"
+    
+    kubectl run postgres-client-test \
+        --rm -i --tty \
+        --image=postgres:16 \
+        --restart=Never \
+        --namespace="$NAMESPACE" \
+        --env="PGPASSWORD=$DB_PASSWORD" \
+        -- psql -h "$RW_SERVICE_FQDN" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME"
+else
+    # Use port-forward for local connection
+    echo -e "\n${YELLOW}Setting up port-forward to PostgreSQL service...${NC}"
+    
+    # Kill any existing port-forward on 5432
+    pkill -f "kubectl.*port-forward.*$RW_SERVICE" 2>/dev/null || true
+    
+    # Start port-forward in background (use service name only, not FQDN)
+    kubectl port-forward -n "$NAMESPACE" "service/$RW_SERVICE" 5432:$DB_PORT > /dev/null 2>&1 &
+    PORT_FORWARD_PID=$!
+    
+    # Cleanup function
+    cleanup() {
+        echo -e "\n${YELLOW}Cleaning up port-forward...${NC}"
+        kill $PORT_FORWARD_PID 2>/dev/null || true
+    }
+    trap cleanup EXIT
+    
+    # Wait for port-forward to be ready
+    echo -e "${YELLOW}Waiting for port-forward to be ready...${NC}"
+    sleep 3
+    
+    echo -e "${GREEN}Connecting to PostgreSQL...${NC}"
+    echo -e "${YELLOW}Password: $DB_PASSWORD${NC}\n"
+    
+    # Use connection string format which is more reliable
+    # Disable GSSAPI and use password authentication only
+    PGPASSWORD="$DB_PASSWORD" psql "postgresql://$DB_USER@localhost:5432/$DB_NAME?gssencmode=disable" \
+        || PGPASSWORD="$DB_PASSWORD" psql -h localhost -p 5432 -U "$DB_USER" -d "$DB_NAME" --no-psqlrc
+fi

--- a/test/postgrescluster-retain-upgrade-flow.sh
+++ b/test/postgrescluster-retain-upgrade-flow.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+# run make install make run in a separate terminal to have the operator running while this test executes
+# this test verifies that when a PostgresCluster with clusterDeletionPolicy=Retain is deleted, the underlying CNPG Cluster and superuser Secret are not deleted and can be re-attached to a new PostgresCluster with the same name (simulating a major version upgrade flow where the cluster needs to be recreated). 
+# then, in a separate terminal, run: NAMESPACE=your-namespace UPGRADE_POSTGRES_VERSION=16 ./test/postgrescluster-retain-upgrade-flow.sh
+
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_DIR="$ROOT_DIR/test"
+SAMPLES_DIR="$ROOT_DIR/config/samples"
+
+CLUSTER_MANIFEST="${CLUSTER_MANIFEST:-$SAMPLES_DIR/enterprise_v4_postgrescluster_dev.yaml}"
+DATABASE_MANIFEST="${DATABASE_MANIFEST:-$SAMPLES_DIR/enterprise_v4_postgresdatabase.yaml}"
+CONNECT_SCRIPT="${CONNECT_SCRIPT:-$TEST_DIR/connect-to-postgres-cluster.sh}"
+UPGRADE_POSTGRES_VERSION="${UPGRADE_POSTGRES_VERSION:-16}"
+POLL_INTERVAL="${POLL_INTERVAL:-5}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-900}"
+REQUIRE_POSTGRESDATABASE_READY="${REQUIRE_POSTGRESDATABASE_READY:-0}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log() {
+    echo -e "${YELLOW}[$(date '+%Y-%m-%d %H:%M:%S')] $*${NC}"
+}
+
+pass() {
+    echo -e "${GREEN}[PASS] $*${NC}"
+}
+
+fail() {
+    echo -e "${RED}[FAIL] $*${NC}" >&2
+    exit 1
+}
+
+require_file() {
+    local path="$1"
+    [[ -f "$path" ]] || fail "Required file not found: $path"
+}
+
+require_command() {
+    local cmd="$1"
+    command -v "$cmd" >/dev/null 2>&1 || fail "Required command not found: $cmd"
+}
+
+current_namespace() {
+    local ns
+    ns="$(kubectl config view --minify --output 'jsonpath={..namespace}' 2>/dev/null || true)"
+    if [[ -z "$ns" ]]; then
+        ns="default"
+    fi
+    printf '%s' "$ns"
+}
+
+preflight_namespace() {
+    local deletion_ts phase
+    deletion_ts="$(kubectl get ns "$NAMESPACE" -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null || true)"
+    phase="$(kubectl get ns "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+    if [[ -n "$deletion_ts" || "$phase" == "Terminating" ]]; then
+        fail "Namespace $NAMESPACE is terminating (deletionTimestamp=$deletion_ts phase=$phase). Use a non-terminating namespace."
+    fi
+}
+
+preflight_cluster_dns() {
+    local host
+    host="${CLUSTER_NAME}-rw.${NAMESPACE}.svc.cluster.local"
+    if getent hosts "$host" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    log "Cluster DNS name is not resolvable from this machine: $host"
+    log "This does not block local connection tests (we use kubectl port-forward), but it blocks PostgresDatabase DB-connection/privilege phases when the operator runs out-of-cluster (make run)."
+    log "Fix: run the operator in-cluster or use telepresence/kubefwd to get cluster DNS/networking on your machine."
+
+    SKIP_POSTGRESDATABASE_READY_CHECK=1
+    if [[ "$REQUIRE_POSTGRESDATABASE_READY" == "1" ]]; then
+        fail "PostgresDatabase readiness required (REQUIRE_POSTGRESDATABASE_READY=1) but cluster DNS is not available."
+    fi
+
+    log "Continuing with degraded PostgresDatabase checks (readiness will not be required)."
+}
+
+resource_exists() {
+    local resource="$1"
+    local name="$2"
+    kubectl get "$resource" "$name" -n "$NAMESPACE" >/dev/null 2>&1
+}
+
+jsonpath_value() {
+    local resource="$1"
+    local name="$2"
+    local jsonpath="$3"
+    kubectl get "$resource" "$name" -n "$NAMESPACE" -o "jsonpath=${jsonpath}" 2>/dev/null
+}
+
+wait_for_jsonpath() {
+    local resource="$1"
+    local name="$2"
+    local jsonpath="$3"
+    local expected="$4"
+    local timeout="${5:-$TIMEOUT_SECONDS}"
+    local deadline=$((SECONDS + timeout))
+    local value=""
+
+    while (( SECONDS < deadline )); do
+        value="$(jsonpath_value "$resource" "$name" "$jsonpath" || true)"
+        if [[ "$value" == "$expected" ]]; then
+            pass "$resource/$name reached ${jsonpath}=${expected}"
+            return 0
+        fi
+        sleep "$POLL_INTERVAL"
+    done
+
+    fail "Timed out waiting for $resource/$name to reach ${jsonpath}=${expected}. Last value: ${value:-<empty>}"
+}
+
+wait_for_contains() {
+    local resource="$1"
+    local name="$2"
+    local jsonpath="$3"
+    local expected_substring="$4"
+    local timeout="${5:-$TIMEOUT_SECONDS}"
+    local deadline=$((SECONDS + timeout))
+    local value=""
+
+    while (( SECONDS < deadline )); do
+        value="$(jsonpath_value "$resource" "$name" "$jsonpath" || true)"
+        if [[ "$value" == *"$expected_substring"* ]]; then
+            pass "$resource/$name contains ${expected_substring} in ${jsonpath}"
+            return 0
+        fi
+        sleep "$POLL_INTERVAL"
+    done
+
+    fail "Timed out waiting for $resource/$name to contain ${expected_substring} in ${jsonpath}. Last value: ${value:-<empty>}"
+}
+
+wait_for_absence() {
+    local resource="$1"
+    local name="$2"
+    local timeout="${3:-$TIMEOUT_SECONDS}"
+    local deadline=$((SECONDS + timeout))
+
+    while (( SECONDS < deadline )); do
+        if ! resource_exists "$resource" "$name"; then
+            pass "$resource/$name is absent"
+            return 0
+        fi
+        sleep "$POLL_INTERVAL"
+    done
+
+    fail "Timed out waiting for $resource/$name to be deleted"
+}
+
+wait_for_presence() {
+    local resource="$1"
+    local name="$2"
+    local timeout="${3:-$TIMEOUT_SECONDS}"
+    local deadline=$((SECONDS + timeout))
+
+    while (( SECONDS < deadline )); do
+        if resource_exists "$resource" "$name"; then
+            pass "$resource/$name exists"
+            return 0
+        fi
+        sleep "$POLL_INTERVAL"
+    done
+
+    fail "Timed out waiting for $resource/$name to exist"
+}
+
+wait_for_owner_reference() {
+    local resource="$1"
+    local name="$2"
+    local owner_kind="$3"
+    local owner_name="$4"
+    local owner_uid="$5"
+    local timeout="${6:-$TIMEOUT_SECONDS}"
+    local deadline=$((SECONDS + timeout))
+    local owners=""
+    local expected="${owner_kind}:${owner_name}:${owner_uid}"
+
+    while (( SECONDS < deadline )); do
+        owners="$(jsonpath_value "$resource" "$name" '{range .metadata.ownerReferences[*]}{.kind}:{.name}:{.uid}{"\n"}{end}' || true)"
+        if [[ "$owners" == *"$expected"* ]]; then
+            pass "$resource/$name is owned by ${owner_kind}/${owner_name}"
+            return 0
+        fi
+        sleep "$POLL_INTERVAL"
+    done
+
+    fail "Timed out waiting for $resource/$name to be owned by ${owner_kind}/${owner_name}. Owners: ${owners:-<none>}"
+}
+
+run_connection_check() {
+    log "Checking superuser connection with $CONNECT_SCRIPT"
+    printf 'SELECT current_user;\n\\q\n' | bash "$CONNECT_SCRIPT" "$CLUSTER_NAME" "$NAMESPACE"
+    pass "Superuser connection succeeded"
+}
+
+patch_cluster() {
+    local deletion_policy="$1"
+    local pooler_enabled="$2"
+    kubectl patch postgrescluster "$CLUSTER_NAME" -n "$NAMESPACE" --type merge \
+        -p "{\"spec\":{\"clusterDeletionPolicy\":\"${deletion_policy}\",\"connectionPoolerEnabled\":${pooler_enabled}}}" >/dev/null
+}
+
+apply_upgraded_cluster_manifest() {
+    local tmp_manifest
+    tmp_manifest="$(mktemp)"
+
+    sed \
+        -e "s/^\([[:space:]]*clusterDeletionPolicy:\).*/\1 Retain/" \
+        -e "s/^\([[:space:]]*postgresVersion:\).*/\1 \"${UPGRADE_POSTGRES_VERSION}\"/" \
+        "$CLUSTER_MANIFEST" > "$tmp_manifest"
+
+    kubectl apply -n "$NAMESPACE" -f "$tmp_manifest" >/dev/null
+    rm -f "$tmp_manifest"
+}
+
+assert_cluster_ready() {
+    wait_for_jsonpath postgrescluster "$CLUSTER_NAME" '{.status.phase}' 'Ready'
+    wait_for_jsonpath postgrescluster "$CLUSTER_NAME" '{.status.conditions[?(@.type=="ClusterReady")].status}' 'True'
+    wait_for_jsonpath postgrescluster "$CLUSTER_NAME" '{.status.conditions[?(@.type=="ConfigMapReady")].status}' 'True'
+}
+
+assert_database_created() {
+    wait_for_presence postgresdatabase "$DATABASE_NAME"
+    for db in "${DATABASES[@]}"; do
+        wait_for_presence databases.postgresql.cnpg.io "${DATABASE_NAME}-${db}"
+    done
+    pass "PostgresDatabase CR exists and CNPG Database CRs are present"
+}
+
+assert_database_ready() {
+    if [[ "${SKIP_POSTGRESDATABASE_READY_CHECK:-0}" == "1" ]]; then
+        assert_database_created
+        return 0
+    fi
+    wait_for_jsonpath postgresdatabase "$DATABASE_NAME" '{.status.phase}' 'Ready'
+    wait_for_jsonpath postgresdatabase "$DATABASE_NAME" '{.status.observedGeneration}' \
+        "$(jsonpath_value postgresdatabase "$DATABASE_NAME" '{.metadata.generation}')"
+}
+
+record_cluster_artifacts() {
+    SUPERUSER_SECRET_NAME="$(jsonpath_value postgrescluster "$CLUSTER_NAME" '{.status.resources.secretRef.name}')"
+    CONFIGMAP_NAME="$(jsonpath_value postgrescluster "$CLUSTER_NAME" '{.status.resources.configMapRef.name}')"
+
+    [[ -n "$SUPERUSER_SECRET_NAME" ]] || fail "PostgresCluster status.resources.secretRef.name is empty"
+    [[ -n "$CONFIGMAP_NAME" ]] || fail "PostgresCluster status.resources.configMapRef.name is empty"
+}
+
+cleanup_database_cr() {
+    if resource_exists postgresdatabase "$DATABASE_NAME"; then
+        log "Deleting PostgresDatabase/$DATABASE_NAME to leave the namespace clean"
+        kubectl delete postgresdatabase "$DATABASE_NAME" -n "$NAMESPACE" --wait=false >/dev/null
+        wait_for_absence postgresdatabase "$DATABASE_NAME"
+    fi
+}
+
+require_command kubectl
+require_file "$CLUSTER_MANIFEST"
+require_file "$DATABASE_MANIFEST"
+require_file "$CONNECT_SCRIPT"
+
+NAMESPACE="${NAMESPACE:-$(current_namespace)}"
+CLUSTER_NAME="${CLUSTER_NAME:-$(kubectl create --dry-run=client -f "$CLUSTER_MANIFEST" -o jsonpath='{.metadata.name}')}"
+DATABASE_NAME="${DATABASE_NAME:-$(kubectl create --dry-run=client -f "$DATABASE_MANIFEST" -o jsonpath='{.metadata.name}')}"
+DATABASES_STR="$(kubectl create --dry-run=client -f "$DATABASE_MANIFEST" -o jsonpath='{range .spec.databases[*]}{.name}{" "}{end}')"
+read -r -a DATABASES <<< "${DATABASES_STR:-}"
+RW_POOLER_NAME="${CLUSTER_NAME}-pooler-rw"
+RO_POOLER_NAME="${CLUSTER_NAME}-pooler-ro"
+
+log "Using namespace: $NAMESPACE"
+log "Cluster manifest: $CLUSTER_MANIFEST"
+log "Database manifest: $DATABASE_MANIFEST"
+log "Upgrade target postgresVersion: $UPGRADE_POSTGRES_VERSION"
+
+preflight_namespace
+preflight_cluster_dns
+
+log "1. Creating PostgresCluster from sample manifest"
+kubectl apply -n "$NAMESPACE" -f "$CLUSTER_MANIFEST"
+
+log "2. Creating PostgresDatabase from sample manifest"
+kubectl apply -n "$NAMESPACE" -f "$DATABASE_MANIFEST"
+
+log "3. Waiting for PostgresCluster and PostgresDatabase to become ready"
+assert_cluster_ready
+assert_database_ready
+record_cluster_artifacts
+pass "PostgresCluster and PostgresDatabase were created successfully"
+
+log "4. Verifying superuser connection to PostgresCluster"
+run_connection_check
+
+log "5. Setting clusterDeletionPolicy=Retain and connectionPoolerEnabled=false"
+patch_cluster "Retain" "false"
+wait_for_jsonpath postgrescluster "$CLUSTER_NAME" '{.spec.clusterDeletionPolicy}' 'Retain'
+wait_for_jsonpath postgrescluster "$CLUSTER_NAME" '{.spec.connectionPoolerEnabled}' 'false'
+wait_for_absence pooler.postgresql.cnpg.io "$RW_POOLER_NAME"
+wait_for_absence pooler.postgresql.cnpg.io "$RO_POOLER_NAME"
+assert_cluster_ready
+
+log "6. Setting connectionPoolerEnabled=true and waiting for poolers"
+patch_cluster "Retain" "true"
+wait_for_jsonpath postgrescluster "$CLUSTER_NAME" '{.spec.connectionPoolerEnabled}' 'true'
+wait_for_presence pooler.postgresql.cnpg.io "$RW_POOLER_NAME"
+wait_for_presence pooler.postgresql.cnpg.io "$RO_POOLER_NAME"
+wait_for_jsonpath postgrescluster "$CLUSTER_NAME" '{.status.conditions[?(@.type=="PoolerReady")].status}' 'True'
+assert_cluster_ready
+
+log "7. Deleting PostgresCluster with retention enabled"
+kubectl delete postgrescluster "$CLUSTER_NAME" -n "$NAMESPACE" --wait=false >/dev/null
+wait_for_absence postgrescluster "$CLUSTER_NAME"
+wait_for_presence cluster.postgresql.cnpg.io "$CLUSTER_NAME"
+wait_for_presence secret "$SUPERUSER_SECRET_NAME"
+pass "CNPG cluster and superuser secret remained after PostgresCluster deletion"
+
+log "8. Recreating PostgresCluster with a major version upgrade"
+apply_upgraded_cluster_manifest
+wait_for_presence postgrescluster "$CLUSTER_NAME"
+wait_for_contains cluster.postgresql.cnpg.io "$CLUSTER_NAME" '{.spec.imageName}' ":${UPGRADE_POSTGRES_VERSION}"
+assert_cluster_ready
+record_cluster_artifacts
+
+log "9. Checking that retained resources were re-attached to the recreated PostgresCluster"
+POSTGRES_CLUSTER_UID="$(jsonpath_value postgrescluster "$CLUSTER_NAME" '{.metadata.uid}')"
+wait_for_owner_reference cluster.postgresql.cnpg.io "$CLUSTER_NAME" "PostgresCluster" "$CLUSTER_NAME" "$POSTGRES_CLUSTER_UID"
+wait_for_owner_reference secret "$SUPERUSER_SECRET_NAME" "PostgresCluster" "$CLUSTER_NAME" "$POSTGRES_CLUSTER_UID"
+
+log "10. Verifying superuser connection after recreate/upgrade"
+run_connection_check
+
+log "11. Setting clusterDeletionPolicy=Delete"
+kubectl patch postgrescluster "$CLUSTER_NAME" -n "$NAMESPACE" --type merge \
+    -p '{"spec":{"clusterDeletionPolicy":"Delete"}}' >/dev/null
+wait_for_jsonpath postgrescluster "$CLUSTER_NAME" '{.spec.clusterDeletionPolicy}' 'Delete'
+
+log "12. Deleting the PostgresCluster"
+kubectl delete postgrescluster "$CLUSTER_NAME" -n "$NAMESPACE" --wait=false >/dev/null
+wait_for_absence postgrescluster "$CLUSTER_NAME"
+
+log "13. Checking that no cluster leftovers remain"
+cleanup_database_cr
+wait_for_absence cluster.postgresql.cnpg.io "$CLUSTER_NAME"
+wait_for_absence pooler.postgresql.cnpg.io "$RW_POOLER_NAME"
+wait_for_absence pooler.postgresql.cnpg.io "$RO_POOLER_NAME"
+wait_for_absence secret "$SUPERUSER_SECRET_NAME"
+wait_for_absence configmap "$CONFIGMAP_NAME"
+pass "No PostgresCluster leftovers remain in namespace $NAMESPACE"
+
+log "Flow finished successfully"


### PR DESCRIPTION
### Tests

created bash script to run tests locally: 

```
NAMESPACE=your-namespace UPGRADE_POSTGRES_VERSION=16 ./test/postgrescluster-retain-upgrade-flow.sh
```

### Description

Calmed reconciliation storm for `postgrescluster_controller.go`

### Key Changes

PostgresCluster does not show a runaway reconcile storm in this log. Its bursts are short, causal, and converge. 

Log analysis: 

The strongest reconcile storm in this log is PostgresDatabase, not PostgresCluster.
There is a short but real burst at operator.log (line 241): PostgresDatabase reconciles, patches users into PostgresCluster, then another PostgresDatabase reconcile starts almost immediately at operator.log (line 252) and hits a resource-version conflict at operator.log (line 256).
After that, PostgresDatabase re-enters again at operator.log (line 263) and still reports pending users at operator.log (line 272). That is classic concurrent-update churn.
The biggest burst is at operator.log (line 281) through operator.log (line 326): 5 separate PostgresDatabase reconciles in about 0.3s, all processing the same two databases and repeatedly logging CNPG Database created/updated successfully.
PostgresCluster also has a burst during recreate/provisioning at operator.log (line 343) through operator.log (line 387): multiple immediate reconciles caused by finalizer add, owner-ref restoration, CNPG patch, then pooler wait/retry.
The two Connection poolers are not ready yet, requeueing entries at operator.log (line 371) and operator.log (line 378) are bounded. They settle by operator.log (line 387), so this is not the main storm.
After that, PostgresCluster reconciles roughly every 10-19s at operator.log (line 388), operator.log (line 396), operator.log (line 404), operator.log (line 412), operator.log (line 420). That looks like normal CNPG phase-change traffic, not a hot loop.
Interpretation

The primary storm driver is PostgresDatabase reconciling the same object repeatedly while related objects are changing under it.
The clearest amplifier is the update conflict at operator.log (line 256).
The second amplifier is child-object churn: the controller appears to reconcile again after each CNPG database create/update, even when it is still converging the same desired state.
PostgresCluster does have short bursts, but they are bounded and consistent with create/delete/provisioning transitions.

**Bottom line**

Real storm: PostgresDatabase around operator.log (line 241) and especially operator.log (line 281).
Not a storm: the later PostgresCluster loop after operator.log (line 388); it looks event-driven and converges to healthy at operator.log (line 425).

### **TODO:** fix reconciliation storm in  `postgresdatabase_operator.go` 

### Logs files. 
[operator_before.log](https://github.com/user-attachments/files/26168590/operator_before.log) - logs before,
[operator_after.log](https://github.com/user-attachments/files/26168039/operator_after.log) - logs after.
[cluster.log](https://github.com/user-attachments/files/26165867/cluster.log) - cluster phase changes.
[postgrescluster.log](https://github.com/user-attachments/files/26165868/postgrescluster.log) - postgrescluster phase changes. 

### Issues fixed.

1. The old controller version had repeated status-update conflicts caused by multiple writes during one reconcile.
The clearest burst is at `19:46:34+01:00`:

- `Failed to sync pooler status` at operator.log:4782, operator.log:4845 operator.log:4887 operator.log:4929.
- each failure is `the object has been modified`
- at the same time, neighboring reconciles still finish with `Reconciliation complete` at operator.log:4817 operator.log:4824, operator.log:4831, operator.log:4880

That is classic self-induced churn from inline `Status().Update(...)` calls racing with other reconciles.

2. The previous controller version had pooler-related reconcile storms.
The log shows repeated successful reconciles mixed with pooler status failures in the same second:

- `Poolers are ready, syncing pooler status` at operator.log:104
- later repeated `Failed to sync pooler status` at operator.log:4782

The old flow updated pooler state in multiple places, including the tail of reconcile, which amplified conflicts and repeat work.

3. The old controller was patching managed roles repeatedly even when the role counts already matched.
Examples:

- `currentCount: 4, desiredCount: 4` but still “roles differ” at operator.log:612
- same pattern at operator.log:4829, operator.log:4836], operator.log:4927

That indicates unnecessary no-op role patching and extra reconcile noise.

4. The old controller was noisy even on healthy convergence.
It reached full success twice within milliseconds at operator.log:105 and operator.log:114, then many more times around operator.log:4817. That points to event amplification from owned resources plus repeated no-op status/resource updates.

5. The old controller had an issue with infinite loop on version major upgrade attempt. 

**Problems  fixed**

- Fixed infinite loop on version upgrade.
- Centralized status persistence addresses the old conflict storm. Moving from immediate status writes throughout reconcile to buffered status mutation plus `persistStatus()` / `persistStatusIfChanged()` directly targets the `object has been modified` failures.
- The pooler flow is now staged more cleanly. Pooler wait/delete paths use explicit requeue behavior, and pooler status is no longer updated in the same scattered way that produced the old `Failed to sync pooler status` bursts.
- The refactor removed the worst control-flow ambiguity in pooler reconciliation. The old code mixed pooler readiness, status writes, ConfigMap reconciliation, and final status sync in one tail section; the new flow separates these phases more clearly.
- Desired/current-state comparison is now more deliberate, which is the right direction for reducing the old managed-role churn where the controller kept patching despite `currentCount == desiredCount`.
- Fixed overall readability and phase separation. In the old logs, secret repair, cluster patching, managed roles, poolers, ConfigMap, and final status writes all interleaved tightly; the refactored controller makes these transitions explicit and easier to reason about.

**Bottom line**

The old log shows two main classes of problems that the refactor improved:
- reconciliation churn from repeated inline status updates and pooler status writes
- noisy no-op reconciliation work, especially around managed roles and tail-end success paths

### Related Issues

[CPI-1913](https://splunk.atlassian.net/browse/CPI-1913) - JIRA ticket
### PR Checklist

- [ ] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [ ] All tests pass locally.
- [ ] The PR description follows the project's guidelines.
