### PR TITLE
Add support for future flag to protect our service from being deploye…

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -302,25 +302,28 @@ func main() {
 	}
 	pgFleetMetricsCollector := pgprometheus.NewFleetCollector()
 
-	if err := (&controller.PostgresDatabaseReconciler{
-		Client:         mgr.GetClient(),
-		Scheme:         mgr.GetScheme(),
-		Recorder:       mgr.GetEventRecorderFor("postgresdatabase-controller"),
-		Metrics:        pgMetricsRecorder,
-		FleetCollector: pgFleetMetricsCollector,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "PostgresDatabase")
-		os.Exit(1)
-	}
-	if err := (&controller.PostgresClusterReconciler{
-		Client:         mgr.GetClient(),
-		Scheme:         mgr.GetScheme(),
-		Recorder:       mgr.GetEventRecorderFor("postgrescluster-controller"),
-		Metrics:        pgMetricsRecorder,
-		FleetCollector: pgFleetMetricsCollector,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "PostgresCluster")
-		os.Exit(1)
+	if config.DefaultMutableFeatureGate.Enabled(config.PostgresController) {
+		if err := (&controller.PostgresDatabaseReconciler{
+			Client:         mgr.GetClient(),
+			Scheme:         mgr.GetScheme(),
+			Recorder:       mgr.GetEventRecorderFor("postgresdatabase-controller"),
+			Metrics:        pgMetricsRecorder,
+			FleetCollector: pgFleetMetricsCollector,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "PostgresDatabase")
+			os.Exit(1)
+		}
+
+		if err := (&controller.PostgresClusterReconciler{
+			Client:         mgr.GetClient(),
+			Scheme:         mgr.GetScheme(),
+			Recorder:       mgr.GetEventRecorderFor("postgrescluster-controller"),
+			Metrics:        pgMetricsRecorder,
+			FleetCollector: pgFleetMetricsCollector,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "PostgresCluster")
+			os.Exit(1)
+		}
 	}
 
 	if _, ok := os.LookupEnv("ENABLE_VALIDATION_WEBHOOK"); ok {

--- a/config/samples/enterprise_v4_postgrescluster_dev.yaml
+++ b/config/samples/enterprise_v4_postgrescluster_dev.yaml
@@ -14,8 +14,8 @@ spec:
   clusterDeletionPolicy: Retain
   instances: 3
   # Storage and PostgreSQL version are overridden from the ClusterClass defaults. Validation rules on the PostgresCluster resource will prevent removing these fields or setting them to lower values than the original overrides.
-  storage: 1Gi
-  postgresVersion: "15.10"
+  storage: 20Gi
+  postgresVersion: "18.10"
   resources:
     requests:
       cpu: "250m"

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -30,4 +30,5 @@ webhooks:
     - monitoringconsoles
     - postgresclusters
     - postgresclusterclasses
+    - postgresdatabases
   sideEffects: None

--- a/docs/FeatureGates.md
+++ b/docs/FeatureGates.md
@@ -49,7 +49,8 @@ When running the operator binary directly, pass feature gates at startup:
 
 | Gate                  | Default | Stage | Since   | Description                                              |
 |-----------------------|---------|-------|---------|----------------------------------------------------------|
-| `ValidationWebhook`  | `false` | Alpha | v3.2.0  | Centralized validation webhook server for CR admission   |
+| `ValidationWebhook`   | `false` | Alpha | v3.2.0  | Centralized validation webhook server for CR admission   |
+| `PostgresController`  | `false` | Alpha | ?       | PostgresCluster, PostgresClusterClass, and PostgresDatabase controllers and CRDs |
 
 ## Adding a New Feature Gate
 
@@ -128,6 +129,20 @@ metadata:
     splunk.com/feature-stage: Alpha
   labels:
     splunk.com/feature-stage: alpha
+```
+
+### d. Enable the gate in tests
+
+Validators and controllers gated behind a feature flag will reject all operations in tests unless the gate is explicitly enabled. Enable it via `SetFromMap` before your tests run:
+
+```go
+func init() {
+    if err := config.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
+        string(config.MyNewFeature): true,
+    }); err != nil {
+        panic(err)
+    }
+}
 ```
 
 ## Promoting a Gate

--- a/pkg/config/featuregates.go
+++ b/pkg/config/featuregates.go
@@ -35,14 +35,16 @@ const (
 	// When enabled, the operator runs a validating webhook that enforces
 	// CR schema rules at admission time.
 	// Replaces the legacy ENABLE_VALIDATION_WEBHOOK env var.
-	ValidationWebhook featuregate.Feature = "ValidationWebhook"
+	ValidationWebhook  featuregate.Feature = "ValidationWebhook"
+	PostgresController featuregate.Feature = "PostgresController"
 )
 
 // defaultFeatureGates is the authoritative registry of all feature gates and
 // their default state / maturity. Each entry here automatically becomes
 // available via --feature-gates on the operator binary.
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	ValidationWebhook: {Default: false, PreRelease: featuregate.Alpha},
+	ValidationWebhook:  {Default: false, PreRelease: featuregate.Alpha},
+	PostgresController: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 var DefaultMutableFeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()

--- a/pkg/postgresql/cluster/adapter/webhook/postgrescluster_validation_test.go
+++ b/pkg/postgresql/cluster/adapter/webhook/postgrescluster_validation_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
+	"github.com/splunk/splunk-operator/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -172,6 +173,22 @@ func TestValidatePostgresClusterUpdate(t *testing.T) {
 			assert.Len(t, errs, tt.wantErrCount, "unexpected error count")
 		})
 	}
+}
+
+func TestValidatePostgresClusterCreateFeatureGateDisabled(t *testing.T) {
+	config.DefaultMutableFeatureGate.SetFromMap(map[string]bool{string(config.PostgresController): false})
+	t.Cleanup(func() {
+		config.DefaultMutableFeatureGate.SetFromMap(map[string]bool{string(config.PostgresController): true})
+	})
+
+	obj := &enterpriseApi.PostgresCluster{
+		Spec: enterpriseApi.PostgresClusterSpec{Class: "dev"},
+	}
+
+	errs := ValidatePostgresClusterCreate(obj)
+	assert.Len(t, errs, 1)
+	assert.Equal(t, "spec", errs[0].Field)
+	assert.Equal(t, "the PostgresController feature is not enabled; set --feature-gates=PostgresController=true to activate", errs[0].Detail)
 }
 
 func TestGetPostgresClusterWarningsOnCreate(t *testing.T) {

--- a/pkg/postgresql/cluster/adapter/webhook/postgresclusterclass_validation.go
+++ b/pkg/postgresql/cluster/adapter/webhook/postgresclusterclass_validation.go
@@ -20,12 +20,21 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
+	"github.com/splunk/splunk-operator/pkg/config"
 	hba "github.com/splunk/splunk-operator/pkg/postgresql/cluster/core"
 )
 
 // ValidatePostgresClusterClassCreate validates a PostgresClusterClass on CREATE.
 func ValidatePostgresClusterClassCreate(obj *enterpriseApi.PostgresClusterClass) field.ErrorList {
 	var allErrs field.ErrorList
+
+	if !config.DefaultMutableFeatureGate.Enabled(config.PostgresController) {
+		allErrs = append(allErrs, field.Forbidden(
+			field.NewPath("spec"),
+			"the PostgresController feature is not enabled; set --feature-gates=PostgresController=true to activate"))
+
+		return allErrs
+	}
 
 	if obj.Spec.Config != nil && len(obj.Spec.Config.PgHBA) > 0 {
 		pgHBAPath := field.NewPath("spec").Child("config").Child("pgHBA")

--- a/pkg/postgresql/cluster/adapter/webhook/postgresclusterclass_validation_test.go
+++ b/pkg/postgresql/cluster/adapter/webhook/postgresclusterclass_validation_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
+	"github.com/splunk/splunk-operator/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -171,6 +172,22 @@ func TestValidatePostgresClusterClassUpdate(t *testing.T) {
 			assert.Len(t, errs, tt.wantErrCount, "unexpected error count")
 		})
 	}
+}
+
+func TestValidatePostgresClusterClassCreateFeatureGateDisabled(t *testing.T) {
+	config.DefaultMutableFeatureGate.SetFromMap(map[string]bool{string(config.PostgresController): false})
+	t.Cleanup(func() {
+		config.DefaultMutableFeatureGate.SetFromMap(map[string]bool{string(config.PostgresController): true})
+	})
+
+	obj := &enterpriseApi.PostgresClusterClass{
+		Spec: enterpriseApi.PostgresClusterClassSpec{Provisioner: "postgresql.cnpg.io"},
+	}
+
+	errs := ValidatePostgresClusterClassCreate(obj)
+	assert.Len(t, errs, 1)
+	assert.Equal(t, "spec", errs[0].Field)
+	assert.Equal(t, "the PostgresController feature is not enabled; set --feature-gates=PostgresController=true to activate", errs[0].Detail)
 }
 
 func TestGetPostgresClusterClassWarningsOnCreate(t *testing.T) {

--- a/pkg/postgresql/cluster/adapter/webhook/testhelpers_test.go
+++ b/pkg/postgresql/cluster/adapter/webhook/testhelpers_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook_test
+
+import (
+	"github.com/splunk/splunk-operator/pkg/config"
+	"github.com/splunk/splunk-operator/pkg/postgresql/shared/testhelpers"
+)
+
+func init() {
+	testhelpers.EnableFeatureGate(config.PostgresController)
+}

--- a/pkg/postgresql/cluster/adapter/webhook/testsetup_test.go
+++ b/pkg/postgresql/cluster/adapter/webhook/testsetup_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"github.com/splunk/splunk-operator/pkg/config"
+	"github.com/splunk/splunk-operator/pkg/postgresql/shared/testhelpers"
+)
+
+func init() {
+	testhelpers.EnableFeatureGate(config.PostgresController)
+}

--- a/pkg/postgresql/database/adapter/webhook/postgresdatabase_validation.go
+++ b/pkg/postgresql/database/adapter/webhook/postgresdatabase_validation.go
@@ -21,11 +21,10 @@ import (
 
 	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
 	"github.com/splunk/splunk-operator/pkg/config"
-	hba "github.com/splunk/splunk-operator/pkg/postgresql/cluster/core"
 )
 
-// ValidatePostgresClusterCreate validates a PostgresCluster on CREATE.
-func ValidatePostgresClusterCreate(obj *enterpriseApi.PostgresCluster) field.ErrorList {
+// ValidatePostgresDatabaseCreate validates a PostgresDatabase on CREATE.
+func ValidatePostgresDatabaseCreate(obj *enterpriseApi.PostgresDatabase) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if !config.DefaultMutableFeatureGate.Enabled(config.PostgresController) {
@@ -36,30 +35,20 @@ func ValidatePostgresClusterCreate(obj *enterpriseApi.PostgresCluster) field.Err
 		return allErrs
 	}
 
-	if len(obj.Spec.PgHBA) > 0 {
-		pgHBAPath := field.NewPath("spec").Child("pgHBA")
-		for _, re := range hba.ValidateRules(obj.Spec.PgHBA) {
-			allErrs = append(allErrs, field.Invalid(
-				pgHBAPath.Index(re.Index),
-				obj.Spec.PgHBA[re.Index],
-				re.Message))
-		}
-	}
-
 	return allErrs
 }
 
-// ValidatePostgresClusterUpdate validates a PostgresCluster on UPDATE.
-func ValidatePostgresClusterUpdate(obj, oldObj *enterpriseApi.PostgresCluster) field.ErrorList {
-	return ValidatePostgresClusterCreate(obj)
+// ValidatePostgresDatabaseUpdate validates a PostgresDatabase on UPDATE.
+func ValidatePostgresDatabaseUpdate(obj, oldObj *enterpriseApi.PostgresDatabase) field.ErrorList {
+	return ValidatePostgresDatabaseCreate(obj)
 }
 
-// GetPostgresClusterWarningsOnCreate returns warnings for PostgresCluster CREATE.
-func GetPostgresClusterWarningsOnCreate(obj *enterpriseApi.PostgresCluster) []string {
+// GetPostgresDatabaseWarningsOnCreate returns warnings for PostgresDatabase CREATE.
+func GetPostgresDatabaseWarningsOnCreate(obj *enterpriseApi.PostgresDatabase) []string {
 	return nil
 }
 
-// GetPostgresClusterWarningsOnUpdate returns warnings for PostgresCluster UPDATE.
-func GetPostgresClusterWarningsOnUpdate(obj, oldObj *enterpriseApi.PostgresCluster) []string {
+// GetPostgresDatabaseWarningsOnUpdate returns warnings for PostgresDatabase UPDATE.
+func GetPostgresDatabaseWarningsOnUpdate(obj, oldObj *enterpriseApi.PostgresDatabase) []string {
 	return nil
 }

--- a/pkg/postgresql/database/adapter/webhook/postgresdatabase_validation_test.go
+++ b/pkg/postgresql/database/adapter/webhook/postgresdatabase_validation_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
+	"github.com/splunk/splunk-operator/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidatePostgresDatabaseCreate(t *testing.T) {
+	tests := []struct {
+		name         string
+		obj          *enterpriseApi.PostgresDatabase
+		wantErrCount int
+	}{
+		{
+			name: "valid - minimal spec",
+			obj: &enterpriseApi.PostgresDatabase{
+				Spec: enterpriseApi.PostgresDatabaseSpec{
+					ClusterRef: corev1.LocalObjectReference{Name: "my-cluster"},
+					Databases:  []enterpriseApi.DatabaseDefinition{{Name: "mydb"}},
+				},
+			},
+			wantErrCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidatePostgresDatabaseCreate(tt.obj)
+			assert.Len(t, errs, tt.wantErrCount, "unexpected error count")
+		})
+	}
+}
+
+func TestValidatePostgresDatabaseCreateFeatureGateDisabled(t *testing.T) {
+	config.DefaultMutableFeatureGate.SetFromMap(map[string]bool{string(config.PostgresController): false})
+	t.Cleanup(func() {
+		config.DefaultMutableFeatureGate.SetFromMap(map[string]bool{string(config.PostgresController): true})
+	})
+
+	obj := &enterpriseApi.PostgresDatabase{
+		Spec: enterpriseApi.PostgresDatabaseSpec{
+			ClusterRef: corev1.LocalObjectReference{Name: "my-cluster"},
+			Databases:  []enterpriseApi.DatabaseDefinition{{Name: "mydb"}},
+		},
+	}
+
+	errs := ValidatePostgresDatabaseCreate(obj)
+	assert.Len(t, errs, 1)
+	assert.Equal(t, "spec", errs[0].Field)
+	assert.Equal(t, "the PostgresController feature is not enabled; set --feature-gates=PostgresController=true to activate", errs[0].Detail)
+}
+
+func TestValidatePostgresDatabaseUpdate(t *testing.T) {
+	obj := &enterpriseApi.PostgresDatabase{
+		Spec: enterpriseApi.PostgresDatabaseSpec{
+			ClusterRef: corev1.LocalObjectReference{Name: "my-cluster"},
+			Databases:  []enterpriseApi.DatabaseDefinition{{Name: "mydb"}},
+		},
+	}
+	errs := ValidatePostgresDatabaseUpdate(obj, obj)
+	assert.Empty(t, errs)
+}
+
+func TestGetPostgresDatabaseWarningsOnCreate(t *testing.T) {
+	obj := &enterpriseApi.PostgresDatabase{
+		Spec: enterpriseApi.PostgresDatabaseSpec{
+			ClusterRef: corev1.LocalObjectReference{Name: "my-cluster"},
+			Databases:  []enterpriseApi.DatabaseDefinition{{Name: "mydb"}},
+		},
+	}
+	assert.Empty(t, GetPostgresDatabaseWarningsOnCreate(obj))
+}
+
+func TestGetPostgresDatabaseWarningsOnUpdate(t *testing.T) {
+	obj := &enterpriseApi.PostgresDatabase{
+		Spec: enterpriseApi.PostgresDatabaseSpec{
+			ClusterRef: corev1.LocalObjectReference{Name: "my-cluster"},
+			Databases:  []enterpriseApi.DatabaseDefinition{{Name: "mydb"}},
+		},
+	}
+	assert.Empty(t, GetPostgresDatabaseWarningsOnUpdate(obj, obj))
+}

--- a/pkg/postgresql/database/adapter/webhook/testsetup_test.go
+++ b/pkg/postgresql/database/adapter/webhook/testsetup_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"github.com/splunk/splunk-operator/pkg/config"
+	"github.com/splunk/splunk-operator/pkg/postgresql/shared/testhelpers"
+)
+
+func init() {
+	testhelpers.EnableFeatureGate(config.PostgresController)
+}

--- a/pkg/postgresql/shared/testhelpers/featuregates.go
+++ b/pkg/postgresql/shared/testhelpers/featuregates.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testhelpers provides shared test utilities for postgresql packages.
+// It must not be imported by production code.
+package testhelpers
+
+import (
+	"k8s.io/component-base/featuregate"
+
+	"github.com/splunk/splunk-operator/pkg/config"
+)
+
+// EnableFeatureGate enables the given feature gates on the default mutable gate.
+// Intended for use in test init() functions.
+func EnableFeatureGate(gates ...featuregate.Feature) {
+	enabled := make(map[string]bool, len(gates))
+	for _, g := range gates {
+		enabled[string(g)] = true
+	}
+	if err := config.DefaultMutableFeatureGate.SetFromMap(enabled); err != nil {
+		panic(err)
+	}
+}

--- a/pkg/splunk/enterprise/validation/registry.go
+++ b/pkg/splunk/enterprise/validation/registry.go
@@ -20,7 +20,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	enterpriseApi "github.com/splunk/splunk-operator/api/v4"
-	pgwebhook "github.com/splunk/splunk-operator/pkg/postgresql/cluster/adapter/webhook"
+	pgclusterwebhook "github.com/splunk/splunk-operator/pkg/postgresql/cluster/adapter/webhook"
+	pgdbwebhook "github.com/splunk/splunk-operator/pkg/postgresql/database/adapter/webhook"
 )
 
 // GVR constants for all Splunk Enterprise CRDs
@@ -83,6 +84,12 @@ var (
 		Group:    "enterprise.splunk.com",
 		Version:  "v4",
 		Resource: "postgresclusterclasses",
+	}
+
+	PostgresDatabaseGVR = schema.GroupVersionResource{
+		Group:    "enterprise.splunk.com",
+		Version:  "v4",
+		Resource: "postgresdatabases",
 	}
 )
 
@@ -195,10 +202,10 @@ var DefaultValidators = map[schema.GroupVersionResource]Validator{
 	},
 
 	PostgresClusterGVR: &GenericValidator[*enterpriseApi.PostgresCluster]{
-		ValidateCreateFunc:   pgwebhook.ValidatePostgresClusterCreate,
-		ValidateUpdateFunc:   pgwebhook.ValidatePostgresClusterUpdate,
-		WarningsOnCreateFunc: pgwebhook.GetPostgresClusterWarningsOnCreate,
-		WarningsOnUpdateFunc: pgwebhook.GetPostgresClusterWarningsOnUpdate,
+		ValidateCreateFunc:   pgclusterwebhook.ValidatePostgresClusterCreate,
+		ValidateUpdateFunc:   pgclusterwebhook.ValidatePostgresClusterUpdate,
+		WarningsOnCreateFunc: pgclusterwebhook.GetPostgresClusterWarningsOnCreate,
+		WarningsOnUpdateFunc: pgclusterwebhook.GetPostgresClusterWarningsOnUpdate,
 		GroupKind: schema.GroupKind{
 			Group: "enterprise.splunk.com",
 			Kind:  "PostgresCluster",
@@ -206,13 +213,23 @@ var DefaultValidators = map[schema.GroupVersionResource]Validator{
 	},
 
 	PostgresClusterClassGVR: &GenericValidator[*enterpriseApi.PostgresClusterClass]{
-		ValidateCreateFunc:   pgwebhook.ValidatePostgresClusterClassCreate,
-		ValidateUpdateFunc:   pgwebhook.ValidatePostgresClusterClassUpdate,
-		WarningsOnCreateFunc: pgwebhook.GetPostgresClusterClassWarningsOnCreate,
-		WarningsOnUpdateFunc: pgwebhook.GetPostgresClusterClassWarningsOnUpdate,
+		ValidateCreateFunc:   pgclusterwebhook.ValidatePostgresClusterClassCreate,
+		ValidateUpdateFunc:   pgclusterwebhook.ValidatePostgresClusterClassUpdate,
+		WarningsOnCreateFunc: pgclusterwebhook.GetPostgresClusterClassWarningsOnCreate,
+		WarningsOnUpdateFunc: pgclusterwebhook.GetPostgresClusterClassWarningsOnUpdate,
 		GroupKind: schema.GroupKind{
 			Group: "enterprise.splunk.com",
 			Kind:  "PostgresClusterClass",
+		},
+	},
+	PostgresDatabaseGVR: &GenericValidator[*enterpriseApi.PostgresDatabase]{
+		ValidateCreateFunc:   pgdbwebhook.ValidatePostgresDatabaseCreate,
+		ValidateUpdateFunc:   pgdbwebhook.ValidatePostgresDatabaseUpdate,
+		WarningsOnCreateFunc: pgdbwebhook.GetPostgresDatabaseWarningsOnCreate,
+		WarningsOnUpdateFunc: pgdbwebhook.GetPostgresDatabaseWarningsOnUpdate,
+		GroupKind: schema.GroupKind{
+			Group: "enterprise.splunk.com",
+			Kind:  "PostgresDatabase",
 		},
 	},
 }


### PR DESCRIPTION
### Description                                 

Enables the PostgresController feature gate mechanism across all three Postgres CRs — PostgresCluster,                   PostgresClusterClass, and PostgresDatabase. When the gate is off (default, Alpha), the validation webhook rejects any attempt to create or update these resources, preventing them from being deployed to environments where the controller is not active. This protects production clusters from silently accumulating CRs that no controller will reconcile.          
                                                                                                                           
### Key Changes
- pkg/postgresql/cluster/adapter/webhook/postgrescluster_validation.go — added PostgresController feature gate guard (was missing)
- pkg/postgresql/database/adapter/webhook/postgresdatabase_validation.go — new validator for PostgresDatabase with feature gate guard, placed in its own package under database/adapter/webhook/                                                      
- pkg/splunk/enterprise/validation/registry.go — fixed three bugs: duplicate map key (PostgresClusterClassGVR used twice), wrong GVR resource name (postgresdatabase → postgresdatabases), typo in function nam (ValidatePostgresDatabaaseUpdate);   
- wires PostgresDatabase into the webhook registry                                                                         
- pkg/postgresql/shared/testhelpers/featuregates.go — new shared EnableFeatureGate(gates ...featuregate.Feature) helper     reusable across all postgres test packages
- docs/FeatureGates.md — added PostgresController to the gates table; added testing guidance for gated validators        
                                                                                                                             
### Testing and Verification                                                                                                 
                                                                                                                             
- All three validators have unit tests covering valid/invalid inputs and an explicit TestValidate*FeatureGateDisabled test  with t.Cleanup restoring gate state between tests                                                                        
- pkg/postgresql/cluster/adapter/webhook and pkg/postgresql/database/adapter/webhook test suites pass cleanly              
                                                                                                                             
ok  github.com/splunk/splunk-operator/pkg/postgresql/cluster/adapter/webhook                                               
ok  github.com/splunk/splunk-operator/pkg/postgresql/database/adapter/webhook                                              
ok  github.com/splunk/splunk-operator/pkg/splunk/enterprise/validation                                                     

### Related Issues

_Jira tickets, GitHub issues, Support tickets..._

### PR Checklist

- [ ] Code changes adhere to the project's coding standards.
- [ ] Relevant unit and integration tests are included.
- [ ] Documentation has been updated accordingly.
- [ ] All tests pass locally.
- [ ] The PR description follows the project's guidelines.
