### PR TITLE
Fix concurrency conflict handling in PostgreSQL controllers                                                                                                    

### DIFF
--- a/internal/controller/postgrescluster_controller.go
+++ b/internal/controller/postgrescluster_controller.go
@@ -22,8 +22,9 @@ import (
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	enterprisev4 "github.com/splunk/splunk-operator/api/v4"
 	clustercore "github.com/splunk/splunk-operator/pkg/postgresql/cluster/core"
-	"github.com/splunk/splunk-operator/pkg/postgresql/shared/ports"
 	pgprometheus "github.com/splunk/splunk-operator/pkg/postgresql/shared/adapter/prometheus"
+	"github.com/splunk/splunk-operator/pkg/postgresql/shared/ports"
+	sharedreconcile "github.com/splunk/splunk-operator/pkg/postgresql/shared/reconcile"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,6 +65,9 @@ func (r *PostgresClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	rc := &clustercore.ReconcileContext{Client: r.Client, Scheme: r.Scheme, Recorder: r.Recorder, Metrics: r.Metrics}
 	result, err := clustercore.PostgresClusterService(ctx, rc, req)
 	r.FleetCollector.CollectClusterMetrics(ctx, r.Client, r.Metrics)
+	if sharedreconcile.IsPureConflict(err) {
+		return ctrl.Result{Requeue: true}, nil
+	}
 	return result, err
 }
 

--- a/internal/controller/postgrescluster_controller_test.go
+++ b/internal/controller/postgrescluster_controller_test.go
@@ -36,6 +36,7 @@ import (
 
 	enterprisev4 "github.com/splunk/splunk-operator/api/v4"
 	"github.com/splunk/splunk-operator/pkg/postgresql/cluster/core"
+	pgprometheus "github.com/splunk/splunk-operator/pkg/postgresql/shared/adapter/prometheus"
 )
 
 /*
@@ -122,9 +123,11 @@ var _ = Describe("PostgresCluster Controller", Label("postgres"), func() {
 		}
 
 		reconciler = &PostgresClusterReconciler{
-			Client:   k8sClient,
-			Scheme:   k8sClient.Scheme(),
-			Recorder: record.NewFakeRecorder(100),
+			Client:         k8sClient,
+			Scheme:         k8sClient.Scheme(),
+			Recorder:       record.NewFakeRecorder(100),
+			Metrics:        &pgprometheus.NoopRecorder{},
+			FleetCollector: pgprometheus.NewFleetCollector(),
 		}
 		req = reconcile.Request{NamespacedName: types.NamespacedName{Name: clusterName, Namespace: namespace}}
 	})

--- a/internal/controller/postgresdatabase_controller.go
+++ b/internal/controller/postgresdatabase_controller.go
@@ -24,8 +24,9 @@ import (
 	enterprisev4 "github.com/splunk/splunk-operator/api/v4"
 	dbadapter "github.com/splunk/splunk-operator/pkg/postgresql/database/adapter"
 	dbcore "github.com/splunk/splunk-operator/pkg/postgresql/database/core"
-	"github.com/splunk/splunk-operator/pkg/postgresql/shared/ports"
 	pgprometheus "github.com/splunk/splunk-operator/pkg/postgresql/shared/adapter/prometheus"
+	"github.com/splunk/splunk-operator/pkg/postgresql/shared/ports"
+	sharedreconcile "github.com/splunk/splunk-operator/pkg/postgresql/shared/reconcile"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -78,7 +79,9 @@ func (r *PostgresDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	rc := &dbcore.ReconcileContext{Client: r.Client, Scheme: r.Scheme, Recorder: r.Recorder, Metrics: r.Metrics}
 	result, err := dbcore.PostgresDatabaseService(ctx, rc, postgresDB, dbadapter.NewDBRepository)
 	r.FleetCollector.CollectDatabaseMetrics(ctx, r.Client, r.Metrics)
-
+	if sharedreconcile.IsPureConflict(err) {
+		return ctrl.Result{Requeue: true}, nil
+	}
 	return result, err
 }
 

--- a/internal/controller/postgresdatabase_controller_test.go
+++ b/internal/controller/postgresdatabase_controller_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	enterprisev4 "github.com/splunk/splunk-operator/api/v4"
+	pgprometheus "github.com/splunk/splunk-operator/pkg/postgresql/shared/adapter/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -80,9 +81,11 @@ const (
 
 func reconcilePostgresDatabase(ctx context.Context, nn types.NamespacedName) (ctrl.Result, error) {
 	reconciler := &PostgresDatabaseReconciler{
-		Client:   k8sClient,
-		Scheme:   k8sClient.Scheme(),
-		Recorder: record.NewFakeRecorder(100),
+		Client:         k8sClient,
+		Scheme:         k8sClient.Scheme(),
+		Recorder:       record.NewFakeRecorder(100),
+		Metrics:        &pgprometheus.NoopRecorder{},
+		FleetCollector: pgprometheus.NewFleetCollector(),
 	}
 	return reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
 }

--- a/pkg/postgresql/cluster/core/cluster.go
+++ b/pkg/postgresql/cluster/core/cluster.go
@@ -79,13 +79,9 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 		}
 		logger.Error(err, "Failed to handle finalizer")
 		rc.emitWarning(postgresCluster, EventCleanupFailed, fmt.Sprintf("Cleanup failed: %v", err))
-		errs := []error{err}
-		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterDeleteFailed,
-			fmt.Sprintf("Failed to delete resources during cleanup: %v", err), failedClusterPhase); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
-			errs = append(errs, statusErr)
-		}
-		return ctrl.Result{}, errors.Join(errs...)
+		statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterDeleteFailed,
+			fmt.Sprintf("Failed to delete resources during cleanup: %v", err), failedClusterPhase)
+		return ctrl.Result{}, errors.Join(err, statusErr)
 	}
 	if postgresCluster.GetDeletionTimestamp() != nil {
 		logger.Info("Deletion cleanup complete, finalizer removed")
@@ -96,10 +92,6 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 	if !controllerutil.ContainsFinalizer(postgresCluster, PostgresClusterFinalizerName) {
 		controllerutil.AddFinalizer(postgresCluster, PostgresClusterFinalizerName)
 		if err := c.Update(ctx, postgresCluster); err != nil {
-			if apierrors.IsConflict(err) {
-				logger.Info("Conflict while adding finalizer, will requeue")
-				return ctrl.Result{Requeue: true}, nil
-			}
 			logger.Error(err, "Failed to add finalizer to PostgresCluster")
 			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 		}
@@ -112,11 +104,9 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 	if err := c.Get(ctx, client.ObjectKey{Name: postgresCluster.Spec.Class}, clusterClass); err != nil {
 		logger.Error(err, "Failed to fetch PostgresClusterClass", "className", postgresCluster.Spec.Class)
 		rc.emitWarning(postgresCluster, EventClusterClassNotFound, fmt.Sprintf("ClusterClass %s not found", postgresCluster.Spec.Class))
-		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterClassNotFound,
-			fmt.Sprintf("ClusterClass %s not found: %v", postgresCluster.Spec.Class, err), failedClusterPhase); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
-		}
-		return ctrl.Result{}, err
+		statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterClassNotFound,
+			fmt.Sprintf("ClusterClass %s not found: %v", postgresCluster.Spec.Class, err), failedClusterPhase)
+		return ctrl.Result{}, errors.Join(err, statusErr)
 	}
 
 	// Merge PostgresClusterSpec on top of PostgresClusterClass defaults.
@@ -124,11 +114,9 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 	if err != nil {
 		logger.Error(err, "Failed to merge PostgresCluster configuration")
 		rc.emitWarning(postgresCluster, EventConfigMergeFailed, fmt.Sprintf("Failed to merge configuration: %v", err))
-		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonInvalidConfiguration,
-			fmt.Sprintf("Failed to merge configuration: %v", err), failedClusterPhase); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
-		}
-		return ctrl.Result{}, err
+		statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonInvalidConfiguration,
+			fmt.Sprintf("Failed to merge configuration: %v", err), failedClusterPhase)
+		return ctrl.Result{}, errors.Join(err, statusErr)
 	}
 
 	// Resolve or derive the superuser secret name.
@@ -144,28 +132,20 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 	if secretErr != nil {
 		logger.Error(secretErr, "Failed to check if PostgresCluster secret exists", "name", postgresSecretName)
 		rc.emitWarning(postgresCluster, EventSecretReconcileFailed, fmt.Sprintf("Failed to check secret existence: %v", secretErr))
-		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonUserSecretFailed,
-			fmt.Sprintf("Failed to check secret existence: %v", secretErr), failedClusterPhase); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
-		}
-		return ctrl.Result{}, secretErr
+		statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonUserSecretFailed,
+			fmt.Sprintf("Failed to check secret existence: %v", secretErr), failedClusterPhase)
+		return ctrl.Result{}, errors.Join(secretErr, statusErr)
 	}
 	if !secretExists {
 		logger.Info("Superuser secret creation started", "name", postgresSecretName)
 		if err := ensureClusterSecret(ctx, c, rc.Scheme, postgresCluster, postgresSecretName, secret); err != nil {
 			logger.Error(err, "Failed to ensure PostgresCluster secret", "name", postgresSecretName)
 			rc.emitWarning(postgresCluster, EventSecretReconcileFailed, fmt.Sprintf("Failed to generate cluster secret: %v", err))
-			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonUserSecretFailed,
-				fmt.Sprintf("Failed to generate PostgresCluster secret: %v", err), failedClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
-			return ctrl.Result{}, err
+			statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonUserSecretFailed,
+				fmt.Sprintf("Failed to generate PostgresCluster secret: %v", err), failedClusterPhase)
+			return ctrl.Result{}, errors.Join(err, statusErr)
 		}
 		if err := c.Status().Update(ctx, postgresCluster); err != nil {
-			if apierrors.IsConflict(err) {
-				logger.Info("Conflict after secret creation, will requeue")
-				return ctrl.Result{Requeue: true}, nil
-			}
 			logger.Error(err, "Failed to update status after secret creation")
 			return ctrl.Result{}, err
 		}
@@ -189,11 +169,9 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 		if err := patchObject(ctx, c, originalSecret, secret, "Secret"); err != nil {
 			logger.Error(err, "Failed to patch existing secret with controller reference")
 			rc.emitWarning(postgresCluster, EventSecretReconcileFailed, fmt.Sprintf("Failed to patch existing secret: %v", err))
-			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonSuperUserSecretFailed,
-				fmt.Sprintf("Failed to patch existing secret: %v", err), failedClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
-			return ctrl.Result{}, err
+			statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonSuperUserSecretFailed,
+				fmt.Sprintf("Failed to patch existing secret: %v", err), failedClusterPhase)
+			return ctrl.Result{}, errors.Join(err, statusErr)
 		}
 	}
 
@@ -217,26 +195,22 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 		if err := c.Create(ctx, newCluster); err != nil {
 			logger.Error(err, "Failed to create CNPG Cluster")
 			rc.emitWarning(postgresCluster, EventClusterCreateFailed, fmt.Sprintf("Failed to create CNPG cluster: %v", err))
-			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterBuildFailed,
-				fmt.Sprintf("Failed to create CNPG Cluster: %v", err), failedClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
-			return ctrl.Result{}, err
+			statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterBuildFailed,
+				fmt.Sprintf("Failed to create CNPG Cluster: %v", err), failedClusterPhase)
+			return ctrl.Result{}, errors.Join(err, statusErr)
 		}
 		rc.emitNormal(postgresCluster, EventClusterCreationStarted, "CNPG cluster created, waiting for healthy state")
 		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterBuildSucceeded,
 			"CNPG Cluster created", pendingClusterPhase); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
+			return ctrl.Result{}, statusErr
 		}
 		logger.Info("CNPG Cluster created, requeueing for status update", "name", postgresCluster.Name)
 		return ctrl.Result{RequeueAfter: retryDelay}, nil
 	case err != nil:
 		logger.Error(err, "Failed to get CNPG Cluster")
-		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterGetFailed,
-			fmt.Sprintf("Failed to get CNPG Cluster: %v", err), failedClusterPhase); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
-		}
-		return ctrl.Result{}, err
+		statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterGetFailed,
+			fmt.Sprintf("Failed to get CNPG Cluster: %v", err), failedClusterPhase)
+		return ctrl.Result{}, errors.Join(err, statusErr)
 	}
 
 	// Patch CNPG Cluster spec if drift detected.
@@ -250,22 +224,16 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 		cnpgCluster.Spec = desiredSpec
 
 		switch patchErr := patchObject(ctx, c, originalCluster, cnpgCluster, "CNPGCluster"); {
-		case apierrors.IsConflict(patchErr):
-			logger.Info("Conflict occurred while updating CNPG Cluster, requeueing", "name", cnpgCluster.Name)
-			return ctrl.Result{Requeue: true}, nil
 		case patchErr != nil:
 			logger.Error(patchErr, "Failed to patch CNPG Cluster", "name", cnpgCluster.Name)
 			rc.emitWarning(postgresCluster, EventClusterUpdateFailed, fmt.Sprintf("Failed to patch CNPG cluster: %v", patchErr))
-			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterPatchFailed,
-				fmt.Sprintf("Failed to patch CNPG Cluster: %v", patchErr), failedClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
-			return ctrl.Result{}, patchErr
+			statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterPatchFailed,
+				fmt.Sprintf("Failed to patch CNPG Cluster: %v", patchErr), failedClusterPhase)
+			return ctrl.Result{}, errors.Join(patchErr, statusErr)
 		default:
 			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonClusterBuildSucceeded,
 				"CNPG Cluster spec updated, waiting for healthy state", provisioningClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status after patch")
-				return ctrl.Result{Requeue: true}, nil
+				return ctrl.Result{}, statusErr
 			}
 			rc.emitNormal(postgresCluster, EventClusterUpdateStarted, "CNPG cluster spec updated, waiting for healthy state")
 			logger.Info("CNPG Cluster patched, requeueing for status update", "name", cnpgCluster.Name)
@@ -277,11 +245,9 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 	if err := reconcileManagedRoles(ctx, c, postgresCluster, cnpgCluster); err != nil {
 		logger.Error(err, "Failed to reconcile managed roles")
 		rc.emitWarning(postgresCluster, EventManagedRolesFailed, fmt.Sprintf("Failed to reconcile managed roles: %v", err))
-		if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonManagedRolesFailed,
-			fmt.Sprintf("Failed to reconcile managed roles: %v", err), failedClusterPhase); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
-		}
-		return ctrl.Result{}, err
+		statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonManagedRolesFailed,
+			fmt.Sprintf("Failed to reconcile managed roles: %v", err), failedClusterPhase)
+		return ctrl.Result{}, errors.Join(err, statusErr)
 	}
 
 	// Reconcile Connection Pooler.
@@ -290,35 +256,25 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 	rwPoolerExists, err := poolerExists(ctx, c, postgresCluster, readWriteEndpoint)
 	if err != nil {
 		logger.Error(err, "Failed to check RW pooler existence")
-		errs := []error{err}
-		if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerReconciliationFailed,
-			fmt.Sprintf("Failed to check pooler existence: %v", err), failedClusterPhase); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
-			errs = append(errs, statusErr)
-		}
-		return ctrl.Result{}, errors.Join(errs...)
+		statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerReconciliationFailed,
+			fmt.Sprintf("Failed to check pooler existence: %v", err), failedClusterPhase)
+		return ctrl.Result{}, errors.Join(err, statusErr)
 	}
 	roPoolerExists, err := poolerExists(ctx, c, postgresCluster, readOnlyEndpoint)
 	if err != nil {
 		logger.Error(err, "Failed to check RO pooler existence")
-		errs := []error{err}
-		if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerReconciliationFailed,
-			fmt.Sprintf("Failed to check pooler existence: %v", err), failedClusterPhase); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
-			errs = append(errs, statusErr)
-		}
-		return ctrl.Result{}, errors.Join(errs...)
+		statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerReconciliationFailed,
+			fmt.Sprintf("Failed to check pooler existence: %v", err), failedClusterPhase)
+		return ctrl.Result{}, errors.Join(err, statusErr)
 	}
 
 	switch {
 	case !poolerEnabled:
 		if err := deleteConnectionPoolers(ctx, c, postgresCluster); err != nil {
 			logger.Error(err, "Failed to delete connection poolers")
-			if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerReconciliationFailed,
-				fmt.Sprintf("Failed to delete connection poolers: %v", err), failedClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
-			return ctrl.Result{}, err
+			statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerReconciliationFailed,
+				fmt.Sprintf("Failed to delete connection poolers: %v", err), failedClusterPhase)
+			return ctrl.Result{}, errors.Join(err, statusErr)
 		}
 		postgresCluster.Status.ConnectionPoolerStatus = nil
 		meta.RemoveStatusCondition(&postgresCluster.Status.Conditions, string(poolerReady))
@@ -327,35 +283,29 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 		if mergedConfig.CNPG == nil || mergedConfig.CNPG.ConnectionPooler == nil {
 			logger.Info("Connection pooler enabled but no config found in class or cluster spec, skipping",
 				"class", postgresCluster.Spec.Class, "cluster", postgresCluster.Name)
-			if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerConfigMissing,
+			statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerConfigMissing,
 				fmt.Sprintf("Connection pooler is enabled but no config found in class %q or cluster %q",
-					postgresCluster.Spec.Class, postgresCluster.Name), failedClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
-			return ctrl.Result{}, nil
+					postgresCluster.Spec.Class, postgresCluster.Name), failedClusterPhase)
+			return ctrl.Result{}, statusErr
 		}
 		if cnpgCluster.Status.Phase != cnpgv1.PhaseHealthy {
 			logger.Info("CNPG Cluster not healthy yet, pending pooler creation", "clusterPhase", cnpgCluster.Status.Phase)
-			if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonCNPGClusterNotHealthy,
-				"Waiting for CNPG cluster to become healthy before creating poolers", pendingClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
-			return ctrl.Result{RequeueAfter: retryDelay}, nil
+			statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonCNPGClusterNotHealthy,
+				"Waiting for CNPG cluster to become healthy before creating poolers", pendingClusterPhase)
+			return ctrl.Result{RequeueAfter: retryDelay}, statusErr
 		}
 		if err := createOrUpdateConnectionPoolers(ctx, c, rc.Scheme, postgresCluster, mergedConfig, cnpgCluster); err != nil {
 			logger.Error(err, "Failed to reconcile connection pooler")
 			rc.emitWarning(postgresCluster, EventPoolerReconcileFailed, fmt.Sprintf("Failed to reconcile connection pooler: %v", err))
-			if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerReconciliationFailed,
-				fmt.Sprintf("Failed to reconcile connection pooler: %v", err), failedClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
-			return ctrl.Result{}, err
+			statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerReconciliationFailed,
+				fmt.Sprintf("Failed to reconcile connection pooler: %v", err), failedClusterPhase)
+			return ctrl.Result{}, errors.Join(err, statusErr)
 		}
 		rc.emitNormal(postgresCluster, EventPoolerCreationStarted, "Connection poolers created, waiting for readiness")
 		logger.Info("Connection pooler creation started, requeueing")
 		if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerCreating,
 			"Connection poolers are being provisioned", provisioningClusterPhase); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
+			return ctrl.Result{}, statusErr
 		}
 		return ctrl.Result{RequeueAfter: retryDelay}, nil
 
@@ -373,14 +323,9 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 		return rwErr != nil || roErr != nil || !arePoolersReady(rwPooler, roPooler)
 	}():
 		logger.Info("Connection Poolers are not ready yet, requeueing")
-		if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerCreating,
-			"Connection poolers are being provisioned", pendingClusterPhase); statusErr != nil {
-			if apierrors.IsConflict(statusErr) {
-				logger.Info("Conflict updating pooler status, will requeue")
-				return ctrl.Result{Requeue: true}, nil
-			}
-		}
-		return ctrl.Result{RequeueAfter: retryDelay}, nil
+		statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerCreating,
+			"Connection poolers are being provisioned", pendingClusterPhase)
+		return ctrl.Result{RequeueAfter: retryDelay}, statusErr
 
 	default:
 		oldConditions := make([]metav1.Condition, len(postgresCluster.Status.Conditions))
@@ -388,11 +333,9 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 		if err := syncPoolerStatus(ctx, c, rc.Metrics, postgresCluster); err != nil {
 			logger.Error(err, "Failed to sync pooler status")
 			rc.emitWarning(postgresCluster, EventPoolerReconcileFailed, fmt.Sprintf("Failed to sync pooler status: %v", err))
-			if statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerReconciliationFailed,
-				fmt.Sprintf("Failed to sync pooler status: %v", err), failedClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
-			return ctrl.Result{}, err
+			statusErr := updateStatus(poolerReady, metav1.ConditionFalse, reasonPoolerReconciliationFailed,
+				fmt.Sprintf("Failed to sync pooler status: %v", err), failedClusterPhase)
+			return ctrl.Result{}, errors.Join(err, statusErr)
 		}
 		rc.emitPoolerReadyTransition(postgresCluster, oldConditions)
 	}
@@ -404,11 +347,9 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 		if err != nil {
 			logger.Error(err, "Failed to generate ConfigMap")
 			rc.emitWarning(postgresCluster, EventConfigMapReconcileFailed, fmt.Sprintf("Failed to reconcile ConfigMap: %v", err))
-			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonConfigMapFailed,
-				fmt.Sprintf("Failed to generate ConfigMap: %v", err), failedClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
-			return ctrl.Result{}, err
+			statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonConfigMapFailed,
+				fmt.Sprintf("Failed to generate ConfigMap: %v", err), failedClusterPhase)
+			return ctrl.Result{}, errors.Join(err, statusErr)
 		}
 		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: desiredCM.Name, Namespace: desiredCM.Namespace}}
 		createOrUpdateResult, err := controllerutil.CreateOrUpdate(ctx, c, cm, func() error {
@@ -425,11 +366,9 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 		if err != nil {
 			logger.Error(err, "Failed to reconcile ConfigMap", "name", desiredCM.Name)
 			rc.emitWarning(postgresCluster, EventConfigMapReconcileFailed, fmt.Sprintf("Failed to reconcile ConfigMap: %v", err))
-			if statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonConfigMapFailed,
-				fmt.Sprintf("Failed to reconcile ConfigMap: %v", err), failedClusterPhase); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status")
-			}
-			return ctrl.Result{}, err
+			statusErr := updateStatus(clusterReady, metav1.ConditionFalse, reasonConfigMapFailed,
+				fmt.Sprintf("Failed to reconcile ConfigMap: %v", err), failedClusterPhase)
+			return ctrl.Result{}, errors.Join(err, statusErr)
 		}
 		switch createOrUpdateResult {
 		case controllerutil.OperationResultCreated:
@@ -453,11 +392,7 @@ func PostgresClusterService(ctx context.Context, rc *ReconcileContext, req ctrl.
 	}
 	if err := syncStatus(ctx, c, rc.Metrics, postgresCluster, cnpgCluster); err != nil {
 		logger.Error(err, "Failed to sync status")
-		if apierrors.IsConflict(err) {
-			logger.Info("Conflict during status update, will requeue")
-			return ctrl.Result{Requeue: true}, nil
-		}
-		return ctrl.Result{}, fmt.Errorf("failed to sync status: %w", err)
+		return ctrl.Result{}, err
 	}
 	var newPhase string
 	if postgresCluster.Status.Phase != nil {

--- a/pkg/postgresql/database/core/database.go
+++ b/pkg/postgresql/database/core/database.go
@@ -60,10 +60,6 @@ func PostgresDatabaseService(
 	if !controllerutil.ContainsFinalizer(postgresDB, postgresDatabaseFinalizerName) {
 		controllerutil.AddFinalizer(postgresDB, postgresDatabaseFinalizerName)
 		if err := c.Update(ctx, postgresDB); err != nil {
-			if errors.IsConflict(err) {
-				logger.Info("Conflict while adding finalizer, will requeue")
-				return ctrl.Result{Requeue: true}, nil
-			}
 			logger.Error(err, "Failed to add finalizer to PostgresDatabase")
 			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 		}
@@ -304,9 +300,6 @@ func PostgresDatabaseService(
 	postgresDB.Status.ObservedGeneration = &postgresDB.Generation
 
 	if err := c.Status().Update(ctx, postgresDB); err != nil {
-		if errors.IsConflict(err) {
-			return ctrl.Result{Requeue: true}, nil
-		}
 		return ctrl.Result{}, fmt.Errorf("failed to persist final status: %w", err)
 	}
 

--- a/pkg/postgresql/database/core/database_unit_test.go
+++ b/pkg/postgresql/database/core/database_unit_test.go
@@ -1425,12 +1425,11 @@ func TestFindRemovedRoleNames(t *testing.T) {
 	}
 }
 
-
 func TestBuildRolesToRemove(t *testing.T) {
 	tests := []struct {
-		name     string
-		deleted  []enterprisev4.DatabaseDefinition
-		want     []enterprisev4.ManagedRole
+		name    string
+		deleted []enterprisev4.DatabaseDefinition
+		want    []enterprisev4.ManagedRole
 	}{
 		{
 			name:    "nothing to remove",
@@ -1458,7 +1457,6 @@ func TestBuildRolesToRemove(t *testing.T) {
 		})
 	}
 }
-
 
 func TestStripOwnerReference(t *testing.T) {
 	obj := &corev1.ConfigMap{

--- a/pkg/postgresql/database/core/types.go
+++ b/pkg/postgresql/database/core/types.go
@@ -34,7 +34,7 @@ const (
 
 	deletionPolicyRetain string = "Retain"
 	deletionPolicyDelete string = "Delete"
-	
+
 	postgresDatabaseFinalizerName string = "postgresdatabases.enterprise.splunk.com/finalizer"
 	annotationRetainedFrom        string = "enterprise.splunk.com/retained-from"
 
@@ -79,10 +79,10 @@ const (
 	reasonUsersAvailable           conditionReasons = "UsersAvailable"
 	reasonRoleConflict             conditionReasons = "RoleConflict"
 	reasonConfigMapsCreationFailed conditionReasons = "ConfigMapsCreationFailed"
-	reasonConfigMapsCreated         conditionReasons = "ConfigMapsCreated"
-	reasonDatabaseReconcileFailed   conditionReasons = "DatabaseReconcileFailed"
-	reasonPrivilegesGranted         conditionReasons = "PrivilegesGranted"
-	reasonPrivilegesGrantFailed     conditionReasons = "PrivilegesGrantFailed"
+	reasonConfigMapsCreated        conditionReasons = "ConfigMapsCreated"
+	reasonDatabaseReconcileFailed  conditionReasons = "DatabaseReconcileFailed"
+	reasonPrivilegesGranted        conditionReasons = "PrivilegesGranted"
+	reasonPrivilegesGrantFailed    conditionReasons = "PrivilegesGrantFailed"
 
 	// ClusterReady sentinel values returned by ensureClusterReady.
 	// Exported so the controller adapter can switch on them if needed.

--- a/pkg/postgresql/shared/reconcile/errors.go
+++ b/pkg/postgresql/shared/reconcile/errors.go
@@ -24,19 +24,18 @@ import (
 // within it is a 409 Conflict. When a business error and a status-write
 // conflict are joined together the business error takes priority and this
 // returns false, preserving exponential backoff for real failures.
-//
-// TODO(human): implement this function.
-// Guidance: errors.Join wraps multiple errors; use the Unwrap() []error
-// interface to walk all joined errors. Consider all four cases:
-//   - err == nil                      → false
-//   - single conflict error           → true
-//   - single non-conflict error       → false
-//   - joined errors, mixed conflict   → false (business error wins)
 func IsPureConflict(err error) bool {
 	if err == nil {
 		return false
 	}
-	_ = apierrors.IsConflict // ensure the import is used once implemented
-	// TODO(human): replace this placeholder with the real implementation
-	return false
+	// check if err can be unwrapped
+	if wrappedErrs, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, err := range wrappedErrs.Unwrap() {
+			if !apierrors.IsConflict(err) {
+				return false
+			}
+		}
+		return true
+	}
+	return apierrors.IsConflict(err)
 }

--- a/pkg/postgresql/shared/reconcile/errors.go
+++ b/pkg/postgresql/shared/reconcile/errors.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcile
+
+import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// IsPureConflict reports whether err is non-nil and every non-nil error
+// within it is a 409 Conflict. When a business error and a status-write
+// conflict are joined together the business error takes priority and this
+// returns false, preserving exponential backoff for real failures.
+//
+// TODO(human): implement this function.
+// Guidance: errors.Join wraps multiple errors; use the Unwrap() []error
+// interface to walk all joined errors. Consider all four cases:
+//   - err == nil                      → false
+//   - single conflict error           → true
+//   - single non-conflict error       → false
+//   - joined errors, mixed conflict   → false (business error wins)
+func IsPureConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	_ = apierrors.IsConflict // ensure the import is used once implemented
+	// TODO(human): replace this placeholder with the real implementation
+	return false
+}

--- a/pkg/postgresql/shared/reconcile/errors_test.go
+++ b/pkg/postgresql/shared/reconcile/errors_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcile
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var conflictErr = apierrors.NewConflict(schema.GroupResource{Group: "enterprise.splunk.com", Resource: "postgresclusters"}, "my-cluster", fmt.Errorf("rv mismatch"))
+var businessErr = fmt.Errorf("failed to fetch ClusterClass")
+
+func TestIsPureConflict(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "single conflict error",
+			err:      conflictErr,
+			expected: true,
+		},
+		{
+			name:     "single non-conflict error",
+			err:      businessErr,
+			expected: false,
+		},
+		{
+			name:     "wrapped non-conflict error (fmt.Errorf %w)",
+			err:      fmt.Errorf("reconcile failed: %w", businessErr),
+			expected: false,
+		},
+		{
+			name:     "joined: business + conflict — business wins",
+			err:      errors.Join(businessErr, conflictErr),
+			expected: false,
+		},
+		{
+			name:     "joined: conflict + business — business wins regardless of order",
+			err:      errors.Join(conflictErr, businessErr),
+			expected: false,
+		},
+		{
+			name:     "joined: two conflict errors",
+			err:      errors.Join(conflictErr, conflictErr),
+			expected: true,
+		},
+		{
+			name:     "joined: single conflict (nil partner discarded by errors.Join)",
+			err:      errors.Join(conflictErr, nil),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsPureConflict(tt.err)
+			if got != tt.expected {
+				t.Errorf("IsPureConflict(%v) = %v, want %v", tt.err, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description                                                                                                                                                
                  
  - Centralises 409 Conflict handling at the reconciler boundary (`Reconcile`) for both `PostgresClusterReconciler` and `PostgresDatabaseReconciler`, removing   
  all inline `apierrors.IsConflict` checks from the core service layer (`cluster.go`, `database.go`)
  - Introduces `IsPureConflict(err error) bool` in `pkg/postgresql/shared/reconcile` — returns `true` only when every error in the joined error tree is a 409    
  Conflict, preserving exponential backoff when a real business error is joined alongside a status write conflict                                                
  - Replaces the `logger.Error + discard` pattern on `updateStatus` failures with `errors.Join(businessErr, statusErr)`, so status write conflicts propagate to
  the reconciler rather than being silently swallowed                                                                                                            
  - Fixes nil `Metrics` and `FleetCollector` in both controller integration test helpers, which were causing panics on all PostgresDatabase test runs
                                                                                                                                                                 
  ### Key Changes                                                                                                                                                
                                                                                                                                                                 
  - `pkg/postgresql/shared/reconcile/errors.go` — new shared `IsPureConflict` function; type-asserts `Unwrap() []error` to handle `errors.Join` chains, falls    
  back to direct `apierrors.IsConflict` for single-wrapped errors
  - `pkg/postgresql/cluster/core/cluster.go` — all `updateStatus` error paths now use `errors.Join(businessErr, statusErr)` instead of discarding the status     
  error; removed all inline `apierrors.IsConflict` checks                                                                                                        
  - `pkg/postgresql/database/core/database.go` — removed two inline `IsConflict` checks (finalizer update and final status write)
  - `internal/controller/postgrescluster_controller.go` — single `IsPureConflict` guard at the `Reconcile` boundary                                              
  - `internal/controller/postgresdatabase_controller.go` — same pattern applied                                                                                  
  - `internal/controller/postgrescluster_controller_test.go` / `postgresdatabase_controller_test.go` — added missing `Metrics: &NoopRecorder{}` and              
  `FleetCollector: NewFleetCollector()` to test reconciler constructors                                                                                          
                                                                                                                                                                 
  ### Testing and Verification                                                                                                                                   
                  
  - `pkg/postgresql/shared/reconcile/errors_test.go` — 8 unit tests covering all input shapes: `nil`, single conflict, single business error, `fmt.Errorf("%w")` 
  wrapped error, `errors.Join(business + conflict)`, `errors.Join(conflict + business)` (order-independent), two conflicts joined, and nil partner discarded by
  `errors.Join`                                                                                                                                                  
  - Existing `pkg/postgresql/cluster/core` and `pkg/postgresql/database/core` unit test suites pass unchanged
  - Integration tests (`internal/controller` with `KUBEBUILDER_ASSETS`) — all 7 PostgresDatabase controller specs now pass; previously panicking due to nil      
  `Metrics`    
### Related Issues

_Jira tickets, GitHub issues, Support tickets..._

### PR Checklist

- [ ] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [ ] All tests pass locally.
- [ ] The PR description follows the project's guidelines.
