### PR TITLE
fake recorder added to tests fix

### DIFF
--- a/internal/controller/postgrescluster_controller_test.go
+++ b/internal/controller/postgrescluster_controller_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +52,9 @@ var _ = Describe("PostgresCluster Controller", func() {
 						Name:      resourceName,
 						Namespace: "default",
 					},
-					// TODO(user): Specify other spec details if needed.
+					Spec: enterprisev4.PostgresClusterSpec{
+						Class: "test-class",
+					},
 				}
 				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 			}
@@ -69,8 +72,9 @@ var _ = Describe("PostgresCluster Controller", func() {
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &PostgresClusterReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: record.NewFakeRecorder(100),
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{

--- a/internal/controller/postgresdatabase_controller_test.go
+++ b/internal/controller/postgresdatabase_controller_test.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -41,8 +42,9 @@ const postgresDatabaseFinalizer = "postgresdatabases.enterprise.splunk.com/final
 
 func reconcilePostgresDatabase(ctx context.Context, nn types.NamespacedName) (ctrl.Result, error) {
 	reconciler := &PostgresDatabaseReconciler{
-		Client: k8sClient,
-		Scheme: k8sClient.Scheme(),
+		Client:   k8sClient,
+		Scheme:   k8sClient.Scheme(),
+		Recorder: record.NewFakeRecorder(100),
 	}
 	return reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
 }


### PR DESCRIPTION
### Description

Issues in our tests while running `make test`:
```bash
2026-03-31T15:57:50.858403+02:00	INFO	Cluster validation done	{"clusterName": "tenant-cluster", "status": "Ready"}
  [PANICKED] Test Panicked
  In [It] at: /opt/homebrew/Cellar/go/1.26.1/libexec/src/runtime/panic.go:336 @ 03/31/26 15:57:50.858

  runtime error: invalid memory address or nil pointer dereference

  Full Stack Trace
    github.com/splunk/splunk-operator/pkg/postgresql/database/core.(*ReconcileContext).emitNormal(...)
    	/Users/kkoterba/Development/projects/splunk-operator/pkg/postgresql/database/core/events.go:35
    github.com/splunk/splunk-operator/pkg/postgresql/database/core.(*ReconcileContext).emitOnConditionTransition(0x17b3c0141c10, {0x106c74710, 0x17b3c00e6900}, {0x0?, 0x17?, 0x17b3bf6730c0?}, {0x1048e72e8, 0xc}, {0x1048f1cf2, 0x10}, ...)
    	/Users/kkoterba/Development/projects/splunk-operator/pkg/postgresql/database/core/events.go:46 +0x154
    github.com/splunk/splunk-operator/pkg/postgresql/database/core.PostgresDatabaseService({0x106c4d6d8, 0x106e9a020}, 0x17b3c0141c10, 0x17b3c00e6900, 0x106c05fd0)
    	/Users/kkoterba/Development/projects/splunk-operator/pkg/postgresql/database/core/database.go:106 +0x5c4
    github.com/splunk/splunk-operator/internal/controller.(*PostgresDatabaseReconciler).Reconcile(0x17b3c0141ca0, {0x106c4d6d8, 0x106e9a020}, {{{0x17b3bfe27ad0?, 0x0?}, {0x1048e959e?, 0x17b3c0141cc8?}}})
    	/Users/kkoterba/Development/projects/splunk-operator/internal/controller/postgresdatabase_controller.go:75 +0x1fc
    github.com/splunk/splunk-operator/internal/controller.reconcilePostgresDatabase({0x106c4d6d8, 0x106e9a020}, {{0x17b3bfe27ad0?, 0x1048d98e3?}, {0x1048e959e?, 0x1048e959e?}})
    	/Users/kkoterba/Development/projects/splunk-operator/internal/controller/postgresdatabase_controller_test.go:47 +0x94
    github.com/splunk/splunk-operator/internal/controller.init.func18.4.1.1()
    	/Users/kkoterba/Development/projects/splunk-operator/internal/controller/postgresdatabase_controller_test.go:405 +0x124
  < Exit [It] reconciles secrets, configmaps, roles, and CNPG databases - /Users/kkoterba/Development/projects/splunk-operator/internal/controller/postgresdatabase_controller_test.go:395 @ 03/31/26 15:57:50.858 (7ms)
  > Enter [AfterEach] PostgresDatabase Controller - /Users/kkoterba/Development/projects/splunk-operator/internal/controller/postgresdatabase_controller_test.go:359 @ 03/31/26 15:57:50.858
  < Exit [AfterEach] PostgresDatabase Controller - /Users/kkoterba/Development/projects/splunk-operator/internal/controller/postgresdatabase_controller_test.go:359 @ 03/31/26 15:57:50.859 (1ms)
• [PANICKED] [0.009 seconds]
PostgresDatabase Controller
```
It looks like the issue was in the test code itself:
```
func reconcilePostgresDatabase(ctx context.Context, nn types.NamespacedName) (ctrl.Result, error) {
	reconciler := &PostgresDatabaseReconciler{
		Client:   k8sClient,
		Scheme:   k8sClient.Scheme(),
		Recorder: record.NewFakeRecorder(100), //missing injection of fake recorder
	}
	return reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
}
```
While adding event's functionality I introduced Recorder in the Postgres<Database/Cluster>Reconciler  struct, but we haven't reflected that in our test code.

-------

```bash
------------------------------
PostgresCluster Controller
/Users/kubych/repos/splunk-operator/internal/controller/postgrescluster_controller_test.go:34
  When reconciling a resource
  /Users/kubych/repos/splunk-operator/internal/controller/postgrescluster_controller_test.go:35
    should successfully reconcile the resource
    /Users/kubych/repos/splunk-operator/internal/controller/postgrescluster_controller_test.go:70
  > Enter [BeforeEach] When reconciling a resource - /Users/kubych/repos/splunk-operator/internal/controller/postgrescluster_controller_test.go:46 @ 04/01/26 09:20:48.909
  STEP: creating the custom resource for the Kind PostgresCluster - /Users/kubych/repos/splunk-operator/internal/controller/postgrescluster_controller_test.go:47 @ 04/01/26 09:20:48.91
  [FAILED] Expected success, but got an error:
      <*errors.StatusError | 0x140020235e0>:
      PostgresCluster.enterprise.splunk.com "test-resource" is invalid: spec.class: Invalid value: "": spec.class in body should be at least 1 chars long
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "PostgresCluster.enterprise.splunk.com \"test-resource\" is invalid: spec.class: Invalid value: \"\": spec.class in body should be at least 1 chars long",
              Reason: "Invalid",
              Details: {
                  Name: "test-resource",
                  Group: "enterprise.splunk.com",
                  Kind: "PostgresCluster",
                  UID: "",
                  Causes: [
                      {
                          Type: "FieldValueInvalid",
                          Message: "Invalid value: \"\": spec.class in body should be at least 1 chars long",
                          Field: "spec.class",
                      },
                  ],
                  RetryAfterSeconds: 0,
              },
              Code: 422,
          },
      }
  In [BeforeEach] at: /Users/kubych/repos/splunk-operator/internal/controller/postgrescluster_controller_test.go:57 @ 04/01/26 09:20:48.914

  Full Stack Trace
    github.com/splunk/splunk-operator/internal/controller.init.func17.1.1()
    	/Users/kubych/repos/splunk-operator/internal/controller/postgrescluster_controller_test.go:57 +0x164
  < Exit [BeforeEach] When reconciling a resource - /Users/kubych/repos/splunk-operator/internal/controller/postgrescluster_controller_test.go:46 @ 04/01/26 09:20:48.914 (5ms)
  > Enter [AfterEach] When reconciling a resource - /Users/kubych/repos/splunk-operator/internal/controller/postgrescluster_controller_test.go:61 @ 04/01/26 09:20:48.915
  [FAILED] Unexpected error:
      <*errors.StatusError | 0x14002bcc460>:
      postgresclusters.enterprise.splunk.com "test-resource" not found
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "postgresclusters.enterprise.splunk.com \"test-resource\" not found",
              Reason: "NotFound",
              Details: {
                  Name: "test-resource",
                  Group: "enterprise.splunk.com",
                  Kind: "postgresclusters",
                  UID: "",
                  Causes: nil,
                  RetryAfterSeconds: 0,
              },
              Code: 404,
          },
      }
  occurred
  In [AfterEach] at: /Users/kubych/repos/splunk-operator/internal/controller/postgrescluster_controller_test.go:65 @ 04/01/26 09:20:48.917

  Full Stack Trace
    github.com/splunk/splunk-operator/internal/controller.init.func17.1.2()
    	/Users/kubych/repos/splunk-operator/internal/controller/postgrescluster_controller_test.go:65 +0xe0
  < Exit [AfterEach] When reconciling a resource - /Users/kubych/repos/splunk-operator/internal/controller/postgrescluster_controller_test.go:61 @ 04/01/26 09:20:48.918 (3ms)
• [FAILED] [0.008 seconds]
PostgresCluster Controller
/Users/kubych/repos/splunk-operator/internal/controller/postgrescluster_controller_test.go:34
  When reconciling a resource [BeforeEach]
  /Users/kubych/repos/splunk-operator/internal/controller/postgrescluster_controller_test.go:46
    should successfully reconcile the resource
    /Users/kubych/repos/splunk-operator/internal/controller/postgrescluster_controller_test.go:70
------------------------------
```
And fix for it is to add class name for example test provided by kubebuilder.


### Key Changes

_Highlight the updates in specific files_

### Testing and Verification

Now it's all green:
```bash
Ran 57 of 57 Specs in 205.258 seconds
SUCCESS! -- 57 Passed | 0 Failed | 0 Pending | 0 Skipped 
```

### Related Issues

_Jira tickets, GitHub issues, Support tickets..._

### PR Checklist

- [ ] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [ ] All tests pass locally.
- [ ] The PR description follows the project's guidelines.
