### PR TITLE
PostgresCluster and PostgresDatabase events emitting

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -283,15 +283,17 @@ func main() {
 		os.Exit(1)
 	}
 	if err := (&controller.PostgresDatabaseReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("postgresdatabase-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PostgresDatabase")
 		os.Exit(1)
 	}
 	if err := (&controller.PostgresClusterReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("postgrescluster-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PostgresCluster")
 		os.Exit(1)

--- a/internal/controller/postgrescluster_controller.go
+++ b/internal/controller/postgrescluster_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,7 +43,8 @@ const (
 // PostgresClusterReconciler reconciles PostgresCluster resources.
 type PostgresClusterReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=enterprise.splunk.com,resources=postgresclusters,verbs=get;list;watch;create;update;patch;delete
@@ -53,9 +55,11 @@ type PostgresClusterReconciler struct {
 // +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=clusters/status,verbs=get
 // +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=poolers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=poolers/status,verbs=get
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 func (r *PostgresClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return clustercore.PostgresClusterService(ctx, r.Client, r.Scheme, req)
+	rc := &clustercore.ReconcileContext{Client: r.Client, Scheme: r.Scheme, Recorder: r.Recorder}
+	return clustercore.PostgresClusterService(ctx, rc, req)
 }
 
 // SetupWithManager registers the controller and owned resource watches.

--- a/internal/controller/postgresdatabase_controller.go
+++ b/internal/controller/postgresdatabase_controller.go
@@ -108,9 +108,12 @@ func (r *PostgresDatabaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				},
 			),
 		)).
-		Owns(&cnpgv1.Database{}).
-		Owns(&corev1.Secret{}).
-		Owns(&corev1.ConfigMap{}).
+		Owns(&cnpgv1.Database{}, builder.WithPredicates(predicate.Funcs{
+			CreateFunc: func(event.CreateEvent) bool { return false },
+			DeleteFunc: func(event.DeleteEvent) bool { return false },
+		})).
+		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(client.Object) bool { return false }))).
+		Owns(&corev1.ConfigMap{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(client.Object) bool { return false }))).
 		Named("postgresdatabase").
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: DatabaseTotalWorker,

--- a/internal/controller/postgresdatabase_controller.go
+++ b/internal/controller/postgresdatabase_controller.go
@@ -110,10 +110,13 @@ func (r *PostgresDatabaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)).
 		Owns(&cnpgv1.Database{}, builder.WithPredicates(predicate.Funcs{
 			CreateFunc: func(event.CreateEvent) bool { return false },
-			DeleteFunc: func(event.DeleteEvent) bool { return false },
 		})).
-		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(client.Object) bool { return false }))).
-		Owns(&corev1.ConfigMap{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(client.Object) bool { return false }))).
+		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.Funcs{
+			CreateFunc: func(event.CreateEvent) bool { return false },
+		})).
+		Owns(&corev1.ConfigMap{}, builder.WithPredicates(predicate.Funcs{
+			CreateFunc: func(event.CreateEvent) bool { return false },
+		})).
 		Named("postgresdatabase").
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: DatabaseTotalWorker,

--- a/internal/controller/postgresdatabase_controller.go
+++ b/internal/controller/postgresdatabase_controller.go
@@ -29,6 +29,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,7 +42,8 @@ import (
 // PostgresDatabaseReconciler reconciles a PostgresDatabase object.
 type PostgresDatabaseReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 }
 
 const (
@@ -56,6 +58,7 @@ const (
 //+kubebuilder:rbac:groups=postgresql.cnpg.io,resources=databases,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;delete
+//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 func (r *PostgresDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
@@ -68,7 +71,8 @@ func (r *PostgresDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 		return ctrl.Result{}, err
 	}
-	return dbcore.PostgresDatabaseService(ctx, r.Client, r.Scheme, postgresDB, dbadapter.NewDBRepository)
+	rc := &dbcore.ReconcileContext{Client: r.Client, Scheme: r.Scheme, Recorder: r.Recorder}
+	return dbcore.PostgresDatabaseService(ctx, rc, postgresDB, dbadapter.NewDBRepository)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/postgresql/cluster/core/cluster.go
+++ b/pkg/postgresql/cluster/core/cluster.go
@@ -38,7 +38,8 @@ import (
 )
 
 // PostgresClusterService is the application service entry point called by the primary adapter (reconciler).
-func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtime.Scheme, req ctrl.Request) (ctrl.Result, error) {
+func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.Request) (ctrl.Result, error) {
+	c := rc.Client
 	logger := log.FromContext(ctx)
 	logger.Info("Reconciling PostgresCluster", "name", req.Name, "namespace", req.Namespace)
 
@@ -66,12 +67,13 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 	}
 
 	// Finalizer handling must come before any other processing.
-	if err := handleFinalizer(ctx, c, scheme, postgresCluster, secret); err != nil {
+	if err := handleFinalizer(ctx, rc, postgresCluster, secret); err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("PostgresCluster already deleted, skipping finalizer update")
 			return ctrl.Result{}, nil
 		}
 		logger.Error(err, "Failed to handle finalizer")
+		rc.emitWarning(postgresCluster, EventCleanupFailed, fmt.Sprintf("Cleanup failed: %v", err))
 		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterDeleteFailed,
 			fmt.Sprintf("Failed to delete resources during cleanup: %v", err), failedClusterPhase); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status")
@@ -102,6 +104,7 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 	clusterClass := &enterprisev4.PostgresClusterClass{}
 	if err := c.Get(ctx, client.ObjectKey{Name: postgresCluster.Spec.Class}, clusterClass); err != nil {
 		logger.Error(err, "Unable to fetch referenced PostgresClusterClass", "className", postgresCluster.Spec.Class)
+		rc.emitWarning(postgresCluster, EventClusterClassNotFound, fmt.Sprintf("ClusterClass %s not found", postgresCluster.Spec.Class))
 		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterClassNotFound,
 			fmt.Sprintf("ClusterClass %s not found: %v", postgresCluster.Spec.Class, err), failedClusterPhase); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status")
@@ -113,6 +116,7 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 	mergedConfig, err := getMergedConfig(clusterClass, postgresCluster)
 	if err != nil {
 		logger.Error(err, "Failed to merge PostgresCluster configuration")
+		rc.emitWarning(postgresCluster, EventConfigMergeFailed, fmt.Sprintf("Failed to merge configuration: %v", err))
 		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonInvalidConfiguration,
 			fmt.Sprintf("Failed to merge configuration: %v", err), failedClusterPhase); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status")
@@ -132,6 +136,7 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 	secretExists, secretErr := clusterSecretExists(ctx, c, postgresCluster.Namespace, postgresSecretName, secret)
 	if secretErr != nil {
 		logger.Error(secretErr, "Failed to check if PostgresCluster secret exists", "name", postgresSecretName)
+		rc.emitWarning(postgresCluster, EventSecretReconcileFailed, fmt.Sprintf("Failed to check secret existence: %v", secretErr))
 		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonUserSecretFailed,
 			fmt.Sprintf("Failed to check secret existence: %v", secretErr), failedClusterPhase); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status")
@@ -140,8 +145,9 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 	}
 	if !secretExists {
 		logger.Info("Creating PostgresCluster secret", "name", postgresSecretName)
-		if err := ensureClusterSecret(ctx, c, scheme, postgresCluster, postgresSecretName, secret); err != nil {
+		if err := ensureClusterSecret(ctx, c, rc.Scheme, postgresCluster, postgresSecretName, secret); err != nil {
 			logger.Error(err, "Failed to ensure PostgresCluster secret", "name", postgresSecretName)
+			rc.emitWarning(postgresCluster, EventSecretReconcileFailed, fmt.Sprintf("Failed to generate cluster secret: %v", err))
 			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonUserSecretFailed,
 				fmt.Sprintf("Failed to generate PostgresCluster secret: %v", err), failedClusterPhase); statusErr != nil {
 				logger.Error(statusErr, "Failed to update status")
@@ -160,7 +166,7 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 	}
 
 	// Re-attach ownerRef if it was stripped (e.g. by a Retain-policy deletion of a previous cluster).
-	hasOwnerRef, ownerRefErr := controllerutil.HasOwnerReference(secret.GetOwnerReferences(), postgresCluster, scheme)
+	hasOwnerRef, ownerRefErr := controllerutil.HasOwnerReference(secret.GetOwnerReferences(), postgresCluster, rc.Scheme)
 	if ownerRefErr != nil {
 		logger.Error(ownerRefErr, "Failed to check owner reference on Secret")
 		return ctrl.Result{}, fmt.Errorf("failed to check owner reference on secret: %w", ownerRefErr)
@@ -168,11 +174,12 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 	if secretExists && !hasOwnerRef {
 		logger.Info("Connecting existing secret to PostgresCluster by adding owner reference", "name", postgresSecretName)
 		originalSecret := secret.DeepCopy()
-		if err := ctrl.SetControllerReference(postgresCluster, secret, scheme); err != nil {
+		if err := ctrl.SetControllerReference(postgresCluster, secret, rc.Scheme); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to set controller reference on existing secret: %w", err)
 		}
 		if err := patchObject(ctx, c, originalSecret, secret, "Secret"); err != nil {
 			logger.Error(err, "Failed to patch existing secret with controller reference")
+			rc.emitWarning(postgresCluster, EventSecretReconcileFailed, fmt.Sprintf("Failed to patch existing secret: %v", err))
 			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonSuperUserSecretFailed,
 				fmt.Sprintf("Failed to patch existing secret: %v", err), failedClusterPhase); statusErr != nil {
 				logger.Error(statusErr, "Failed to update status")
@@ -198,15 +205,17 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 	switch {
 	case apierrors.IsNotFound(err):
 		logger.Info("CNPG Cluster not found, creating", "name", postgresCluster.Name)
-		newCluster := buildCNPGCluster(scheme, postgresCluster, mergedConfig, postgresSecretName)
+		newCluster := buildCNPGCluster(rc.Scheme, postgresCluster, mergedConfig, postgresSecretName)
 		if err := c.Create(ctx, newCluster); err != nil {
 			logger.Error(err, "Failed to create CNPG Cluster")
+			rc.emitWarning(postgresCluster, EventClusterCreateFailed, fmt.Sprintf("Failed to create CNPG cluster: %v", err))
 			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterBuildFailed,
 				fmt.Sprintf("Failed to create CNPG Cluster: %v", err), failedClusterPhase); statusErr != nil {
 				logger.Error(statusErr, "Failed to update status")
 			}
 			return ctrl.Result{}, err
 		}
+		rc.emitNormal(postgresCluster, EventClusterCreating, "CNPG cluster created, waiting for healthy state")
 		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterBuildSucceeded,
 			"CNPG Cluster created", pendingClusterPhase); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status")
@@ -238,12 +247,14 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 			return ctrl.Result{Requeue: true}, nil
 		case patchErr != nil:
 			logger.Error(patchErr, "Failed to patch CNPG Cluster", "name", cnpgCluster.Name)
+			rc.emitWarning(postgresCluster, EventClusterUpdateFailed, fmt.Sprintf("Failed to patch CNPG cluster: %v", patchErr))
 			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterPatchFailed,
 				fmt.Sprintf("Failed to patch CNPG Cluster: %v", patchErr), failedClusterPhase); statusErr != nil {
 				logger.Error(statusErr, "Failed to update status")
 			}
 			return ctrl.Result{}, patchErr
 		default:
+			rc.emitNormal(postgresCluster, EventClusterUpdated, "CNPG cluster spec updated")
 			logger.Info("CNPG Cluster patched successfully, requeueing for status update", "name", cnpgCluster.Name)
 			return ctrl.Result{RequeueAfter: retryDelay}, nil
 		}
@@ -252,6 +263,7 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 	// 7a. Reconcile ManagedRoles.
 	if err := reconcileManagedRoles(ctx, c, postgresCluster, cnpgCluster); err != nil {
 		logger.Error(err, "Failed to reconcile managed roles")
+		rc.emitWarning(postgresCluster, EventManagedRolesFailed, fmt.Sprintf("Failed to reconcile managed roles: %v", err))
 		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonManagedRolesFailed,
 			fmt.Sprintf("Failed to reconcile managed roles: %v", err), failedClusterPhase); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status")
@@ -293,8 +305,9 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 			}
 			return ctrl.Result{RequeueAfter: retryDelay}, nil
 		}
-		if err := createOrUpdateConnectionPoolers(ctx, c, scheme, postgresCluster, mergedConfig, cnpgCluster); err != nil {
+		if err := createOrUpdateConnectionPoolers(ctx, c, rc.Scheme, postgresCluster, mergedConfig, cnpgCluster); err != nil {
 			logger.Error(err, "Failed to reconcile connection pooler")
+			rc.emitWarning(postgresCluster, EventPoolerReconcileFailed, fmt.Sprintf("Failed to reconcile connection pooler: %v", err))
 			if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerReconciliationFailed,
 				fmt.Sprintf("Failed to reconcile connection pooler: %v", err), failedClusterPhase); statusErr != nil {
 				logger.Error(statusErr, "Failed to update status")
@@ -332,22 +345,27 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 		return ctrl.Result{RequeueAfter: retryDelay}, nil
 
 	default:
+		oldConditions := make([]metav1.Condition, len(postgresCluster.Status.Conditions))
+		copy(oldConditions, postgresCluster.Status.Conditions)
 		if err := syncPoolerStatus(ctx, c, postgresCluster); err != nil {
 			logger.Error(err, "Failed to sync pooler status")
+			rc.emitWarning(postgresCluster, EventPoolerReconcileFailed, fmt.Sprintf("Failed to sync pooler status: %v", err))
 			if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerReconciliationFailed,
 				fmt.Sprintf("Failed to sync pooler status: %v", err), failedClusterPhase); statusErr != nil {
 				logger.Error(statusErr, "Failed to update status")
 			}
 			return ctrl.Result{}, err
 		}
+		rc.emitPoolerReadyTransition(postgresCluster, oldConditions)
 	}
 
 	// 8. Reconcile ConfigMap when CNPG cluster is healthy.
 	if cnpgCluster.Status.Phase == cnpgv1.PhaseHealthy {
 		logger.Info("CNPG Cluster is ready, reconciling ConfigMap for connection details")
-		desiredCM, err := generateConfigMap(ctx, c, scheme, postgresCluster, cnpgCluster, postgresSecretName)
+		desiredCM, err := generateConfigMap(ctx, c, rc.Scheme, postgresCluster, cnpgCluster, postgresSecretName)
 		if err != nil {
 			logger.Error(err, "Failed to generate ConfigMap")
+			rc.emitWarning(postgresCluster, EventConfigMapReconcileFailed, fmt.Sprintf("Failed to reconcile ConfigMap: %v", err))
 			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonConfigMapFailed,
 				fmt.Sprintf("Failed to generate ConfigMap: %v", err), failedClusterPhase); statusErr != nil {
 				logger.Error(statusErr, "Failed to update status")
@@ -360,7 +378,7 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 			cm.Annotations = desiredCM.Annotations
 			cm.Labels = desiredCM.Labels
 			if !metav1.IsControlledBy(cm, postgresCluster) {
-				if err := ctrl.SetControllerReference(postgresCluster, cm, scheme); err != nil {
+				if err := ctrl.SetControllerReference(postgresCluster, cm, rc.Scheme); err != nil {
 					return fmt.Errorf("set controller reference failed: %w", err)
 				}
 			}
@@ -368,6 +386,7 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 		})
 		if err != nil {
 			logger.Error(err, "Failed to reconcile ConfigMap", "name", desiredCM.Name)
+			rc.emitWarning(postgresCluster, EventConfigMapReconcileFailed, fmt.Sprintf("Failed to reconcile ConfigMap: %v", err))
 			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonConfigMapFailed,
 				fmt.Sprintf("Failed to reconcile ConfigMap: %v", err), failedClusterPhase); statusErr != nil {
 				logger.Error(statusErr, "Failed to update status")
@@ -388,6 +407,10 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 	}
 
 	// 9. Final status sync.
+	var oldPhase string
+	if postgresCluster.Status.Phase != nil {
+		oldPhase = *postgresCluster.Status.Phase
+	}
 	if err := syncStatus(ctx, c, postgresCluster, cnpgCluster); err != nil {
 		logger.Error(err, "Failed to sync status")
 		if apierrors.IsConflict(err) {
@@ -396,6 +419,11 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to sync status: %w", err)
 	}
+	var newPhase string
+	if postgresCluster.Status.Phase != nil {
+		newPhase = *postgresCluster.Status.Phase
+	}
+	rc.emitClusterPhaseTransition(postgresCluster, oldPhase, newPhase)
 	if cnpgCluster.Status.Phase == cnpgv1.PhaseHealthy {
 		rwPooler := &cnpgv1.Pooler{}
 		rwErr := c.Get(ctx, types.NamespacedName{
@@ -409,7 +437,10 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 		}, roPooler)
 		if rwErr == nil && roErr == nil && arePoolersReady(rwPooler, roPooler) {
 			logger.Info("Poolers are ready, syncing pooler status")
+			poolerOldConditions := make([]metav1.Condition, len(postgresCluster.Status.Conditions))
+			copy(poolerOldConditions, postgresCluster.Status.Conditions)
 			_ = syncPoolerStatus(ctx, c, postgresCluster)
+			rc.emitPoolerReadyTransition(postgresCluster, poolerOldConditions)
 		}
 	}
 	logger.Info("Reconciliation complete")
@@ -873,7 +904,9 @@ func deleteCNPGCluster(ctx context.Context, c client.Client, cnpgCluster *cnpgv1
 
 // handleFinalizer processes deletion cleanup: removes poolers, then deletes or orphans the CNPG Cluster
 // based on ClusterDeletionPolicy, then removes the finalizer.
-func handleFinalizer(ctx context.Context, c client.Client, scheme *runtime.Scheme, cluster *enterprisev4.PostgresCluster, secret *corev1.Secret) error {
+func handleFinalizer(ctx context.Context, rc *ReconcileContext, cluster *enterprisev4.PostgresCluster, secret *corev1.Secret) error {
+	c := rc.Client
+	scheme := rc.Scheme
 	logger := log.FromContext(ctx)
 	if cluster.GetDeletionTimestamp() == nil {
 		logger.Info("PostgresCluster not marked for deletion, skipping finalizer logic")
@@ -896,15 +929,16 @@ func handleFinalizer(ctx context.Context, c client.Client, scheme *runtime.Schem
 	}
 	logger.Info("Processing finalizer cleanup for PostgresCluster")
 
-	if err := deleteConnectionPoolers(ctx, c, cluster); err != nil {
-		logger.Error(err, "Failed to delete connection poolers during cleanup")
-		return fmt.Errorf("failed to delete connection poolers: %w", err)
-	}
-
-	// Dereference *string — empty string falls through to default (unknown policy).
+	// Emit deletion event — policy is resolved below, use the raw pointer for the message.
 	policy := ""
 	if cluster.Spec.ClusterDeletionPolicy != nil {
 		policy = *cluster.Spec.ClusterDeletionPolicy
+	}
+	rc.emitNormal(cluster, EventClusterDeleting, fmt.Sprintf("Starting cleanup (policy: %s)", policy))
+
+	if err := deleteConnectionPoolers(ctx, c, cluster); err != nil {
+		logger.Error(err, "Failed to delete connection poolers during cleanup")
+		return fmt.Errorf("failed to delete connection poolers: %w", err)
 	}
 
 	switch policy {
@@ -973,6 +1007,7 @@ func handleFinalizer(ctx context.Context, c client.Client, scheme *runtime.Schem
 		logger.Error(err, "Failed to remove finalizer from PostgresCluster")
 		return fmt.Errorf("failed to remove finalizer: %w", err)
 	}
+	rc.emitNormal(cluster, EventCleanupComplete, "Cleanup complete")
 	logger.Info("Finalizer removed, cleanup complete")
 	return nil
 }

--- a/pkg/postgresql/cluster/core/cluster.go
+++ b/pkg/postgresql/cluster/core/cluster.go
@@ -162,6 +162,7 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 			logger.Error(err, "Failed to update status after secret creation")
 			return ctrl.Result{}, err
 		}
+		rc.emitNormal(postgresCluster, EventSecretReady, fmt.Sprintf("Superuser secret %s created", postgresSecretName))
 		logger.Info("SuperUserSecretRef persisted to status")
 	}
 
@@ -173,6 +174,7 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 	}
 	if secretExists && !hasOwnerRef {
 		logger.Info("Connecting existing secret to PostgresCluster by adding owner reference", "name", postgresSecretName)
+		rc.emitNormal(postgresCluster, EventClusterAdopted, fmt.Sprintf("Adopted existing CNPG cluster and secret %s", postgresSecretName))
 		originalSecret := secret.DeepCopy()
 		if err := ctrl.SetControllerReference(postgresCluster, secret, rc.Scheme); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to set controller reference on existing secret: %w", err)
@@ -395,8 +397,10 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 		}
 		switch createOrUpdateResult {
 		case controllerutil.OperationResultCreated:
+			rc.emitNormal(postgresCluster, EventConfigMapReady, fmt.Sprintf("ConfigMap %s created", desiredCM.Name))
 			logger.Info("ConfigMap created", "name", desiredCM.Name)
 		case controllerutil.OperationResultUpdated:
+			rc.emitNormal(postgresCluster, EventConfigMapReady, fmt.Sprintf("ConfigMap %s updated", desiredCM.Name))
 			logger.Info("ConfigMap updated", "name", desiredCM.Name)
 		default:
 			logger.Info("ConfigMap unchanged", "name", desiredCM.Name)

--- a/pkg/postgresql/cluster/core/cluster.go
+++ b/pkg/postgresql/cluster/core/cluster.go
@@ -217,7 +217,7 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 			}
 			return ctrl.Result{}, err
 		}
-		rc.emitNormal(postgresCluster, EventClusterCreating, "CNPG cluster created, waiting for healthy state")
+		rc.emitNormal(postgresCluster, EventClusterCreationStarted, "CNPG cluster created, waiting for healthy state")
 		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterBuildSucceeded,
 			"CNPG Cluster created", pendingClusterPhase); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status")
@@ -256,7 +256,12 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 			}
 			return ctrl.Result{}, patchErr
 		default:
-			rc.emitNormal(postgresCluster, EventClusterUpdated, "CNPG cluster spec updated")
+			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterBuildSucceeded,
+				"CNPG Cluster spec updated, waiting for healthy state", provisioningClusterPhase); statusErr != nil {
+				logger.Error(statusErr, "Failed to update status after patch")
+				return ctrl.Result{Requeue: true}, nil
+			}
+			rc.emitNormal(postgresCluster, EventClusterUpdateStarted, "CNPG cluster spec updated, waiting for healthy state")
 			logger.Info("CNPG Cluster patched successfully, requeueing for status update", "name", cnpgCluster.Name)
 			return ctrl.Result{RequeueAfter: retryDelay}, nil
 		}
@@ -316,6 +321,7 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 			}
 			return ctrl.Result{}, err
 		}
+		rc.emitNormal(postgresCluster, EventPoolerCreationStarted, "Connection poolers created, waiting for readiness")
 		logger.Info("Connection Poolers created, requeueing to check readiness")
 		if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerCreating,
 			"Connection poolers are being provisioned", provisioningClusterPhase); statusErr != nil {
@@ -933,12 +939,10 @@ func handleFinalizer(ctx context.Context, rc *ReconcileContext, cluster *enterpr
 	}
 	logger.Info("Processing finalizer cleanup for PostgresCluster")
 
-	// Emit deletion event — policy is resolved below, use the raw pointer for the message.
 	policy := ""
 	if cluster.Spec.ClusterDeletionPolicy != nil {
 		policy = *cluster.Spec.ClusterDeletionPolicy
 	}
-	rc.emitNormal(cluster, EventClusterDeleting, fmt.Sprintf("Starting cleanup (policy: %s)", policy))
 
 	if err := deleteConnectionPoolers(ctx, c, cluster); err != nil {
 		logger.Error(err, "Failed to delete connection poolers during cleanup")
@@ -1011,7 +1015,7 @@ func handleFinalizer(ctx context.Context, rc *ReconcileContext, cluster *enterpr
 		logger.Error(err, "Failed to remove finalizer from PostgresCluster")
 		return fmt.Errorf("failed to remove finalizer: %w", err)
 	}
-	rc.emitNormal(cluster, EventCleanupComplete, "Cleanup complete")
+	rc.emitNormal(cluster, EventCleanupComplete, fmt.Sprintf("Cleanup complete (policy: %s)", policy))
 	logger.Info("Finalizer removed, cleanup complete")
 	return nil
 }

--- a/pkg/postgresql/cluster/core/events.go
+++ b/pkg/postgresql/cluster/core/events.go
@@ -1,0 +1,57 @@
+package core
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Event reason constants — stable strings for kubectl filtering.
+const (
+	EventClusterCreating          = "ClusterCreating"
+	EventClusterUpdated           = "ClusterUpdated"
+	EventClusterReady             = "ClusterReady"
+	EventPoolerReady              = "PoolerReady"
+	EventClusterDeleting          = "ClusterDeleting"
+	EventCleanupComplete          = "CleanupComplete"
+	EventClusterClassNotFound     = "ClusterClassNotFound"
+	EventConfigMergeFailed        = "ConfigMergeFailed"
+	EventSecretReconcileFailed    = "SecretReconcileFailed"
+	EventClusterCreateFailed      = "ClusterCreateFailed"
+	EventClusterUpdateFailed      = "ClusterUpdateFailed"
+	EventManagedRolesFailed       = "ManagedRolesFailed"
+	EventPoolerReconcileFailed    = "PoolerReconcileFailed"
+	EventConfigMapReconcileFailed = "ConfigMapReconcileFailed"
+	EventClusterDegraded          = "ClusterDegraded"
+	EventCleanupFailed            = "CleanupFailed"
+)
+
+func (rc *ReconcileContext) emitNormal(obj client.Object, reason, message string) {
+	rc.Recorder.Event(obj, corev1.EventTypeNormal, reason, message)
+}
+
+func (rc *ReconcileContext) emitWarning(obj client.Object, reason, message string) {
+	rc.Recorder.Event(obj, corev1.EventTypeWarning, reason, message)
+}
+
+// emitClusterPhaseTransition emits ClusterReady or ClusterDegraded only on
+// actual phase transitions. No event is emitted when the phase is unchanged.
+func (rc *ReconcileContext) emitClusterPhaseTransition(obj client.Object, oldPhase, newPhase string) {
+	switch {
+	case oldPhase != string(readyClusterPhase) && newPhase == string(readyClusterPhase):
+		rc.emitNormal(obj, EventClusterReady, "Cluster is up and running")
+	case oldPhase == string(readyClusterPhase) && newPhase != string(readyClusterPhase):
+		rc.emitWarning(obj, EventClusterDegraded, fmt.Sprintf("Cluster entered phase: %s", newPhase))
+	}
+}
+
+// emitPoolerReadyTransition emits PoolerReady only when the condition was not
+// previously True — prevents re-emission on every reconcile while already ready.
+func (rc *ReconcileContext) emitPoolerReadyTransition(obj client.Object, conditions []metav1.Condition) {
+	if !meta.IsStatusConditionTrue(conditions, string(poolerReady)) {
+		rc.emitNormal(obj, EventPoolerReady, "Connection poolers are ready")
+	}
+}

--- a/pkg/postgresql/cluster/core/events.go
+++ b/pkg/postgresql/cluster/core/events.go
@@ -11,6 +11,9 @@ import (
 
 // Event reason constants — stable strings for kubectl filtering.
 const (
+	EventSecretReady              = "SecretReady"
+	EventConfigMapReady           = "ConfigMapReady"
+	EventClusterAdopted           = "ClusterAdopted"
 	EventClusterCreating          = "ClusterCreating"
 	EventClusterUpdated           = "ClusterUpdated"
 	EventClusterReady             = "ClusterReady"

--- a/pkg/postgresql/cluster/core/events.go
+++ b/pkg/postgresql/cluster/core/events.go
@@ -9,7 +9,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Event reason constants — stable strings for kubectl filtering.
 const (
 	EventSecretReady              = "SecretReady"
 	EventConfigMapReady           = "ConfigMapReady"

--- a/pkg/postgresql/cluster/core/events.go
+++ b/pkg/postgresql/cluster/core/events.go
@@ -13,11 +13,11 @@ const (
 	EventSecretReady              = "SecretReady"
 	EventConfigMapReady           = "ConfigMapReady"
 	EventClusterAdopted           = "ClusterAdopted"
-	EventClusterCreating          = "ClusterCreating"
-	EventClusterUpdated           = "ClusterUpdated"
+	EventClusterCreationStarted   = "ClusterCreationStarted"
+	EventClusterUpdateStarted     = "ClusterUpdateStarted"
 	EventClusterReady             = "ClusterReady"
+	EventPoolerCreationStarted    = "PoolerCreationStarted"
 	EventPoolerReady              = "PoolerReady"
-	EventClusterDeleting          = "ClusterDeleting"
 	EventCleanupComplete          = "CleanupComplete"
 	EventClusterClassNotFound     = "ClusterClassNotFound"
 	EventConfigMergeFailed        = "ConfigMergeFailed"
@@ -40,12 +40,15 @@ func (rc *ReconcileContext) emitWarning(obj client.Object, reason, message strin
 }
 
 // emitClusterPhaseTransition emits ClusterReady or ClusterDegraded only on
-// actual phase transitions. No event is emitted when the phase is unchanged.
+// actual phase transitions. Provisioning and Configuring are expected phases
+// after our own create/update operations, so they don't emit ClusterDegraded.
 func (rc *ReconcileContext) emitClusterPhaseTransition(obj client.Object, oldPhase, newPhase string) {
 	switch {
 	case oldPhase != string(readyClusterPhase) && newPhase == string(readyClusterPhase):
 		rc.emitNormal(obj, EventClusterReady, "Cluster is up and running")
-	case oldPhase == string(readyClusterPhase) && newPhase != string(readyClusterPhase):
+	// only when cluster degraded from ready but not to provisioning or configuring
+	case oldPhase == string(readyClusterPhase) && newPhase != string(readyClusterPhase) &&
+		newPhase != string(provisioningClusterPhase) && newPhase != string(configuringClusterPhase):
 		rc.emitWarning(obj, EventClusterDegraded, fmt.Sprintf("Cluster entered phase: %s", newPhase))
 	}
 }

--- a/pkg/postgresql/cluster/core/types.go
+++ b/pkg/postgresql/cluster/core/types.go
@@ -5,7 +5,19 @@ import (
 
 	enterprisev4 "github.com/splunk/splunk-operator/api/v4"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// ReconcileContext bundles infrastructure dependencies injected by the controller
+// shell (primary adapter). The service layer declares what it needs via this struct
+// rather than reaching into context — keeping ports explicit and testable.
+type ReconcileContext struct {
+	Client   client.Client
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+}
 
 // normalizedCNPGClusterSpec is a subset of cnpgv1.ClusterSpec fields used for drift detection.
 // Only fields we set in buildCNPGClusterSpec are included — CNPG-injected defaults are excluded

--- a/pkg/postgresql/database/core/database.go
+++ b/pkg/postgresql/database/core/database.go
@@ -32,11 +32,11 @@ type NewDBRepoFunc func(ctx context.Context, host, dbName, password string) (DBR
 // newDBRepo is injected to keep the core free of pgx imports.
 func PostgresDatabaseService(
 	ctx context.Context,
-	c client.Client,
-	scheme *runtime.Scheme,
+	rc *ReconcileContext,
 	postgresDB *enterprisev4.PostgresDatabase,
 	newDBRepo NewDBRepoFunc,
 ) (ctrl.Result, error) {
+	c := rc.Client
 	logger := log.FromContext(ctx)
 	logger.Info("Reconciling PostgresDatabase", "name", postgresDB.Name, "namespace", postgresDB.Namespace)
 
@@ -46,8 +46,9 @@ func PostgresDatabaseService(
 
 	// Finalizer: cleanup on deletion, register on creation.
 	if postgresDB.GetDeletionTimestamp() != nil {
-		if err := handleDeletion(ctx, c, postgresDB); err != nil {
+		if err := handleDeletion(ctx, rc, postgresDB); err != nil {
 			logger.Error(err, "Cleanup failed for PostgresDatabase")
+			rc.emitWarning(postgresDB, EventCleanupFailed, fmt.Sprintf("Cleanup failed: %v", err))
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
@@ -71,6 +72,7 @@ func PostgresDatabaseService(
 	cluster, err := fetchCluster(ctx, c, postgresDB)
 	if err != nil {
 		if errors.IsNotFound(err) {
+			rc.emitWarning(postgresDB, EventClusterNotFound, fmt.Sprintf("PostgresCluster %s not found", postgresDB.Spec.ClusterRef.Name))
 			if err := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterNotFound, "Cluster CR not found", pendingDBPhase); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -87,12 +89,14 @@ func PostgresDatabaseService(
 
 	switch clusterStatus {
 	case ClusterNotReady, ClusterNoProvisionerRef:
+		rc.emitWarning(postgresDB, EventClusterNotReady, "Referenced PostgresCluster is not ready yet")
 		if err := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterProvisioning, "Cluster is not in ready state yet", pendingDBPhase); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: retryDelay}, nil
 
 	case ClusterReady:
+		rc.emitConditionTransition(postgresDB, postgresDB.Status.Conditions, string(clusterReady), EventClusterValidated, "Referenced PostgresCluster is ready")
 		if err := updateStatus(clusterReady, metav1.ConditionTrue, reasonClusterAvailable, "Cluster is operational", provisioningDBPhase); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -105,6 +109,7 @@ func PostgresDatabaseService(
 			"If you deleted a previous PostgresDatabase, recreate it with the original name to re-adopt the orphaned resources.",
 			strings.Join(roleConflicts, ", "))
 		logger.Error(nil, conflictMsg)
+		rc.emitWarning(postgresDB, EventRoleConflict, conflictMsg)
 		if statusErr := updateStatus(rolesReady, metav1.ConditionFalse, reasonRoleConflict, conflictMsg, failedDBPhase); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status")
 		}
@@ -124,7 +129,8 @@ func PostgresDatabaseService(
 
 	// Phase: CredentialProvisioning — secrets must exist before roles are patched.
 	// CNPG rejects a PasswordSecretRef pointing at a missing secret.
-	if err := reconcileUserSecrets(ctx, c, scheme, postgresDB); err != nil {
+	if err := reconcileUserSecrets(ctx, c, rc.Scheme, postgresDB); err != nil {
+		rc.emitWarning(postgresDB, EventUserSecretsFailed, fmt.Sprintf("Failed to reconcile user secrets: %v", err))
 		if statusErr := updateStatus(secretsReady, metav1.ConditionFalse, reasonSecretsCreationFailed,
 			fmt.Sprintf("Failed to reconcile user secrets: %v", err), provisioningDBPhase); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status")
@@ -139,7 +145,8 @@ func PostgresDatabaseService(
 	// Phase: ConnectionMetadata — ConfigMaps carry connection info consumers need as soon
 	// as databases are ready, so they are created alongside secrets.
 	endpoints := resolveClusterEndpoints(cluster, cnpgCluster, postgresDB.Namespace)
-	if err := reconcileRoleConfigMaps(ctx, c, scheme, postgresDB, endpoints); err != nil {
+	if err := reconcileRoleConfigMaps(ctx, c, rc.Scheme, postgresDB, endpoints); err != nil {
+		rc.emitWarning(postgresDB, EventAccessConfigFailed, fmt.Sprintf("Failed to reconcile ConfigMaps: %v", err))
 		if statusErr := updateStatus(configMapsReady, metav1.ConditionFalse, reasonConfigMapsCreationFailed,
 			fmt.Sprintf("Failed to reconcile ConfigMaps: %v", err), provisioningDBPhase); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status")
@@ -165,8 +172,10 @@ func PostgresDatabaseService(
 		logger.Info("User spec changed, patching CNPG Cluster", "missing", missing)
 		if err := patchManagedRoles(ctx, c, postgresDB, cluster); err != nil {
 			logger.Error(err, "Failed to patch users in CNPG Cluster")
+			rc.emitWarning(postgresDB, EventManagedRolesPatchFailed, fmt.Sprintf("Failed to patch managed roles: %v", err))
 			return ctrl.Result{}, err
 		}
+		rc.emitNormal(postgresDB, EventUsersReconciling, fmt.Sprintf("Waiting for %d users to reconcile", len(desiredUsers)))
 		if err := updateStatus(rolesReady, metav1.ConditionFalse, reasonWaitingForCNPG,
 			fmt.Sprintf("Waiting for %d roles to be reconciled", len(desiredUsers)), provisioningDBPhase); err != nil {
 			return ctrl.Result{}, err
@@ -176,6 +185,7 @@ func PostgresDatabaseService(
 
 	notReadyRoles, err := verifyRolesReady(ctx, desiredUsers, cnpgCluster)
 	if err != nil {
+		rc.emitWarning(postgresDB, EventRoleFailed, fmt.Sprintf("Role reconciliation failed: %v", err))
 		if statusErr := updateStatus(rolesReady, metav1.ConditionFalse, reasonUsersCreationFailed,
 			fmt.Sprintf("Role creation failed: %v", err), failedDBPhase); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status")
@@ -189,14 +199,16 @@ func PostgresDatabaseService(
 		}
 		return ctrl.Result{RequeueAfter: retryDelay}, nil
 	}
+	rc.emitConditionTransition(postgresDB, postgresDB.Status.Conditions, string(rolesReady), EventRolesReady, fmt.Sprintf("All %d users reconciled", len(desiredUsers)))
 	if err := updateStatus(rolesReady, metav1.ConditionTrue, reasonUsersAvailable,
 		fmt.Sprintf("All %d users in PostgreSQL", len(desiredUsers)), provisioningDBPhase); err != nil {
 		return ctrl.Result{}, err
 	}
 
 	// Phase: DatabaseProvisioning
-	if err := reconcileCNPGDatabases(ctx, c, scheme, postgresDB, cluster); err != nil {
+	if err := reconcileCNPGDatabases(ctx, c, rc.Scheme, postgresDB, cluster); err != nil {
 		logger.Error(err, "Failed to reconcile CNPG Databases")
+		rc.emitWarning(postgresDB, EventDatabasesReconcileFailed, fmt.Sprintf("Failed to reconcile databases: %v", err))
 		return ctrl.Result{}, err
 	}
 
@@ -212,6 +224,7 @@ func PostgresDatabaseService(
 		}
 		return ctrl.Result{RequeueAfter: retryDelay}, nil
 	}
+	rc.emitConditionTransition(postgresDB, postgresDB.Status.Conditions, string(databasesReady), EventDatabasesReady, fmt.Sprintf("All %d databases ready", len(postgresDB.Spec.Databases)))
 	if err := updateStatus(databasesReady, metav1.ConditionTrue, reasonDatabasesAvailable,
 		fmt.Sprintf("All %d databases ready", len(postgresDB.Spec.Databases)), readyDBPhase); err != nil {
 		return ctrl.Result{}, err
@@ -247,12 +260,14 @@ func PostgresDatabaseService(
 		}
 
 		if err := reconcileRWRolePrivileges(ctx, endpoints.RWHost, string(pw), dbNames, newDBRepo); err != nil {
+			rc.emitWarning(postgresDB, EventPrivilegesGrantFailed, fmt.Sprintf("Failed to grant RW role privileges: %v", err))
 			if statusErr := updateStatus(privilegesReady, metav1.ConditionFalse, reasonPrivilegesGrantFailed,
 				fmt.Sprintf("Failed to grant RW role privileges: %v", err), provisioningDBPhase); statusErr != nil {
 				logger.Error(statusErr, "Failed to update status")
 			}
 			return ctrl.Result{}, err
 		}
+		rc.emitConditionTransition(postgresDB, postgresDB.Status.Conditions, string(privilegesReady), EventPrivilegesReady, fmt.Sprintf("RW role privileges granted for all %d databases", len(postgresDB.Spec.Databases)))
 		if err := updateStatus(privilegesReady, metav1.ConditionTrue, reasonPrivilegesGranted,
 			fmt.Sprintf("RW role privileges granted for all %d databases", len(postgresDB.Spec.Databases)), readyDBPhase); err != nil {
 			return ctrl.Result{}, err
@@ -491,8 +506,10 @@ func buildDeletionPlan(databases []enterprisev4.DatabaseDefinition) deletionPlan
 	return plan
 }
 
-func handleDeletion(ctx context.Context, c client.Client, postgresDB *enterprisev4.PostgresDatabase) error {
+func handleDeletion(ctx context.Context, rc *ReconcileContext, postgresDB *enterprisev4.PostgresDatabase) error {
+	c := rc.Client
 	plan := buildDeletionPlan(postgresDB.Spec.Databases)
+	rc.emitNormal(postgresDB, EventDatabaseDeleting, fmt.Sprintf("Starting cleanup (%d retain, %d delete)", len(plan.retained), len(plan.deleted)))
 	if err := orphanRetainedResources(ctx, c, postgresDB, plan.retained); err != nil {
 		return err
 	}
@@ -509,6 +526,7 @@ func handleDeletion(ctx context.Context, c client.Client, postgresDB *enterprise
 		}
 		return fmt.Errorf("removing finalizer: %w", err)
 	}
+	rc.emitNormal(postgresDB, EventCleanupComplete, "Cleanup complete")
 	log.FromContext(ctx).Info("Cleanup complete", "name", postgresDB.Name, "retained", len(plan.retained), "deleted", len(plan.deleted))
 	return nil
 }

--- a/pkg/postgresql/database/core/database.go
+++ b/pkg/postgresql/database/core/database.go
@@ -96,7 +96,7 @@ func PostgresDatabaseService(
 		return ctrl.Result{RequeueAfter: retryDelay}, nil
 
 	case ClusterReady:
-		rc.emitNormal(postgresDB, EventClusterValidated, "Referenced PostgresCluster is ready")
+		rc.emitOnConditionTransition(postgresDB, postgresDB.Status.Conditions, clusterReady, EventClusterValidated, "Referenced PostgresCluster is ready")
 		if err := updateStatus(clusterReady, metav1.ConditionTrue, reasonClusterAvailable, "Cluster is operational", provisioningDBPhase); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -137,7 +137,7 @@ func PostgresDatabaseService(
 		}
 		return ctrl.Result{}, err
 	}
-	rc.emitNormal(postgresDB, EventSecretsReady, fmt.Sprintf("All secrets provisioned for %d databases", len(postgresDB.Spec.Databases)))
+	rc.emitOnConditionTransition(postgresDB, postgresDB.Status.Conditions, secretsReady, EventSecretsReady, fmt.Sprintf("All secrets provisioned for %d databases", len(postgresDB.Spec.Databases)))
 	if err := updateStatus(secretsReady, metav1.ConditionTrue, reasonSecretsCreated,
 		fmt.Sprintf("All secrets provisioned for %d databases", len(postgresDB.Spec.Databases)), provisioningDBPhase); err != nil {
 		return ctrl.Result{}, err
@@ -154,7 +154,7 @@ func PostgresDatabaseService(
 		}
 		return ctrl.Result{}, err
 	}
-	rc.emitNormal(postgresDB, EventConfigMapsReady, fmt.Sprintf("All ConfigMaps provisioned for %d databases", len(postgresDB.Spec.Databases)))
+	rc.emitOnConditionTransition(postgresDB, postgresDB.Status.Conditions, configMapsReady, EventConfigMapsReady, fmt.Sprintf("All ConfigMaps provisioned for %d databases", len(postgresDB.Spec.Databases)))
 	if err := updateStatus(configMapsReady, metav1.ConditionTrue, reasonConfigMapsCreated,
 		fmt.Sprintf("All ConfigMaps provisioned for %d databases", len(postgresDB.Spec.Databases)), provisioningDBPhase); err != nil {
 		return ctrl.Result{}, err
@@ -201,7 +201,7 @@ func PostgresDatabaseService(
 		}
 		return ctrl.Result{RequeueAfter: retryDelay}, nil
 	}
-	rc.emitNormal(postgresDB, EventRolesReady, fmt.Sprintf("All %d roles reconciled", len(desiredUsers)))
+	rc.emitOnConditionTransition(postgresDB, postgresDB.Status.Conditions, rolesReady, EventRolesReady, fmt.Sprintf("All %d roles reconciled", len(desiredUsers)))
 	if err := updateStatus(rolesReady, metav1.ConditionTrue, reasonUsersAvailable,
 		fmt.Sprintf("All %d users in PostgreSQL", len(desiredUsers)), provisioningDBPhase); err != nil {
 		return ctrl.Result{}, err
@@ -230,7 +230,7 @@ func PostgresDatabaseService(
 		}
 		return ctrl.Result{RequeueAfter: retryDelay}, nil
 	}
-	rc.emitNormal(postgresDB, EventDatabasesReady, fmt.Sprintf("All %d databases ready", len(postgresDB.Spec.Databases)))
+	rc.emitOnConditionTransition(postgresDB, postgresDB.Status.Conditions, databasesReady, EventDatabasesReady, fmt.Sprintf("All %d databases ready", len(postgresDB.Spec.Databases)))
 	if err := updateStatus(databasesReady, metav1.ConditionTrue, reasonDatabasesAvailable,
 		fmt.Sprintf("All %d databases ready", len(postgresDB.Spec.Databases)), readyDBPhase); err != nil {
 		return ctrl.Result{}, err
@@ -273,7 +273,7 @@ func PostgresDatabaseService(
 			}
 			return ctrl.Result{}, err
 		}
-		rc.emitNormal(postgresDB, EventPrivilegesReady, fmt.Sprintf("RW role privileges granted for all %d databases", len(postgresDB.Spec.Databases)))
+		rc.emitOnConditionTransition(postgresDB, postgresDB.Status.Conditions, privilegesReady, EventPrivilegesReady, fmt.Sprintf("RW role privileges granted for all %d databases", len(postgresDB.Spec.Databases)))
 		if err := updateStatus(privilegesReady, metav1.ConditionTrue, reasonPrivilegesGranted,
 			fmt.Sprintf("RW role privileges granted for all %d databases", len(postgresDB.Spec.Databases)), readyDBPhase); err != nil {
 			return ctrl.Result{}, err

--- a/pkg/postgresql/database/core/database.go
+++ b/pkg/postgresql/database/core/database.go
@@ -96,7 +96,7 @@ func PostgresDatabaseService(
 		return ctrl.Result{RequeueAfter: retryDelay}, nil
 
 	case ClusterReady:
-		rc.emitConditionTransition(postgresDB, postgresDB.Status.Conditions, string(clusterReady), EventClusterValidated, "Referenced PostgresCluster is ready")
+		rc.emitNormal(postgresDB, EventClusterValidated, "Referenced PostgresCluster is ready")
 		if err := updateStatus(clusterReady, metav1.ConditionTrue, reasonClusterAvailable, "Cluster is operational", provisioningDBPhase); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -137,6 +137,7 @@ func PostgresDatabaseService(
 		}
 		return ctrl.Result{}, err
 	}
+	rc.emitNormal(postgresDB, EventSecretsReady, fmt.Sprintf("All secrets provisioned for %d databases", len(postgresDB.Spec.Databases)))
 	if err := updateStatus(secretsReady, metav1.ConditionTrue, reasonSecretsCreated,
 		fmt.Sprintf("All secrets provisioned for %d databases", len(postgresDB.Spec.Databases)), provisioningDBPhase); err != nil {
 		return ctrl.Result{}, err
@@ -153,6 +154,7 @@ func PostgresDatabaseService(
 		}
 		return ctrl.Result{}, err
 	}
+	rc.emitNormal(postgresDB, EventConfigMapsReady, fmt.Sprintf("All ConfigMaps provisioned for %d databases", len(postgresDB.Spec.Databases)))
 	if err := updateStatus(configMapsReady, metav1.ConditionTrue, reasonConfigMapsCreated,
 		fmt.Sprintf("All ConfigMaps provisioned for %d databases", len(postgresDB.Spec.Databases)), provisioningDBPhase); err != nil {
 		return ctrl.Result{}, err
@@ -175,7 +177,7 @@ func PostgresDatabaseService(
 			rc.emitWarning(postgresDB, EventManagedRolesPatchFailed, fmt.Sprintf("Failed to patch managed roles: %v", err))
 			return ctrl.Result{}, err
 		}
-		rc.emitNormal(postgresDB, EventUsersReconciling, fmt.Sprintf("Waiting for %d users to reconcile", len(desiredUsers)))
+		rc.emitNormal(postgresDB, EventRoleReconciliationStarted, fmt.Sprintf("Patched managed roles, waiting for %d roles to reconcile", len(desiredUsers)))
 		if err := updateStatus(rolesReady, metav1.ConditionFalse, reasonWaitingForCNPG,
 			fmt.Sprintf("Waiting for %d roles to be reconciled", len(desiredUsers)), provisioningDBPhase); err != nil {
 			return ctrl.Result{}, err
@@ -199,17 +201,21 @@ func PostgresDatabaseService(
 		}
 		return ctrl.Result{RequeueAfter: retryDelay}, nil
 	}
-	rc.emitConditionTransition(postgresDB, postgresDB.Status.Conditions, string(rolesReady), EventRolesReady, fmt.Sprintf("All %d users reconciled", len(desiredUsers)))
+	rc.emitNormal(postgresDB, EventRolesReady, fmt.Sprintf("All %d roles reconciled", len(desiredUsers)))
 	if err := updateStatus(rolesReady, metav1.ConditionTrue, reasonUsersAvailable,
 		fmt.Sprintf("All %d users in PostgreSQL", len(desiredUsers)), provisioningDBPhase); err != nil {
 		return ctrl.Result{}, err
 	}
 
 	// Phase: DatabaseProvisioning
-	if err := reconcileCNPGDatabases(ctx, c, rc.Scheme, postgresDB, cluster); err != nil {
+	adopted, err := reconcileCNPGDatabases(ctx, c, rc.Scheme, postgresDB, cluster)
+	if err != nil {
 		logger.Error(err, "Failed to reconcile CNPG Databases")
 		rc.emitWarning(postgresDB, EventDatabasesReconcileFailed, fmt.Sprintf("Failed to reconcile databases: %v", err))
 		return ctrl.Result{}, err
+	}
+	if len(adopted) > 0 {
+		rc.emitNormal(postgresDB, EventResourcesAdopted, fmt.Sprintf("Adopted retained databases: %v", adopted))
 	}
 
 	notReadyDBs, err := verifyDatabasesReady(ctx, c, postgresDB)
@@ -224,7 +230,7 @@ func PostgresDatabaseService(
 		}
 		return ctrl.Result{RequeueAfter: retryDelay}, nil
 	}
-	rc.emitConditionTransition(postgresDB, postgresDB.Status.Conditions, string(databasesReady), EventDatabasesReady, fmt.Sprintf("All %d databases ready", len(postgresDB.Spec.Databases)))
+	rc.emitNormal(postgresDB, EventDatabasesReady, fmt.Sprintf("All %d databases ready", len(postgresDB.Spec.Databases)))
 	if err := updateStatus(databasesReady, metav1.ConditionTrue, reasonDatabasesAvailable,
 		fmt.Sprintf("All %d databases ready", len(postgresDB.Spec.Databases)), readyDBPhase); err != nil {
 		return ctrl.Result{}, err
@@ -267,13 +273,14 @@ func PostgresDatabaseService(
 			}
 			return ctrl.Result{}, err
 		}
-		rc.emitConditionTransition(postgresDB, postgresDB.Status.Conditions, string(privilegesReady), EventPrivilegesReady, fmt.Sprintf("RW role privileges granted for all %d databases", len(postgresDB.Spec.Databases)))
+		rc.emitNormal(postgresDB, EventPrivilegesReady, fmt.Sprintf("RW role privileges granted for all %d databases", len(postgresDB.Spec.Databases)))
 		if err := updateStatus(privilegesReady, metav1.ConditionTrue, reasonPrivilegesGranted,
 			fmt.Sprintf("RW role privileges granted for all %d databases", len(postgresDB.Spec.Databases)), readyDBPhase); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
 
+	rc.emitNormal(postgresDB, EventPostgresDatabaseReady, fmt.Sprintf("PostgresDatabase %s is ready", postgresDB.Name))
 	postgresDB.Status.Databases = populateDatabaseStatus(postgresDB)
 	postgresDB.Status.ObservedGeneration = &postgresDB.Generation
 
@@ -436,8 +443,9 @@ func verifyRolesReady(ctx context.Context, expectedUsers []string, cnpgCluster *
 	return notReady, nil
 }
 
-func reconcileCNPGDatabases(ctx context.Context, c client.Client, scheme *runtime.Scheme, postgresDB *enterprisev4.PostgresDatabase, cluster *enterprisev4.PostgresCluster) error {
+func reconcileCNPGDatabases(ctx context.Context, c client.Client, scheme *runtime.Scheme, postgresDB *enterprisev4.PostgresDatabase, cluster *enterprisev4.PostgresCluster) ([]string, error) {
 	logger := log.FromContext(ctx)
+	var adopted []string
 	for _, dbSpec := range postgresDB.Spec.Databases {
 		cnpgDBName := cnpgDatabaseName(postgresDB.Name, dbSpec.Name)
 		cnpgDB := &cnpgv1.Database{
@@ -449,6 +457,7 @@ func reconcileCNPGDatabases(ctx context.Context, c client.Client, scheme *runtim
 			if reAdopting {
 				logger.Info("Re-adopting orphaned CNPG Database", "name", cnpgDBName)
 				delete(cnpgDB.Annotations, annotationRetainedFrom)
+				adopted = append(adopted, dbSpec.Name)
 			}
 			if cnpgDB.CreationTimestamp.IsZero() || reAdopting {
 				return controllerutil.SetControllerReference(postgresDB, cnpgDB, scheme)
@@ -456,10 +465,10 @@ func reconcileCNPGDatabases(ctx context.Context, c client.Client, scheme *runtim
 			return nil
 		})
 		if err != nil {
-			return fmt.Errorf("reconciling CNPG Database %s: %w", cnpgDBName, err)
+			return adopted, fmt.Errorf("reconciling CNPG Database %s: %w", cnpgDBName, err)
 		}
 	}
-	return nil
+	return adopted, nil
 }
 
 func verifyDatabasesReady(ctx context.Context, c client.Client, postgresDB *enterprisev4.PostgresDatabase) ([]string, error) {

--- a/pkg/postgresql/database/core/database.go
+++ b/pkg/postgresql/database/core/database.go
@@ -224,6 +224,7 @@ func PostgresDatabaseService(
 		return ctrl.Result{}, err
 	}
 	if len(notReadyDBs) > 0 {
+		rc.emitOnceBeforeWait(postgresDB, postgresDB.Status.Conditions, databasesReady, EventDatabaseReconciliationStarted, fmt.Sprintf("Reconciling %d databases, waiting for readiness", len(postgresDB.Spec.Databases)))
 		if err := updateStatus(databasesReady, metav1.ConditionFalse, reasonWaitingForCNPG,
 			fmt.Sprintf("Waiting for databases to be ready: %v", notReadyDBs), provisioningDBPhase); err != nil {
 			return ctrl.Result{}, err
@@ -518,7 +519,6 @@ func buildDeletionPlan(databases []enterprisev4.DatabaseDefinition) deletionPlan
 func handleDeletion(ctx context.Context, rc *ReconcileContext, postgresDB *enterprisev4.PostgresDatabase) error {
 	c := rc.Client
 	plan := buildDeletionPlan(postgresDB.Spec.Databases)
-	rc.emitNormal(postgresDB, EventDatabaseDeleting, fmt.Sprintf("Starting cleanup (%d retain, %d delete)", len(plan.retained), len(plan.deleted)))
 	if err := orphanRetainedResources(ctx, c, postgresDB, plan.retained); err != nil {
 		return err
 	}
@@ -535,7 +535,7 @@ func handleDeletion(ctx context.Context, rc *ReconcileContext, postgresDB *enter
 		}
 		return fmt.Errorf("removing finalizer: %w", err)
 	}
-	rc.emitNormal(postgresDB, EventCleanupComplete, "Cleanup complete")
+	rc.emitNormal(postgresDB, EventCleanupComplete, fmt.Sprintf("Cleanup complete (%d retained, %d deleted)", len(plan.retained), len(plan.deleted)))
 	log.FromContext(ctx).Info("Cleanup complete", "name", postgresDB.Name, "retained", len(plan.retained), "deleted", len(plan.deleted))
 	return nil
 }

--- a/pkg/postgresql/database/core/events.go
+++ b/pkg/postgresql/database/core/events.go
@@ -1,0 +1,45 @@
+package core
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Event reason constants — stable strings for kubectl filtering.
+const (
+	EventClusterValidated         = "ClusterValidated"
+	EventUsersReconciling         = "UsersReconciling"
+	EventRolesReady               = "RolesReady"
+	EventDatabasesReady           = "DatabasesReady"
+	EventPrivilegesReady          = "PrivilegesReady"
+	EventDatabaseDeleting         = "DatabaseDeleting"
+	EventCleanupComplete          = "CleanupComplete"
+	EventClusterNotFound          = "ClusterNotFound"
+	EventClusterNotReady          = "ClusterNotReady"
+	EventRoleConflict             = "RoleConflict"
+	EventUserSecretsFailed        = "UserSecretsFailed"
+	EventAccessConfigFailed       = "AccessConfigFailed"
+	EventManagedRolesPatchFailed  = "ManagedRolesPatchFailed"
+	EventRoleFailed               = "RoleFailed"
+	EventDatabasesReconcileFailed = "DatabasesReconcileFailed"
+	EventPrivilegesGrantFailed    = "PrivilegesGrantFailed"
+	EventCleanupFailed            = "CleanupFailed"
+)
+
+func (rc *ReconcileContext) emitNormal(obj client.Object, reason, message string) {
+	rc.Recorder.Event(obj, corev1.EventTypeNormal, reason, message)
+}
+
+func (rc *ReconcileContext) emitWarning(obj client.Object, reason, message string) {
+	rc.Recorder.Event(obj, corev1.EventTypeWarning, reason, message)
+}
+
+// emitConditionTransition emits a Normal event only when the given condition
+// was not previously True — prevents re-emission while already in the target state.
+func (rc *ReconcileContext) emitConditionTransition(obj client.Object, conditions []metav1.Condition, condType string, reason, message string) {
+	if !meta.IsStatusConditionTrue(conditions, condType) {
+		rc.emitNormal(obj, reason, message)
+	}
+}

--- a/pkg/postgresql/database/core/events.go
+++ b/pkg/postgresql/database/core/events.go
@@ -7,7 +7,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Event reason constants — stable strings for kubectl filtering.
 const (
 	EventPostgresDatabaseReady     = "PostgresDatabaseReady"
 	EventResourcesAdopted          = "ResourcesAdopted"

--- a/pkg/postgresql/database/core/events.go
+++ b/pkg/postgresql/database/core/events.go
@@ -2,30 +2,32 @@ package core
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Event reason constants — stable strings for kubectl filtering.
 const (
-	EventClusterValidated         = "ClusterValidated"
-	EventUsersReconciling         = "UsersReconciling"
-	EventRolesReady               = "RolesReady"
-	EventDatabasesReady           = "DatabasesReady"
-	EventPrivilegesReady          = "PrivilegesReady"
-	EventDatabaseDeleting         = "DatabaseDeleting"
-	EventCleanupComplete          = "CleanupComplete"
-	EventClusterNotFound          = "ClusterNotFound"
-	EventClusterNotReady          = "ClusterNotReady"
-	EventRoleConflict             = "RoleConflict"
-	EventUserSecretsFailed        = "UserSecretsFailed"
-	EventAccessConfigFailed       = "AccessConfigFailed"
-	EventManagedRolesPatchFailed  = "ManagedRolesPatchFailed"
-	EventRoleFailed               = "RoleFailed"
-	EventDatabasesReconcileFailed = "DatabasesReconcileFailed"
-	EventPrivilegesGrantFailed    = "PrivilegesGrantFailed"
-	EventCleanupFailed            = "CleanupFailed"
+	EventPostgresDatabaseReady     = "PostgresDatabaseReady"
+	EventResourcesAdopted          = "ResourcesAdopted"
+	EventClusterValidated          = "ClusterValidated"
+	EventSecretsReady              = "SecretsReady"
+	EventConfigMapsReady           = "ConfigMapsReady"
+	EventRoleReconciliationStarted = "RoleReconciliationStarted"
+	EventRolesReady                = "RolesReady"
+	EventDatabasesReady            = "DatabasesReady"
+	EventPrivilegesReady           = "PrivilegesReady"
+	EventDatabaseDeleting          = "DatabaseDeleting"
+	EventCleanupComplete           = "CleanupComplete"
+	EventClusterNotFound           = "ClusterNotFound"
+	EventClusterNotReady           = "ClusterNotReady"
+	EventRoleConflict              = "RoleConflict"
+	EventUserSecretsFailed         = "UserSecretsFailed"
+	EventAccessConfigFailed        = "AccessConfigFailed"
+	EventManagedRolesPatchFailed   = "ManagedRolesPatchFailed"
+	EventRoleFailed                = "RoleFailed"
+	EventDatabasesReconcileFailed  = "DatabasesReconcileFailed"
+	EventPrivilegesGrantFailed     = "PrivilegesGrantFailed"
+	EventCleanupFailed             = "CleanupFailed"
 )
 
 func (rc *ReconcileContext) emitNormal(obj client.Object, reason, message string) {
@@ -34,12 +36,4 @@ func (rc *ReconcileContext) emitNormal(obj client.Object, reason, message string
 
 func (rc *ReconcileContext) emitWarning(obj client.Object, reason, message string) {
 	rc.Recorder.Event(obj, corev1.EventTypeWarning, reason, message)
-}
-
-// emitConditionTransition emits a Normal event only when the given condition
-// was not previously True — prevents re-emission while already in the target state.
-func (rc *ReconcileContext) emitConditionTransition(obj client.Object, conditions []metav1.Condition, condType string, reason, message string) {
-	if !meta.IsStatusConditionTrue(conditions, condType) {
-		rc.emitNormal(obj, reason, message)
-	}
 }

--- a/pkg/postgresql/database/core/events.go
+++ b/pkg/postgresql/database/core/events.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -36,4 +38,12 @@ func (rc *ReconcileContext) emitNormal(obj client.Object, reason, message string
 
 func (rc *ReconcileContext) emitWarning(obj client.Object, reason, message string) {
 	rc.Recorder.Event(obj, corev1.EventTypeWarning, reason, message)
+}
+
+// emitOnConditionTransition emits a Normal event only when the condition is not
+// already True — prevents duplicate events on repeated reconciles.
+func (rc *ReconcileContext) emitOnConditionTransition(obj client.Object, conditions []metav1.Condition, condType conditionTypes, reason, message string) {
+	if !meta.IsStatusConditionTrue(conditions, string(condType)) {
+		rc.emitNormal(obj, reason, message)
+	}
 }

--- a/pkg/postgresql/database/core/events.go
+++ b/pkg/postgresql/database/core/events.go
@@ -8,27 +8,27 @@ import (
 )
 
 const (
-	EventPostgresDatabaseReady     = "PostgresDatabaseReady"
-	EventResourcesAdopted          = "ResourcesAdopted"
-	EventClusterValidated          = "ClusterValidated"
-	EventSecretsReady              = "SecretsReady"
-	EventConfigMapsReady           = "ConfigMapsReady"
-	EventRoleReconciliationStarted = "RoleReconciliationStarted"
-	EventRolesReady                = "RolesReady"
-	EventDatabasesReady            = "DatabasesReady"
-	EventPrivilegesReady           = "PrivilegesReady"
-	EventDatabaseDeleting          = "DatabaseDeleting"
-	EventCleanupComplete           = "CleanupComplete"
-	EventClusterNotFound           = "ClusterNotFound"
-	EventClusterNotReady           = "ClusterNotReady"
-	EventRoleConflict              = "RoleConflict"
-	EventUserSecretsFailed         = "UserSecretsFailed"
-	EventAccessConfigFailed        = "AccessConfigFailed"
-	EventManagedRolesPatchFailed   = "ManagedRolesPatchFailed"
-	EventRoleFailed                = "RoleFailed"
-	EventDatabasesReconcileFailed  = "DatabasesReconcileFailed"
-	EventPrivilegesGrantFailed     = "PrivilegesGrantFailed"
-	EventCleanupFailed             = "CleanupFailed"
+	EventPostgresDatabaseReady         = "PostgresDatabaseReady"
+	EventResourcesAdopted              = "ResourcesAdopted"
+	EventClusterValidated              = "ClusterValidated"
+	EventSecretsReady                  = "SecretsReady"
+	EventConfigMapsReady               = "ConfigMapsReady"
+	EventRoleReconciliationStarted     = "RoleReconciliationStarted"
+	EventRolesReady                    = "RolesReady"
+	EventDatabaseReconciliationStarted = "DatabaseReconciliationStarted"
+	EventDatabasesReady                = "DatabasesReady"
+	EventPrivilegesReady               = "PrivilegesReady"
+	EventCleanupComplete               = "CleanupComplete"
+	EventClusterNotFound               = "ClusterNotFound"
+	EventClusterNotReady               = "ClusterNotReady"
+	EventRoleConflict                  = "RoleConflict"
+	EventUserSecretsFailed             = "UserSecretsFailed"
+	EventAccessConfigFailed            = "AccessConfigFailed"
+	EventManagedRolesPatchFailed       = "ManagedRolesPatchFailed"
+	EventRoleFailed                    = "RoleFailed"
+	EventDatabasesReconcileFailed      = "DatabasesReconcileFailed"
+	EventPrivilegesGrantFailed         = "PrivilegesGrantFailed"
+	EventCleanupFailed                 = "CleanupFailed"
 )
 
 func (rc *ReconcileContext) emitNormal(obj client.Object, reason, message string) {
@@ -43,6 +43,16 @@ func (rc *ReconcileContext) emitWarning(obj client.Object, reason, message strin
 // already True — prevents duplicate events on repeated reconciles.
 func (rc *ReconcileContext) emitOnConditionTransition(obj client.Object, conditions []metav1.Condition, condType conditionTypes, reason, message string) {
 	if !meta.IsStatusConditionTrue(conditions, string(condType)) {
+		rc.emitNormal(obj, reason, message)
+	}
+}
+
+// emitOnceBeforeWait emits a Normal event when the condition is either absent
+// or currently True — i.e. the first time we enter a wait cycle. On subsequent
+// requeue polls the condition is already False, so no duplicate is emitted.
+func (rc *ReconcileContext) emitOnceBeforeWait(obj client.Object, conditions []metav1.Condition, condType conditionTypes, reason, message string) {
+	cond := meta.FindStatusCondition(conditions, string(condType))
+	if cond == nil || cond.Status == metav1.ConditionTrue {
 		rc.emitNormal(obj, reason, message)
 	}
 }

--- a/pkg/postgresql/database/core/types.go
+++ b/pkg/postgresql/database/core/types.go
@@ -10,8 +10,6 @@ import (
 )
 
 // ReconcileContext bundles infrastructure dependencies injected by the controller
-// shell (primary adapter). The service layer declares what it needs via this struct
-// rather than reaching into context — keeping ports explicit and testable.
 type ReconcileContext struct {
 	Client   client.Client
 	Scheme   *runtime.Scheme

--- a/pkg/postgresql/database/core/types.go
+++ b/pkg/postgresql/database/core/types.go
@@ -4,7 +4,19 @@ import (
 	"time"
 
 	enterprisev4 "github.com/splunk/splunk-operator/api/v4"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// ReconcileContext bundles infrastructure dependencies injected by the controller
+// shell (primary adapter). The service layer declares what it needs via this struct
+// rather than reaching into context — keeping ports explicit and testable.
+type ReconcileContext struct {
+	Client   client.Client
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+}
 
 type reconcileDBPhases string
 type conditionTypes string


### PR DESCRIPTION
### Description

Add Kubernetes event emission to PostgresCluster and PostgresDatabase controllers for improved observability. Events are emitted on key lifecycle transitions (create, update, delete, ready) and on failures, making it easier to debug issues via `kubectl describe` or `kubectl get events`.

### Key Changes

  - Introduced ReconcileContext struct in both cluster and database core packages to bundle Client, Scheme, and EventRecorder
  - Added events.go with event reason constants and helper methods (emitNormal, emitWarning, transition-aware emitters) for each controller
  - Wired EventRecorder from controller-runtime manager into both reconcilers
  - Added events RBAC permission (create, patch) to both controllers
  - Events are deduplicated on phase/condition transitions to avoid noise on steady-state reconciles

### Testing and Verification

I tested changes manually with following scenerios:
1. Role conflict on the postgresdatabase
```bash
❯ k describe postgresdatabase db-owner-two
Name:         db-owner-two
Namespace:    test1
Labels:       <none>
Annotations:  <none>
API Version:  enterprise.splunk.com/v4
Kind:         PostgresDatabase
Metadata:
  Creation Timestamp:  2026-03-27T11:43:46Z
  Finalizers:
    postgresdatabases.enterprise.splunk.com/finalizer
  Generation:        1
  Resource Version:  2079126
  UID:               5ab55286-2a4d-450a-9bb5-d59623af68d9
Spec:
  Cluster Ref:
    Name:  conflict-test
  Databases:
    Deletion Policy:  Delete
    Name:             shareddb
Status:
  Conditions:
    Last Transition Time:  2026-03-27T11:43:46Z
    Message:               Cluster is operational
    Observed Generation:   1
    Reason:                ClusterAvailable
    Status:                True
    Type:                  ClusterReady
    Last Transition Time:  2026-03-27T11:43:46Z
    Message:               Role conflict: shareddb_admin (owned by postgresdatabase-db-owner-one), shareddb_rw (owned by postgresdatabase-db-owner-one). If you deleted a previous PostgresDatabase, recreate it with the original name to re-adopt the orphaned resources.
    Observed Generation:   1
    Reason:                RoleConflict
    Status:                False
    Type:                  RolesReady
  Phase:                   Failed
Events:
  Type     Reason            Age    From                         Message
  ----     ------            ----   ----                         -------
  Normal   ClusterValidated  2m37s  postgresdatabase-controller  Referenced PostgresCluster is ready
  Warning  RoleConflict      2m37s  postgresdatabase-controller  Role conflict: shareddb_admin (owned by postgresdatabase-db-owner-one), shareddb_rw (owned by postgresdatabase-db-owner-one). If you deleted a previous PostgresDatabase, recreate it with the original name to re-adopt the orphaned resources.
```

2. PostgresClass not found
```bash
❯ k describe postgrescluster warn-repeat-test
Name:         warn-repeat-test
Namespace:    test1
Labels:       <none>
Annotations:  <none>
API Version:  enterprise.splunk.com/v4
Kind:         PostgresCluster
Metadata:
  Creation Timestamp:  2026-03-27T11:48:53Z
  Finalizers:
    postgresclusters.enterprise.splunk.com/finalizer
  Generation:        1
  Resource Version:  2079841
  UID:               247fad74-fd37-4559-9656-3edb7188bb52
Spec:
  Class:                      does-not-exist
  Cluster Deletion Policy:    Delete
  Connection Pooler Enabled:  false
  Pg HBA:
  Postgresql Config:
Status:
  Conditions:
    Last Transition Time:  2026-03-27T11:48:53Z
    Message:               ClusterClass does-not-exist not found: PostgresClusterClass.enterprise.splunk.com "does-not-exist" not found
    Observed Generation:   1
    Reason:                ClusterClassNotFound
    Status:                False
    Type:                  ClusterReady
  Phase:                   Failed
  Resources:
Events:
  Type     Reason                Age                From                        Message
  ----     ------                ----               ----                        -------
  Warning  ClusterClassNotFound  9s (x14 over 50s)  postgrescluster-controller  ClusterClass does-not-exist not found
```

3. Postgrescluster not found in the database CR
```bash
❯ k describe postgresdatabase orphan-db
Name:         orphan-db
Namespace:    test1
Labels:       <none>
Annotations:  <none>
API Version:  enterprise.splunk.com/v4
Kind:         PostgresDatabase
Metadata:
  Creation Timestamp:  2026-03-27T11:50:36Z
  Finalizers:
    postgresdatabases.enterprise.splunk.com/finalizer
  Generation:        1
  Resource Version:  2080097
  UID:               58f85fd1-dd73-4d41-8e60-0239c5150173
Spec:
  Cluster Ref:
    Name:  nonexistent-cluster
  Databases:
    Deletion Policy:  Delete
    Name:             mydb
Status:
  Conditions:
    Last Transition Time:  2026-03-27T11:50:36Z
    Message:               Cluster CR not found
    Observed Generation:   1
    Reason:                ClusterNotFound
    Status:                False
    Type:                  ClusterReady
  Phase:                   Pending
Events:
  Type     Reason           Age                From                         Message
  ----     ------           ----               ----                         -------
  Warning  ClusterNotFound  14s (x2 over 44s)  postgresdatabase-controller  PostgresCluster nonexistent-cluster not found
```

4. Correct events for both
4.1. Cluster
```bash
  ⎿  LAST SEEN   TYPE     REASON                        OBJECT                MESSAGE
     29s         Normal   SecretReady                   postgrescluster/ev4   Superuser secret ev4-secret created
     29s         Normal   ClusterCreationStarted        postgrescluster/ev4   CNPG cluster created, waiting for healthy state
     10s         Normal   ConfigMapReady                postgrescluster/ev4   ConfigMap ev4-configmap created
     10s         Normal   ClusterReady                  postgrescluster/ev4   Cluster is up and running
```

4.2 Postgresdatabase
```bash
  ⎿  LAST SEEN   TYPE     REASON                          OBJECT                    MESSAGE
     24s         Normal   ClusterValidated                postgresdatabase/ev4-db   Referenced PostgresCluster is ready
     24s         Normal   SecretsReady                    postgresdatabase/ev4-db   All secrets provisioned for 1 databases
     24s         Normal   ConfigMapsReady                 postgresdatabase/ev4-db   All ConfigMaps provisioned for 1 databases
     24s         Normal   RoleReconciliationStarted       postgresdatabase/ev4-db   Patched managed roles, waiting for 2 roles to reconcile
     9s          Normal   RolesReady                      postgresdatabase/ev4-db   All 2 roles reconciled
     9s          Normal   DatabaseReconciliationStarted   postgresdatabase/ev4-db   Reconciling 1 databases, waiting for readiness
     9s          Normal   DatabasesReady                  postgresdatabase/ev4-db   All 1 databases ready
     8s          Normal   PrivilegesReady                 postgresdatabase/ev4-db   RW role privileges granted for all 1 databases
     8s          Normal   PostgresDatabaseReady           postgresdatabase/ev4-db   PostgresDatabase ev4-db is ready
```

5. Deletion
5.1. Cluster
```bash
     24s         Normal   ClusterReady                  postgrescluster/ev4   Cluster is up and running
     5s          Normal   CleanupComplete               postgrescluster/ev4   Cleanup complete (policy: Retain)
```
5.2. Database
```bash
     35s         Normal   DatabasesReady                  postgresdatabase/ev4-db   All 2 databases ready
     6s          Normal   CleanupComplete                 postgresdatabase/ev4-db   Cleanup complete (0 retained, 2 deleted)
```

6. Events on recreation:
6.1. Cluster
```bash
  ⎿  LAST SEEN   TYPE     REASON                        OBJECT                       MESSAGE
     109s        Normal   ClusterAdopted                postgrescluster/adopt-test   Adopted existing CNPG cluster and secret adopt-test-secret
     109s        Normal   ClusterCreationStarted        postgrescluster/adopt-test   CNPG cluster created, waiting for healthy state
     90s         Normal   ConfigMapReady                postgrescluster/adopt-test   ConfigMap adopt-test-configmap created
     90s         Normal   ClusterReady                  postgrescluster/adopt-test   Cluster is up and running
     55s         Normal   CleanupComplete               postgrescluster/adopt-test   Cleanup complete (policy: Retain)
     16s         Normal   ClusterAdopted                postgrescluster/adopt-test   Adopted existing CNPG cluster and secret adopt-test-secret
     16s         Normal   ConfigMapReady                postgrescluster/adopt-test   ConfigMap adopt-test-configmap created
     16s         Normal   ClusterReady                  postgrescluster/adopt-test   Cluster is up and running
```

6.2. Database
```bash
     18s         Normal   ClusterValidated                postgresdatabase/adopt-db   Referenced PostgresCluster is ready
     18s         Normal   SecretsReady                    postgresdatabase/adopt-db   All secrets provisioned for 1 databases
     18s         Normal   ConfigMapsReady                 postgresdatabase/adopt-db   All ConfigMaps provisioned for 1 databases
     18s         Normal   RoleReconciliationStarted       postgresdatabase/adopt-db   Patched managed roles, waiting for 2 roles to reconcile
     18s         Normal   RolesReady                      postgresdatabase/adopt-db   All 2 roles reconciled
     18s         Normal   ResourcesAdopted                postgresdatabase/adopt-db   Adopted retained databases: [adoptdb1]
     18s         Normal   DatabasesReady                  postgresdatabase/adopt-db   All 1 databases ready
     18s         Normal   PrivilegesReady                 postgresdatabase/adopt-db   RW role privileges granted for all 1 databases
     18s         Normal   PostgresDatabaseReady           postgresdatabase/adopt-db   PostgresDatabase adopt-db is ready
```
### Related Issues

CPI-1852

### PR Checklist

- [ ] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [ ] All tests pass locally.
- [ ] The PR description follows the project's guidelines.
