### PR TITLE
CSPL-4715: fix empty pod name in ClusterManager bundle push

### DIFF
--- a/pkg/splunk/enterprise/clustermanager.go
+++ b/pkg/splunk/enterprise/clustermanager.go
@@ -227,7 +227,8 @@ func ApplyClusterManager(ctx context.Context, client splcommon.ControllerClient,
 
 		// Create podExecClient (use injected one if provided, otherwise create real one)
 		if podExecClient == nil {
-			podExecClient = splutil.GetPodExecClient(client, cr, "")
+			cmPodName := GetSplunkStatefulsetPodName(SplunkClusterManager, cr.GetName(), 0)
+			podExecClient = splutil.GetPodExecClient(client, cr, cmPodName)
 		}
 
 		// Add a splunk operator telemetry app

--- a/pkg/splunk/enterprise/names.go
+++ b/pkg/splunk/enterprise/names.go
@@ -210,7 +210,7 @@ version = 1.0.0
 `
 
 	telAppDefMetaConfString = `[]
-access = read : [ * ], write : [ admin ] 
+access = read : [ * ], write : [ admin ]
 `
 
 	// Command to create telemetry app on non SHC scenarios


### PR DESCRIPTION
### Description

Fixes a 3.1.0 regression where `PerformCmBundlePush` receives a `podExecClient` with an empty `targetPodName`, causing `Pod "" not found` errors that block bundle push, app framework, and SmartStore config checks.

### Key Changes

- `pkg/splunk/enterprise/clustermanager.go` — set correct CM pod name on `podExecClient` at creation
- `pkg/splunk/enterprise/names.go` — trailing whitespace cleanup

### Testing and Verification

- Existing unit tests pass

### Related Issues

- [CSPL-4715](https://splunk.atlassian.net/browse/CSPL-4715)

### PR Checklist

- [x] Code changes adhere to the project's coding standards
- [ ] Relevant unit and integration tests are included
- [ ] Documentation has been updated accordingly
- [ ] If test framework files were changed, `docs/IntegrationTesting.md` has been updated
- [ ] All tests pass locally
- [x] The PR description follows the project's guidelines