### PR TITLE
CSPL-4631: add Helm chart support for feature gates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,21 @@ docs-preview: ## Preview documentation locally with Jekyll (requires Ruby and bu
 	@cd docs && bundle exec jekyll serve --livereload
 	@echo "Documentation available at http://localhost:4000/splunk-operator"
 
+##@ Helm
+
+HELM_OPERATOR_CHART = helm-chart/splunk-operator
+
+.PHONY: helm-lint
+helm-lint: ## Lint Helm charts
+	helm lint $(HELM_OPERATOR_CHART)
+
+.PHONY: helm-test
+helm-test: setup/helm-unittest ## Run Helm chart unit tests
+	helm unittest $(HELM_OPERATOR_CHART)
+
+.PHONY: helm-check
+helm-check: helm-lint helm-test ## Run Helm lint and unit tests
+
 ##@ Build
 
 build: setup/ginkgo manifests generate fmt vet ## Build manager binary.
@@ -226,6 +241,7 @@ $(LOCALBIN):
 KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.18.0
 GOLANGCI_LINT_VERSION ?= v2.1.0
+HELM_UNITTEST_VERSION ?= v1.0.3
 
 CONTROLLER_GEN = $(LOCALBIN)/controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
@@ -463,6 +479,11 @@ setup/ginkgo:
 	@go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@latest
 	@echo Installing gomega
 	@go get github.com/onsi/gomega/...
+
+.PHONY: setup/helm-unittest
+setup/helm-unittest:
+	@helm plugin list 2>/dev/null | grep -q unittest || \
+		helm plugin install https://github.com/helm-unittest/helm-unittest.git --version $(HELM_UNITTEST_VERSION)
 
 .PHONY: build-installer
 build-installer: manifests generate kustomize

--- a/docs/FeatureGates.md
+++ b/docs/FeatureGates.md
@@ -1,10 +1,37 @@
+---
+title: Feature Gates
+parent: Reference
+nav_order: 7
+---
+
 # Feature Gates
 
 The Splunk Operator uses the Kubernetes [FeatureGate](https://pkg.go.dev/k8s.io/component-base/featuregate) pattern to control rollout of new functionality. Feature gates allow new code to be merged to the main branch without activating in production, giving teams a safe, per-environment opt-in mechanism.
 
 ## Usage
 
-Enable or disable feature gates at operator startup:
+### Helm Chart
+
+Set feature gates via the `splunkOperator.featureGates` map in your values file:
+
+```yaml
+splunkOperator:
+  featureGates:
+    ValidationWebhook: true
+```
+
+Or pass them on the command line:
+
+```bash
+helm install splunk-operator splunk/splunk-operator \
+  --set splunkOperator.featureGates.ValidationWebhook=true
+```
+
+The chart formats the map into a single `--feature-gates=Key1=true,Key2=false` argument automatically. Adding a new gate requires no chart changes — just add an entry to the map.
+
+### Direct Binary
+
+When running the operator binary directly, pass feature gates at startup:
 
 ```bash
 /manager --feature-gates=ValidationWebhook=true

--- a/docs/ValidationWebhook.md
+++ b/docs/ValidationWebhook.md
@@ -83,7 +83,26 @@ If you prefer not to use cert-manager, you can provide your own TLS certificates
 
 ### Deployment Options
 
-#### Option 1: Use the Webhook-Enabled Kustomize Overlay
+#### Option 1: Enable via Helm Feature Gates
+
+If deploying with Helm, enable the feature gate through the `splunkOperator.featureGates` value:
+
+```bash
+helm install splunk-operator splunk/splunk-operator \
+  --set splunkOperator.featureGates.ValidationWebhook=true
+```
+
+Or in your values file:
+
+```yaml
+splunkOperator:
+  featureGates:
+    ValidationWebhook: true
+```
+
+**Note:** This requires the webhook Kubernetes resources (Service, ValidatingWebhookConfiguration, TLS certificates) to be deployed separately.
+
+#### Option 2: Use the Webhook-Enabled Kustomize Overlay
 
 Deploy using the `config/default-with-webhook` overlay which includes all necessary webhook components and enables the `ValidationWebhook` feature gate automatically:
 
@@ -94,7 +113,7 @@ make deploy IMG=<your-image> ENVIRONMENT=default-with-webhook \
 
 This uses the same `make deploy` target as the standard deployment, which substitutes the `WATCH_NAMESPACE`, `SPLUNK_ENTERPRISE_IMAGE`, and `SPLUNK_GENERAL_TERMS` placeholder values before running `kustomize build`.
 
-#### Option 2: Enable via Feature Gate on Existing Deployment
+#### Option 3: Enable via Feature Gate on Existing Deployment
 
 If you already have the operator deployed with the webhook Kubernetes resources (Service, ValidatingWebhookConfiguration, TLS certificates), enable the feature gate by patching the container args:
 
@@ -105,7 +124,7 @@ kubectl patch deployment splunk-operator-controller-manager -n splunk-operator \
 
 **Note:** This requires the webhook service, ValidatingWebhookConfiguration, and TLS certificates to already be deployed. Use Option 1 for a complete deployment.
 
-#### Option 3: Modify Default Kustomization
+#### Option 4: Modify Default Kustomization
 
 Edit `config/default/kustomization.yaml` to uncomment the webhook-related sections:
 

--- a/helm-chart/splunk-operator/templates/_helpers.tpl
+++ b/helm-chart/splunk-operator/templates/_helpers.tpl
@@ -72,3 +72,15 @@ Define namespace of release and allow for namespace override
 {{- default .Release.Namespace .Values.namespaceOverride }}
 {{- end }}
 
+{{/*
+Format splunkOperator.featureGates map into a --feature-gates arg value.
+Produces: Key1=true,Key2=false
+*/}}
+{{- define "splunk-operator.featureGates" -}}
+{{- $pairs := list -}}
+{{- range $gate, $enabled := .Values.splunkOperator.featureGates -}}
+{{- $pairs = append $pairs (printf "%s=%t" $gate $enabled) -}}
+{{- end -}}
+{{- join "," $pairs -}}
+{{- end }}
+

--- a/helm-chart/splunk-operator/templates/deployment.yaml
+++ b/helm-chart/splunk-operator/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
           args:
             - --leader-elect
             - --pprof
+{{- if .Values.splunkOperator.featureGates }}
+            - --feature-gates={{ include "splunk-operator.featureGates" . }}
+{{- end }}
           command:
             - /manager
 {{- with .Values.splunkOperator.livenessProbe }}
@@ -78,7 +81,7 @@ spec:
             - name: SPLUNK_GENERAL_TERMS
               value: {{ .Values.splunkOperator.splunkGeneralTerms | default "" }}
 {{- with .Values.extraEnvs }}
-{{- toYaml . | trim | nindent 10 }}
+{{- toYaml . | trim | nindent 12 }}
 {{- end }}
           ports:
             {{- range .Values.splunkOperator.service.ports }}

--- a/helm-chart/splunk-operator/tests/deployment_test.yaml
+++ b/helm-chart/splunk-operator/tests/deployment_test.yaml
@@ -1,0 +1,185 @@
+suite: deployment
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: should be a Deployment
+    asserts:
+      - isKind:
+          of: Deployment
+
+  - it: should set the correct name
+    asserts:
+      - equal:
+          path: metadata.name
+          value: splunk-operator-controller-manager
+
+  - it: should use Recreate strategy
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: should include default args without feature-gates
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - --leader-elect
+            - --pprof
+
+  - it: should include feature-gates arg with a single gate
+    set:
+      splunkOperator.featureGates:
+        ValidationWebhook: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --feature-gates=ValidationWebhook=true
+
+  - it: should include feature-gates arg with multiple gates
+    set:
+      splunkOperator.featureGates:
+        ValidationWebhook: true
+        MyNewFeature: false
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: "^--feature-gates="
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: "ValidationWebhook=true"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: "MyNewFeature=false"
+
+  - it: should not include feature-gates arg when featureGates is empty
+    set:
+      splunkOperator.featureGates: {}
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - --leader-elect
+            - --pprof
+
+  - it: should always include --leader-elect and --pprof even with feature gates
+    set:
+      splunkOperator.featureGates:
+        ValidationWebhook: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --pprof
+
+  - it: should set the command to /manager
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /manager
+
+  - it: should use the configured image
+    set:
+      splunkOperator.image.repository: my-registry/splunk-operator:test
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: my-registry/splunk-operator:test
+
+  - it: should set WATCH_NAMESPACE to watchNamespaces when clusterWideAccess is true
+    set:
+      splunkOperator.clusterWideAccess: true
+      splunkOperator.watchNamespaces: "ns1,ns2"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WATCH_NAMESPACE
+            value: "ns1,ns2"
+
+  - it: should set WATCH_NAMESPACE to release namespace when clusterWideAccess is false
+    release:
+      namespace: my-namespace
+    set:
+      splunkOperator.clusterWideAccess: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WATCH_NAMESPACE
+            value: my-namespace
+
+  - it: should add custom labels to deployment
+    set:
+      splunkOperator.labels:
+        custom-label: custom-value
+    asserts:
+      - equal:
+          path: metadata.labels.custom-label
+          value: custom-value
+
+  - it: should add custom annotations to deployment
+    set:
+      splunkOperator.annotations:
+        custom-annotation: custom-value
+    asserts:
+      - equal:
+          path: metadata.annotations.custom-annotation
+          value: custom-value
+
+  - it: should add pod labels
+    set:
+      splunkOperator.podLabels:
+        pod-label: pod-value
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.pod-label
+          value: pod-value
+
+  - it: should add pod annotations
+    set:
+      splunkOperator.podAnnotations:
+        pod-annotation: pod-value
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.pod-annotation
+          value: pod-value
+
+  - it: should set security context defaults
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: should disable host namespaces by default
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+      - equal:
+          path: spec.template.spec.hostPID
+          value: false
+      - equal:
+          path: spec.template.spec.hostIPC
+          value: false
+
+  - it: should set extra environment variables
+    set:
+      extraEnvs:
+        - name: MY_VAR
+          value: my-value
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_VAR
+            value: my-value

--- a/helm-chart/splunk-operator/tests/helpers_test.yaml
+++ b/helm-chart/splunk-operator/tests/helpers_test.yaml
@@ -1,0 +1,57 @@
+suite: helpers
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: should use default operator fullname
+    asserts:
+      - equal:
+          path: metadata.name
+          value: splunk-operator-controller-manager
+
+  - it: should allow overriding operator name
+    set:
+      splunkOperator.nameOverride: my-operator
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-operator-controller-manager
+
+  - it: should use default namespace from release
+    release:
+      namespace: test-ns
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: test-ns
+
+  - it: should allow namespace override
+    release:
+      namespace: test-ns
+    set:
+      namespaceOverride: overridden-ns
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: overridden-ns
+
+  - it: should include common labels
+    chart:
+      version: 1.2.3
+      appVersion: 3.1.0
+    release:
+      name: my-release
+    asserts:
+      - exists:
+          path: metadata.labels["helm.sh/chart"]
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: metadata.labels["app.kubernetes.io/version"]
+          value: "3.1.0"
+
+  - it: should derive service account name from operator fullname
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: splunk-operator-controller-manager

--- a/helm-chart/splunk-operator/values.yaml
+++ b/helm-chart/splunk-operator/values.yaml
@@ -146,6 +146,16 @@ splunkOperator:
   # Mandatory acknowledgment mechanism for the Splunk General Terms (SGT) 
   splunkGeneralTerms: ""
 
+  # Feature gates to enable or disable on the operator.
+  # Each key is a gate name and the value is a boolean (true/false).
+  # The map is formatted into a single --feature-gates arg automatically.
+  # Adding a new gate requires no chart changes — just add an entry here.
+  # reference: https://splunk.github.io/splunk-operator/FeatureGates
+  featureGates: {}
+  # featureGates:
+  #   ValidationWebhook: true
+  #   MyNewFeature: false
+
 # Array with extra yaml to deploy with the chart. Evaluated as a template
 extraManifests: []
 # extraManifests:


### PR DESCRIPTION
### Description

Add `splunkOperator.featureGates` map to the Helm chart so operators can enable feature gates via `helm install/upgrade` without per-gate chart modifications.

### Key Changes

- Add `featureGates` map to values and a helper template that formats it into `--feature-gates=Key=bool,...`
- Deployment template conditionally renders the arg when the map is non-empty
- Add helm-unittest framework with 25 tests and `make helm-check` target
- Update `FeatureGates.md` and `ValidationWebhook.md` with Helm usage

### Testing and Verification

- `helm lint` passes
- `helm template` verified for 0, 1, and 2 gates
- 25 helm-unittest tests pass (`make helm-check`)

### Related Issues

- [CSPL-4631](https://splunk.atlassian.net/browse/CSPL-4631)

### PR Checklist

- [x] Code changes adhere to the project's coding standards
- [x] Relevant unit and integration tests are included
- [x] Documentation has been updated accordingly
- [ ] If test framework files were changed (`test/testenv/`, `test/run-tests.sh`, `test/env.sh`), `docs/IntegrationTesting.md` has been updated
- [x] All tests pass locally
- [x] The PR description follows the project's guidelines