### PR TITLE
fix: handle app download dir stat errors

### DIFF
--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -543,21 +543,12 @@ func getBundlePushState(afwPipeline *AppInstallPipeline) enterpriseApi.BundlePus
 }
 
 // createAppDownloadDir creates the app download directory on the operator pod
-func createAppDownloadDir(ctx context.Context, path string) error {
-	reqLogger := log.FromContext(ctx)
-	scopedLog := reqLogger.WithName("createAppDownloadDir").WithValues("path", path)
+func createAppDownloadDir(_ context.Context, path string) error {
 	_, err := os.Stat(path)
 	if errors.Is(err, os.ErrNotExist) {
-		errDir := os.MkdirAll(path, 0700)
-		if errDir != nil {
-			scopedLog.Error(errDir, "Unable to create directory at path")
-			return errDir
-		}
-	} else if err != nil {
-		scopedLog.Error(err, "Unable to access path")
-		return err
+		return os.MkdirAll(path, 0700)
 	}
-	return nil
+	return err
 }
 
 // getAvailableDiskSpace returns the disk space available to download apps at volume "/opt/splunk/appframework"

--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -553,6 +553,9 @@ func createAppDownloadDir(ctx context.Context, path string) error {
 			scopedLog.Error(errDir, "Unable to create directory at path")
 			return errDir
 		}
+	} else if err != nil {
+		scopedLog.Error(err, "Unable to access path")
+		return err
 	}
 	return nil
 }

--- a/pkg/splunk/enterprise/util_test.go
+++ b/pkg/splunk/enterprise/util_test.go
@@ -22,6 +22,7 @@ import (
 
 	//"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -1196,7 +1197,13 @@ func TestCreateAppDownloadDir(t *testing.T) {
 		t.Errorf("Didn't expect error")
 	}
 
-	err = createAppDownloadDir(ctx, "/xyzzz.txt")
+	blockerFile, err := os.CreateTemp(t.TempDir(), "app-download-dir-blocker")
+	if err != nil {
+		t.Fatalf("failed to create blocker file: %v", err)
+	}
+	defer blockerFile.Close()
+
+	err = createAppDownloadDir(ctx, filepath.Join(blockerFile.Name(), "child"))
 	if err == nil {
 		t.Errorf("Expected error")
 	}


### PR DESCRIPTION
## Summary
- return non-ErrNotExist path access errors from createAppDownloadDir
- make TestCreateAppDownloadDir use a portable ENOTDIR case instead of relying on root path permissions

## Why
GitLab CI runs the unit tests inside a root-capable container, so the old test assumption that /xyzzz.txt creation must fail is not portable. The function also swallowed non-ErrNotExist stat errors, which the portable test exposes.

## Validation
- `go test ./pkg/splunk/enterprise -run TestCreateAppDownloadDir -count=1`
