### PR TITLE
docs: fix federated search resource links

### DIFF
--- a/docs/federated-search-setup.md
+++ b/docs/federated-search-setup.md
@@ -799,11 +799,11 @@ kubectl -n $NAMESPACE delete pod -l app.kubernetes.io/instance=splunk-local-shc-
 
 ## Additional Resources
 
-- [About Federated Search for Splunk](https://help.splunk.com/?resourceId=Splunk_FederatedSearch_fss2sAbout)
-- [Define a Splunk platform federated provider](https://help.splunk.com/?resourceId=Splunk_FederatedSearch_fss2sDefineProvider)
+- [About Federated Search for Splunk](https://help.splunk.com/en/splunk-enterprise/search/federated-search/9.2/run-federated-searches-across-other-splunk-deployments/about-federated-search-for-splunk)
+- [Define a Splunk platform federated provider](https://help.splunk.com/splunk-enterprise/search/federated-search/9.4/run-federated-searches-across-other-splunk-deployments/define-a-splunk-platform-federated-provider)
 - [Define roles on the Splunk platform with capabilities](https://help.splunk.com/en/splunk-enterprise/administer/manage-users-and-security/10.2/manage-splunk-platform-users-and-roles/define-roles-on-the-splunk-platform-with-capabilities)
-- [App Framework](AppFramework.html)
-- [Ingress](Ingress.html)
+- [App Framework](https://splunk.github.io/splunk-operator/AppFramework.html)
+- [Ingress](https://splunk.github.io/splunk-operator/Ingress.html)
 - [Azure Workload Identity](https://azure.github.io/azure-workload-identity/)
 
 ---

--- a/docs/federated-search-setup.md
+++ b/docs/federated-search-setup.md
@@ -799,8 +799,8 @@ kubectl -n $NAMESPACE delete pod -l app.kubernetes.io/instance=splunk-local-shc-
 
 ## Additional Resources
 
-- [About Federated Search for Splunk](https://help.splunk.com/en/splunk-enterprise/search/federated-search/9.2/run-federated-searches-across-other-splunk-deployments/about-federated-search-for-splunk)
-- [Define a Splunk platform federated provider](https://help.splunk.com/splunk-enterprise/search/federated-search/9.4/run-federated-searches-across-other-splunk-deployments/define-a-splunk-platform-federated-provider)
+- [About Federated Search for Splunk](https://help.splunk.com/en/splunk-enterprise/search/federated-search/10.2/run-federated-searches-across-other-splunk-deployments/about-federated-search-for-splunk)
+- [Define a Splunk platform federated provider](https://help.splunk.com/en/splunk-enterprise/search/federated-search/10.2/run-federated-searches-across-other-splunk-deployments/define-a-splunk-platform-federated-provider)
 - [Define roles on the Splunk platform with capabilities](https://help.splunk.com/en/splunk-enterprise/administer/manage-users-and-security/10.2/manage-splunk-platform-users-and-roles/define-roles-on-the-splunk-platform-with-capabilities)
 - [App Framework](https://splunk.github.io/splunk-operator/AppFramework.html)
 - [Ingress](https://splunk.github.io/splunk-operator/Ingress.html)


### PR DESCRIPTION
## Summary
Fix the broken Additional Resources links in `docs/federated-search-setup.md`.

## Changes
- Replace brittle `help.splunk.com/?resourceId=...` links with direct Splunk docs URLs
- Replace repo-local `AppFramework.html` and `Ingress.html` links with absolute published documentation URLs

## Testing
- Verified the updated links resolve to the intended published docs targets
