### PR TITLE
CSPL-4736: Upgrade moby/spdystream version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG PLATFORMS=linux/amd64,linux/arm64
 
 ARG BASE_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal
-ARG BASE_IMAGE_VERSION=8.10-1775152441
+ARG BASE_IMAGE_VERSION=8.10-1776645784
 
 # Build the manager binary
 FROM golang:1.26.2 AS builder

--- a/Makefile
+++ b/Makefile
@@ -183,12 +183,12 @@ docker-push: ## Push docker image with the manager.
 # Defaults:
 #   Build Platform: linux/amd64,linux/arm64
 #   Build Base OS: registry.access.redhat.com/ubi8/ubi-minimal
-#   Build Base OS Version: 8.10-1775152441
+#   Build Base OS Version: 8.10-1776645784
 # Pass only what is required, the rest will be defaulted
 # Setup defaults for build arguments
 PLATFORMS ?= linux/amd64,linux/arm64
 BASE_IMAGE ?= registry.access.redhat.com/ubi8/ubi-minimal
-BASE_IMAGE_VERSION ?= 8.10-1775152441
+BASE_IMAGE_VERSION ?= 8.10-1776645784
 
 docker-buildx:
 	@if [ -z "${IMG}" ]; then \

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/minio/md5-simd v1.1.0 // indirect
 	github.com/minio/sha256-simd v0.1.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/moby/spdystream v0.5.0 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/minio/sha256-simd v0.1.1 h1:5QHSlgo3nt5yKOJrC7W8w7X+NFl8cMPZm96iu8kKU
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
-github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
### Description

This PR updates the github.com/moby/spdystream dependency version from v0.5.0 to 0.5.1. It also updates the ubi8 minimal image to 8.10-1776645784.

Library | Remediated Version | Details
-- | -- | --
github.com/moby/spdystream | 0.5.1 | spdystream is a Go library for multiplexing streams over SPDY connections. In versions 0.5.0 and below, the SPDY/3 frame parser does not validate attacker-controlled counts and lengths before allocating memory. Three allocation paths are affected: the SETTINGS frame entry count, the header count in parseHeaderValueBlock, and individual header field sizes — all read as 32-bit integers and used directly as allocation sizes with no bounds checking. Because SPDY header blocks are zlib-compressed, a small on-the-wire payload can decompress into large attacker-controlled values. A remote peer that can send SPDY frames to a service using spdystream can exhaust process memory and cause an out-of-memory crash with a single crafted control frame. This issue has been fixed in version 0.5.1.
libarchive | 3.3.3-7.el8_10 | CVE-2026-4424   
libnghttp2 | 1.33.0-6.el8_10.2 | A flaw was found in nghttp2. Due to missing internal state validation, the library continues to process incoming data even after a session has been terminated. A remote attacker could exploit this by sending a specially crafted HTTP/2 frame, leading to an assertion failure and a denial of service (DoS).

### Key Changes

- Updated github.com/moby/spdystream in go.mod and go.sum
- Updated ubi8 minimal image in Makefile and Dockerfile

### Testing and Verification

- Unit tests pass
- Smoke tests pass

### Related Issues

- https://splunk.atlassian.net/browse/CSPL-4736
- https://splunk.atlassian.net/browse/VULN-71928

### PR Checklist

- [X] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [X] All tests pass locally.
- [X] The PR description follows the project's guidelines.
