### PR TITLE
Update Splunk Enterprise version to 10.2.0 in helm-chart values

### DIFF
--- a/helm-chart/splunk-operator/values.yaml
+++ b/helm-chart/splunk-operator/values.yaml
@@ -3,7 +3,7 @@ splunk-operator:
 
 # Splunk image
 image:
-  repository: docker.io/splunk/splunk:10.0.0
+  repository: docker.io/splunk/splunk:10.2.0
 
 # Splunk Operator configurations
 splunkOperator:


### PR DESCRIPTION
## Summary
- Updates Splunk Enterprise image version from 10.0.0 to 10.2.0 in helm-chart values.yaml

## Changes
- `helm-chart/splunk-operator/values.yaml`: Updated image repository from `docker.io/splunk/splunk:10.0.0` to `docker.io/splunk/splunk:10.2.0`

## Related
- Follows up on the Splunk Enterprise 10.2.0 version updates made in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)