### PR TITLE
backport: handle app download dir stat errors in develop

### DIFF
--- a/pkg/splunk/enterprise/util.go
+++ b/pkg/splunk/enterprise/util.go
@@ -543,18 +543,12 @@ func getBundlePushState(afwPipeline *AppInstallPipeline) enterpriseApi.BundlePus
 }
 
 // createAppDownloadDir creates the app download directory on the operator pod
-func createAppDownloadDir(ctx context.Context, path string) error {
-	reqLogger := log.FromContext(ctx)
-	scopedLog := reqLogger.WithName("createAppDownloadDir").WithValues("path", path)
+func createAppDownloadDir(_ context.Context, path string) error {
 	_, err := os.Stat(path)
 	if errors.Is(err, os.ErrNotExist) {
-		errDir := os.MkdirAll(path, 0700)
-		if errDir != nil {
-			scopedLog.Error(errDir, "Unable to create directory at path")
-			return errDir
-		}
+		return os.MkdirAll(path, 0700)
 	}
-	return nil
+	return err
 }
 
 // getAvailableDiskSpace returns the disk space available to download apps at volume "/opt/splunk/appframework"

--- a/pkg/splunk/enterprise/util_test.go
+++ b/pkg/splunk/enterprise/util_test.go
@@ -22,6 +22,7 @@ import (
 
 	//"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -1196,7 +1197,13 @@ func TestCreateAppDownloadDir(t *testing.T) {
 		t.Errorf("Didn't expect error")
 	}
 
-	err = createAppDownloadDir(ctx, "/xyzzz.txt")
+	blockerFile, err := os.CreateTemp(t.TempDir(), "app-download-dir-blocker")
+	if err != nil {
+		t.Fatalf("failed to create blocker file: %v", err)
+	}
+	defer blockerFile.Close()
+
+	err = createAppDownloadDir(ctx, filepath.Join(blockerFile.Name(), "child"))
 	if err == nil {
 		t.Errorf("Expected error")
 	}


### PR DESCRIPTION
## Summary
- backport the app download dir stat error fix from main to develop
- carry the portable unit-test update with it

## Why
PR #1817 was merged to main, but develop does not yet contain the same fix. Keeping develop behind means main and develop stay inconsistent on this portability bug.

This PR intentionally backports only the #1817 fix.

## Validation
- cherry-picked only commit c3828cd00276d4f2f378d5fb39097569e7c7bb56
- GOCACHE=/tmp/go-build go test ./pkg/splunk/enterprise -run TestCreateAppDownloadDir -count=1

## Source
- main PR: #1817