### PR TITLE
Add AFW behavioral contract regression test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -472,3 +472,52 @@ build-installer: manifests generate kustomize
 	mkdir -p dist
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default > dist/install.yaml
+
+# Temporary goal for the App Deployment team: not to break existing logic based on the Behavior Contract.
+AFW_BC_TESTS_LIST := \
+	TestHandleAppRepoChanges \
+	TestInitAndCheckAppInfoStatus \
+	TestInitAndCheckAppInfoStatusShouldFail \
+	TestHasAppRepoCheckTimerExpired \
+	TestShouldCheckAppRepoStatus \
+	TestUpdateManualAppUpdateConfigMapLocked \
+	TestSetLastAppInfoCheckTime \
+	TestCheckIfAnAppIsActiveOnRemoteStore \
+	TestGetCleanObjectDigest \
+	TestChangePhaseInfo \
+	TestSetPhaseStatusToPending \
+	TestIsPhaseStatusComplete \
+	TestValidatePhaseInfo \
+	TestIsPhaseMaxRetriesReached \
+	TestIsPhaseInfoEligibleForSchedulerEntry \
+	TestCheckIfWorkerIsEligibleForRun \
+	TestTransitionWorkerPhase \
+	TestMarkWorkerPhaseInstallationComplete \
+	TestIsFanOutApplicableToCR \
+	TestCheckIfBundlePushIsDone \
+	TestNeedToUseAuxPhaseInfo \
+	TestSetInstallSetForClusterScopedApps \
+	TestCanAppScopeHaveInstallWorker \
+	TestBundlePushStateAsStr \
+	TestGetSetBundlePushStatusString \
+	TestAppPhaseStatusAsStr \
+	TestValidateAppFramework \
+	TestRemoveStaleEntriesFromAuxPhaseInfo \
+	TestCheckAndMigrateAppDeployStatus \
+	TestAppFrameworkApplyStandaloneShouldNotFail \
+	TestAppFrameworkApplyStandaloneScalingUpShouldNotFail \
+	TestAppFrameworkApplyClusterManagerShouldNotFail \
+	TestAppFrameworkSearchHeadClusterShouldNotFail \
+	TestPerformCmBundlePush \
+	TestPushManagerAppsBundle \
+	TestStandaloneWitAppFramework
+AFW_BC_TESTS := $(subst $(space),|,$(strip $(AFW_BC_TESTS_LIST)))
+
+.PHONY: test-afw-bc
+test-afw-bc: ## Run App Framework Behavioral Contract regression tests (no cluster needed).
+	@go test \
+		./pkg/splunk/enterprise/... \
+		./pkg/splunk/enterprise/validation/... \
+		-run '$(AFW_BC_TESTS)' \
+		-v \
+		-count=1


### PR DESCRIPTION
Introduce a dedicated `test-afw-bc` Makefile target to guard against regressions in core App Framework logic. The curated test list defines the behavioral contract the App Deployment team must not break during refactoring or feature work, and runs entirely as unit tests without requiring a live cluster.

- Define AFW_BC_TESTS_LIST with all contract-critical test functions
- Build a pipe-separated regex pattern for `go test -run`
- Add `test-afw-bc` phony target targeting enterprise and validation packages

### Description

_What does this PR have in it?_

A temporary goal was added to run a set of application framework tests to help prevent breaking existing logic. After the implementation is complete, the Makefile goal should be removed.

### Key Changes

_Highlight the updates in specific files_

The temporary goal has been added to the Makefile.

### Testing and Verification

_How did you test these changes? What automated tests are added?_

The changes were tested manually; no automated tests were added.

### Related Issues

_Jira tickets, GitHub issues, Support tickets..._

https://splunk.atlassian.net/browse/SPL-296238

### PR Checklist

- [x] Code changes adhere to the project's coding standards.
- [x] Relevant unit and integration tests are included.
- [x] Documentation has been updated accordingly.
- [x] All tests pass locally.
- [x] The PR description follows the project's guidelines.
