### PR TITLE
  fix(postgres): address PR review — API validation, type cleanup, controller correctness

### DIFF
--- a/api/v4/postgrescluster_types.go
+++ b/api/v4/postgrescluster_types.go
@@ -44,7 +44,7 @@ type ManagedRole struct {
 // Validation rules ensure immutability of Class, and that Storage and PostgresVersion can only be set once and cannot be removed or downgraded.
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.postgresVersion) || (has(self.postgresVersion) && int(self.postgresVersion.split('.')[0]) >= int(oldSelf.postgresVersion.split('.')[0]))",messageExpression="!has(self.postgresVersion) ? 'postgresVersion cannot be removed once set (was: ' + oldSelf.postgresVersion + ')' : 'postgresVersion major version cannot be downgraded (from: ' + oldSelf.postgresVersion + ', to: ' + self.postgresVersion + ')'"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.storage) || (has(self.storage) && quantity(self.storage).compareTo(quantity(oldSelf.storage)) >= 0)",messageExpression="!has(self.storage) ? 'storage cannot be removed once set (was: ' + string(oldSelf.storage) + ')' : 'storage size cannot be decreased (from: ' + string(oldSelf.storage) + ', to: ' + string(self.storage) + ')'"
-// +kubebuilder:validation:XValidation:rule="!has(self.connectionPoolerConfig)",message="connectionPoolerConfig cannot be overridden on PostgresCluster"
+
 type PostgresClusterSpec struct {
 	// This field is IMMUTABLE after creation.
 	// +kubebuilder:validation:Required
@@ -92,13 +92,8 @@ type PostgresClusterSpec struct {
 
 	// ConnectionPoolerEnabled controls whether PgBouncer connection pooling is deployed for this cluster.
 	// When set, takes precedence over the class-level connectionPoolerEnabled value.
-	// +kubebuilder:default=false
 	// +optional
 	ConnectionPoolerEnabled *bool `json:"connectionPoolerEnabled,omitempty"`
-
-	// Only takes effect when connection pooling is enabled.
-	// +optional
-	ConnectionPoolerConfig *ConnectionPoolerConfig `json:"connectionPoolerConfig,omitempty"`
 
 	// ManagedRoles contains PostgreSQL roles that should be created in the cluster.
 	// This field supports Server-Side Apply with per-role granularity, allowing
@@ -185,6 +180,7 @@ type ConnectionPoolerStatus struct {
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // PostgresCluster is the Schema for the postgresclusters API.
+// +kubebuilder:validation:XValidation:rule="size(self.metadata.name) <= 50",message="name must be 50 characters or fewer to accommodate derived resource names"
 type PostgresCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v4/postgresclusterclass_types.go
+++ b/api/v4/postgresclusterclass_types.go
@@ -24,8 +24,10 @@ import (
 
 // +kubebuilder:validation:XValidation:rule="!has(self.cnpg) || self.provisioner == 'postgresql.cnpg.io'",message="cnpg config can only be set when provisioner is postgresql.cnpg.io"
 // +kubebuilder:validation:XValidation:rule="!has(self.config) || !has(self.config.connectionPoolerEnabled) || !self.config.connectionPoolerEnabled || (has(self.cnpg) && has(self.cnpg.connectionPooler))",message="cnpg.connectionPooler must be set when config.connectionPoolerEnabled is true"
+// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="PostgresClusterClass is immutable after creation"
 // PostgresClusterClassSpec defines the desired state of PostgresClusterClass.
 // PostgresClusterClass is immutable after creation - it serves as a template for Cluster CRs.
+
 type PostgresClusterClassSpec struct {
 	// Provisioner identifies which database provisioner to use.
 	// Currently supported: "postgresql.cnpg.io" (CloudNativePG)
@@ -174,9 +176,9 @@ type PostgresClusterClassStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:printcolumn:name="Provisioner",type=string,JSONPath=`.spec.provisioner`
-// +kubebuilder:printcolumn:name="Instances",type=integer,JSONPath=`.spec.postgresClusterConfig.instances`
-// +kubebuilder:printcolumn:name="Storage",type=string,JSONPath=`.spec.postgresClusterConfig.storage`
-// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.spec.postgresClusterConfig.postgresVersion`
+// +kubebuilder:printcolumn:name="Instances",type=integer,JSONPath=`.spec.config.instances`
+// +kubebuilder:printcolumn:name="Storage",type=string,JSONPath=`.spec.config.storage`
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.spec.config.postgresVersion`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/api/v4/postgresdatabase_types.go
+++ b/api/v4/postgresdatabase_types.go
@@ -23,6 +23,7 @@ import (
 
 // PostgresDatabaseSpec defines the desired state of PostgresDatabase.
 // +kubebuilder:validation:XValidation:rule="self.clusterRef == oldSelf.clusterRef",message="clusterRef is immutable"
+// +kubebuilder:validation:XValidation:rule="self.clusterRef.name != ''",message="clusterRef.name must not be empty"
 type PostgresDatabaseSpec struct {
 	// Reference to Postgres Cluster managed by postgresCluster controller
 	// +kubebuilder:validation:Required
@@ -37,7 +38,9 @@ type PostgresDatabaseSpec struct {
 
 type DatabaseDefinition struct {
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=30
+	// +kubebuilder:validation:Pattern=`^[a-z_][a-z0-9_]*$`
 	Name       string   `json:"name"`
 	Extensions []string `json:"extensions,omitempty"`
 	// +kubebuilder:validation:Enum=Delete;Retain
@@ -51,7 +54,7 @@ type DatabaseInfo struct {
 	DatabaseRef        *corev1.LocalObjectReference `json:"databaseRef,omitempty"`
 	AdminUserSecretRef *corev1.SecretKeySelector    `json:"adminUserSecretRef,omitempty"`
 	RWUserSecretRef    *corev1.SecretKeySelector    `json:"rwUserSecretRef,omitempty"`
-	ConfigMapRef       *corev1.LocalObjectReference `json:"configMap,omitempty"`
+	ConfigMapRef       *corev1.LocalObjectReference `json:"configMapRef,omitempty"`
 }
 
 // PostgresDatabaseStatus defines the observed state of PostgresDatabase.
@@ -74,6 +77,7 @@ type PostgresDatabaseStatus struct {
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // PostgresDatabase is the Schema for the postgresdatabases API.
+// +kubebuilder:validation:XValidation:rule="size(self.metadata.name) <= 50",message="name must be 50 characters or fewer to accommodate derived resource names"
 type PostgresDatabase struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v4/zz_generated.deepcopy.go
+++ b/api/v4/zz_generated.deepcopy.go
@@ -1413,11 +1413,6 @@ func (in *PostgresClusterSpec) DeepCopyInto(out *PostgresClusterSpec) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.ConnectionPoolerConfig != nil {
-		in, out := &in.ConnectionPoolerConfig, &out.ConnectionPoolerConfig
-		*out = new(ConnectionPoolerConfig)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.ManagedRoles != nil {
 		in, out := &in.ManagedRoles, &out.ManagedRoles
 		*out = make([]ManagedRole, len(*in))

--- a/config/crd/bases/enterprise.splunk.com_postgresclusterclasses.yaml
+++ b/config/crd/bases/enterprise.splunk.com_postgresclusterclasses.yaml
@@ -18,13 +18,13 @@ spec:
     - jsonPath: .spec.provisioner
       name: Provisioner
       type: string
-    - jsonPath: .spec.postgresClusterConfig.instances
+    - jsonPath: .spec.config.instances
       name: Instances
       type: integer
-    - jsonPath: .spec.postgresClusterConfig.storage
+    - jsonPath: .spec.config.storage
       name: Storage
       type: string
-    - jsonPath: .spec.postgresClusterConfig.postgresVersion
+    - jsonPath: .spec.config.postgresVersion
       name: Version
       type: string
     - jsonPath: .status.phase
@@ -58,9 +58,6 @@ spec:
           metadata:
             type: object
           spec:
-            description: |-
-              PostgresClusterClassSpec defines the desired state of PostgresClusterClass.
-              PostgresClusterClass is immutable after creation - it serves as a template for Cluster CRs.
             properties:
               cnpg:
                 description: |-
@@ -251,6 +248,8 @@ spec:
                 is true
               rule: '!has(self.config) || !has(self.config.connectionPoolerEnabled)
                 || !self.config.connectionPoolerEnabled || (has(self.cnpg) && has(self.cnpg.connectionPooler))'
+            - message: PostgresClusterClass is immutable after creation
+              rule: self == oldSelf
           status:
             description: PostgresClusterClassStatus defines the observed state of
               PostgresClusterClass.

--- a/config/crd/bases/enterprise.splunk.com_postgresclusters.yaml
+++ b/config/crd/bases/enterprise.splunk.com_postgresclusters.yaml
@@ -47,9 +47,6 @@ spec:
           metadata:
             type: object
           spec:
-            description: |-
-              PostgresClusterSpec defines the desired state of PostgresCluster.
-              Validation rules ensure immutability of Class, and that Storage and PostgresVersion can only be set once and cannot be removed or downgraded.
             properties:
               class:
                 description: This field is IMMUTABLE after creation.
@@ -66,37 +63,7 @@ spec:
                 - Delete
                 - Retain
                 type: string
-              connectionPoolerConfig:
-                description: Only takes effect when connection pooling is enabled.
-                properties:
-                  config:
-                    additionalProperties:
-                      type: string
-                    description: |-
-                      Config contains PgBouncer configuration parameters.
-                      Passed directly to CNPG Pooler spec.pgbouncer.parameters.
-                      See: https://cloudnative-pg.io/docs/1.28/connection_pooling/#pgbouncer-configuration-options
-                    type: object
-                  instances:
-                    default: 3
-                    description: |-
-                      Instances is the number of PgBouncer pod replicas.
-                      Higher values provide better availability and load distribution.
-                    format: int32
-                    maximum: 10
-                    minimum: 1
-                    type: integer
-                  mode:
-                    default: transaction
-                    description: Mode defines the connection pooling strategy.
-                    enum:
-                    - session
-                    - transaction
-                    - statement
-                    type: string
-                type: object
               connectionPoolerEnabled:
-                default: false
                 description: |-
                   ConnectionPoolerEnabled controls whether PgBouncer connection pooling is deployed for this cluster.
                   When set, takes precedence over the class-level connectionPoolerEnabled value.
@@ -270,8 +237,6 @@ spec:
                 '' + string(self.storage) + '')'''
               rule: '!has(oldSelf.storage) || (has(self.storage) && quantity(self.storage).compareTo(quantity(oldSelf.storage))
                 >= 0)'
-            - message: connectionPoolerConfig cannot be overridden on PostgresCluster
-              rule: '!has(self.connectionPoolerConfig)'
           status:
             description: PostgresClusterStatus defines the observed state of PostgresCluster.
             properties:
@@ -463,6 +428,10 @@ spec:
                 type: object
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: name must be 50 characters or fewer to accommodate derived resource
+            names
+          rule: size(self.metadata.name) <= 50
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/enterprise.splunk.com_postgresdatabases.yaml
+++ b/config/crd/bases/enterprise.splunk.com_postgresdatabases.yaml
@@ -79,6 +79,8 @@ spec:
                       type: array
                     name:
                       maxLength: 30
+                      minLength: 1
+                      pattern: ^[a-z_][a-z0-9_]*$
                       type: string
                   required:
                   - name
@@ -96,6 +98,8 @@ spec:
             x-kubernetes-validations:
             - message: clusterRef is immutable
               rule: self.clusterRef == oldSelf.clusterRef
+            - message: clusterRef.name must not be empty
+              rule: self.clusterRef.name != ''
           status:
             description: PostgresDatabaseStatus defines the observed state of PostgresDatabase.
             properties:
@@ -182,7 +186,7 @@ spec:
                       - key
                       type: object
                       x-kubernetes-map-type: atomic
-                    configMap:
+                    configMapRef:
                       description: |-
                         LocalObjectReference contains enough information to let you locate the
                         referenced object inside the same namespace.
@@ -253,6 +257,10 @@ spec:
                 type: string
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: name must be 50 characters or fewer to accommodate derived resource
+            names
+          rule: size(self.metadata.name) <= 50
     served: true
     storage: true
     subresources:

--- a/config/crd/patches/patch_preserve_unknown_fields.yaml
+++ b/config/crd/patches/patch_preserve_unknown_fields.yaml
@@ -47,10 +47,34 @@ metadata:
 spec:
   preserveUnknownFields: false
 
----    
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: searchheadclusters.enterprise.splunk.com
+spec:
+  preserveUnknownFields: false
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: postgresclusters.enterprise.splunk.com
+spec:
+  preserveUnknownFields: false
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: postgresclusterclasses.enterprise.splunk.com
+spec:
+  preserveUnknownFields: false
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: postgresdatabases.enterprise.splunk.com
 spec:
   preserveUnknownFields: false

--- a/internal/controller/postgrescluster_controller.go
+++ b/internal/controller/postgrescluster_controller.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -61,6 +60,7 @@ func (r *PostgresClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 // SetupWithManager registers the controller and owned resource watches.
 func (r *PostgresClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithEventFilter(predicate.Funcs{GenericFunc: func(event.GenericEvent) bool { return false }}).
 		For(&enterprisev4.PostgresCluster{}, builder.WithPredicates(postgresClusterPredicator())).
 		Owns(&cnpgv1.Cluster{}, builder.WithPredicates(cnpgClusterPredicator())).
 		Owns(&cnpgv1.Pooler{}, builder.WithPredicates(cnpgPoolerPredicator())).
@@ -73,107 +73,71 @@ func (r *PostgresClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func deletionTimestampChanged(oldObj, newObj metav1.Object) bool {
-	return !equality.Semantic.DeepEqual(oldObj.GetDeletionTimestamp(), newObj.GetDeletionTimestamp())
-}
-
 func ownerReferencesChanged(oldObj, newObj metav1.Object) bool {
 	return !equality.Semantic.DeepEqual(oldObj.GetOwnerReferences(), newObj.GetOwnerReferences())
 }
 
-// postgresClusterPredicator triggers on generation changes, deletion, and finalizer transitions.
+// postgresClusterPredicator triggers on spec changes, deletion, and finalizer transitions.
 func postgresClusterPredicator() predicate.Predicate {
-	return predicate.Funcs{
-		CreateFunc: func(event.CreateEvent) bool { return true },
-		DeleteFunc: func(event.DeleteEvent) bool { return true },
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			oldObj, oldOK := e.ObjectOld.(*enterprisev4.PostgresCluster)
-			newObj, newOK := e.ObjectNew.(*enterprisev4.PostgresCluster)
-			if !oldOK || !newOK {
-				return true
-			}
-			if oldObj.Generation != newObj.Generation {
-				return true
-			}
-			if deletionTimestampChanged(oldObj, newObj) {
-				return true
-			}
-			// Finalizer changes indicate registration or deletion  always reconcile.
-			return controllerutil.ContainsFinalizer(oldObj, clustercore.PostgresClusterFinalizerName) !=
-				controllerutil.ContainsFinalizer(newObj, clustercore.PostgresClusterFinalizerName)
+	return predicate.Or(
+		predicate.GenerationChangedPredicate{},
+		predicate.Funcs{
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				// DeletionTimestamp set means the object entered the deletion phase.
+				if !equality.Semantic.DeepEqual(e.ObjectOld.GetDeletionTimestamp(), e.ObjectNew.GetDeletionTimestamp()) {
+					return true
+				}
+				// Finalizer list change signals a cleanup lifecycle transition.
+				return !equality.Semantic.DeepEqual(e.ObjectOld.GetFinalizers(), e.ObjectNew.GetFinalizers())
+			},
 		},
-		GenericFunc: func(event.GenericEvent) bool { return false },
-	}
+	)
 }
 
-// cnpgClusterPredicator triggers only on phase changes or owner reference changes.
+// cnpgClusterPredicator triggers on spec changes, phase changes, or owner reference changes.
+// Generation catches spec drift before CNPG reflects it in status.
 func cnpgClusterPredicator() predicate.Predicate {
-	return predicate.Funcs{
-		CreateFunc: func(event.CreateEvent) bool { return true },
-		DeleteFunc: func(event.DeleteEvent) bool { return true },
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			oldObj, oldOK := e.ObjectOld.(*cnpgv1.Cluster)
-			newObj, newOK := e.ObjectNew.(*cnpgv1.Cluster)
-			if !oldOK || !newOK {
-				return true
-			}
-			return oldObj.Status.Phase != newObj.Status.Phase ||
-				ownerReferencesChanged(oldObj, newObj)
+	return predicate.Or(
+		predicate.GenerationChangedPredicate{},
+		predicate.Funcs{
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				oldObj := e.ObjectOld.(*cnpgv1.Cluster)
+				newObj := e.ObjectNew.(*cnpgv1.Cluster)
+				return oldObj.Status.Phase != newObj.Status.Phase ||
+					ownerReferencesChanged(oldObj, newObj)
+			},
 		},
-		GenericFunc: func(event.GenericEvent) bool { return false },
-	}
+	)
 }
 
-// cnpgPoolerPredicator triggers only on instance count changes.
+// cnpgPoolerPredicator triggers on spec changes or instance count changes.
+// Generation catches spec drift before CNPG reflects it in instance status.
 func cnpgPoolerPredicator() predicate.Predicate {
-	return predicate.Funcs{
-		CreateFunc: func(event.CreateEvent) bool { return true },
-		DeleteFunc: func(event.DeleteEvent) bool { return true },
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			oldObj, oldOK := e.ObjectOld.(*cnpgv1.Pooler)
-			newObj, newOK := e.ObjectNew.(*cnpgv1.Pooler)
-			if !oldOK || !newOK {
-				return true
-			}
-			return oldObj.Status.Instances != newObj.Status.Instances
+	return predicate.Or(
+		predicate.GenerationChangedPredicate{},
+		predicate.Funcs{
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				oldObj := e.ObjectOld.(*cnpgv1.Pooler)
+				newObj := e.ObjectNew.(*cnpgv1.Pooler)
+				return oldObj.Status.Instances != newObj.Status.Instances
+			},
 		},
-		GenericFunc: func(event.GenericEvent) bool { return false },
-	}
+	)
 }
 
-// secretPredicator triggers only on owner reference changes.
+// secretPredicator triggers only when ownership changes.
+// In retain-state mode we release ownership (remove ownerRef) without deleting the Secret,
+// so this transition must trigger reconciliation to update our tracking state.
 func secretPredicator() predicate.Predicate {
 	return predicate.Funcs{
-		CreateFunc: func(event.CreateEvent) bool { return true },
-		DeleteFunc: func(event.DeleteEvent) bool { return true },
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			oldObj, oldOK := e.ObjectOld.(*corev1.Secret)
-			newObj, newOK := e.ObjectNew.(*corev1.Secret)
-			if !oldOK || !newOK {
-				return true
-			}
-			return ownerReferencesChanged(oldObj, newObj)
+			return ownerReferencesChanged(e.ObjectOld, e.ObjectNew)
 		},
-		GenericFunc: func(event.GenericEvent) bool { return false },
 	}
 }
 
-// configMapPredicator triggers on data, label, annotation, or owner reference changes.
+// configMapPredicator triggers on any content change.
+// ConfigMap has no status subresource, so every resourceVersion bump is a real change.
 func configMapPredicator() predicate.Predicate {
-	return predicate.Funcs{
-		CreateFunc: func(event.CreateEvent) bool { return true },
-		DeleteFunc: func(event.DeleteEvent) bool { return true },
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			oldObj, oldOK := e.ObjectOld.(*corev1.ConfigMap)
-			newObj, newOK := e.ObjectNew.(*corev1.ConfigMap)
-			if !oldOK || !newOK {
-				return true
-			}
-			return !equality.Semantic.DeepEqual(oldObj.Data, newObj.Data) ||
-				!equality.Semantic.DeepEqual(oldObj.Labels, newObj.Labels) ||
-				!equality.Semantic.DeepEqual(oldObj.Annotations, newObj.Annotations) ||
-				ownerReferencesChanged(oldObj, newObj)
-		},
-		GenericFunc: func(event.GenericEvent) bool { return false },
-	}
+	return predicate.ResourceVersionChangedPredicate{}
 }

--- a/pkg/postgresql/cluster/core/cluster.go
+++ b/pkg/postgresql/cluster/core/cluster.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -72,11 +73,13 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 			return ctrl.Result{}, nil
 		}
 		logger.Error(err, "Failed to handle finalizer")
+		errs := []error{err}
 		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterDeleteFailed,
 			fmt.Sprintf("Failed to delete resources during cleanup: %v", err), failedClusterPhase); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status")
+			errs = append(errs, statusErr)
 		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, errors.Join(errs...)
 	}
 	if postgresCluster.GetDeletionTimestamp() != nil {
 		logger.Info("PostgresCluster is being deleted, cleanup complete")
@@ -88,8 +91,8 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 		controllerutil.AddFinalizer(postgresCluster, PostgresClusterFinalizerName)
 		if err := c.Update(ctx, postgresCluster); err != nil {
 			if apierrors.IsConflict(err) {
-				logger.Info("Conflict while adding finalizer, will retry on next reconcile")
-				return ctrl.Result{Requeue: true}, nil
+				logger.Error(err, "Conflict while adding finalizer. Retrying...")
+				return ctrl.Result{}, fmt.Errorf("conflict while adding finalizer: %w", err)
 			}
 			logger.Error(err, "Failed to add finalizer to PostgresCluster")
 			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
@@ -98,7 +101,7 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 		return ctrl.Result{}, nil
 	}
 
-	// 2. Load the referenced PostgresClusterClass.
+	// Load the referenced PostgresClusterClass.
 	clusterClass := &enterprisev4.PostgresClusterClass{}
 	if err := c.Get(ctx, client.ObjectKey{Name: postgresCluster.Spec.Class}, clusterClass); err != nil {
 		logger.Error(err, "Unable to fetch referenced PostgresClusterClass", "className", postgresCluster.Spec.Class)
@@ -109,7 +112,7 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 		return ctrl.Result{}, err
 	}
 
-	// 3. Merge PostgresClusterSpec on top of PostgresClusterClass defaults.
+	// Merge PostgresClusterSpec on top of PostgresClusterClass defaults.
 	mergedConfig, err := getMergedConfig(clusterClass, postgresCluster)
 	if err != nil {
 		logger.Error(err, "Failed to merge PostgresCluster configuration")
@@ -120,7 +123,7 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 		return ctrl.Result{}, err
 	}
 
-	// 4. Resolve or derive the superuser secret name.
+	// Resolve or derive the superuser secret name.
 	if postgresCluster.Status.Resources != nil && postgresCluster.Status.Resources.SuperUserSecretRef != nil {
 		postgresSecretName = postgresCluster.Status.Resources.SuperUserSecretRef.Name
 		logger.Info("Using existing secret from status", "name", postgresSecretName)
@@ -189,10 +192,10 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 		}
 	}
 
-	// 5. Build desired CNPG Cluster spec.
+	// Build desired CNPG Cluster spec.
 	desiredSpec := buildCNPGClusterSpec(mergedConfig, postgresSecretName)
 
-	// 6. Fetch existing CNPG Cluster or create it.
+	// Fetch existing CNPG Cluster or create it.
 	existingCNPG := &cnpgv1.Cluster{}
 	err = c.Get(ctx, types.NamespacedName{Name: postgresCluster.Name, Namespace: postgresCluster.Namespace}, existingCNPG)
 	switch {
@@ -222,7 +225,7 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 		return ctrl.Result{}, err
 	}
 
-	// 7. Patch CNPG Cluster spec if drift detected.
+	// Patch CNPG Cluster spec if drift detected.
 	cnpgCluster = existingCNPG
 	currentNormalized := normalizeCNPGClusterSpec(cnpgCluster.Spec, mergedConfig.Spec.PostgreSQLConfig)
 	desiredNormalized := normalizeCNPGClusterSpec(desiredSpec, mergedConfig.Spec.PostgreSQLConfig)
@@ -249,7 +252,7 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 		}
 	}
 
-	// 7a. Reconcile ManagedRoles.
+	// Reconcile ManagedRoles.
 	if err := reconcileManagedRoles(ctx, c, postgresCluster, cnpgCluster); err != nil {
 		logger.Error(err, "Failed to reconcile managed roles")
 		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonManagedRolesFailed,
@@ -259,7 +262,7 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 		return ctrl.Result{}, err
 	}
 
-	// 7b. Reconcile Connection Pooler.
+	// Reconcile Connection Pooler.
 	poolerEnabled = mergedConfig.Spec.ConnectionPoolerEnabled != nil && *mergedConfig.Spec.ConnectionPoolerEnabled
 	switch {
 	case !poolerEnabled:
@@ -342,7 +345,7 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 		}
 	}
 
-	// 8. Reconcile ConfigMap when CNPG cluster is healthy.
+	// Reconcile ConfigMap when CNPG cluster is healthy.
 	if cnpgCluster.Status.Phase == cnpgv1.PhaseHealthy {
 		logger.Info("CNPG Cluster is ready, reconciling ConfigMap for connection details")
 		desiredCM, err := generateConfigMap(ctx, c, scheme, postgresCluster, cnpgCluster, postgresSecretName)
@@ -387,7 +390,7 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 		}
 	}
 
-	// 9. Final status sync.
+	// Final status sync.
 	if err := syncStatus(ctx, c, postgresCluster, cnpgCluster); err != nil {
 		logger.Error(err, "Failed to sync status")
 		if apierrors.IsConflict(err) {

--- a/pkg/postgresql/cluster/core/cluster.go
+++ b/pkg/postgresql/cluster/core/cluster.go
@@ -91,8 +91,8 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 		controllerutil.AddFinalizer(postgresCluster, PostgresClusterFinalizerName)
 		if err := c.Update(ctx, postgresCluster); err != nil {
 			if apierrors.IsConflict(err) {
-				logger.Error(err, "Conflict while adding finalizer. Retrying...")
-				return ctrl.Result{}, fmt.Errorf("conflict while adding finalizer: %w", err)
+				logger.Info("Conflict while adding finalizer, will requeue")
+				return ctrl.Result{Requeue: true}, nil
 			}
 			logger.Error(err, "Failed to add finalizer to PostgresCluster")
 			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
@@ -264,6 +264,30 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 
 	// Reconcile Connection Pooler.
 	poolerEnabled = mergedConfig.Spec.ConnectionPoolerEnabled != nil && *mergedConfig.Spec.ConnectionPoolerEnabled
+
+	rwPoolerExists, err := poolerExists(ctx, c, postgresCluster, readWriteEndpoint)
+	if err != nil {
+		logger.Error(err, "Failed to check RW pooler existence")
+		errs := []error{err}
+		if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerReconciliationFailed,
+			fmt.Sprintf("Failed to check pooler existence: %v", err), failedClusterPhase); statusErr != nil {
+			logger.Error(statusErr, "Failed to update status")
+			errs = append(errs, statusErr)
+		}
+		return ctrl.Result{}, errors.Join(errs...)
+	}
+	roPoolerExists, err := poolerExists(ctx, c, postgresCluster, readOnlyEndpoint)
+	if err != nil {
+		logger.Error(err, "Failed to check RO pooler existence")
+		errs := []error{err}
+		if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerReconciliationFailed,
+			fmt.Sprintf("Failed to check pooler existence: %v", err), failedClusterPhase); statusErr != nil {
+			logger.Error(statusErr, "Failed to update status")
+			errs = append(errs, statusErr)
+		}
+		return ctrl.Result{}, errors.Join(errs...)
+	}
+
 	switch {
 	case !poolerEnabled:
 		if err := deleteConnectionPoolers(ctx, c, postgresCluster); err != nil {
@@ -277,7 +301,7 @@ func PostgresClusterService(ctx context.Context, c client.Client, scheme *runtim
 		postgresCluster.Status.ConnectionPoolerStatus = nil
 		meta.RemoveStatusCondition(&postgresCluster.Status.Conditions, string(poolerReady))
 
-	case !poolerExists(ctx, c, postgresCluster, readWriteEndpoint) || !poolerExists(ctx, c, postgresCluster, readOnlyEndpoint):
+	case !rwPoolerExists || !roPoolerExists:
 		if mergedConfig.CNPG == nil || mergedConfig.CNPG.ConnectionPooler == nil {
 			logger.Info("Connection pooler enabled but no config found in class or cluster spec, skipping",
 				"class", postgresCluster.Spec.Class, "cluster", postgresCluster.Name)
@@ -444,6 +468,9 @@ func getMergedConfig(class *enterprisev4.PostgresClusterClass, cluster *enterpri
 		if len(result.PgHBA) == 0 {
 			result.PgHBA = defaults.PgHBA
 		}
+		if result.ConnectionPoolerEnabled == nil {
+			result.ConnectionPoolerEnabled = defaults.ConnectionPoolerEnabled
+		}
 	}
 
 	if result.Instances == nil || result.PostgresVersion == nil || result.Storage == nil {
@@ -578,20 +605,20 @@ func poolerResourceName(clusterName, poolerType string) string {
 	return fmt.Sprintf("%s%s%s", clusterName, defaultPoolerSuffix, poolerType)
 }
 
-func poolerExists(ctx context.Context, c client.Client, cluster *enterprisev4.PostgresCluster, poolerType string) bool {
+func poolerExists(ctx context.Context, c client.Client, cluster *enterprisev4.PostgresCluster, poolerType string) (bool, error) {
 	pooler := &cnpgv1.Pooler{}
 	err := c.Get(ctx, types.NamespacedName{
 		Name:      poolerResourceName(cluster.Name, poolerType),
 		Namespace: cluster.Namespace,
 	}, pooler)
 	if apierrors.IsNotFound(err) {
-		return false
+		return false, nil
 	}
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Failed to check pooler existence", "type", poolerType)
-		return false
+		return false, err
 	}
-	return true
+	return true, nil
 }
 
 func arePoolersReady(rwPooler, roPooler *cnpgv1.Pooler) bool {
@@ -666,7 +693,11 @@ func deleteConnectionPoolers(ctx context.Context, c client.Client, cluster *ente
 	logger := log.FromContext(ctx)
 	for _, poolerType := range []string{readWriteEndpoint, readOnlyEndpoint} {
 		poolerName := poolerResourceName(cluster.Name, poolerType)
-		if !poolerExists(ctx, c, cluster, poolerType) {
+		exist, err := poolerExists(ctx, c, cluster, poolerType)
+		if err != nil {
+			return fmt.Errorf("Can't check the pooler exist due to transient error %w", err)
+		}
+		if !exist {
 			continue
 		}
 		pooler := &cnpgv1.Pooler{}
@@ -769,7 +800,11 @@ func syncStatus(ctx context.Context, c client.Client, cluster *enterprisev4.Post
 }
 
 // setStatus sets the phase, condition and persists the status.
+// It skips the API write when the resulting status is identical to the current
+// state, avoiding unnecessary etcd churn and ResourceVersion bumps on stable clusters.
 func setStatus(ctx context.Context, c client.Client, cluster *enterprisev4.PostgresCluster, condType conditionTypes, status metav1.ConditionStatus, reason conditionReasons, message string, phase reconcileClusterPhases) error {
+	before := cluster.Status.DeepCopy()
+
 	p := string(phase)
 	cluster.Status.Phase = &p
 	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
@@ -779,6 +814,11 @@ func setStatus(ctx context.Context, c client.Client, cluster *enterprisev4.Postg
 		Message:            message,
 		ObservedGeneration: cluster.Generation,
 	})
+
+	if equality.Semantic.DeepEqual(*before, cluster.Status) {
+		return nil
+	}
+
 	if err := c.Status().Update(ctx, cluster); err != nil {
 		return fmt.Errorf("failed to update PostgresCluster status: %w", err)
 	}
@@ -800,7 +840,15 @@ func generateConfigMap(ctx context.Context, c client.Client, scheme *runtime.Sch
 		"SUPER_USER_NAME":       superUsername,
 		"SUPER_USER_SECRET_REF": secretName,
 	}
-	if poolerExists(ctx, c, cluster, readWriteEndpoint) && poolerExists(ctx, c, cluster, readOnlyEndpoint) {
+	rwExists, err := poolerExists(ctx, c, cluster, readWriteEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check RW pooler existence: %w", err)
+	}
+	roExists, err := poolerExists(ctx, c, cluster, readOnlyEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check RO pooler existence: %w", err)
+	}
+	if rwExists && roExists {
 		data["CLUSTER_POOLER_RW_ENDPOINT"] = fmt.Sprintf("%s.%s", poolerResourceName(cnpgCluster.Name, readWriteEndpoint), cnpgCluster.Namespace)
 		data["CLUSTER_POOLER_RO_ENDPOINT"] = fmt.Sprintf("%s.%s", poolerResourceName(cnpgCluster.Name, readOnlyEndpoint), cnpgCluster.Namespace)
 	}

--- a/pkg/postgresql/database/core/database.go
+++ b/pkg/postgresql/database/core/database.go
@@ -52,12 +52,18 @@ func PostgresDatabaseService(
 		}
 		return ctrl.Result{}, nil
 	}
+	// Add finalizer if not present.
 	if !controllerutil.ContainsFinalizer(postgresDB, postgresDatabaseFinalizerName) {
 		controllerutil.AddFinalizer(postgresDB, postgresDatabaseFinalizerName)
 		if err := c.Update(ctx, postgresDB); err != nil {
+			if errors.IsConflict(err) {
+				logger.Info("Conflict while adding finalizer, will requeue")
+				return ctrl.Result{Requeue: true}, nil
+			}
 			logger.Error(err, "Failed to add finalizer to PostgresDatabase")
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 		}
+		logger.Info("Finalizer added successfully")
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/postgresql/database/core/database.go
+++ b/pkg/postgresql/database/core/database.go
@@ -105,10 +105,12 @@ func PostgresDatabaseService(
 			"If you deleted a previous PostgresDatabase, recreate it with the original name to re-adopt the orphaned resources.",
 			strings.Join(roleConflicts, ", "))
 		logger.Error(nil, conflictMsg)
+		errs := []error{fmt.Errorf("role conflict detected: %s", strings.Join(roleConflicts, ", "))}
 		if statusErr := updateStatus(rolesReady, metav1.ConditionFalse, reasonRoleConflict, conflictMsg, failedDBPhase); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status")
+			errs = append(errs, fmt.Errorf("failed to update status: %w", statusErr))
 		}
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, stderrors.Join(errs...)
 	}
 
 	// We need the CNPG Cluster directly because PostgresCluster status does not yet


### PR DESCRIPTION
### Description
Addresses  issues raised in code review against the postgres cluster, cluster class, and database controllers.

### Key Changes

#### API & Type Fixes

##### ConnectionPoolerConfig removed from PostgresClusterSpec (postgrescluster_types.go)

  ConnectionPoolerConfig was dead code — the field was declared on PostgresClusterSpec but never read by the reconciler, which exclusively uses the class-level config. Removed
  the field and its DeepCopyInto generated code to eliminate the misleading API surface.

##### DatabaseDefinition.Name pattern validation (postgresdatabase_types.go)

  Added +kubebuilder:validation:Pattern=^[a-z_][a-z0-9_]*$ and MinLength=1. Without this, names such as "123db" or "my-db" passed admission but failed at the PostgreSQL layer
  with an opaque SQL error. Validation now enforced at the API boundary.

##### PostgresClusterClass immutability enforced (postgresclusterclass_types.go)

  Added +kubebuilder:validation:XValidation:rule="self == oldSelf" to PostgresClusterClassSpec. Classes serve as immutable provisioning templates — previously nothing prevented
  mutation after clusters were already referencing a class.

##### JSON tag inconsistency fixed: ConfigMapRef (postgresdatabase_types.go)

  DatabaseInfo.ConfigMapRef was serialising as "configMap" due to a mismatched json tag. Corrected to "configMapRef" for consistency with all other ref fields. This is a
  breaking wire-format change for any existing stored objects using this field.


##### Typo fixed: PosgresClusterClassConfig (postgresclusterclass_types.go)

  Renamed to PostgresClusterClassConfig. The transposed s and g had been propagated into the generated CRD and deep copy code.

##### Name length constraint added to PostgresCluster and PostgresDatabase (postgrescluster_types.go, postgresdatabase_types.go)

  Added +kubebuilder:validation:XValidation:rule="size(self.metadata.name) <= 50" to both types to prevent derived resource name overflow (secrets, configmaps, poolers all
  append suffixes to the CR name).

  ---
  #### CRD & Config Fixes


##### Broken print columns in PostgresClusterClass CRD

  Column JSONPaths referenced spec.postgresClusterConfig.* which no longer existed after the field rename to spec.config.*. Updated all three columns (Instances, Storage,
  Version). CRDs regenerated.

##### Database CRDs missing from preserveUnknownFields patch (patch_preserve_unknown_fields.yaml)

  Added postgresclusters, postgresclusterclasses, postgresdatabases to the existing patch for consistency with all other operator-managed CRDs. No functional change —
  apiextensions.k8s.io/v1 defaults to false — but aligns new types with the established convention.

##### Samples kustomization referenced non-existent files

  Removed stale file references in the samples kustomization that were pointing to files removed in a prior refactor.

  ---
  #### Controller Fixes

##### poolerExists errors propagated (cluster.go)

  Changed poolerExists return type from bool to (bool, error). Transient API errors were previously silently treated as "pooler not found", causing the controller to incorrectly
   attempt recreation. Updated all three call sites — main service loop errors joined with errors.Join, generateConfigMap propagates as (nil, err).

##### Secret deletion no longer breaks retained CNPG clusters (cluster.go)

  When ClusterDeletionPolicy: Retain is set, the finalizer handler now removes the owner reference from the superuser secret before removing the finalizer. Previously, the
  secret was deleted via garbage collection when the PostgresCluster was removed, leaving the retained CNPG cluster without credentials.

##### Conflict handling for finalizer updates in PostgresDatabase

  The finalizer update path in the PostgresDatabase reconciler was not handling apierrors.IsConflict. Added Requeue: true response consistent with the existing pattern in
  PostgresCluster.

##### setStatus skips write when nothing changed (cluster.go)

  Added a DeepEqual guard: snapshots cluster.Status before applying mutations and skips Status().Update() when the result is semantically identical. Eliminates redundant API
  writes on stable healthy clusters. Uses equality.Semantic.DeepEqual to correctly handle Kubernetes type semantics (resource.Quantity normalisation, nil vs empty map).
  Mid-reconcile status checkpoints are preserved, the guard only prevents no-op writes, not intentional state transitions.

  ---
### Testing and Verification

_How did you test these changes? What automated tests are added?_

### Related Issues

_Jira tickets, GitHub issues, Support tickets..._

### PR Checklist

- [ ] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [ ] All tests pass locally.
- [ ] The PR description follows the project's guidelines.
