### PR TITLE
Security scan fixes - gosec

### DIFF
--- a/pkg/postgresql/cluster/core/cluster.go
+++ b/pkg/postgresql/cluster/core/cluster.go
@@ -213,7 +213,11 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 	switch {
 	case apierrors.IsNotFound(err):
 		logger.Info("CNPG Cluster creation started", "name", postgresCluster.Name)
-		newCluster := buildCNPGCluster(rc.Scheme, postgresCluster, mergedConfig, postgresSecretName)
+		newCluster, err := buildCNPGCluster(rc.Scheme, postgresCluster, mergedConfig, postgresSecretName)
+		if err != nil {
+			logger.Error(err, "Failed to build CNPG Cluster", "name", postgresCluster.Name)
+			return ctrl.Result{}, err
+		}
 		if err := c.Create(ctx, newCluster); err != nil {
 			logger.Error(err, "Failed to create CNPG Cluster")
 			rc.emitWarning(postgresCluster, EventClusterCreateFailed, fmt.Sprintf("Failed to create CNPG cluster: %v", err))
@@ -560,13 +564,15 @@ func buildCNPGClusterSpec(cfg *MergedConfig, secretName string) cnpgv1.ClusterSp
 	}
 }
 
-func buildCNPGCluster(scheme *runtime.Scheme, cluster *enterprisev4.PostgresCluster, cfg *MergedConfig, secretName string) *cnpgv1.Cluster {
+func buildCNPGCluster(scheme *runtime.Scheme, cluster *enterprisev4.PostgresCluster, cfg *MergedConfig, secretName string) (*cnpgv1.Cluster, error) {
 	cnpg := &cnpgv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{Name: cluster.Name, Namespace: cluster.Namespace},
 		Spec:       buildCNPGClusterSpec(cfg, secretName),
 	}
-	ctrl.SetControllerReference(cluster, cnpg, scheme)
-	return cnpg
+	if err := ctrl.SetControllerReference(cluster, cnpg, scheme); err != nil {
+		return nil, fmt.Errorf("setting controller reference on CNPG cluster: %w", err)
+	}
+	return cnpg, nil
 }
 
 func normalizeCNPGClusterSpec(spec cnpgv1.ClusterSpec, customDefinedParameters map[string]string) normalizedCNPGClusterSpec {
@@ -705,10 +711,14 @@ func createConnectionPooler(ctx context.Context, c client.Client, scheme *runtim
 		return err
 	}
 	logger.Info("CNPG Pooler creation started", "name", poolerName, "type", poolerType)
-	return c.Create(ctx, buildCNPGPooler(scheme, cluster, cfg, cnpgCluster, poolerType))
+	pooler, err := buildCNPGPooler(scheme, cluster, cfg, cnpgCluster, poolerType)
+	if err != nil {
+		return err
+	}
+	return c.Create(ctx, pooler)
 }
 
-func buildCNPGPooler(scheme *runtime.Scheme, cluster *enterprisev4.PostgresCluster, cfg *MergedConfig, cnpgCluster *cnpgv1.Cluster, poolerType string) *cnpgv1.Pooler {
+func buildCNPGPooler(scheme *runtime.Scheme, cluster *enterprisev4.PostgresCluster, cfg *MergedConfig, cnpgCluster *cnpgv1.Cluster, poolerType string) (*cnpgv1.Pooler, error) {
 	pc := cfg.CNPG.ConnectionPooler
 	instances := *pc.Instances
 	mode := cnpgv1.PgBouncerPoolMode(*pc.Mode)
@@ -724,8 +734,10 @@ func buildCNPGPooler(scheme *runtime.Scheme, cluster *enterprisev4.PostgresClust
 			},
 		},
 	}
-	ctrl.SetControllerReference(cluster, pooler, scheme)
-	return pooler
+	if err := ctrl.SetControllerReference(cluster, pooler, scheme); err != nil {
+		return nil, fmt.Errorf("setting controller reference on CNPG pooler: %w", err)
+	}
+	return pooler, nil
 }
 
 // deleteConnectionPoolers removes RW and RO poolers if they exist.

--- a/pkg/postgresql/cluster/core/cluster_unit_test.go
+++ b/pkg/postgresql/cluster/core/cluster_unit_test.go
@@ -403,8 +403,9 @@ func TestBuildCNPGPooler(t *testing.T) {
 	}
 
 	t.Run("rw pooler", func(t *testing.T) {
-		pooler := buildCNPGPooler(scheme, postgresCluster, cfg, cnpgCluster, "rw")
+		pooler, err := buildCNPGPooler(scheme, postgresCluster, cfg, cnpgCluster, "rw")
 
+		require.NoError(t, err)
 		assert.Equal(t, "my-cluster-pooler-rw", pooler.Name)
 		assert.Equal(t, "db-ns", pooler.Namespace)
 		assert.Equal(t, "my-cluster", pooler.Spec.Cluster.Name)
@@ -418,8 +419,9 @@ func TestBuildCNPGPooler(t *testing.T) {
 	})
 
 	t.Run("ro pooler", func(t *testing.T) {
-		pooler := buildCNPGPooler(scheme, postgresCluster, cfg, cnpgCluster, "ro")
+		pooler, err := buildCNPGPooler(scheme, postgresCluster, cfg, cnpgCluster, "ro")
 
+		require.NoError(t, err)
 		assert.Equal(t, "my-cluster-pooler-ro", pooler.Name)
 		assert.Equal(t, cnpgv1.PoolerType("ro"), pooler.Spec.Type)
 	})
@@ -451,8 +453,9 @@ func TestBuildCNPGCluster(t *testing.T) {
 		},
 	}
 
-	cluster := buildCNPGCluster(scheme, postgresCluster, cfg, "my-secret")
+	cluster, err := buildCNPGCluster(scheme, postgresCluster, cfg, "my-secret")
 
+	require.NoError(t, err)
 	assert.Equal(t, "my-cluster", cluster.Name)
 	assert.Equal(t, "db-ns", cluster.Namespace)
 	require.Len(t, cluster.OwnerReferences, 1)


### PR DESCRIPTION
### Description

Handle previously ignored error return values from ctrl.SetControllerReference in the PostgreSQL cluster builder functions, flagged by gosec (G104 / CWE-703).

### Key Changes

- `pkg/postgresql/cluster/core/cluster.go`: `buildCNPGCluster` and `buildCNPGPooler` now return error, propagating `SetControllerReference` failures to callers. Updated call sites at the reconciler level (Reconcile) and `createConnectionPooler` to handle the new error.
- `pkg/postgresql/cluster/core/cluster_unit_test.go`: Updated tests for `TestBuildCNPGCluster`, `TestBuildCNPGPooler/rw_pooler`, and `TestBuildCNPGPooler/ro_pooler` to assert no error on the new return signature.

### Testing and Verification

- All existing unit tests pass (go test ./pkg/postgresql/cluster/core/ -v)
- gosec no longer reports G104 on cluster.go:567 and cluster.go:726

### Related Issues

CPI-1859

### PR Checklist

- [ ] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [ ] All tests pass locally.
- [ ] The PR description follows the project's guidelines.
