### PR TITLE
Fix CEL validation error when provider field is missing in VolumeSpec

### DIFF
--- a/api/v4/common_types.go
+++ b/api/v4/common_types.go
@@ -327,7 +327,7 @@ type IndexConfDefaultsSpec struct {
 }
 
 // VolumeSpec defines remote volume config
-// +kubebuilder:validation:XValidation:rule="self.provider != 'aws' || size(self.region) > 0",message="region is required when provider is aws"
+// +kubebuilder:validation:XValidation:rule="!has(self.provider) || self.provider != 'aws' || (has(self.region) && size(self.region) > 0)",message="region is required when provider is aws"
 type VolumeSpec struct {
 	// Remote volume name
 	// +kubebuilder:validation:Required

--- a/config/crd/bases/enterprise.splunk.com_clustermanagers.yaml
+++ b/config/crd/bases/enterprise.splunk.com_clustermanagers.yaml
@@ -1164,7 +1164,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                 type: object
               clusterManagerRef:
@@ -2375,7 +2376,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
@@ -4626,7 +4628,8 @@ spec:
                           type: object
                           x-kubernetes-validations:
                           - message: region is required when provider is aws
-                            rule: self.provider != 'aws' || size(self.region) > 0
+                            rule: '!has(self.provider) || self.provider != ''aws''
+                              || (has(self.region) && size(self.region) > 0)'
                         type: array
                     type: object
                   appSrcDeployStatus:
@@ -4919,7 +4922,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                     x-kubernetes-list-map-keys:
                     - name

--- a/config/crd/bases/enterprise.splunk.com_clustermasters.yaml
+++ b/config/crd/bases/enterprise.splunk.com_clustermasters.yaml
@@ -1160,7 +1160,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                 type: object
               clusterManagerRef:
@@ -2371,7 +2372,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
@@ -4622,7 +4624,8 @@ spec:
                           type: object
                           x-kubernetes-validations:
                           - message: region is required when provider is aws
-                            rule: self.provider != 'aws' || size(self.region) > 0
+                            rule: '!has(self.provider) || self.provider != ''aws''
+                              || (has(self.region) && size(self.region) > 0)'
                         type: array
                     type: object
                   appSrcDeployStatus:
@@ -4912,7 +4915,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                     x-kubernetes-list-map-keys:
                     - name

--- a/config/crd/bases/enterprise.splunk.com_ingestorclusters.yaml
+++ b/config/crd/bases/enterprise.splunk.com_ingestorclusters.yaml
@@ -1160,7 +1160,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                 type: object
               clusterManagerRef:
@@ -4579,7 +4580,8 @@ spec:
                           type: object
                           x-kubernetes-validations:
                           - message: region is required when provider is aws
-                            rule: self.provider != 'aws' || size(self.region) > 0
+                            rule: '!has(self.provider) || self.provider != ''aws''
+                              || (has(self.region) && size(self.region) > 0)'
                         type: array
                     type: object
                   appSrcDeployStatus:

--- a/config/crd/bases/enterprise.splunk.com_licensemanagers.yaml
+++ b/config/crd/bases/enterprise.splunk.com_licensemanagers.yaml
@@ -1154,7 +1154,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                 type: object
               clusterManagerRef:
@@ -4473,7 +4474,8 @@ spec:
                           type: object
                           x-kubernetes-validations:
                           - message: region is required when provider is aws
-                            rule: self.provider != 'aws' || size(self.region) > 0
+                            rule: '!has(self.provider) || self.provider != ''aws''
+                              || (has(self.region) && size(self.region) > 0)'
                         type: array
                     type: object
                   appSrcDeployStatus:

--- a/config/crd/bases/enterprise.splunk.com_licensemasters.yaml
+++ b/config/crd/bases/enterprise.splunk.com_licensemasters.yaml
@@ -1149,7 +1149,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                 type: object
               clusterManagerRef:
@@ -4468,7 +4469,8 @@ spec:
                           type: object
                           x-kubernetes-validations:
                           - message: region is required when provider is aws
-                            rule: self.provider != 'aws' || size(self.region) > 0
+                            rule: '!has(self.provider) || self.provider != ''aws''
+                              || (has(self.region) && size(self.region) > 0)'
                         type: array
                     type: object
                   appSrcDeployStatus:

--- a/config/crd/bases/enterprise.splunk.com_monitoringconsoles.yaml
+++ b/config/crd/bases/enterprise.splunk.com_monitoringconsoles.yaml
@@ -1156,7 +1156,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                 type: object
               clusterManagerRef:
@@ -4474,7 +4475,8 @@ spec:
                           type: object
                           x-kubernetes-validations:
                           - message: region is required when provider is aws
-                            rule: self.provider != 'aws' || size(self.region) > 0
+                            rule: '!has(self.provider) || self.provider != ''aws''
+                              || (has(self.region) && size(self.region) > 0)'
                         type: array
                     type: object
                   appSrcDeployStatus:
@@ -5776,7 +5778,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                 type: object
               clusterManagerRef:
@@ -9094,7 +9097,8 @@ spec:
                           type: object
                           x-kubernetes-validations:
                           - message: region is required when provider is aws
-                            rule: self.provider != 'aws' || size(self.region) > 0
+                            rule: '!has(self.provider) || self.provider != ''aws''
+                              || (has(self.region) && size(self.region) > 0)'
                         type: array
                     type: object
                   appSrcDeployStatus:

--- a/config/crd/bases/enterprise.splunk.com_searchheadclusters.yaml
+++ b/config/crd/bases/enterprise.splunk.com_searchheadclusters.yaml
@@ -1162,7 +1162,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                 type: object
               clusterManagerRef:
@@ -4497,7 +4498,8 @@ spec:
                           type: object
                           x-kubernetes-validations:
                           - message: region is required when provider is aws
-                            rule: self.provider != 'aws' || size(self.region) > 0
+                            rule: '!has(self.provider) || self.provider != ''aws''
+                              || (has(self.region) && size(self.region) > 0)'
                         type: array
                     type: object
                   appSrcDeployStatus:
@@ -5869,7 +5871,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                 type: object
               clusterManagerRef:
@@ -9462,7 +9465,8 @@ spec:
                           type: object
                           x-kubernetes-validations:
                           - message: region is required when provider is aws
-                            rule: self.provider != 'aws' || size(self.region) > 0
+                            rule: '!has(self.provider) || self.provider != ''aws''
+                              || (has(self.region) && size(self.region) > 0)'
                         type: array
                     type: object
                   appSrcDeployStatus:

--- a/config/crd/bases/enterprise.splunk.com_standalones.yaml
+++ b/config/crd/bases/enterprise.splunk.com_standalones.yaml
@@ -1157,7 +1157,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                 type: object
               clusterManagerRef:
@@ -2372,7 +2373,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
@@ -4624,7 +4626,8 @@ spec:
                           type: object
                           x-kubernetes-validations:
                           - message: region is required when provider is aws
-                            rule: self.provider != 'aws' || size(self.region) > 0
+                            rule: '!has(self.provider) || self.provider != ''aws''
+                              || (has(self.region) && size(self.region) > 0)'
                         type: array
                     type: object
                   appSrcDeployStatus:
@@ -4911,7 +4914,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
@@ -6075,7 +6079,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                 type: object
               clusterManagerRef:
@@ -7291,7 +7296,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
@@ -9543,7 +9549,8 @@ spec:
                           type: object
                           x-kubernetes-validations:
                           - message: region is required when provider is aws
-                            rule: self.provider != 'aws' || size(self.region) > 0
+                            rule: '!has(self.provider) || self.provider != ''aws''
+                              || (has(self.region) && size(self.region) > 0)'
                         type: array
                     type: object
                   appSrcDeployStatus:
@@ -9833,7 +9840,8 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: region is required when provider is aws
-                        rule: self.provider != 'aws' || size(self.region) > 0
+                        rule: '!has(self.provider) || self.provider != ''aws'' ||
+                          (has(self.region) && size(self.region) > 0)'
                     type: array
                     x-kubernetes-list-map-keys:
                     - name


### PR DESCRIPTION
## Problem
After upgrading to v3.1.0, customers encountered validation errors when updating existing Standalone CRs that were created with previous versions:

```
The Standalone "standalone" is invalid: status.smartstore.volumes[0]: 
Invalid value: "object": no such key: provider evaluating rule: 
region is required when provider is aws
```

This error occurred because the CEL validation rule added in #1740 attempted to access `self.provider` without first checking if the field exists. In upgrade scenarios, status fields populated by older operator versions may not include the `provider` field, causing the validation to fail with "no such key: provider".

## Root Cause
The original CEL validation rule was:
```
self.provider != 'aws' || size(self.region) > 0
```

This rule evaluates `self.provider` even when the field doesn't exist, violating CEL's requirement to check field existence with `has()` before accessing optional fields.

## Solution
Updated the CEL validation rule in `api/v4/common_types.go` to:
```
!has(self.provider) || self.provider != 'aws' || (has(self.region) && size(self.region) > 0)
```

This change:
1. First checks if `provider` field exists with `!has(self.provider)`
2. If it doesn't exist, validation passes (allows backward compatibility)
3. Only validates the AWS region requirement when provider is explicitly set to 'aws'
4. Also checks `has(self.region)` before accessing the region field

## Testing
Reproduced the issue by:
1. Deployed v3.1.0 operator and CRDs to an EKS cluster
2. Created a Standalone CR with the buggy v3.1.0 CRDs
3. Attempted to patch the status with a volume object missing the `provider` field (simulating an upgrade scenario)
4. Confirmed the error: `The Standalone "standalone" is invalid: status.smartstore.volumes[0]: Invalid value: "object": no such key: provider evaluating rule: region is required when provider is aws`
5. Applied the fix (regenerated CRDs with the corrected validation rule)
6. Verified the same patch operation succeeds without errors

## Impact
- **Fixes**: Upgrade path from pre-3.1.0 versions where status fields were populated without the provider field
- **Maintains**: The validation requirement that AWS volumes must have a region
- **No impact**: On new deployments as they will include the provider field

## Checklist
- [x] Changes have been tested and validated
- [x] CRDs regenerated using `make manifests`
- [x] Commit includes Co-Authored-By for compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)