### PR TITLE
Add documentation for Splunk General Terms in both helm charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 
 docs-preview: ## Preview documentation locally with Jekyll (requires Ruby and bundler)
 	@echo "Installing dependencies locally..."
-	@cd docs && bundle install --path vendor/bundle
+	@cd docs && bundle config set --local path vendor/bundle && bundle install
 	@echo "Starting Jekyll server for documentation preview..."
 	@cd docs && bundle exec jekyll serve --livereload
 	@echo "Documentation available at http://localhost:4000/splunk-operator"

--- a/docs/Helm.md
+++ b/docs/Helm.md
@@ -44,6 +44,8 @@ helm show values splunk/splunk-operator
 
 ### Configuring Splunk Operator deployments
 
+**Note: The `SPLUNK_GENERAL_TERMS` environment variable is set to an empty string by default. This will need to be manually updated to the required value. See [SplunkGeneralTermsMigration.md](SplunkGeneralTermsMigration.html) for instructions on how to set the variable using helm commands with both the splunk/splunk-operator and splunk/splunk-enterprise charts.**
+
 There are a couple ways you can configure your operator deployment
 
 1. Using a ```new_values.yaml``` file to override default values (Recommended)

--- a/docs/SplunkGeneralTermsMigration.md
+++ b/docs/SplunkGeneralTermsMigration.md
@@ -26,7 +26,7 @@ Existing deployments of the Splunk Operator for Kubernetes will not be affected 
 
 When you are ready to upgrade from version 1.x.x or 2.x.x to 3.0.0 or later, there are a few options you have to set the `SPLUNK_GENERAL_TERMS` to the proper value. By default, the SPLUNK_GENERAL_TERMS environment variable will be set to an empty string.
 1. Pass the `SPLUNK_GENERAL_TERMS` parameter with the [required value](index.html#splunk-general-terms-acceptance) to the `make deploy` command.
-```
+```bash
 make deploy IMG=docker.io/splunk/splunk-operator:<tag name> SPLUNK_GENERAL_TERMS="<required value>"
 ```
 2. Update the value in the Splunk Operator installation file from the [release](https://github.com/splunk/splunk-operator/releases/latest) on GitHub with the [required value](index.html#splunk-general-terms-acceptance).
@@ -49,11 +49,16 @@ make deploy IMG=docker.io/splunk/splunk-operator:<tag name> SPLUNK_GENERAL_TERMS
 ...
 ```
 3. Set the [required value](index.html#splunk-general-terms-acceptance) in a `helm install` command.
-```
+
+```bash
+# If using the splunk/splunk-operator helm chart
 helm install -f new_values.yaml --set splunkOperator.splunkGeneralTerms="<required value>" <RELEASE_NAME> splunk/splunk-operator -n <RELEASE_NAMESPACE>
+
+# If using the splunk/splunk-enterprise helm chart and deploying the operator
+helm install -f new_values.yaml --set splunk-operator.enabled=true --set splunk-operator.splunkOperator.splunkGeneralTerms="<required value>" <RELEASE_NAME> splunk/splunk-enterprise -n <RELEASE_NAMESPACE>
 ```
 4. Edit the splunk-operator-controller-manager deployment after it is deployed to include the [required value](index.html#splunk-general-terms-acceptance).
-```
+```bash
 kubectl edit deployment splunk-operator-controller-manager -n splunk-operator
 ```
 
@@ -62,7 +67,7 @@ kubectl edit deployment splunk-operator-controller-manager -n splunk-operator
 The splunk operator logs and the specific CRs will show errors if there is an issue with the SGT acknowledgement. The following examples work for any of the Custom Resources provided by the Splunk Operator.
 
 Look in the operator logs to see reconciliation errors:
-```
+```bash
 > kubectl logs <splunk-operator-controller-manager pod name> -n splunk-operator
 ...
 2025-04-24T19:26:51.669674377Z	ERROR	Reconciler error	{"controller": "searchheadcluster", "controllerGroup": "enterprise.splunk.com", "controllerKind": "SearchHeadCluster", "SearchHeadCluster": {"name":"shc","namespace":"splunk-operator"}, "namespace": "splunk-operator", "name": "shc", "reconcileID": "e2440955-3766-4b88-8e19-fc2d681763a7", "error": "license not accepted, please adjust SPLUNK_GENERAL_TERMS to indicate you have accepted the current/latest version of the license. See README file for additional information"}
@@ -70,7 +75,7 @@ Look in the operator logs to see reconciliation errors:
 ```
 
 Getting the specific CRs will also show error messages
-```
+```bash
 > kubectl get shc -n splunk-operator
 NAME   PHASE   DEPLOYER   DESIRED   READY   AGE   MESSAGE
 shc    Error   Error      3         0       22h   license not accepted, please adjust SPLUNK_GENERAL_TERMS to indicate you have accepted the current/latest version of the license. See README file for additional information


### PR DESCRIPTION
### Description

This pull request makes several documentation improvements to clarify how to set the `SPLUNK_GENERAL_TERMS` environment variable when deploying or upgrading the Splunk Operator, and updates code blocks for better formatting and usability.

### Key Changes

* Added a prominent note in `docs/Helm.md` to clarify that `SPLUNK_GENERAL_TERMS` defaults to an empty string and must be manually set, with a reference to migration instructions.
* Expanded instructions in `docs/SplunkGeneralTermsMigration.md` to cover both `splunk/splunk-operator` and `splunk/splunk-enterprise` Helm charts for setting the `SPLUNK_GENERAL_TERMS` value.

### Testing and Verification

* `make docs-preview` showed correct formatting

### Related Issues

N/A

### PR Checklist

- [ ] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [X] Documentation has been updated accordingly.
- [ ] All tests pass locally.
- [X] The PR description follows the project's guidelines.
